### PR TITLE
Update metric value for Dash_Units

### DIFF
--- a/subaru_global_2017.dbc
+++ b/subaru_global_2017.dbc
@@ -360,4 +360,4 @@ CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
 CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
-CM_ SG_ 1677 Units "1 = imperial, 5 = metric";
+CM_ SG_ 1677 Units "1 = imperial, 6 = metric";


### PR DESCRIPTION
Minor fix, with 3-bit units signal metric units decimal value is 6 on XV 2018:

<img width="417" alt="Screenshot 2019-05-13 at 21 48 47" src="https://user-images.githubusercontent.com/148686/57724716-25a02380-7694-11e9-91c8-6e47f82da123.png">
