### PR TITLE
Add Honda-Bosch lane line detection signals.

### DIFF
--- a/generator/honda/_bosch_2018.dbc
+++ b/generator/honda/_bosch_2018.dbc
@@ -160,6 +160,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -284,5 +360,9 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;

--- a/honda_accord_lx15t_2018_can_generated.dbc
+++ b/honda_accord_lx15t_2018_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_accord_lx15t_2018_can.dbc starts here"

--- a/honda_accord_s2t_2018_can_generated.dbc
+++ b/honda_accord_s2t_2018_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_accord_s2t_2018_can.dbc starts here"

--- a/honda_civic_hatchback_ex_2017_can_generated.dbc
+++ b/honda_civic_hatchback_ex_2017_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_civic_hatchback_ex_2017_can.dbc starts here"

--- a/honda_civic_sedan_16_diesel_2019_can_generated.dbc
+++ b/honda_civic_sedan_16_diesel_2019_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_civic_sedan_16_diesel_2019_can.dbc starts here"

--- a/honda_crv_ex_2017_can_generated.dbc
+++ b/honda_crv_ex_2017_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_crv_ex_2017_can.dbc starts here"

--- a/honda_crv_hybrid_2019_can_generated.dbc
+++ b/honda_crv_hybrid_2019_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_crv_hybrid_2019_can.dbc starts here"

--- a/honda_insight_ex_2019_can_generated.dbc
+++ b/honda_insight_ex_2019_can_generated.dbc
@@ -164,6 +164,82 @@ BO_ 545 XXX_16: 6 SCM
  SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" BDY
 
+BO_ 576 LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 577 LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+ 
+BO_ 579 RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 580 RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 582 ADJACENT_LEFT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 583 ADJACENT_LEFT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 585 ADJACENT_RIGHT_LANE_LINE_1: 8 CAM
+ SG_ LINE_DISTANCE_VISIBLE : 39|9@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_PROBABILITY : 46|6@0+ (0.015625,0) [0|1] "" XXX
+ SG_ LINE_OFFSET : 23|12@0+ (0.004,-8.192) [0|1] "Meters" XXX
+ SG_ LINE_ANGLE : 7|12@0+ (0.0005,-1.024) [0|1] "" XXX
+ SG_ FRAME_INDEX : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
+BO_ 586 ADJACENT_RIGHT_LANE_LINE_2: 8 CAM
+ SG_ LINE_FAR_EDGE_POSITION : 55|8@0+ (1,-128) [0|1] "" XXX
+ SG_ LINE_SOLID : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_DASHED : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LINE_CURVATURE : 23|12@0+ (0.00001,-0.02048) [0|1] "" XXX
+ SG_ LINE_PARAMETER : 39|12@0+ (1,0) [0|1] "" XXX
+ SG_ FRAME_INDEX : 7|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|1] "" XXX
+
 BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ WHEEL_SPEED_FL : 7|8@0+ (1,0) [0|255] "mph" EON
  SG_ WHEEL_SPEED_FR : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -288,7 +364,11 @@ BO_ 891 STALK_STATUS_2: 8 XXX
 CM_ SG_ 479 AEB_STATUS "set for the duration of AEB event";
 CM_ SG_ 479 AEB_BRAKING "set when braking is commanded during AEB event";
 CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
-
+CM_ SG_ 576 LINE_DISTANCE_VISIBLE "Length of line visible, undecoded";
+CM_ SG_ 577 LINE_FAR_EDGE_POSITION "Appears to be a measure of line thickness, indicates location of the portion of the line furthest from the car, undecoded";
+CM_ SG_ 577 LINE_PARAMETER "Unclear if this is low quality line curvature rate or if this is something else, but it is correlated with line curvature, undecoded";
+CM_ SG_ 577 LINE_DASHED "1 = line is dashed";
+CM_ SG_ 577 LINE_SOLID "1 = line is solid";
 VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;
 
 CM_ "honda_insight_ex_2019_can.dbc starts here"


### PR DESCRIPTION
This pull request is joint with jpancotti.

This seeks to add information about the Honda-Bosch camera system lane line detection signals. It includes values to support a degree three polynomial lane line model (LINE_OFFSET, LINE_ANGLE, LINE_CURVATURE). Line curvature rate is currently listed as LINE_PARAMETER because it is unknown if this is a low-quality curvature rate value or if it is something else. Have seen it spike up in magnitude for curbs, so it may be some kind of line upward / downward slope or line height value. Other signals include an indicator for solid / dashed line texture, line detection probability, line distance visible, a value related to line thickness. Many signal values are still undecoded. Please see the comments in the DBC. There may also be some additional unidentified signals such as line colour.

The Bosch camera outputs appear to stay in the same message structure across different vehicles. Observed in the Accord, Civic, CR-V.

For decoding the polynomial coefficients, attached is a comparison of OpenPilot and (approximately) decoded Bosch lane line parameters. The scenario is of the vehicle taking a moderate left curve then driving straight. Note that the suspected "line jerk" (curvature rate) value does not match the OpenPilot curvature rate term at all. It is also interesting to note that Bosch detects the curve at least a second or two later than OpenPilot.

![image](https://user-images.githubusercontent.com/60021269/75749940-dcc76300-5cd7-11ea-959e-0d1fdc5b7587.png)

Additional justification comes from displaying the decoded Bosch lane lines on the EON UI.

https://www.youtube.com/watch?v=7fSF1RXnJTY


