### PR TITLE
Subaru DBC update

### DIFF
--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -249,6 +249,7 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
+ SG_ Short_Distance : 16|4@1+ (1,0) [0|1] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -206,6 +206,7 @@ BO_ 577 NEW_MSG_16: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_1 : 16|12@1+ (1,0) [0|255] "" XXX
+ SG_ NEW_SIGNAL_2 : 55|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 552 BSD_RCTA: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -222,6 +223,7 @@ BO_ 912 Dashlights: 8 XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_3 : 24|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 940 BodyInfo: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
@@ -236,6 +238,7 @@ BO_ 940 BodyInfo: 8 XXX
  SG_ Highbeam : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ FOG_LIGHTS2 : 60|1@1+ (1,0) [0|1] "" XXX
  SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
+ SG_ BRAKE : 54|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 801 ES_DashStatus: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -252,6 +255,7 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
+ SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -293,7 +297,6 @@ BO_ 837 NEW_MSG_24: 8 XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_3 : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_4 : 32|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_5 : 24|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 838 NEW_MSG_25: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -394,6 +397,12 @@ BO_ 1787 NEW_MSG_45: 8 XXX
  SG_ NEW_SIGNAL_2 : 8|8@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
 
+BO_ 372 NEW_MSG_2: 8 XXX
+ SG_ NEW_SIGNAL_1 : 40|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_2 : 42|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_3 : 32|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_4 : 33|1@0+ (1,0) [0|1] "" XXX
+
 
 
 
@@ -411,6 +420,7 @@ CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
+CM_ SG_ 801 Conventional_Cruise "";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
 CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -66,8 +66,8 @@ BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
+ SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
  SG_ Cruise_RPM : 40|16@1+ (1,0) [0|255] "" XXX
 
 BO_ 316 NEW_MSG_3: 8 XXX
@@ -158,6 +158,7 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 33|4@1+ (1,0) [0|1] "" XXX
@@ -169,16 +170,15 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_1 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -396,7 +396,8 @@ BO_ 1787 NEW_MSG_45: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
-CM_ SG_ 545 Cruise_Throttle "RPM output signal";
+CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
+CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -174,13 +174,13 @@ BO_ 545 ES_Distance: 8 XXX
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
+ SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -155,46 +155,46 @@ BO_ 722 NEW_MSG_10: 8 XXX
 BO_ 544 ES_Brake: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pressure : 16|16@1+ (1,0) [0|255] "" XXX
- SG_ Signal3 : 40|24@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 32|4@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Lights : 36|1@1+ (1,0) [0|63] "" XXX
+ SG_ Cruise_Brake_Fault : 37|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Active : 38|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 39|1@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Brake_Lights : 36|1@1+ (1,0) [0|63] "" XXX
- SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Brake_Fault : 37|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 40|24@1+ (1,0) [0|1] "" XXX
 
 BO_ 545 ES_Distance: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Fault : 15|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
+ SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
+ SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
+ SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 12|3@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Fault : 15|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
- SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Fault : 15|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Brake_Lights : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 12|3@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Fault : 15|1@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -264,17 +264,17 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Signal2 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 33|2@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal4 : 37|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
+ SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal5 : 49|2@1+ (1,0) [0|3] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal6 : 53|3@1+ (1,0) [0|1] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
- SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -429,15 +429,13 @@ CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
 CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
-CM_ SG_ 545 Cruise_EPB "Electric Parking Brake set";
+CM_ SG_ 545 Cruise_EPB "1 = set Electric Parking Brake";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
-CM_ SG_ 546 Brake_Lights "1 when ES_Brake State 12 or 13 or Brake_Pedal pressed";
 CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
-CM_ SG_ 801 PCB_Off "Pre-Collision Braking";
-CM_ SG_ 801 Conventional_Cruise "";
+CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -64,11 +64,7 @@ BO_ 65 NEW_MSG_1: 8 XXX
  SG_ NEW_SIGNAL_7 : 59|2@0+ (1,0) [0|255] "" XXX
 
 BO_ 72 Transmission: 8 XXX
-<<<<<<< HEAD
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
-=======
- SG_ Checksum : 0|8@1+ (1,0) [0|255] "" XXX
->>>>>>> add Transmission and Gear values
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -197,9 +197,10 @@ BO_ 557 NEW_MSG_14: 8 XXX
 BO_ 576 CruiseControl: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_5 : 42|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_On : 40|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Activated : 41|1@1+ (1,0) [0|3] "" XXX
+ SG_ Signal1 : 12|28@1+ (1,0) [0|1] "" XXX
+ SG_ Signal2 : 42|22@1+ (1,0) [0|3] "" XXX
 
 BO_ 577 NEW_MSG_16: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -403,13 +404,13 @@ CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 545 Cruise_EPB "Electric Parking Brake set";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
-CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
 CM_ SG_ 546 Brake_Lights "1 when ES_Brake State 12 or 13 or Brake_Pedal pressed";
+CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";
-CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
+CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
 CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -44,30 +44,17 @@ BO_ 2 Steering: 8 XXX
 BO_ 64 Throttle: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Engine_RPM : 16|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Throttle_Pedal : 32|8@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Cruise : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Combo : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 56|4@1+ (1,0) [0|255] "" XXX
  SG_ Off_Accel : 60|4@1+ (1,0) [0|7] "" XXX
 
-BO_ 65 NEW_MSG_1: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_4 : 32|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 16|12@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_5 : 31|1@0+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_6 : 48|8@1+ (1,0) [0|63] "" XXX
- SG_ NEW_SIGNAL_7 : 59|2@0+ (1,0) [0|255] "" XXX
-
 BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
  SG_ RPM : 40|16@1+ (1,0) [0|255] "" XXX
 
 BO_ 316 Brake_Status: 8 XXX
@@ -100,18 +87,9 @@ BO_ 314 Wheel_Speeds: 8 XXX
  SG_ FL : 51|13@1+ (0.057,0) [0|255] "kph" XXX
  SG_ RL : 38|13@1+ (0.057,0) [0|255] "kph" XXX
 
-BO_ 73 NEW_MSG_5: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_1 : 32|8@1+ (1,0) [0|4095] "" XXX
- SG_ NEW_SIGNAL_2 : 24|8@1+ (1,0) [0|127] "" XXX
-
 BO_ 280 STOP_START: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_1 : 12|12@1- (1,0) [0|4095] "" XXX
- SG_ NEW_SIGNAL_4 : 40|4@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 48|8@1- (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 61|1@1+ (1,0) [0|7] "" XXX
  SG_ State : 63|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 281 Steering_Torque: 8 XXX
@@ -144,13 +122,6 @@ BO_ 290 ES_LKAS: 8 XXX
  SG_ LKAS_Output : 16|13@1- (-1,0) [0|3] "" XXX
  SG_ LKAS_Request : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ SET_1 : 12|1@0+ (1,0) [0|3] "" XXX
-
-BO_ 722 NEW_MSG_10: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_1 : 27|3@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 56|2@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_5 : 45|2@0+ (1,0) [0|3] "" XXX
 
 BO_ 544 ES_Brake: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -202,10 +173,6 @@ BO_ 554 ES_Blank: 8 XXX
  SG_ SET_65535 : 39|16@1+ (1,0) [0|16777215] "" XXX
  SG_ SET_1 : 13|1@1+ (1,0) [0|7] "" XXX
 
-BO_ 557 NEW_MSG_14: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
 BO_ 576 CruiseControl: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
@@ -217,7 +184,6 @@ BO_ 576 CruiseControl: 8 XXX
 BO_ 577 Cruise_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_1 : 16|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_On : 54|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 55|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Active : 57|4@1+ (1,0) [0|1] "" XXX
@@ -233,8 +199,6 @@ BO_ 552 BSD_RCTA: 8 XXX
 BO_ 912 Dashlights: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 24|1@0+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_1 : 32|1@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
@@ -300,130 +264,10 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ Right_Depart : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal5 : 37|27@1+ (1,0) [0|1] "" XXX
 
-BO_ 805 ES_NEW_MSG_22: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 22|2@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_1 : 14|1@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_4 : 15|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 808 NEW_MSG_23: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 837 NEW_MSG_24: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 32|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 838 NEW_MSG_25: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 40|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 842 NEW_MSG_26: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 32|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 915 NEW_MSG_27: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 32|9@1+ (1,0) [0|255] "" XXX
-
-BO_ 1788 NEW_MSG_28: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 40|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_4 : 48|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 816 NEW_MSG_29: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 826 NEW_MSG_30: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 839 NEW_MSG_31: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 2015 NEW_MSG_32: 8 XXX
- SG_ NEW_SIGNAL_2 : 16|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 2024 NEW_MSG_33: 8 XXX
- SG_ NEW_SIGNAL_1 : 24|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 0|3@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 32|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 1614 NEW_MSG_34: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1617 NEW_MSG_35: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1632 NEW_MSG_36: 8 XXX
- SG_ NEW_SIGNAL_1 : 55|16@0+ (1,0) [0|255] "" XXX
-
-BO_ 1650 NEW_MSG_37: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1657 NEW_MSG_38: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1658 NEW_MSG_39: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 33|1@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_4 : 31|1@0+ (1,0) [0|3] "" XXX
-
 BO_ 1677 Dash_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|4@1+ (1,0) [0|15] "" XXX
  SG_ Units : 29|3@1+ (1,0) [0|7] "" XXX
- SG_ Icy_Road_Warning : 20|1@1+ (1,0) [0|1] "" XXX
-
-BO_ 1743 NEW_MSG_41: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1785 NEW_MSG_42: 8 XXX
- SG_ NEW_SIGNAL_1 : 0|4@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 21|1@1+ (1,0) [0|31] "" XXX
- SG_ NEW_SIGNAL_3 : 17|1@1+ (1,0) [0|7] "" XXX
-
-BO_ 1759 NEW_MSG_43: 8 XXX
- SG_ NEW_SIGNAL_1 : 17|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 1786 NEW_MSG_44: 8 XXX
- SG_ NEW_SIGNAL_1 : 0|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_2 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 8|8@1+ (1,0) [0|15] "" XXX
-
-BO_ 1787 NEW_MSG_45: 8 XXX
- SG_ NEW_SIGNAL_1 : 0|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_2 : 8|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 372 NEW_MSG_2: 8 XXX
- SG_ NEW_SIGNAL_1 : 40|1@0+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_2 : 42|1@0+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_3 : 32|1@0+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_4 : 33|1@0+ (1,0) [0|1] "" XXX
-
-
-
 
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
@@ -433,12 +277,10 @@ CM_ SG_ 545 Cruise_EPB "1 = set Electric Parking Brake";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
 CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
-CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
-CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
-CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
-CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
+CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
+CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";
 VAL_ 72 Gear 2 "N" 3 "R" 4 "P" 121 "D" 137 "1" 145 "2" 153 "3" 161 "4" 169 "5" 177 "6";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -68,9 +68,16 @@ BO_ 72 Transmission: 8 XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
- SG_ Cruise_RPM : 40|16@1+ (1,0) [0|255] "" XXX
+ SG_ RPM : 40|16@1+ (1,0) [0|255] "" XXX
 
-BO_ 316 NEW_MSG_3: 8 XXX
+BO_ 316 Brake_Status: 8 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 12|46@1+ (1,0) [0|1] "" XXX
+ SG_ ES_Brake : 58|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal2 : 59|3@1+ (1,0) [0|1] "" XXX
+ SG_ Brake : 62|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 63|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 326 Cruise_Buttons: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -202,11 +209,13 @@ BO_ 576 CruiseControl: 8 XXX
  SG_ Signal1 : 12|28@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 42|22@1+ (1,0) [0|3] "" XXX
 
-BO_ 577 NEW_MSG_16: 8 XXX
+BO_ 577 Cruise_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_1 : 16|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 55|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_1 : 16|8@1+ (1,0) [0|255] "" XXX
+ SG_ Cruise_On : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Activated : 55|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Active : 57|4@1+ (1,0) [0|1] "" XXX
 
 BO_ 552 BSD_RCTA: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -279,7 +279,7 @@ CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
 CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
-CM_ SG_ 545 Cruise_EPB "1 = set Electric Parking Brake";
+CM_ SG_ 545 Cruise_EPB "1 = Electric Parking Brake set";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
 CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -231,13 +231,13 @@ BO_ 552 BSD_RCTA: 8 XXX
  SG_ L_APPROACHING : 59|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 912 Dashlights: 8 XXX
- SG_ NEW_SIGNAL_1 : 32|1@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_2 : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
- SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
- SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_3 : 24|1@0+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_1 : 32|1@1+ (1,0) [0|3] "" XXX
+ SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
+ SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
+ SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 940 BodyInfo: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -46,12 +46,11 @@ BO_ 64 Throttle: 8 XXX
  SG_ Counter : 8|4@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Engine_RPM : 16|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 28|5@1+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_4 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Throttle_Pedal : 32|8@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Cruise : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ Throttle_Combo : 48|7@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 55|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 56|4@1+ (1,0) [0|255] "" XXX
+ SG_ Throttle_Combo : 48|8@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 56|4@1+ (1,0) [0|255] "" XXX
  SG_ Off_Accel : 60|4@1+ (1,0) [0|7] "" XXX
 
 BO_ 65 NEW_MSG_1: 8 XXX
@@ -67,9 +66,9 @@ BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_3 : 40|16@1+ (1,0) [0|255] "" XXX
+ SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 316 NEW_MSG_3: 8 XXX
 
@@ -158,17 +157,19 @@ BO_ 544 ES_Brake: 8 XXX
 BO_ 545 ES_Distance: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ ES_Cruise_Throttle : 12|20@1+ (1,0) [0|15] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 33|4@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 38|2@1+ (1,0) [0|1] "" XXX
  SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 48|8@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 12|4@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 59|5@1+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_1 : 48|8@1+ (1,0) [0|1] "" XXX
+ SG_ Signal5 : 59|5@1+ (1,0) [0|1] "" XXX
+ SG_ ES_Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -177,6 +178,7 @@ BO_ 546 ES_Status: 8 XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ NEW_SIGNAL_1 : 28|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -393,8 +395,8 @@ BO_ 1787 NEW_MSG_45: 8 XXX
 
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
-CM_ SG_ 545 ES_Cruise_Throttle "signal might be smaller, values do not correlate with Throttle:CruiseThrottle";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
+CM_ SG_ 545 ES_Cruise_Throttle "signal might be smaller, values do not correlate with Throttle:CruiseThrottle";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -175,10 +175,12 @@ BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_1 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
+ SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -395,8 +397,8 @@ BO_ 1787 NEW_MSG_45: 8 XXX
 
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
-CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
+CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -37,9 +37,9 @@ BU_: XXX X
 
 
 BO_ 2 Steering: 8 XXX
+ SG_ Steering_Angle : 7|16@0- (0.1,0) [0|65535] "" XXX
  SG_ Counter : 25|3@1+ (1,0) [0|7] "" XXX
  SG_ CHECKSUM : 32|8@1+ (1,0) [0|255] "" XXX
- SG_ Steering_Angle : 7|16@0- (0.1,0) [0|65535] "" XXX
 
 BO_ 64 Throttle: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -57,6 +57,11 @@ BO_ 72 Transmission: 8 XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ RPM : 40|16@1+ (1,0) [0|255] "" XXX
 
+BO_ 73 CVT: 8 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ CVT_Gear : 24|8@1+ (1,0) [0|127] "" XXX
+
 BO_ 316 Brake_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|1] "" XXX
@@ -71,13 +76,13 @@ BO_ 326 Cruise_Buttons: 8 XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Signal1 : 12|30@1+ (1,0) [0|1073741823] "" XXX
  SG_ Main : 42|1@1+ (1,0) [0|1] "" XXX
- SG_ set : 43|1@1+ (1,0) [0|1] "" XXX
+ SG_ Set : 43|1@1+ (1,0) [0|1] "" XXX
  SG_ Resume : 44|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 45|19@1+ (1,0) [0|524287] "" XXX
 
 BO_ 315 G_Sensor: 8 XXX
- SG_ longitudinal : 63|8@0- (1,0) [0|255] "" XXX
- SG_ Latitudinal : 48|8@1- (1,0) [0|255] "" XXX
+ SG_ Lateral : 48|8@1- (-0.1,0) [0|255] "m/s2" XXX
+ SG_ Longitudinal : 56|8@1- (-0.1,0) [0|255] "m/s2" XXX
 
 BO_ 314 Wheel_Speeds: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -94,10 +99,11 @@ BO_ 280 STOP_START: 8 XXX
 
 BO_ 281 Steering_Torque: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|3] "" XXX
- SG_ counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Steer_Error_1 : 12|1@0+ (1,0) [0|7] "" XXX
  SG_ Steer_Torque_Sensor : 16|11@1- (-1,0) [0|3] "" XXX
  SG_ Steer_Error_2 : 28|1@1+ (1,0) [0|3] "" XXX
+ SG_ Steer_Warning : 29|1@1+ (1,0) [0|1] "" XXX
  SG_ Steering_Angle : 32|16@1- (-0.0217,0) [0|255] "" X
  SG_ Steer_Torque_Output : 48|11@1- (-1,0) [0|31] "" XXX
 
@@ -110,7 +116,8 @@ BO_ 312 Brake_Pressure_L_R: 8 XXX
 BO_ 313 Brake_Pedal: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 12|22@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
+ SG_ Speed : 16|12@1+ (0.05625,0) [0|255] "kph" XXX
  SG_ Brake_Lights : 34|1@1+ (1,0) [0|7] "" XXX
  SG_ Signal2 : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pedal : 36|12@1+ (1,0) [0|65535] "" XXX
@@ -119,9 +126,9 @@ BO_ 313 Brake_Pedal: 8 XXX
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ SET_1 : 12|1@0+ (1,0) [0|3] "" XXX
  SG_ LKAS_Output : 16|13@1- (-1,0) [0|3] "" XXX
  SG_ LKAS_Request : 29|1@0+ (1,0) [0|3] "" XXX
- SG_ SET_1 : 12|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 544 ES_Brake: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -167,18 +174,12 @@ BO_ 546 ES_Status: 8 XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
 
-BO_ 554 ES_Blank: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ SET_65535 : 39|16@1+ (1,0) [0|16777215] "" XXX
- SG_ SET_1 : 13|1@1+ (1,0) [0|7] "" XXX
-
 BO_ 576 CruiseControl: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|28@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_On : 40|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Activated : 41|1@1+ (1,0) [0|3] "" XXX
- SG_ Signal1 : 12|28@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 42|22@1+ (1,0) [0|3] "" XXX
 
 BO_ 577 Cruise_Status: 8 XXX
@@ -199,6 +200,7 @@ BO_ 552 BSD_RCTA: 8 XXX
 BO_ 912 Dashlights: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ ICY_ROAD : 32|2@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
@@ -223,20 +225,22 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Counter : 8|4@1+ (1,0) [0|7] "" XXX
  SG_ PCB_Off : 12|1@1+ (1,0) [0|1] "" XXX
  SG_ LDW_Off : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|14@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 14|10@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Soft_Disable : 24|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal2 : 25|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Distance : 28|3@1+ (1,0) [0|3] "" XXX
- SG_ Signal2 : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 33|2@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 33|2@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
- SG_ Signal4 : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ Signal5 : 37|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 49|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal6 : 49|2@1+ (1,0) [0|3] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
- SG_ Signal6 : 53|3@1+ (1,0) [0|1] "" XXX
+ SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
 
@@ -250,19 +254,21 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ Signal2 : 18|5@1+ (1,0) [0|7] "" XXX
  SG_ Backward_Speed_Limit_Menu : 23|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_ENABLE_3 : 24|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 25|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Light_Blink : 25|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_ENABLE_2 : 26|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 27|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Right_Line_Light_Blink : 27|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Left_Line_Visible : 28|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal6 : 29|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Green : 29|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Right_Line_Visible : 30|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal7 : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ FCW_Cont_Beep : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ FCW_Repeated_Beep : 33|1@1+ (1,0) [0|1] "" XXX
- SG_ Throttle_Management_Activated : 34|1@1+ (1,0) [0|1] "" XXX
- SG_ Lead_Vehicle_Start_Alert : 35|1@1+ (1,0) [0|1] "" XXX
- SG_ Right_Depart : 36|1@1+ (1,0) [0|3] "" XXX
- SG_ Signal5 : 37|27@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Right_Line_Green : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Alert : 32|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal3 : 36|28@1+ (1,0) [0|1] "" XXX
+
+BO_ 722 AC_State: 8 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ AC_Mode : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ AC_ON : 24|2@1+ (1,0) [0|1] "" XXX
 
 BO_ 1677 Dash_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -280,7 +286,11 @@ CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
+CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
+CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
+CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
-CM_ SG_ 1677 Units "1 = imperial, 6 = metric";
+CM_ SG_ 1677 Units "AU/EU: 1 = imperial, 3 = metric US: 3 = imperial, 4 = metric";
 VAL_ 72 Gear 2 "N" 3 "R" 4 "P" 121 "D" 137 "1" 145 "2" 153 "3" 161 "4" 169 "5" 177 "6";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -155,41 +155,46 @@ BO_ 722 NEW_MSG_10: 8 XXX
 BO_ 544 ES_Brake: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pressure : 16|16@1+ (1,0) [0|255] "" XXX
- SG_ Signal2 : 32|4@1+ (1,0) [0|1] "" XXX
- SG_ State : 36|4@1+ (1,0) [0|63] "" XXX
  SG_ Signal3 : 40|24@1+ (1,0) [0|1] "" XXX
+ SG_ Signal2 : 32|4@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Active : 38|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Activated : 39|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Lights : 36|1@1+ (1,0) [0|63] "" XXX
+ SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Fault : 37|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 545 ES_Distance: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
- SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 12|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Fault : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
+ SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
+ SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
+ SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
+ SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
- SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Brake_Lights : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 12|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Fault : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -259,17 +264,17 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Signal2 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 33|2@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal4 : 37|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal5 : 49|2@1+ (1,0) [0|3] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal6 : 53|3@1+ (1,0) [0|1] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
+ SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
+ SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -422,19 +427,19 @@ BO_ 372 NEW_MSG_2: 8 XXX
 
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
-CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
+CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
 CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
-CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 545 Cruise_EPB "Electric Parking Brake set";
+CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
 CM_ SG_ 546 Brake_Lights "1 when ES_Brake State 12 or 13 or Brake_Pedal pressed";
 CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";
+CM_ SG_ 801 Conventional_Cruise "";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
-CM_ SG_ 801 Conventional_Cruise "";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
 CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -126,10 +126,10 @@ BO_ 313 Brake_Pedal: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 12|22@1+ (1,0) [0|1] "" XXX
+ SG_ Brake_Lights : 34|1@1+ (1,0) [0|7] "" XXX
  SG_ Signal2 : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pedal : 36|12@1+ (1,0) [0|65535] "" XXX
  SG_ Signal3 : 48|16@1+ (1,0) [0|1] "" XXX
- SG_ Brake_Lights : 34|1@1+ (1,0) [0|7] "" XXX
 
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -161,17 +161,17 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
+ SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
  SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
  SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -180,9 +180,9 @@ BO_ 546 ES_Status: 8 XXX
  SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
+ SG_ Brake_Lights : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
- SG_ Brake_Lights : 30|1@1+ (1,0) [0|3] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -247,10 +247,10 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_10 : 49|2@1+ (1,0) [0|3] "" XXX
+ SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
- SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -126,10 +126,10 @@ BO_ 313 Brake_Pedal: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|1] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 12|22@1+ (1,0) [0|1] "" XXX
- SG_ Brake_Pedal_On : 34|1@1+ (1,0) [0|7] "" XXX
  SG_ Signal2 : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Pedal : 36|12@1+ (1,0) [0|65535] "" XXX
  SG_ Signal3 : 48|16@1+ (1,0) [0|1] "" XXX
+ SG_ Brake_Lights : 34|1@1+ (1,0) [0|7] "" XXX
 
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -161,15 +161,17 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 33|4@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
- SG_ Signal4 : 38|2@1+ (1,0) [0|1] "" XXX
  SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
  SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Brake_Active : 36|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 33|3@1+ (1,0) [0|1] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -178,9 +180,9 @@ BO_ 546 ES_Status: 8 XXX
  SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ Signal2 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
- SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 32|32@1+ (1,0) [0|1] "" XXX
+ SG_ Brake_Lights : 30|1@1+ (1,0) [0|3] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -245,11 +247,10 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_10 : 49|2@1+ (1,0) [0|3] "" XXX
- SG_ Brake_Pedal : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
- SG_ Short_Distance : 16|4@1+ (1,0) [0|1] "" XXX
+ SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -396,14 +397,19 @@ BO_ 1787 NEW_MSG_45: 8 XXX
 
 
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
+CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
 CM_ SG_ 545 Cruise_Throttle "RPM-like output signal";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
+CM_ SG_ 545 Cruise_EPB "Electric Parking Brake set";
 CM_ SG_ 546 Cruise_RPM "ES RPM output for ECM and TCM";
+CM_ SG_ 546 Signal3 "0 when cruise_activated = 1";
+CM_ SG_ 546 Brake_Lights "1 when ES_Brake State 12 or 13 or Brake_Pedal pressed";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
+CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
 CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -396,7 +396,7 @@ BO_ 1787 NEW_MSG_45: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
-CM_ SG_ 545 ES_Cruise_Throttle "signal might be smaller, values do not correlate with Throttle:CruiseThrottle";
+CM_ SG_ 545 Throttle_Cruise "RPM output signal";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -254,22 +254,22 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Counter : 8|4@1+ (1,0) [0|7] "" XXX
  SG_ PCB_Off : 12|1@1+ (1,0) [0|1] "" XXX
  SG_ LDW_Off : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Cruise_Distance : 28|3@1+ (1,0) [0|3] "" XXX
- SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
- SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
- SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
- SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
- SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
- SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal2 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 14|14@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Distance : 28|3@1+ (1,0) [0|3] "" XXX
+ SG_ Signal2 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 33|2@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|3] "" XXX
+ SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal4 : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
+ SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal5 : 49|2@1+ (1,0) [0|3] "" XXX
+ SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
+ SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal6 : 53|3@1+ (1,0) [0|1] "" XXX
+ SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
+ SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -66,9 +66,9 @@ BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
+ SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_3 : 40|16@1+ (1,0) [0|255] "" XXX
- SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 316 NEW_MSG_3: 8 XXX
 
@@ -157,28 +157,28 @@ BO_ 544 ES_Brake: 8 XXX
 BO_ 545 ES_Distance: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
+ SG_ Throttle_Cruise : 16|12@1+ (1,0) [0|15] "" XXX
+ SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 33|4@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 33|4@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 37|1@1+ (1,0) [0|15] "" XXX
- SG_ Signal2 : 38|2@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 38|2@1+ (1,0) [0|1] "" XXX
  SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
- SG_ Signal3 : 12|4@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 28|4@1+ (1,0) [0|1] "" XXX
+ SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_1 : 48|8@1+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 59|5@1+ (1,0) [0|1] "" XXX
- SG_ ES_Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
+ SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ RPM : 16|12@1+ (1,0) [0|255] "" XXX
+ SG_ NEW_SIGNAL_1 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_1 : 28|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -259,12 +259,17 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_10 : 49|2@1+ (1,0) [0|3] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal2 : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal1 : 14|14@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 33|2@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ Signal5 : 49|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal6 : 53|3@1+ (1,0) [0|1] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -64,7 +64,11 @@ BO_ 65 NEW_MSG_1: 8 XXX
  SG_ NEW_SIGNAL_7 : 59|2@0+ (1,0) [0|255] "" XXX
 
 BO_ 72 Transmission: 8 XXX
+<<<<<<< HEAD
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+=======
+ SG_ Checksum : 0|8@1+ (1,0) [0|255] "" XXX
+>>>>>>> add Transmission and Gear values
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
@@ -401,4 +405,4 @@ CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
 CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";
-VAL_ 72 Gear 2 "N" 3 "R" 4 "P" 121 "D" 137 "1" 145 "2" 153 "3" 161 "4" 169 "5" 177 "6" ;
+VAL_ 72 Gear 2 "N" 3 "R" 4 "P" 121 "D" 137 "1" 145 "2" 153 "3" 161 "4" 169 "5" 177 "6";

--- a/subaru_crosstrek_2018.dbc
+++ b/subaru_crosstrek_2018.dbc
@@ -66,9 +66,9 @@ BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 40|16@1+ (1,0) [0|255] "" XXX
+ SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
+ SG_ Cruise_RPM : 40|16@1+ (1,0) [0|255] "" XXX
 
 BO_ 316 NEW_MSG_3: 8 XXX
 
@@ -158,7 +158,6 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|1] "" XXX
- SG_ Throttle_Cruise : 16|12@1+ (1,0) [0|15] "" XXX
  SG_ Signal2 : 28|4@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 32|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 33|4@1+ (1,0) [0|1] "" XXX
@@ -170,15 +169,16 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Resume : 58|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal6 : 59|5@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Throttle : 16|12@1+ (1,0) [0|15] "" XXX
 
 BO_ 546 ES_Status: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ NEW_SIGNAL_1 : 28|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Hold : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_RPM : 16|12@1+ (1,0) [0|255] "" XXX
 
 BO_ 554 ES_Blank: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -396,7 +396,7 @@ BO_ 1787 NEW_MSG_45: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 544 State "0 = ES disabled, 8 = ES enabled, 12, 13 = ES_Brake active";
 CM_ SG_ 545 Distance_Swap "Switch from Close to Far distance";
-CM_ SG_ 545 Throttle_Cruise "RPM output signal";
+CM_ SG_ 545 Cruise_Throttle "RPM output signal";
 CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking";

--- a/subaru_global_2017.dbc
+++ b/subaru_global_2017.dbc
@@ -47,7 +47,7 @@ BO_ 64 Throttle: 8 XXX
  SG_ Engine_RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Pedal : 32|8@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Cruise : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ Throttle_Combo : 55|8@1+ (1,0) [0|255] "" XXX
+ SG_ Throttle_Combo : 48|8@1+ (1,0) [0|255] "" XXX
  SG_ Off_Accel : 60|4@1+ (1,0) [0|7] "" XXX
 
 BO_ 72 Transmission: 8 XXX

--- a/subaru_global_2017.dbc
+++ b/subaru_global_2017.dbc
@@ -192,12 +192,12 @@ BO_ 552 BSD_RCTA: 8 XXX
  SG_ L_APPROACHING : 59|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 912 Dashlights: 8 XXX
- SG_ NEW_SIGNAL_1 : 32|1@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_2 : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
- SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ NEW_SIGNAL_1 : 32|1@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
+ SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
+ SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 940 BodyInfo: 8 XXX
  SG_ DOOR_OPEN_FL : 32|1@1+ (1,0) [0|255] "" XXX

--- a/subaru_global_2017.dbc
+++ b/subaru_global_2017.dbc
@@ -44,34 +44,16 @@ BO_ 2 Steering: 8 XXX
 BO_ 64 Throttle: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Off_Accel : 60|4@1+ (1,0) [0|7] "" XXX
- SG_ NEW_SIGNAL_3 : 56|4@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Cruise : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Combo : 55|8@1+ (1,0) [0|255] "" XXX
  SG_ Throttle_Pedal : 32|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 48|7@1+ (1,0) [0|1] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|255] "" XXX
  SG_ Engine_RPM : 16|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_1 : 12|4@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_4 : 28|5@1+ (1,0) [0|1] "" XXX
-
-BO_ 65 NEW_MSG_1: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_4 : 32|12@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 16|12@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_5 : 31|1@0+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_6 : 48|8@1+ (1,0) [0|63] "" XXX
- SG_ NEW_SIGNAL_7 : 59|2@0+ (1,0) [0|255] "" XXX
 
 BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 38|3@0+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 40|16@1+ (1,0) [0|255] "" XXX
-
-BO_ 316 NEW_MSG_3: 8 XXX
 
 BO_ 326 Cruise_Buttons: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -94,20 +76,9 @@ BO_ 314 Wheel_Speeds: 8 XXX
  SG_ FL : 51|13@1+ (0.057,0) [0|255] "kph" XXX
  SG_ RL : 38|13@1+ (0.057,0) [0|255] "kph" XXX
 
-BO_ 73 NEW_MSG_5: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_1 : 32|8@1+ (1,0) [0|4095] "" XXX
- SG_ NEW_SIGNAL_2 : 24|8@1+ (1,0) [0|127] "" XXX
-
-BO_ 280 NEW_MSG_6: 8 XXX
- SG_ NEW_SIGNAL_1 : 12|12@1- (1,0) [0|4095] "" XXX
- SG_ NEW_SIGNAL_2 : 48|8@1- (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 61|1@1+ (1,0) [0|7] "" XXX
- SG_ NEW_SIGNAL_4 : 40|4@1+ (1,0) [0|255] "" XXX
-
 BO_ 281 Steering_Torque: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|3] "" XXX
- SG_ counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Steer_Torque_Sensor : 16|11@1- (-1,0) [0|3] "" XXX
  SG_ Steering_Angle : 32|16@1- (-0.0217,0) [0|255] "" X
  SG_ Steer_Torque_Output : 48|11@1- (-1,0) [0|31] "" XXX
@@ -132,13 +103,6 @@ BO_ 290 ES_LKAS: 8 XXX
  SG_ LKAS_Output : 16|13@1- (-1,0) [0|3] "" XXX
  SG_ LKAS_Request : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ SET_1 : 12|1@0+ (1,0) [0|3] "" XXX
-
-BO_ 722 NEW_MSG_10: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_1 : 27|3@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 56|2@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_5 : 45|2@0+ (1,0) [0|3] "" XXX
 
 BO_ 544 ES_Brake: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -167,21 +131,11 @@ BO_ 554 ES_Blank: 8 XXX
  SG_ SET_65535 : 39|16@1+ (1,0) [0|16777215] "" XXX
  SG_ SET_1 : 13|1@1+ (1,0) [0|7] "" XXX
 
-BO_ 557 NEW_MSG_14: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
 BO_ 576 CruiseControl: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_5 : 42|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_On : 40|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Activated : 41|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 577 NEW_MSG_16: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_1 : 16|12@1+ (1,0) [0|255] "" XXX
 
 BO_ 552 BSD_RCTA: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -194,7 +148,6 @@ BO_ 552 BSD_RCTA: 8 XXX
 BO_ 912 Dashlights: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_1 : 32|1@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|3] "" XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
@@ -219,7 +172,6 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
- SG_ NEW_SIGNAL_10 : 49|2@1+ (1,0) [0|3] "" XXX
  SG_ Brake_Pedal : 51|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|3] "" XXX
  SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
@@ -249,130 +201,14 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ Right_Depart : 36|1@1+ (1,0) [0|3] "" XXX
  SG_ Signal5 : 37|27@1+ (1,0) [0|1] "" XXX
 
-BO_ 805 ES_NEW_MSG_22: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 22|2@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_1 : 14|1@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_4 : 15|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 808 NEW_MSG_23: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 837 NEW_MSG_24: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 32|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_5 : 24|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 838 NEW_MSG_25: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 40|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 842 NEW_MSG_26: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 32|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 915 NEW_MSG_27: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 32|9@1+ (1,0) [0|255] "" XXX
-
-BO_ 1788 NEW_MSG_28: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 40|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_4 : 48|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_5 : 16|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 816 NEW_MSG_29: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 826 NEW_MSG_30: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 839 NEW_MSG_31: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 2015 NEW_MSG_32: 8 XXX
- SG_ NEW_SIGNAL_2 : 16|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 2024 NEW_MSG_33: 8 XXX
- SG_ NEW_SIGNAL_1 : 24|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 0|3@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_4 : 32|8@1+ (1,0) [0|255] "" XXX
-
-BO_ 1614 NEW_MSG_34: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1617 NEW_MSG_35: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1632 NEW_MSG_36: 8 XXX
- SG_ NEW_SIGNAL_1 : 55|16@0+ (1,0) [0|255] "" XXX
-
-BO_ 1650 NEW_MSG_37: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1657 NEW_MSG_38: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1658 NEW_MSG_39: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 33|1@1+ (1,0) [0|3] "" XXX
- SG_ NEW_SIGNAL_4 : 31|1@0+ (1,0) [0|3] "" XXX
-
 BO_ 1677 Dash_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_3 : 16|4@1+ (1,0) [0|15] "" XXX
  SG_ Units : 29|3@1+ (1,0) [0|7] "" XXX
 
-BO_ 1743 NEW_MSG_41: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
-
-BO_ 1785 NEW_MSG_42: 8 XXX
- SG_ NEW_SIGNAL_1 : 0|4@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_2 : 21|1@1+ (1,0) [0|31] "" XXX
- SG_ NEW_SIGNAL_3 : 17|1@1+ (1,0) [0|7] "" XXX
-
-BO_ 1759 NEW_MSG_43: 8 XXX
- SG_ NEW_SIGNAL_1 : 17|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 1786 NEW_MSG_44: 8 XXX
- SG_ NEW_SIGNAL_1 : 0|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_2 : 16|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 8|8@1+ (1,0) [0|15] "" XXX
-
-BO_ 1787 NEW_MSG_45: 8 XXX
- SG_ NEW_SIGNAL_1 : 0|4@1+ (1,0) [0|15] "" XXX
- SG_ NEW_SIGNAL_2 : 8|8@1+ (1,0) [0|255] "" XXX
- SG_ NEW_SIGNAL_3 : 16|8@1+ (1,0) [0|255] "" XXX
-
-
-
-
-CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
-CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 801 Cruise_State "0 = Normal, 3 = Hold";
 CM_ SG_ 802 Traffic_light_Ahead "Crosstrek 2018 = car in front has moved";
-CM_ SG_ 805 NEW_SIGNAL_3 "always 3";
-CM_ SG_ 805 NEW_SIGNAL_4 "always 1";
+CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
+CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 1677 Units "1 = imperial, 6 = metric";
 VAL_ 72 Gear 2 "N" 3 "R" 4 "P" 121 "D" 137 "1" 145 "2" 153 "3" 161 "4" 169 "5" 177 "6";

--- a/subaru_global_2017.dbc
+++ b/subaru_global_2017.dbc
@@ -37,18 +37,18 @@ BU_: XXX X
 
 
 BO_ 2 Steering: 8 XXX
+ SG_ Steering_Angle : 7|16@0- (0.1,0) [0|65535] "" XXX
  SG_ Counter : 25|3@1+ (1,0) [0|7] "" XXX
  SG_ CHECKSUM : 32|8@1+ (1,0) [0|255] "" XXX
- SG_ Steering_Angle : 7|16@0- (0.1,0) [0|65535] "" XXX
 
 BO_ 64 Throttle: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Off_Accel : 60|4@1+ (1,0) [0|7] "" XXX
- SG_ Throttle_Cruise : 40|8@1+ (1,0) [0|255] "" XXX
- SG_ Throttle_Combo : 55|8@1+ (1,0) [0|255] "" XXX
- SG_ Throttle_Pedal : 32|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|255] "" XXX
  SG_ Engine_RPM : 16|12@1+ (1,0) [0|255] "" XXX
+ SG_ Throttle_Pedal : 32|8@1+ (1,0) [0|255] "" XXX
+ SG_ Throttle_Cruise : 40|8@1+ (1,0) [0|255] "" XXX
+ SG_ Throttle_Combo : 55|8@1+ (1,0) [0|255] "" XXX
+ SG_ Off_Accel : 60|4@1+ (1,0) [0|7] "" XXX
 
 BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -65,8 +65,8 @@ BO_ 326 Cruise_Buttons: 8 XXX
  SG_ Signal2 : 45|19@1+ (1,0) [0|524287] "" XXX
 
 BO_ 315 G_Sensor: 8 XXX
- SG_ longitudinal : 63|8@0- (1,0) [0|255] "" XXX
- SG_ Latitudinal : 48|8@1- (1,0) [0|255] "" XXX
+ SG_ Lateral : 48|8@1- (-0.1,0) [0|255] "m/s2" XXX
+ SG_ Longitudinal : 56|8@1- (-0.1,0) [0|255] "m/s2" XXX
 
 BO_ 314 Wheel_Speeds: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -79,17 +79,17 @@ BO_ 314 Wheel_Speeds: 8 XXX
 BO_ 281 Steering_Torque: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|3] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Steer_Error_1 : 12|1@0+ (1,0) [0|7] "" XXX
  SG_ Steer_Torque_Sensor : 16|11@1- (-1,0) [0|3] "" XXX
+ SG_ Steer_Error_2 : 28|1@1+ (1,0) [0|3] "" XXX
  SG_ Steering_Angle : 32|16@1- (-0.0217,0) [0|255] "" X
  SG_ Steer_Torque_Output : 48|11@1- (-1,0) [0|31] "" XXX
- SG_ Steer_Error_1 : 12|1@0+ (1,0) [0|7] "" XXX
- SG_ Steer_Error_2 : 28|1@1+ (1,0) [0|3] "" XXX
 
 BO_ 312 Brake_Pressure_L_R: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|31] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|3] "" XXX
- SG_ Brake_2 : 56|8@1+ (1,0) [0|255] "" XXX
  SG_ Brake_1 : 48|8@1+ (1,0) [0|255] "" XXX
+ SG_ Brake_2 : 56|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 313 Brake_Pedal: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -100,9 +100,9 @@ BO_ 313 Brake_Pedal: 8 XXX
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ SET_1 : 12|1@0+ (1,0) [0|3] "" XXX
  SG_ LKAS_Output : 16|13@1- (-1,0) [0|3] "" XXX
  SG_ LKAS_Request : 29|1@0+ (1,0) [0|3] "" XXX
- SG_ SET_1 : 12|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 544 ES_Brake: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -124,12 +124,6 @@ BO_ 546 ES_Status: 8 XXX
  SG_ RPM : 16|12@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Activated : 29|1@0+ (1,0) [0|3] "" XXX
  SG_ Cruise_Brake : 30|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 554 ES_Blank: 8 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ SET_65535 : 39|16@1+ (1,0) [0|16777215] "" XXX
- SG_ SET_1 : 13|1@1+ (1,0) [0|7] "" XXX
 
 BO_ 576 CruiseControl: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX


### PR DESCRIPTION
Added new messages and signals, mostly related to testing and developing Openpilot longitudinal control on global platform (Crosstrek 2018):
- Brake_Status (Brake pedal and ES_Brake status feedback for Eyesight)
- Cruise_Status (second message with CruiseControl status info)
- AC_State (A/C state)

New and updated signals:
- Throttle Throttle_Combo
- Transmission RPM
- Brake Pedal Brake_Lights
- ES_Brake Cruise_*
- ES_Distance Cruise_*
- ES_Status Cruise_*
- Dashlights Counter (both crosstrek and global dbc)
- BodyInfo Brake
- ES_DashStatus Conventional_Cruise
- ES_DashStatus Cruise_Soft_Disable
- Steering_Torque Steer_Warning
- Brake_Pedal Speed
- ES_LKAS_State LKAS_*
