### PR TITLE
Create RAM_Cummins_2019.dbc

### DIFF
--- a/RAM_Cummins_2019.dbc
+++ b/RAM_Cummins_2019.dbc
@@ -1,0 +1,6054 @@
+VERSION ""
+
+
+NS_ :
+    NS_DESC_
+    CM_
+    BA_DEF_
+    BA_
+    VAL_
+    CAT_DEF_
+    CAT_
+    FILTER
+    BA_DEF_DEF_
+    EV_DATA_
+    ENVVAR_DATA_
+    SGTYPE_
+    SGTYPE_VAL_
+    BA_DEF_SGTYPE_
+    BA_SGTYPE_
+    SIG_TYPE_REF_
+    VAL_TABLE_
+    SIG_GROUP_
+    SIG_VALTYPE_
+    SIGTYPE_VALTYPE_
+    BO_TX_BU_
+    BA_DEF_REL_
+    BA_REL_
+    BA_DEF_DEF_REL_
+    BU_SG_REL_
+    BU_EV_REL_
+    BU_BO_REL_
+    SG_MUL_VAL_
+
+BS_:
+
+BU_: VSIM TTPM TCM SGW SCCM RF_HUB PTS PCM ORC ITBM IRCM IC FTM FDCM ETM ESM ESC ECM DTCM DIAGNOST CBC ATMM ASCM AFLS 4 _ 0 C I w E 6 S A V Vector__XXX T
+
+
+BO_ 992 VIN: 8 ECM
+ SG_ VIN_MSG : 0|2@1+ (1,0) [0|0] "" FTM,TTPM,ATMM,IRCM,SGW,ITBM,FDCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,DTCM,CBC,ASCM,AFLS
+ SG_ VIN_DATA : 15|56@0+ (1,0) [0|0] "" FTM,TTPM,ATMM,IRCM,SGW,ITBM,FDCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,DTCM,CBC,ASCM,AFLS
+
+BO_ 257 ECM_SKIM_OBD: 5 ECM
+ SG_ CARB_Temp : 0|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ Inp_GD_Fail : 1|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ InpICC_Fail : 2|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ CARB_PERM : 3|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ OBD_GnrlDenCond_Stat : 5|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ IgnCntrTrue : 6|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ ENGINE_RESET : 8|1@1+ (1,0) [0|0] "" SGW
+ SG_ ECM_SKIM_STAT : 9|2@1+ (1,0) [0|0] "" SGW
+ SG_ EngLoad_OBD : 16|8@1+ (0.3922,0) [0|100] "%" FTM,SGW,TCM,ETM
+ SG_ AccelPdlPosn_OBD : 24|8@1+ (0.3922,0) [0|100] "%" SGW,VSIM,TCM,ETM
+ SG_ RAD_FAN1_STAT : 32|8@1+ (1,0) [0|100] "%" FTM,SGW,ETM
+
+BO_ 258 SCCM_STW_ANGL_STAT: 8 SCCM
+ SG_ LRW : 5|14@0+ (0.5,-2048) [-2048|2047] "Degrees" FTM,IRCM,SGW,PCM,TCM,ORC,ESC,ECM,DTCM,CBC,ASCM,AFLS
+ SG_ LRW_PLRTY : 7|1@1+ (1,0) [0|0] "" IRCM,SGW,ORC,ETM,ESC,AFLS
+ SG_ VLRW : 21|14@0+ (0.5,-2048) [-2048|2047] "°/s" IRCM,SGW,PCM,ESC,ECM,DTCM,AFLS
+ SG_ LRWS_ST : 32|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ORC,ESC,ECM,DTCM,CBC,ASCM,AFLS
+ SG_ Pad_Shft : 34|3@1+ (1,0) [0|0] "" SGW,PCM,TCM
+ SG_ MC_STW_Angle_STAT : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,PTS,ORC,ETM,ESC,ECM
+ SG_ CRC_STW_Angle_STAT : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,PCM,PTS,ORC,ETM,ESC,ECM
+
+BO_ 264 ECM_A1: 8 ECM
+ SG_ EngRPM : 7|16@0+ (1,0) [0|65534] "rpm" ATMM,IRCM,SGW,VSIM,TCM,RF_HUB,ORC,IC,ETM,ESC,DTCM,CBC,ASCM,AFLS
+ SG_ EngTrqStatic : 20|13@0+ (0.25,-500) [-500|1547.5] "Nm" FTM,IRCM,SGW,TCM,ORC,ETM,ESC,DTCM
+ SG_ ExpEngTrq : 36|13@0+ (0.25,-500) [-500|1547.5] "Nm" IRCM,SGW,TCM,ESC
+ SG_ MC_ECM_A1 : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,TCM,ESC
+ SG_ CRC_ECM_A1 : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,TCM,ESC
+ SG_ ECM_LHOM_Trans : 38|2@1+ (1,0) [0|0] "" SGW,TCM
+
+BO_ 268 ESP_A2: 8 ESC
+ SG_ EngTrq_Rq_ESC : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" FTM,SGW,PCM,ETM,ECM
+ SG_ DAS_Enbl_Rq : 5|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ EngTrqMax_Rq_ESC : 6|1@1+ (1,0) [0|0] "" SGW,PCM,VSIM,TCM,ECM
+ SG_ EngTrqMin_Rq_ESC : 7|1@1+ (1,0) [0|0] "" SGW,PCM,VSIM,TCM,ECM,DTCM
+ SG_ EngTrq_Rq_As : 20|13@0+ (0.25,-500) [-500|1547.5] "Nm" IRCM,SGW,PCM,ORC,ECM
+ SG_ ASRActive : 21|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,VSIM,ORC
+ SG_ EngTrqMax_Rq_AS : 22|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ BrkBstrVac : 32|8@1+ (0.55,-119.7) [-119.7|20] "kPa" SGW,PCM,ORC,ECM
+ SG_ PrefillActive : 40|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ TrlrBrkRq : 41|6@1+ (2,0) [0|100] "%" SGW,ITBM
+ SG_ DsblFuelShutOff : 47|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ DAS_RqActv : 48|3@1+ (1,0) [0|0] "" IRCM,SGW,ORC
+ SG_ Brk_Jrk_Rsp : 51|1@1+ (1,0) [0|0] "" IRCM,SGW,ORC
+ SG_ MC_ENG_RQ_ESC : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,TCM,ECM
+ SG_ CRC_ENG_RQ_ESC : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,ECM
+
+BO_ 280 ECM_ENG_TRQ: 8 ECM
+ SG_ EngTrqMax : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" IRCM,SGW,TCM,ESC,DTCM
+ SG_ ANL_LFT : 5|1@1+ (1,0) [0|0] "" SGW,CBC,ASCM
+ SG_ Clutch_Disengg : 6|1@1+ (1,0) [0|0] "" SGW,ORC,ESC,CBC
+ SG_ ClutchInterLk : 7|1@1+ (1,0) [0|0] "" SGW,ORC,ESC,DTCM
+ SG_ EngTrqMin : 20|13@0+ (0.25,-500) [-500|1547.5] "Nm" IRCM,SGW,ESC,DTCM
+ SG_ MdsAct : 21|1@1+ (1,0) [0|0] "" FTM,SGW,TCM,IC,ETM
+ SG_ FullOFC_Actv : 22|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC
+ SG_ CYL_CUT_POSS : 23|1@1+ (1,0) [0|0] "" SGW
+ SG_ StartRelayBCMCmd : 49|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ MC_ECM_ENG_TRQ : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,TCM,ESC
+ SG_ CRC_ECM_ENG_TRQ : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,TCM,ESC
+ SG_ MdsActforANC : 38|1@1+ (1,0) [0|0] "" ATMM,SGW,CBC
+ SG_ ECM_WTS_Inhbt : 50|2@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 284 ESP_A8: 8 ESC
+ SG_ VehSpSts : 7|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ VEH_SPEED : 39|16@0+ (0.0078125,0) [0|511.984375] "km/h" FTM,TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,RF_HUB,PTS,ORC,IC,ECM,DTCM,CBC,ASCM,AFLS
+ SG_ MC_VEH_SPEED : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,TCM,PTS,ORC,IC,ESM,ECM,CBC
+ SG_ CRC_VEH_SPEED : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,PTS,ORC,IC,ESM,ECM,CBC
+ SG_ BrkTrq_D : 21|14@0+ (3,0) [0|49146] "Nm" IRCM,SGW,ECM
+ SG_ BrkTrq : 5|14@0+ (3,0) [0|49146] "Nm" IRCM,SGW,ITBM,TCM,ORC,ECM
+
+BO_ 288 ECM_A2: 7 ECM
+ SG_ EngTrqSel_D_TTC : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" IRCM,SGW,TCM,ORC,ESC
+ SG_ EngTrq_Enbl_Rq_AS : 5|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC
+ SG_ EngTrq_Enbl_Rq_ESC : 6|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC
+ SG_ EngTrq_Enbl_Rq_TCM : 7|1@1+ (1,0) [0|0] "" SGW,TCM,ORC
+ SG_ AccelPdlPosn : 16|8@1+ (0.4,0) [0|100] "%" FTM,SGW,TCM,ETM,ESC,DTCM,CBC
+ SG_ EngTrq_DrvReqMod : 28|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,TCM,ESC
+ SG_ ECM_LHOM : 29|1@1+ (1,0) [0|0] "" IRCM,SGW,TCM
+ SG_ AccelPdlPosnSens_Flt : 30|1@1+ (1,0) [0|0] "" IRCM,SGW,TCM,ESC,CBC
+ SG_ CRUISE_OVERRIDE : 31|1@1+ (1,0) [0|0] "" IRCM,SGW,TCM,ORC,ESC
+ SG_ RPMOverRev : 42|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ LV12PwrFreeRq : 43|1@1+ (1,0) [0|0] "" SGW,TCM,ESC
+ SG_ MC_ECM_A2 : 44|4@1+ (1,0) [0|15] "" IRCM,SGW,TCM,ESC
+ SG_ CRC_ECM_A2 : 48|8@1+ (1,0) [0|0] "" IRCM,SGW,TCM,ESC
+ SG_ ESS_RqShftPark : 41|1@1+ (1,0) [0|0] "" SGW,TCM
+
+BO_ 290 ECM_GEAR: 6 ECM
+ SG_ KickDnSw_Psd : 3|1@1+ (1,0) [0|0] "" SGW,TCM,ESC
+ SG_ TxAC_EMCC_rq : 5|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ EngTrqMaxCorrFctr : 8|8@1+ (0.0078,0) [0|1.98] "Nm" SGW,TCM
+ SG_ GrMin_Rq_ECM : 16|3@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ GrMax_Rq_ECM : 19|3@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ NMOTS : 39|16@0+ (1,0) [0|65534] "rpm" SGW,TCM,ESC
+ SG_ EngTrq_Ack_ECM : 0|1@1+ (1,0) [0|0] "" SGW,TCM
+
+BO_ 292 ESP_A5: 8 ESC
+ SG_ WhlPlsCnt_FL : 0|8@1+ (1,0) [0|254] "Impulse" IRCM,SGW,RF_HUB,CBC
+ SG_ WhlPlsCnt_FR : 8|8@1+ (1,0) [0|254] "Impulse" IRCM,SGW,RF_HUB,CBC
+ SG_ WhlPlsCnt_RL : 16|8@1+ (1,0) [0|254] "Impulse" IRCM,SGW,RF_HUB,CBC
+ SG_ WhlPlsCnt_RR : 24|8@1+ (1,0) [0|254] "Impulse" IRCM,SGW,RF_HUB,CBC
+ SG_ CENT_DIFF_ESP_RQ : 34|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ R_DIFF_ESP_RQ : 36|2@1+ (1,0) [0|0] "" SGW,FDCM
+ SG_ CENT_DIFF_TRQ_RQ : 48|8@1+ (10,0) [0|2540] "Nm" SGW,DTCM
+
+BO_ 308 ECM_CRUISE_MAP: 8 ECM
+ SG_ CRUISE_EGD : 5|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,TCM,ORC,IC,ESC,CBC
+ SG_ CRUISE_ON : 7|1@1+ (1,0) [0|0] "" FTM,SGW,TCM,ORC,IC,ESC
+ SG_ V_MAX_TM : 8|8@1+ (1,0) [0|250] "km/h(mph)" SGW,TCM
+ SG_ MAP_ENG : 16|8@1+ (0.8,0) [0|203.2] "kPa" FTM,SGW,ETM,ESC
+ SG_ BARO_ENG : 24|8@1+ (1,0) [0|254] "kPaA" SGW,ETM,ESC
+ SG_ Rel_Thrt_ENG : 32|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,ETM,ESC
+ SG_ Rel_Pdl_ENG : 40|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,ETM,ESC
+ SG_ MC_134h : 52|4@1+ (1,0) [0|15] "" SGW,TCM,ESC
+
+BO_ 320 ESP_A1: 8 ESC
+ SG_ Brk_Stat : 0|2@1+ (1,0) [0|0] "" FTM,SGW,ITBM,PCM,VSIM,TCM,ETM,ECM,CBC
+ SG_ BrkPdl_Stat : 2|2@1+ (1,0) [0|0] "" IRCM,SGW,ITBM,PCM,VSIM,TCM,RF_HUB,ORC,ECM,DTCM,CBC
+ SG_ BrkPdl_Flt : 4|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,ETM,ECM
+ SG_ BrkIntrvntn_Actv_ESP : 5|1@1+ (1,0) [0|0] "" FTM,SGW,TCM,ORC,ETM,DTCM
+ SG_ BrkIntrvntn_Actv_AS : 6|1@1+ (1,0) [0|0] "" IRCM,SGW,TCM,ETM
+ SG_ BrkIntrvntn_Enbl : 7|1@1+ (1,0) [0|0] "" SGW,TCM,ORC,ECM
+ SG_ EmgBrk_Actv : 8|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ FullBrk_Actv : 9|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ ESP_Sys_Stat : 10|2@1+ (1,0) [0|0] "" SGW,PCM,TCM,ETM,ECM
+ SG_ ABS_BrkEvt : 14|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PCM,VSIM,TCM,ORC,ETM,ECM,DTCM
+ SG_ DTR_CC_Engaged : 15|1@1+ (1,0) [0|0] "" SGW,PCM,TCM,ECM,CBC
+ SG_ GrMin_Rq_ESC : 16|3@1+ (1,0) [0|0] "" SGW,PCM,TCM
+ SG_ GrMax_Rq_ESC : 19|3@1+ (1,0) [0|0] "" SGW,PCM,TCM
+ SG_ GrMinMax_Rq_DTR : 22|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ DTR_CC_Enabled : 23|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ Brk_Thermdl : 25|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ ShftChrDsp_Rq_ESC : 26|4@1+ (1,0) [0|0] "" SGW,PCM,TCM,ECM
+ SG_ RollTestMd_Actv : 30|2@1+ (1,0) [0|0] "" IRCM,SGW,DTCM
+ SG_ REF_VEH_SPEED : 33|10@0+ (0.5,0) [0|511] "km/h" SGW,TCM,ORC,ECM
+ SG_ SPCR_AS_Off_Rq : 38|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ECM
+ SG_ MC_Brk_Stat : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,TCM,PTS,ORC,ECM
+ SG_ CRC_Brk_Stat : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,PTS,ORC,ECM
+
+BO_ 324 TRNS_SPD: 8 TCM
+ SG_ K_STO_B : 0|1@1+ (1,0) [0|0] "" FTM,SGW,ETM,ECM
+ SG_ EngSt_Enbl_Rq_TCM : 5|1@1+ (1,0) [0|0] "" FTM,SGW,RF_HUB,ETM
+ SG_ Gr : 8|4@1+ (1,0) [0|0] "" FTM,IRCM,SGW,VSIM,RF_HUB,ORC,IC,ESC,ECM,DTCM,CBC,ASCM
+ SG_ Gr_Target : 12|4@1+ (1,0) [0|0] "" FTM,IRCM,SGW,ESC,ECM,CBC
+ SG_ K_G_B : 17|1@1+ (1,0) [0|0] "" FTM,SGW,ETM,ECM
+ SG_ K_O_B : 18|1@1+ (1,0) [0|0] "" FTM,SGW,ETM,ECM
+ SG_ K_S_B : 19|1@1+ (1,0) [0|0] "" FTM,SGW,ETM,ECM
+ SG_ Trns_EMCC_Achvd : 20|1@1+ (1,0) [0|0] "" FTM,SGW,ETM,ECM
+ SG_ OUTPUT_SPEED : 31|16@0+ (1,0) [0|65534] "rpm" FTM,SGW,ETM,ESC,ECM,DTCM
+ SG_ N_Turb : 47|16@0+ (1,0) [0|65534] "rpm" FTM,SGW,ETM,ECM
+ SG_ OutputSpdPolarity : 56|2@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ TCM_TmpManMd : 62|1@1+ (1,0) [0|0] "" SGW
+ SG_ TCM_ManMd : 63|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ DrvRst_Hi : 4|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ GearSwitchActiveSts : 2|1@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ KS : 16|1@1+ (1,0) [0|0] "" FTM,SGW,ETM,ECM
+ SG_ TRNS_SPD_MC : 58|4@1+ (1,0) [0|15] "" FTM,SGW,ETM,ESC,ECM
+ SG_ Ups_Inh_Act : 1|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ OD_OFF : 3|1@1+ (1,0) [0|0] "" SGW
+ SG_ EngBrkCanRq : 22|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ PTO_Enbl : 23|1@1+ (1,0) [0|0] "" SGW,VSIM,ECM
+
+BO_ 331 ESP_A3: 8 ESC
+ SG_ BrkPrss_TMC : 2|11@0+ (0.1,0) [0|200] "bar" FTM,SGW,TCM,ORC,ETM,ECM
+ SG_ HSA_BrkPrss : 32|6@1+ (1,0) [0|50] "bar" SGW,ITBM,PCM,ORC,ETM,ECM
+ SG_ BrkBstrVac_OBD : 40|8@1+ (0.019607843,0) [0|5] "Volts" SGW,ECM
+ SG_ MC_ESP_A3 : 52|4@1+ (1,0) [0|15] "" SGW,PCM,TCM,PTS,ORC,ECM
+ SG_ CRC_ESP_A3 : 56|8@1+ (1,0) [0|0] "" SGW,PCM,TCM,PTS,ORC,ECM
+
+BO_ 332 ESP_A4: 8 ESC
+ SG_ VehYawRate_Raw : 7|16@0+ (0.01,-327.68) [-327.68|327.66] "°/s" IRCM,SGW,ETM,DTCM,CBC,AFLS
+ SG_ VehYawRate_Offset : 16|8@1+ (0.08,-10.24) [-6.96|6.96] "" IRCM,SGW,ORC,DTCM,AFLS
+ SG_ VehAccel_X_Offset : 24|8@1+ (0.02,-2.56) [-2.56|2.52] "m/s²" IRCM,SGW,TCM,ETM,ECM,DTCM
+ SG_ VehAccel_X : 32|8@1+ (0.08,-10.24) [-10.24|10.08] "m/s²" FTM,IRCM,SGW,TCM,ECM,DTCM,CBC,ASCM
+ SG_ VehAccel_Y : 40|8@1+ (0.08,-10.24) [-10.24|10.08] "m/s²" FTM,IRCM,SGW,TCM,ECM,DTCM,CBC,ASCM
+ SG_ MC_VEH_DYN_STAT : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,TCM,PTS,ORC,ETM,ECM
+ SG_ VehAccel_Y_Offset : 56|8@1+ (0.02,-2.56) [-2.56|2.52] "m/s²" IRCM,SGW,TCM,ETM,ECM,DTCM
+
+BO_ 344 ESP_A6: 8 ESC
+ SG_ WhlRPM_FL : 5|14@0+ (0.5,0) [0|8191] "rpm" FTM,IRCM,SGW,FDCM,TCM,ORC,ETM,DTCM
+ SG_ WhlDir_FL_Stat : 6|2@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ WhlRPM_FR : 21|14@0+ (0.5,0) [0|8191] "rpm" FTM,IRCM,SGW,FDCM,TCM,ORC,ETM,ECM,DTCM
+ SG_ WhlDir_FR_Stat : 22|2@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ WhlRPM_RL : 37|14@0+ (0.5,0) [0|8191] "rpm" FTM,IRCM,SGW,FDCM,TCM,ORC,ETM,DTCM
+ SG_ WhlDir_RL_Stat : 38|2@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ WhlRPM_RR : 53|14@0+ (0.5,0) [0|8191] "rpm" FTM,IRCM,SGW,FDCM,TCM,ORC,ETM,ECM,DTCM
+ SG_ WhlDir_RR_Stat : 54|2@1+ (1,0) [0|0] "" IRCM,SGW
+
+BO_ 352 DTCM_A1: 8 CBC
+ SG_ TCASE_STAT : 1|3@1+ (1,0) [0|0] "" FTM,IRCM,SGW,FDCM,PCM,TCM,ORC,IC,ESC,ECM,CBC,ASCM
+ SG_ ACT_CNT_DIF_TRQ : 24|8@1+ (10,0) [0|2540] "Nm" SGW,ESC
+ SG_ DES_CNT_DIF_TRQ : 48|8@1+ (10,0) [0|2540] "Nm" SGW
+ SG_ SHFT_ABRT : 4|1@1+ (1,0) [0|0] "" SGW
+
+BO_ 368 TRNS_STAT: 8 TCM
+ SG_ PRND_STAT : 2|3@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PTS,ORC,IC,ESC,ECM,CBC
+ SG_ EngStEnblRqTCM : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ECM
+ SG_ SHFT_PROG : 8|8@1+ (1,0) [0|0] "" FTM,SGW,IC,ESC,ECM,CBC
+ SG_ PRNDL_DISP : 16|8@1+ (1,0) [0|0] "" SGW,VSIM,ORC,IC,ESM,ESC,ECM,DTCM,CBC,AFLS
+ SG_ SHFT_LOCK : 29|1@1+ (1,0) [0|0] "" SGW,ESM
+ SG_ PRNDL_Blink : 49|3@1+ (1,0) [0|0] "" SGW,IC,ESM
+ SG_ MC_TRNS_STAT : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,PTS,ESM,ESC,ECM
+ SG_ CRC_TRNS_STAT : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,PTS,ESM,ESC,ECM
+ SG_ APCM_Rq : 5|2@1+ (1,0) [0|0] "" SGW,ESM
+
+BO_ 376 TRNS_STAT2: 3 TCM
+ SG_ MIL_OnRq_TCM : 0|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,ECM
+ SG_ GS_NOTL : 2|1@1+ (1,0) [0|0] "" IRCM,SGW,ORC,ECM
+ SG_ TxTemp_Excess : 3|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM,ECM
+ SG_ FAN_RQ : 4|4@1+ (7.2,0) [0|100] "%" SGW,ECM
+ SG_ TX_TEMP : 8|8@1+ (1,-50) [-50|204] "°C" FTM,SGW,VSIM,IC,ECM,DTCM,CBC
+ SG_ TX_WARN : 16|4@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ TX_FAULT : 20|2@1+ (1,0) [0|0] "" SGW,RF_HUB,ETM
+
+BO_ 384 ECM_B3: 8 ECM
+ SG_ IntkAirTemp : 0|8@1+ (1,-40) [-40|214] "°C" SGW,VSIM,TCM,ETM
+ SG_ EngCoolTemp : 8|8@1+ (1,-40) [-40|214] "°C" FTM,SGW,VSIM,TCM,IC,ETM,ESC,DTCM,CBC
+ SG_ AirPress_Outsd : 16|8@1+ (1,0) [0|254] "kPaA" TTPM,IRCM,SGW,VSIM,TCM,RF_HUB,ESC
+ SG_ SysVolt : 32|8@1+ (0.0618,0) [0|15.6972] "Volts" SGW
+ SG_ R134a_Press_Stat : 40|9@0+ (0.1,0) [0|40] "bar" SGW,CBC
+ SG_ CHRG_FAIL : 41|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ AM_ECM_Prsnt : 45|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AC_CLTCH_EGD : 47|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,TCM,CBC
+
+BO_ 416 TCM_ENG_TRQ: 7 TCM
+ SG_ Trans_Trq_Ratio : 2|11@0+ (0.01,0) [0|20.46] "" FTM,IRCM,SGW,ETM,ESC,ECM
+ SG_ TxIdleRq : 16|8@1+ (4,500) [500|1516] "rpm" SGW,ESC,ECM
+ SG_ EngTrq_Rq_TCM : 28|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,ESC,ECM
+ SG_ EngTrqMax_Rq_TCM : 29|1@1+ (1,0) [0|0] "" SGW,ESC,ECM
+ SG_ EngTrqMin_Rq_TCM : 30|1@1+ (1,0) [0|0] "" SGW,ESC,ECM
+ SG_ MC_TCM_ENG_TRQ : 44|4@1+ (1,0) [0|15] "" IRCM,SGW,ESC,ECM
+ SG_ CRC_TCM_ENG_TRQ : 48|8@1+ (1,0) [0|0] "" IRCM,SGW,ESC,ECM
+
+BO_ 448 RFHUB_A2: 6 RF_HUB
+ SG_ RFFuncReq : 0|5@1+ (1,0) [0|0] "" SGW,VSIM,IC,ETM,CBC
+ SG_ RFReq : 5|3@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ RFCfgReq : 24|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ RFFobNum : 27|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PE_ENABLE : 31|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ TFASts : 42|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+
+BO_ 456 CBC_VTA: 4 CBC
+ SG_ VTA_STAT : 0|3@1+ (1,0) [0|0] "" SGW,VSIM,RF_HUB,ETM
+
+BO_ 464 ORC_A1: 8 ORC
+ SG_ SRS_IndLmp_Rq : 2|2@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ DRV_SEATBELT : 16|2@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PCM,VSIM,TCM,IC,ETM,ESC,ECM
+ SG_ PSG_SEATBELT : 18|2@1+ (1,0) [0|0] "" FTM,SGW,VSIM,IC
+ SG_ PSG_ODS_STAT : 26|2@1+ (1,0) [0|0] "" FTM,SGW,VSIM,IC
+ SG_ ORC_A1_Par : 7|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ ORC_A1_Tog : 1|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ DrvSbltUnFltr : 13|3@1+ (1,0) [0|0] "" SGW
+
+BO_ 466 ORC_A2: 2 ORC
+ SG_ IMPACT_B : 1|1@1+ (1,0) [0|0] "" FTM,SGW,ETM
+ SG_ Impact_F : 5|1@1+ (1,0) [0|0] "" FTM,SGW,ETM
+ SG_ Impact_Tgl : 7|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,ETM,ECM,CBC
+ SG_ IMPACT_I : 9|1@1+ (1,0) [0|0] "" FTM,SGW,ETM
+ SG_ IMPACT_L : 11|1@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ IMPACT_X : 15|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,VSIM,ETM,ECM,CBC
+
+BO_ 500 DAS_A3: 8 IRCM
+ SG_ EngTrqRq_DAS : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,ETM,ESC
+ SG_ EngTrqMaxRq_DAS : 7|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ DAS_ACCEL_Rq : 19|12@0+ (0.004885,-16) [-16|4] "m/s²" SGW,ORC,ESC
+ SG_ ACC_Enbl : 20|1@1+ (1,0) [0|0] "" SGW,IC,ESC
+ SG_ ACC_Engd : 21|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ESC,CBC
+ SG_ DsblFuelShutOff_ACC : 23|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ GrMax_RqDAS : 32|4@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ DAS_Rq_ID : 36|3@1+ (1,0) [0|0] "" SGW,ITBM,ORC,ESC
+ SG_ DAS_Sts : 46|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Brk_Jrk_Rq : 48|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Brk_PreFill_Rq : 49|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ As_DispRq : 50|2@1+ (1,0) [0|0] "" SGW,ORC,IC,ESC
+ SG_ MC_DAS_A3 : 52|4@1+ (1,0) [0|15] "" SGW,PCM,ESC,ECM
+ SG_ CRC_DAS_A3 : 56|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ ACC_Drive_Cmd : 6|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ ACC_Still_Cmd : 5|1@1+ (1,0) [0|0] "" SGW,ORC,ESC
+
+BO_ 501 DAS_A4: 8 IRCM
+ SG_ HMI_Screens : 0|8@1+ (1,0) [0|254] "Text" SGW,IC
+ SG_ SetSpeed_KPH : 8|8@1+ (1,0) [0|250] "km/h" SGW,PCM,TCM,IC,ECM
+ SG_ SetSpeed_MPH : 16|8@1+ (1,0) [0|250] "mph" SGW,PCM,TCM,ORC,IC
+ SG_ FCW_Error : 26|2@1+ (1,0) [0|0] "" SGW,ORC,IC,ETM
+ SG_ ACCOnOff : 36|3@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ Sm_ICON_Dspl : 40|6@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RadarBlocked : 46|1@1+ (1,0) [0|0] "" SGW,ORC,IC,CBC
+ SG_ ACConlyNA_DASMSts : 48|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ NCConlyNA_DASMSts : 49|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ACCFaulted : 50|1@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ FCWonlyNA_DASMSts : 51|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ACCNA_DASMSts : 52|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ NCCNA_DASMSts : 53|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ObjIntrstDist : 56|8@1+ (1,0) [0|253] "m" SGW,PCM,TCM,ORC,ESC
+ SG_ CameraBlocked : 54|1@1+ (1,0) [0|0] "" SGW,ORC,IC,CBC
+ SG_ CameraFailure : 55|1@1+ (1,0) [0|0] "" SGW,ORC,IC
+ SG_ CIPV_Fused : 30|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ FCW_BrkOn : 29|1@1+ (1,0) [0|0] "" SGW,ORC,CBC
+ SG_ FCWBrakingOff : 47|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ACC_EB_Req : 39|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+
+BO_ 512 CBC_PT3: 8 CBC
+ SG_ AirTemp_Outsd : 0|8@1+ (0.5,-40) [-40|85] "°C" IRCM,SGW,PCM,ORC,ECM,DTCM
+ SG_ AMB_TEMP_AVG : 15|16@0+ (0.01,-40) [-40|85] "°C" SGW,VSIM,TCM,RF_HUB,PTS,ESC,ASCM
+ SG_ AMB_TEMP_VOLT : 24|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,PCM,ECM
+ SG_ FUEL_VOLT : 32|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,PCM,IC,ECM
+ SG_ FUEL_VOLT2 : 40|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,PCM,IC,ECM
+ SG_ BATT_VOLT : 48|8@1+ (0.1,0) [5|18] "Volts" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+
+BO_ 514 WHEEL_SPEED_2: 8 ESC
+ SG_ BrkPdlRawStat : 33|10@0+ (0.0048828125,0) [0|4.9951171875] "Volts" FTM,SGW,PCM,ETM,ECM
+
+BO_ 520 CBC_PT6: 8 CBC
+ SG_ AC_OutptCurrStat : 8|8@1+ (0.008,0) [0|2] "Amp" SGW,PCM,ECM
+ SG_ BrkPdlStat_CBC : 18|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ CBCEngineOffRequest : 48|1@1+ (1,0) [0|0] "" ECM
+ SG_ CRC_CBC_PT6 : 56|8@1+ (1,0) [0|0] "" ECM
+ SG_ MC_CBC_PT6 : 52|4@1+ (1,0) [0|15] "" ECM
+
+BO_ 557 SWS_8: 8 CBC
+ SG_ HrnSwPsd : 8|1@1+ (1,0) [0|0] "" SGW,VSIM
+
+BO_ 559 ECM_A5: 8 ECM
+ SG_ ActlAccelPdlPosn : 0|8@1+ (0.4,0) [0|100] "%" FTM,IRCM,SGW,ORC,ETM,ESC
+ SG_ MC_ECM_A5 : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,ESC
+ SG_ CRC_ECM_A5 : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,ESC
+ SG_ ECM_WARN_BTO : 48|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 584 PN14_STAT: 8 CBC
+ SG_ PN14_LS_Actv : 0|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Batt_ST_Crit : 42|1@1+ (1,0) [0|0] "" SGW,IC,ASCM
+
+BO_ 608 PTS_2: 8 PTS
+ SG_ CRC_PTS_2 : 56|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ MC_PTS_2 : 52|4@1+ (1,0) [0|15] "" SGW,ESC
+ SG_ PTS_FT_TEMP_NA : 37|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_Off_Status : 34|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_PopUpRqst : 24|8@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_RR_TEMP_NA : 38|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_STAT_Front : 8|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ LooseShip_Rear : 51|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ LooseShip_Front : 50|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 624 CBC_PT8: 8 CBC
+ SG_ EngineOffTimer : 51|12@0+ (1,0) [0|4080] "min" SGW,PCM,ETM,ECM
+ SG_ PNC_ALM_ACT : 55|1@1+ (1,0) [0|0] "" SGW,VSIM
+ SG_ Gate_Req_PE : 22|2@1+ (1,0) [0|0] "" SGW,RF_HUB,ETM
+ SG_ FuelTxfrSts : 42|2@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ HAZARD_STATUS : 47|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM
+
+BO_ 632 ECM_B2: 8 ECM
+ SG_ CC_SetSpdDspl : 0|8@1+ (1,0) [0|250] "km/h" FTM,SGW,VSIM,IC
+ SG_ EVPmpStat : 12|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ CC_SetSpdDsplMPH : 40|8@1+ (1,0) [0|254] "mph" FTM,SGW,IC,ETM
+ SG_ IdleShutDwnApply : 11|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ EnblFuelTxfr : 35|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 639 GW_IBS_DATA: 8 CBC
+ SG_ IBS_Q_received : 7|16@0+ (0.125,0) [0|8191.75] "Ah" SGW
+ SG_ IBS_Q_released : 23|16@0+ (0.125,0) [0|8191.75] "Ah" SGW
+ SG_ IBS_Tm_Lst_Reset_Sec : 39|16@0+ (2,0) [0|86398] "sec" SGW
+ SG_ IBS_Tm_Lst_Reset_Days : 51|12@0+ (1,0) [0|4094] "Days" SGW
+
+BO_ 656 RF_CHAR: 4 RF_HUB
+ SG_ UConnSeed1 : 0|8@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ UConnSeed2 : 8|8@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ UConnSeed3 : 16|8@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ UConnSeed4 : 24|8@1+ (1,0) [0|0] "" SGW,ETM
+
+BO_ 660 DST_TOC: 8 ESC
+ SG_ MC_294h : 52|4@1+ (1,0) [0|15] "" SGW
+ SG_ CRC_294h : 56|8@1+ (1,0) [0|0] "" SGW
+ SG_ BrkPrss_One : 17|10@0+ (0.0048828125,0) [0|4.9951171875] "Volts" SGW,PCM,ECM
+ SG_ BrkPrss_Two : 33|10@0+ (0.0048828125,0) [0|4.9951171875] "Volts" SGW,PCM,ECM
+ SG_ SyncPos : 37|3@1+ (1,0) [0|0] "" SGW,PCM,ECM
+
+BO_ 672 ECM_INDICATORS: 8 ECM
+ SG_ MIL_OnRq : 0|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,ORC,IC,ETM,CBC
+ SG_ MIL_IND_BLINK : 1|1@1+ (1,0) [0|0] "" SGW,VSIM,ORC,IC,CBC
+ SG_ ETC_IND_LMP : 2|2@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM,CBC
+ SG_ OIL_IND_LMP_FLSH : 8|1@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ EngOilIndLmp_On_Rq : 10|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,IC,ETM,CBC
+ SG_ OIL_TEMP_IND_RQ : 11|2@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ ChkFuelCap : 15|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ OIL_PRESS : 16|8@1+ (4,0) [0|1016] "kPaG" FTM,SGW,VSIM,IC,ETM
+ SG_ EngOilTemp : 24|8@1+ (1,-40) [-40|160] "°C" FTM,SGW,TCM,IC,ETM
+ SG_ FuelCons : 39|16@0+ (0.21668,0) [0|14200] "µl/100ms" FTM,SGW,VSIM,IC,ETM
+ SG_ DefFuelEcon : 48|8@1+ (0.2,0) [0|50] "kmpl" SGW,IC
+ SG_ EngRun_Stat : 56|3@1+ (1,0) [0|0] "" SGW,VSIM,TCM,RF_HUB,IC,ESC,CBC,ASCM
+ SG_ CoolLo : 7|1@1+ (1,0) [0|0] "" FTM,SGW,IC
+
+BO_ 680 TCM_A7: 8 TCM
+ SG_ EngTrgtSpdCtrl : 3|12@0+ (2.5,0) [0|10235] "rpm" SGW,ECM
+ SG_ EngShutOffRq_TCM : 4|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ EngTrgtSpdCtrl_Active : 7|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ CurrentGear : 16|4@1+ (1,0) [0|0] "" FTM,IRCM,SGW,ECM
+ SG_ CurrentGearForDisplay : 20|4@1+ (1,0) [0|0] "" SGW,VSIM,IC
+ SG_ TargetGear : 24|4@1+ (1,0) [0|0] "" IRCM,SGW,ECM
+ SG_ TX_WARN2 : 40|8@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ MC_TCM_A7 : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,ESC,ECM
+ SG_ CRC_TCM_A7 : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,ESC,ECM
+
+BO_ 698 Uconnect_1: 4 ETM
+ SG_ UConnReq : 0|5@1+ (1,0) [0|0] "" RF_HUB
+ SG_ UConnReqAuthCode : 15|16@0+ (1,0) [0|0] "" RF_HUB
+ SG_ UConnReqFOBNum : 24|4@1+ (1,0) [0|0] "" RF_HUB
+
+BO_ 706 EcuCfg15: 8 CBC
+ SG_ EC_ECUCfg15_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,ASCM
+ SG_ EC_CBC15A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC15B : 15|40@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Suspension : 55|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 707 EcuBuCfg15: 8 RF_HUB
+ SG_ EC_BU_ECUCfg15_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC15A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC15B : 15|40@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Suspension : 55|16@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 719 STATUS_C_PTS: 8 PTS
+ SG_ PTS_DBD : 16|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 720 BSM_A1: 6 CBC
+ SG_ BSM_CFG_STAT : 8|2@1+ (1,0) [0|0] "" IRCM,SGW,ORC,IC
+ SG_ BSM_SRV_RQ : 10|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,ORC,IC
+ SG_ BSM_OPR_STAT : 11|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,IC
+ SG_ BSM_Blind_RQ : 13|1@1+ (1,0) [0|0] "" IRCM,SGW,ORC,IC
+ SG_ BSM_LT_WRN : 0|3@1+ (1,0) [0|0] "" IRCM,SGW,ORC
+ SG_ BSM_RT_WRN : 3|3@1+ (1,0) [0|0] "" IRCM,SGW,ORC
+
+BO_ 736 ESP_B1: 8 ESC
+ SG_ LT_DIST : 7|16@0+ (4,0) [0|262136] "cm" SGW,PCM,PTS,IC,ECM,CBC
+ SG_ RT_DIST : 23|16@0+ (4,0) [0|262136] "cm" SGW,PCM,PTS,IC,ECM,CBC
+ SG_ YRS_DataRq : 32|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ HSA_EN : 47|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ ESP_DSBL : 51|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PCM,ORC,IC,ECM,DTCM,CBC
+ SG_ HILL_DES_STAT : 52|2@1+ (1,0) [0|0] "" SGW,PCM,TCM,ORC,IC,CBC
+ SG_ ESP_Off_IndLmp_On_Rq : 54|1@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,DTCM,CBC
+ SG_ ESC_CtrlLmp_Info : 56|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM,DTCM
+ SG_ ABS_IndLmp_On_Rq : 58|2@1+ (1,0) [0|0] "" FTM,SGW,VSIM,IC,ETM,ECM
+ SG_ BrkIndLmp_On_Rq_ESC : 60|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ SelSpdLmp : 62|2@1+ (1,0) [0|0] "" SGW,ORC,IC,ETM,CBC
+
+BO_ 746 SBW_ROT1: 5 ESM
+ SG_ DrvRqShftROT : 0|3@1+ (1,0) [0|0] "" FTM,SGW,TCM,RF_HUB,ETM,ECM
+ SG_ ShftSensFltROT : 8|1@1+ (1,0) [0|0] "" SGW,TCM,IC
+ SG_ ShftDispFltROT : 10|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ ShftLkFltROT : 11|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ MC_SBW_ROT1 : 28|4@1+ (1,0) [0|15] "" SGW,PCM,TCM
+ SG_ CRC_SBW_ROT1 : 32|8@1+ (1,0) [0|0] "" SGW,PCM,TCM
+ SG_ APCM_Stat : 12|2@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ RackFlt : 9|1@1+ (1,0) [0|0] "" SGW,TCM
+
+BO_ 760 ECM_A3: 8 ECM
+ SG_ EngTrqTgt_SEM : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,TCM
+ SG_ EngTrqStatic_SEM : 20|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,TCM
+ SG_ TRANS_CLU_SLIP_MODE : 21|3@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ ThrmlMngActv : 36|1@1+ (1,0) [0|0] "" IRCM,SGW,TCM
+ SG_ EngMaxRPM : 40|8@1+ (50,0) [0|12700] "rpm" SGW,TCM
+ SG_ MC_ECM_A3 : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,TCM,PTS,ESC
+ SG_ CRC_ECM_A3 : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,TCM,PTS,ESC
+
+BO_ 761 TCM_EngTrq2: 8 TCM
+ SG_ MC_TCM_EngTrq2 : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,ECM
+ SG_ CRC_TCM_EngTrq2 : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,ECM
+
+BO_ 764 PCM_EDR: 8 ECM
+ SG_ ApplyTrq : 0|1@1+ (1,0) [0|0] "" SGW
+ SG_ BrkSw1Stat : 1|1@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ ESP_TrqRqEnabl : 3|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ ETC_LmpFlash : 4|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ ETC_LmpOn : 5|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ Lv1CrsCtrlOff : 6|1@1+ (1,0) [0|0] "" SGW,ORC
+ SG_ CruiseEGD : 7|1@1+ (1,0) [0|0] "" SGW
+ SG_ RawPVS1 : 8|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,ORC
+ SG_ RawPVS2 : 16|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,ORC
+ SG_ RawTPS1 : 24|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,ORC
+ SG_ RawTPS2 : 32|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW,ORC
+ SG_ RelativePdl : 40|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW
+ SG_ RelativeThrt : 48|8@1+ (0.019607843,0) [0|4.98] "Volts" SGW
+ SG_ MAP : 56|8@1+ (0.8,0) [0|203.2] "kPa" FTM,SGW,ESC
+
+BO_ 766 PCM_EDR2: 8 ECM
+ SG_ VVT_ExhCam1Pos : 0|8@1+ (1,0) [1|255] "Degrees" SGW
+ SG_ VVT_ExhCam2Pos : 8|8@1+ (1,0) [1|255] "Degrees" SGW
+ SG_ VVT_IntCam1Pos : 16|8@1+ (1,0) [1|255] "Degrees" SGW
+ SG_ VVT_IntCam2Pos : 24|8@1+ (1,0) [1|255] "Degrees" SGW
+ SG_ GF_Charge : 39|16@0+ (0.2,0) [0|13106.8] "mg/cycle/cyl" SGW,ORC,ETM
+ SG_ RelativeThrtPct : 48|8@1+ (0.4,0) [0|100] "%" SGW,ORC
+
+BO_ 776 DTCM_B1: 8 DTCM
+ SG_ CNT_DIFF_MOD : 18|2@1+ (1,0) [0|0] "" SGW
+ SG_ DTCM_HMI_Rq : 40|5@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TCASE_FAIL : 0|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ TCASE_SRV_RQ : 2|2@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ TcaseAWD : 10|2@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ TCASE_INHBT : 1|1@1+ (1,0) [0|0] "" SGW
+ SG_ Tcase4Low : 6|2@1+ (1,0) [0|0] "" SGW,IC,ETM,CBC
+ SG_ TcaseNtrlStat : 8|2@1+ (1,0) [0|0] "" SGW,IC,ETM,CBC
+ SG_ Tcase4Lock : 4|2@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ Tcase2WD_Stat : 22|2@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 779 ECM_B5: 8 ECM
+ SG_ DisOilLifeRst : 7|16@0+ (1,0) [0|65534] "km" FTM,SGW,IC,CBC
+ SG_ OilLifeLeft : 16|8@1+ (1,0) [0|100] "%" FTM,SGW,IC,ETM
+ SG_ MntncSts : 29|2@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ OilLifeLeftRst : 31|1@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ HoursOilLifeRst : 27|12@0+ (1,0) [0|4000] "Hours" SGW,CBC
+ SG_ FuelFltrRq : 56|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ FuelFltrLeft : 48|8@1+ (1,0) [0|100] "%" FTM,SGW,IC
+ SG_ FuelFltrAck : 57|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 784 IC_A1: 8 IC
+ SG_ AvgFuelLvl : 0|9@0+ (0.5,0) [0|255] "liters" FTM,SGW,PCM,VSIM,ETM,ECM,CBC
+ SG_ SRS_LMP_STAT : 4|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,ETM
+ SG_ FuelLvlLow : 6|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,ETM,ECM,CBC
+ SG_ OilChgRst : 29|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ ODO : 39|24@0+ (0.1,0) [0|1677721.4] "km" FTM,TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,ETM,ESM,ESC,ECM,DTCM,CBC,ASCM,AFLS
+ SG_ WTS_LmpRqOn : 7|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ Trailer_Trp_Rst : 28|1@1+ (1,0) [0|0] "" SGW,ITBM
+ SG_ FuelFltrRst : 30|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ FuelSavDispEnbl : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 788 CFG_RQ: 3 CBC
+ SG_ CFG_FEATURE : 0|8@1+ (1,0) [0|0] "" IRCM,SGW,ITBM,PCM,RF_HUB,PTS,IC,ESC,ECM,ASCM,AFLS
+ SG_ CFG_STAT_RQ : 8|2@1+ (1,0) [0|0] "" IRCM,SGW,ITBM,PCM,RF_HUB,PTS,IC,ESC,ECM,ASCM,AFLS
+ SG_ CFG_SET : 16|8@1+ (1,0) [0|255] "" IRCM,SGW,ITBM,PCM,RF_HUB,PTS,IC,ESC,ECM,ASCM,AFLS
+
+BO_ 790 CFG_RQ_C: 3 IC
+ SG_ CFG_FEATURE_C : 0|8@1+ (1,0) [0|0] "" IRCM,SGW,ITBM,PCM,RF_HUB,PTS,ESC,ECM,CBC,ASCM,AFLS
+ SG_ CFG_STAT_RQ_C : 8|2@1+ (1,0) [0|0] "" IRCM,SGW,ITBM,PCM,RF_HUB,PTS,ESC,ECM,CBC,ASCM,AFLS
+ SG_ CFG_SET_C : 16|8@1+ (1,0) [0|255] "" IRCM,SGW,ITBM,PCM,RF_HUB,PTS,ESC,ECM,CBC,ASCM,AFLS
+
+BO_ 792 StW_Actn_Rq: 8 SCCM
+ SG_ TurnIndLvr_Stat : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,CBC
+ SG_ HiBmLvr_Stat : 2|2@1+ (1,0) [0|0] "" SGW,ETM,CBC
+ SG_ WprWashSw_Psd : 4|2@1+ (1,0) [0|0] "" SGW,ETM,CBC
+ SG_ WprSw6Posn : 16|4@1+ (1,0) [0|0] "" IRCM,SGW,ETM,CBC
+ SG_ VOL : 26|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ Up_Arw_Rq : 36|2@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ StW_TempSens_Flt : 42|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ StW_Temp : 48|8@1+ (0.5,-40) [-40|85] "°C" SGW,CBC
+ SG_ SEEK : 28|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ RT_ARW_RST_RQ : 38|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PRESET_CFG : 30|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ MENU_RQ : 32|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ HrnSw_Psd : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DN_ARW_STEP_RQ : 34|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CELL_VR : 40|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AUD_MODE_ADV : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 799 GW_LIN_I_C2: 8 CBC
+ SG_ IBS_R_Batt : 2|11@0+ (0.05,0) [0|20] "mOhm" SGW
+ SG_ IBS_R_Batt_25 : 18|11@0+ (0.05,0) [0|20] "mOhm" SGW
+ SG_ RainSensorFailSts : 63|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TGW_AUD_MD_CAB_DR : 3|5@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PSS_Display : 19|4@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 804 CBC_PT4: 8 CBC
+ SG_ TurnLmp_FL_Flt : 13|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ TurnLmp_FR_Flt : 14|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ TurnLmp_RL_Flt : 24|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ TurnLmp_RR_Flt : 25|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ ACC_DLY_ACT : 26|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RemSt_Inhibit : 32|8@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ WPR_SYS_OFF : 40|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_LOW : 41|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_HIGH : 42|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_INT : 43|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_AUTO : 44|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_MIST : 45|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_WASH : 46|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ WPR_SYS_FLT : 47|1@1+ (1,0) [0|0] "" IRCM,SGW,ESC,DTCM
+ SG_ AirSusp_DnSw : 18|2@1+ (1,0) [0|0] "" SGW,ASCM
+ SG_ HdAjar : 10|1@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ CargoLampOn : 27|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ WTS_Active : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ CBC_WTS_AS : 9|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 808 TGW_DATA_IC: 8 CBC
+ SG_ TGW_GrpNum_IC : 4|4@1+ (1,1) [1|16] "Group" SGW,IC
+ SG_ TGW_GrpTyp_IC : 8|6@1+ (1,0) [1|40] "Text" SGW,IC
+ SG_ TGW_HiGrpMark_IC : 14|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TGW_TEXT_IC : 23|48@0+ (1,0) [0|0] "" SGW,IC
+
+BO_ 810 ECM_B6: 8 ECM
+ SG_ PTO_Md : 0|3@1+ (1,0) [0|0] "" SGW,VSIM,TCM,IC
+ SG_ PTO_MaxVehSpd : 3|5@1+ (1,0) [0|0] "" IRCM,SGW,IC
+ SG_ PTO_AutoRsm : 8|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTO_TYPES : 10|2@1+ (1,0) [0|0] "" SGW,TCM,IC
+ SG_ PTO_ENGD_RQ : 12|1@1+ (1,0) [0|0] "" SGW,VSIM,TCM
+ SG_ PTO_Incab : 13|1@1+ (1,0) [0|0] "" SGW
+ SG_ PTO_HornRq : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTO_SingleRPM : 16|8@1+ (25,600) [600|6950] "rpm" SGW,IC
+ SG_ PTO_RPM1 : 24|8@1+ (25,600) [600|6950] "rpm" SGW,IC
+ SG_ PTO_RPM2 : 32|8@1+ (25,600) [600|6950] "rpm" SGW,IC
+ SG_ PTO_RPM3 : 40|8@1+ (25,600) [600|6950] "rpm" SGW,IC
+ SG_ PTO_Sts : 48|5@1+ (1,0) [0|0] "" FTM,IRCM,SGW,VSIM,IC,CBC
+ SG_ FuelTransSts : 61|3@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 816 GW_I_C1: 8 CBC
+ SG_ TRAC_PSD : 19|1@1+ (1,0) [0|0] "" SGW,ETM,ESC
+ SG_ HILL_DES_RQ : 20|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ AHB_ENBL : 36|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ phone_pop_up_active : 30|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TILT_IN_REV_D : 6|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RemStNrmlStEnbl_DCS : 39|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RemStEnbl_DCS : 38|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ EB_SW_PSD : 10|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+
+BO_ 820 CBC_PT1: 8 CBC
+ SG_ FT_FOG_RQ : 2|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ REV_GEAR : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ORC,IC,ESC,DTCM,ASCM
+ SG_ DR_LK_STAT : 5|2@1+ (1,0) [0|0] "" SGW,VSIM
+ SG_ FOB_SrchRq : 8|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ AHB_ACT : 14|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PARK_LMP_ON : 16|1@1+ (1,0) [0|0] "" SGW,VSIM,IC,ETM
+ SG_ DRV_AJAR : 17|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PCM,VSIM,TCM,RF_HUB,IC,ETM,ESC,ECM,ASCM
+ SG_ PSG_AJAR : 18|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,VSIM,RF_HUB,IC,ETM,ESC,ECM,ASCM
+ SG_ L_R_AJAR : 19|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,VSIM,RF_HUB,IC,ETM,ECM,ASCM
+ SG_ R_R_AJAR : 20|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,VSIM,RF_HUB,IC,ETM,ECM,ASCM
+ SG_ TLG_AJAR : 22|1@1+ (1,0) [0|0] "" FTM,SGW,ETM
+ SG_ PARK_BRK_EGD : 23|1@1+ (1,0) [0|0] "" SGW,PCM,VSIM,RF_HUB,ORC,IC,ESC,ECM,ASCM
+ SG_ IGN_OFF_TIME_LNG : 27|12@0+ (1,0) [0|4080] "min" FTM,IRCM,SGW,PCM,TCM,RF_HUB,ESC,DTCM
+ SG_ SHIP_STAT : 28|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,RF_HUB,IC,ECM,ASCM
+ SG_ TurnInd_LT_ON : 30|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,IC,ETM
+ SG_ TurnInd_RT_ON : 31|1@1+ (1,0) [0|0] "" FTM,SGW,VSIM,IC,ETM
+ SG_ DAY_LGT_MD : 40|1@1+ (1,0) [0|0] "" SGW,SCCM,RF_HUB,IC,ESM
+ SG_ PANEL_INTS : 48|8@1+ (0.5,0) [0|100] "%" SGW,VSIM,SCCM,RF_HUB,IC,ESM
+ SG_ FT_WPR_NOT_PRK : 56|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ECM,DTCM
+ SG_ LOBEAM_ON : 57|1@1+ (1,0) [0|0] "" SGW,PCM,VSIM,ETM,ECM,AFLS
+ SG_ HIBEAM_ON : 58|1@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PCM,VSIM,IC,ETM,ECM
+ SG_ BRK_FLUID_LO : 62|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM,ESC
+ SG_ WASH_FLUID_LO : 63|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ R_FOG_RQ : 3|1@1+ (1,0) [0|0] "" SGW,IC,ETM
+ SG_ PTC_REL1_STAT : 42|2@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ PTC_REL2_STAT : 44|2@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ PTC_REL3_STAT : 46|2@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ PoliceStlthMdAct : 59|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC,ESM
+
+BO_ 825 PTS_CHIME_STAT: 2 PTS
+ SG_ PTS_RR_CHIME_RQ : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTS_LR_CHIME_RQ : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTS_CHIME_TYPE : 4|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTS_CHIME_REP_RATE : 8|4@1+ (1,0) [0|15] "Hz" SGW,CBC
+ SG_ PTS_RR_VOL : 14|2@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_FT_VOL : 12|2@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_LF_CHIME_RQ : 1|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTS_RF_CHIME_RQ : 0|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 826 PTS_1: 8 PTS
+ SG_ PTS_RR_NA : 4|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_SRV_RQ : 5|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_AlrRL : 24|4@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_GraphicRL : 30|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_AlrRR : 32|4@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_GraphicRR : 38|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_AlrRC : 48|4@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_GraphicRC : 54|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_RR_SRV : 59|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ PTS_STAT : 60|2@1+ (1,0) [0|0] "" SGW,ETM,CBC
+ SG_ PTS_AlrFC : 40|4@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_AlrFL : 8|4@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_AlrFR : 16|4@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ PTS_FT_NA : 3|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_FT_SRV : 58|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ PTS_GraphicFC : 46|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_GraphicFL : 14|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTS_GraphicFR : 22|2@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 832 IC_500Cyc: 8 IC
+ SG_ VehSpd_MPH : 47|1@1+ (1,0) [0|0] "" SGW,PCM,ECM,CBC
+ SG_ VehSpdDisp : 55|16@0+ (1,0) [0|65534] "" SGW,CBC
+ SG_ xtended_AvgFuelLvl : 19|12@0+ (0.5,0) [0|2047] "liters" SGW,PCM,ECM,CBC
+
+BO_ 838 AS_CHIME_STAT: 2 IRCM
+ SG_ AS_RF_CHIME_RQ : 0|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AS_LF_CHIME_RQ : 1|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AS_CHIME_TYPE : 4|4@1+ (1,0) [0|0] "" SGW,ORC,CBC
+ SG_ AS_CHIME_REP_RATE : 8|4@1+ (1,0) [0|15] "Hz" SGW,CBC
+
+BO_ 840 ESP_C1: 8 ESC
+ SG_ FailSafeError : 7|16@0+ (1,0) [0|65534] "" IRCM,SGW
+
+BO_ 848 Clock_Date: 8 CBC
+ SG_ DateTmSec : 0|8@1+ (1,0) [0|59] "sec" SGW,ITBM,IC
+ SG_ DateTmMinute : 8|8@1+ (1,0) [0|59] "min" SGW,ITBM,VSIM,RF_HUB,IC
+ SG_ DateTmHour : 16|8@1+ (1,0) [0|23] "Hours" SGW,ITBM,VSIM,RF_HUB,IC
+ SG_ DateTmYear : 31|16@0+ (1,0) [0|65534] "Years" SGW,ITBM,RF_HUB,IC
+ SG_ DateTmMonth : 40|8@1+ (1,0) [1|12] "Months" SGW,ITBM,RF_HUB,IC
+ SG_ DateTmDay : 48|8@1+ (1,0) [1|31] "Days" SGW,ITBM,RF_HUB,IC
+ SG_ DateTmFormat : 56|3@1+ (1,0) [0|0] "" SGW,ITBM,IC
+
+BO_ 850 ECM_APPL2: 8 DIAGNOST
+ SG_ ECM_APPL2 : 7|64@0+ (1,0) [0|0] "" PCM,ECM
+
+BO_ 853 GW_LIN_I_C1: 8 CBC
+ SG_ RrAxleLckr_Rq : 16|2@1+ (1,0) [0|0] "" SGW,FDCM
+ SG_ TCASE_NEUT_RQ : 4|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ TcaseSwTyp : 14|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ TcaseAWD_Rq : 8|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ Tcase4Low_Rq : 12|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ Tcase4Lock_Rq : 10|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ Tcase2WD_Rq : 6|2@1+ (1,0) [0|0] "" SGW,DTCM
+ SG_ PARK_ASST_RQ : 21|2@1+ (1,0) [0|0] "" SGW,PTS
+ SG_ FT_PARK_ASST_RQ : 48|2@1+ (1,0) [0|0] "" SGW,PTS
+ SG_ CLS_UnlkSw_Psd_P : 46|1@1+ (1,0) [0|0] "" SGW,VSIM
+ SG_ CLS_UnlkSw_Psd_D : 40|1@1+ (1,0) [0|0] "" SGW,VSIM
+ SG_ CLS_LkSw_Psd_P : 47|1@1+ (1,0) [0|0] "" SGW,VSIM
+ SG_ CLS_LkSw_Psd_D : 41|1@1+ (1,0) [0|0] "" SGW,VSIM
+ SG_ ASBM_AUX6_On : 39|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+
+BO_ 856 COMPASS_A1: 4 CBC
+ SG_ CMP_DIR : 0|4@1+ (1,0) [0|0] "" FTM,SGW,IC
+ SG_ VAR_VAL : 4|4@1+ (1,1) [1|15] "" SGW,IC
+ SG_ CMP_DIR_RAW : 8|9@0+ (1,0) [0|359] "Degrees" SGW
+ SG_ IN_CAL_MD : 11|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 860 DIRECT_INFO: 6 CBC
+ SG_ DIST_TO_TURN : 7|16@0+ (1,0) [0|65534] "" SGW,IC
+ SG_ UNITS : 16|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ T_BY_T_ON : 19|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TURN_COMP : 20|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ NAV_ARROW : 24|6@1+ (1,0) [1|63] "Arrow" SGW,IC
+ SG_ NAVPrsnt : 30|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 863 ECM_B8: 8 ECM
+ SG_ RevOilLifeRst : 55|16@0+ (1000,0) [0|65534000] "Rev's" SGW,CBC
+
+BO_ 864 ECM_APPL1: 8 ECM
+ SG_ ECM_APPL1 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 872 TCM_HSA: 8 TCM
+ SG_ TCM_HSA : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 880 ECM_APPL3: 8 ECM
+ SG_ ECM_APPL3 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 882 IC_A3: 8 IC
+ SG_ TorqueUnit : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ LANG_C : 11|5@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PowerUnit : 34|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PressureUnit : 36|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ CapacityUnit : 38|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DistanceUnit : 50|1@1+ (1,0) [0|0] "" FTM,SGW,PCM,ECM,CBC
+ SG_ SpeedUnit : 51|1@1+ (1,0) [0|0] "" IRCM,SGW,FDCM,PCM,IC,ECM,CBC
+ SG_ TemperatureUnit : 52|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ConsumptionUnit : 53|3@1+ (1,0) [0|0] "" FTM,SGW,CBC
+ SG_ UNIT_SET_CSO : 24|2@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 888 TCM_HSB: 8 TCM
+ SG_ TCM_HSB : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 896 ECM_APPL4: 8 ECM
+ SG_ ECM_APPL4 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 897 VehCfg7: 8 CBC
+ SG_ VC_VehCfg7_Stat : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,FDCM,PCM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ESC,ECM,DTCM,ASCM
+ SG_ VC_LDW : 2|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TrnsDrvMdPrsnt : 3|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB
+ SG_ VC_PdlsMdPrsnt : 4|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB
+ SG_ VC_DST_Present : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_STP_PRSNT : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_eShifter_Prsnt : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TransType : 8|6@1+ (1,0) [0|0] "" SGW,RF_HUB,IC,ESC
+ SG_ VC_AS_ERS : 14|2@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB,IC
+ SG_ VC_FullSpeedRange_FCW : 18|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,IC,ESC
+ SG_ VC_ACC_Type : 19|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,IC,ESC,ECM
+ SG_ VC_SuspPrsnt : 21|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ASCM
+ SG_ VC_DampingPrsnt : 22|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AxleLockerPrsnt : 26|2@1+ (1,0) [0|0] "" SGW,FDCM,RF_HUB,IC
+ SG_ VC_PBTyp : 29|3@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB
+ SG_ VC_RedKey : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TeenKey : 16|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TPMS_Configuration : 32|3@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_Trans_Equipped : 28|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,PTS,ORC,IC,ESC
+ SG_ VC_TSBM_Prsnt : 39|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SVC_Prsnt : 17|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Trans_N_Hold_Prsnt : 23|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ABSM : 25|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HybridType : 36|3@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SUNR_Prsnt : 47|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Temp_Display_Resolution : 42|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Suspension_Type : 60|4@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SmartAlternator : 35|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PTCPrsnt : 43|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ VC_MOC_Type : 45|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Glovebox : 44|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Brake_Type : 56|4@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AGSprsnt : 41|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ADR_PRSNT : 40|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_GlareFree_Prsnt : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Vehicle_Package : 50|3@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TrafficSignInfo : 53|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PAD_Lamp_Ctrl : 49|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LDW_Audio : 55|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LaneCentering : 54|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 898 VehCfgBu7: 8 RF_HUB
+ SG_ VC_BU_VehCfg7_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LDW : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TrnsDrvMdPrsnt : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PdlsMdPrsnt : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DST_Present : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_STP_PRSNT : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_eShifter_Prsnt : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TransType : 8|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AS_ERS : 14|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FullSpeedRange_FCW : 18|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ACC_Type : 19|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SuspPrsnt : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DampingPrsnt : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AxleLockerPrsnt : 26|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PBTyp : 29|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RedKey : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TeenKey : 16|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TPMS_Configuration : 32|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Trans_Equipped : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TSBM_Prsnt : 39|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SVC_Prsnt : 17|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Trans_N_Hold_Prsnt : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ABSM : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HybridType : 36|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SUNR_Prsnt : 47|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Temp_Display_Resolution : 42|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Suspension_Type : 60|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SmartAlternator : 35|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PTCPrsnt : 43|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MOC_Type : 45|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Glovebox : 44|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Brake_Type : 56|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AGSprsnt : 41|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ADR_PRSNT : 40|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Vehicle_Package : 50|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TrafficSignInfo : 53|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PAD_Lamp_Ctrl : 49|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_GlareFree_Prsnt : 48|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LDW_Audio : 55|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LaneCentering : 54|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 904 TCM_HSC: 8 TCM
+ SG_ TCM_HSC : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 912 ECM_APPL5: 8 ECM
+ SG_ ECM_APPL5 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 920 TCM_HSD: 8 TCM
+ SG_ TCM_HSD : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 928 ECM_APPL6: 8 ECM
+ SG_ ECM_APPL6 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 936 ECM_APPL7: 8 ECM
+ SG_ ECM_APPL7 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 937 CBC_CFG1: 8 CBC
+ SG_ SOUND_LK : 1|1@1+ (1,0) [0|0] "" SGW
+ SG_ FLASH_LK : 2|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ HL_WPR : 3|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CFG_AUTO_WPR : 7|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ILL_APRCH_TIME : 8|8@1+ (1,0) [0|254] "sec" SGW,IC
+ SG_ HL_DLY_TIME : 16|8@1+ (1,0) [0|254] "sec" SGW,IC
+ SG_ ACC_DLY_TIME : 31|16@0+ (1,0) [0|65534] "sec" SGW,IC
+ SG_ DRL_ON : 40|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ SOUND_RS : 52|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ SOUND_LK_1ST_2ND : 56|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ AUTO_LK : 4|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ AUTO_UNLK : 5|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RKE_ONE_PRESS_ENBL : 0|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ R_G_LGT_STS : 46|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Backup_Alarm : 45|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 944 TCM_APPL2: 8 DIAGNOST
+ SG_ TCM_APPL2 : 7|64@0+ (1,0) [0|0] "" PCM,TCM
+
+BO_ 945 TCM_APPL1: 8 TCM
+ SG_ TCM_APPL1 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 946 TCM_APPL3: 8 TCM
+ SG_ TCM_APPL3 : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 947 VehCfgCSM1: 8 CBC
+ SG_ VC_VehCfgCSO1_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PRK_AST_CSO : 2|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PRK_AST_BRK_CSO : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PRK_FT_VOL_CSO : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PRK_RR_VOL_CSO : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_EPS_CSO : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FCW_CSO : 8|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FCW_BRK_CSO : 10|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HRN_RMT_LK_CSO : 11|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_HRN_RMT_ST_CSO : 13|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_HRN_RMT_LWR_CSO : 14|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_CHMSL_LINE_CSO : 15|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DCS_CSO : 16|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_AUX_SWS_CSO : 18|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_CMRA_GRDLNS_CSO : 20|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ACC_DLY_CSO : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_AFLS_CSO : 25|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_AMB_DMR_CSO : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ASCM_TJ_CSO : 27|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_ASCM_WRN_CSO : 28|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_AUTO_AERO_CSO : 29|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AUTO_HB_CSO : 30|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_AUTO_PRK_CSO : 31|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BLIND_SPOT_CSO : 32|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_CAPACITY_CSO : 33|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_CLK_DSP_CSO : 34|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_CMP_CAL_CSO : 35|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_CMP_VAR_CSO : 36|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_CONS_CSO : 37|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_DISTANCE_CSO : 38|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_DR_LK_CSO : 39|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_DR_UNLK_CSO : 40|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_DRL_CSO : 41|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_EASY_EXIT_CSO : 42|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_ENTRY_EXIT_CSO : 43|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_EPB_SERV_CSO : 44|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FLSH_LMP_LK_CSO : 45|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_HL_DRP_CSO : 46|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HL_OFF_DLY_CSO : 47|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_HL_WPR_CSO : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_HSA_CSO : 49|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_ILL_APPRCH_CSO : 50|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_LDW_TRQ_CSO : 51|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LDW_WRN_CSO : 52|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LGHT_RMT_LWR_CSO : 53|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_NAV_TRN_CSO : 54|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PE_CSO : 55|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PER_SHFT_ENBL_CSO : 56|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PER_SHFT_RPM_CSO : 57|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PLG_CHM_CSO : 58|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_POWER_CSO : 59|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PRESSURE_CSO : 60|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PTO_CSO : 61|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_RAIN_WPR_CSO : 62|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_REAR_CMRA_CSO : 63|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_POLICE_PE_CSO : 23|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_UNIT_SET_CSO : 22|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+
+BO_ 948 VehCfgCSM2: 8 CBC
+ SG_ VC_VehCfgCSO2_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_REAR_CMRA_DLY_CSO : 2|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_RKE_MEM_CSO : 3|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_RKE_UNLK_CSO : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_SPEED_CSO : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TLT_MRR_CSO : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TORQUE_CSO : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TRLR_CSO : 8|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TRLR_NAME_CSO : 9|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TRLR_TYPE_CSO : 10|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TRNS_MD_CSO : 11|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_US_METRIC_CSO : 12|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_WHL_ALGN_CSO : 13|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_FUEL_SAV_CSO : 14|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEMP_CSO : 15|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_FCW_SW_CSO : 47|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PADDLE_SHIFT_CSO : 39|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PWR_FLD_MRR_CSO : 17|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_FCW_BRK_CSO : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_FCW_SENS_CSO : 23|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_MAX_SPEED_CSO : 28|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HOLD_N_GO_CSO : 16|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HANDS_FREE_LFT_CSO : 18|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HANDS_FREE_SLDR_CSO : 19|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SVC_GRIDLINES_CSO : 20|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_SVC_DELAY_CSO : 21|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_SLD_DR_ALRT_CSO : 22|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_PRK_ASST_CSO : 25|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_FT_PRK_VOL_CSO : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_RR_PRK_VOL_CSO : 27|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_FUEL_WRN_CSO : 29|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_FUEL_POPUP_CSO : 30|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_BLIND_SPOT_CSO : 31|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_RAIN_WPR_CSO : 32|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_AUTO_HB_CSO : 33|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_LGHT_WPR_CSO : 34|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_SLD_DR_ALRT_CSO : 35|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_PLG_CHIME_CSO : 36|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SLD_DR_CHM_CSO : 37|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_SLD_DR_CHM_CSO : 38|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FLSH_LMP_SLDR_CSO : 40|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SPEED_WARNING_CSO : 41|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LDW_ON_CSO : 43|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PRK_ASST_TYPE_CSO : 44|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_EPB_ON_CSO : 45|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AIRBAG_ON_CSO : 46|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RDY_DRV_CSO : 55|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TEEN_PRK_ASST_BRK_CSO : 51|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PCS_CSO : 52|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FCW_WARN_BRK_CSO : 49|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DOORS_OFF_ACC_DLY_CSO : 50|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BSM_TRLR_CSO : 53|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AUTO_SS_CSO : 54|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_MOTORIZED_SEATBELT_STRN_CSO : 57|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_MOTORIZED_SEATBELT_CSO : 56|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LKA_CSO : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BLIND_SPOT_WARNING_CSO : 58|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ABSD_WARNING_CSO : 60|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ABSD_STRN_CSO : 62|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ABSD_SENS_CSO : 61|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ABSD_HAPTIC_CSO : 63|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ABSD_CSO : 59|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 949 VehCfgCSM1_BU: 8 RF_HUB
+ SG_ VC_BU_VehCfgCSO1_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PRK_AST_CSO : 2|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PRK_AST_BRK_CSO : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PRK_FT_VOL_CSO : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PRK_RR_VOL_CSO : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EPS_CSO : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FCW_CSO : 8|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FCW_BRK_CSO : 10|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HRN_RMT_LK_CSO : 11|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HRN_RMT_ST_CSO : 13|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HRN_RMT_LWR_CSO : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CHMSL_LINE_CSO : 15|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DCS_CSO : 16|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUX_SWS_CSO : 18|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CMRA_GRDLNS_CSO : 20|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ACC_DLY_CSO : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AFLS_CSO : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AMB_DMR_CSO : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ASCM_TJ_CSO : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ASCM_WRN_CSO : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_AERO_CSO : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_HB_CSO : 30|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_PRK_CSO : 31|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BLIND_SPOT_CSO : 32|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CAPACITY_CSO : 33|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CLK_DSP_CSO : 34|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CMP_CAL_CSO : 35|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CMP_VAR_CSO : 36|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CONS_CSO : 37|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DISTANCE_CSO : 38|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DR_LK_CSO : 39|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DR_UNLK_CSO : 40|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DRL_CSO : 41|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EASY_EXIT_CSO : 42|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ENTRY_EXIT_CSO : 43|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EPB_SERV_CSO : 44|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FLSH_LMP_LK_CSO : 45|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HL_DRP_CSO : 46|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HL_OFF_DLY_CSO : 47|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HL_WPR_CSO : 48|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HSA_CSO : 49|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ILL_APPRCH_CSO : 50|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LDW_TRQ_CSO : 51|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LDW_WRN_CSO : 52|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LGHT_RMT_LWR_CSO : 53|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_NAV_TRN_CSO : 54|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PE_CSO : 55|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PER_SHFT_ENBL_CSO : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PER_SHFT_RPM_CSO : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PLG_CHM_CSO : 58|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_POWER_CSO : 59|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PRESSURE_CSO : 60|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PTO_CSO : 61|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RAIN_WPR_CSO : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_REAR_CMRA_CSO : 63|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_POLICE_PE_CSO : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_UNIT_SET_CSO : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 950 VehCfgCSM2_BU: 8 RF_HUB
+ SG_ VC_BU_VehCfgCSO2_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_REAR_CMRA_DLY_CSO : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RKE_MEM_CSO : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RKE_UNLK_CSO : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SPEED_CSO : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TLT_MRR_CSO : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TORQUE_CSO : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TRLR_CSO : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TRLR_NAME_CSO : 9|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TRLR_TYPE_CSO : 10|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TRNS_MD_CSO : 11|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_US_METRIC_CSO : 12|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_WHL_ALGN_CSO : 13|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FUEL_SAV_CSO : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEMP_CSO : 15|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FCW_SW_CSO : 47|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PADDLE_SHIFT_CSO : 39|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PWR_FLD_MRR_CSO : 17|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_FCW_BRK_CSO : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_FCW_SENS_CSO : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_MAX_SPEED_CSO : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HOLD_N_GO_CSO : 16|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HANDS_FREE_LFT_CSO : 18|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HANDS_FREE_SLDR_CSO : 19|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SVC_GRIDLINES_CSO : 20|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SVC_DELAY_CSO : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SLD_DR_ALRT_CSO : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_PRK_ASST_CSO : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_FT_PRK_VOL_CSO : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_RR_PRK_VOL_CSO : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_FUEL_WRN_CSO : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_FUEL_POPUP_CSO : 30|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_BLIND_SPOT_CSO : 31|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_RAIN_WPR_CSO : 32|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_AUTO_HB_CSO : 33|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_LGHT_WPR_CSO : 34|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_SLD_DR_ALRT_CSO : 35|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_PLG_CHIME_CSO : 36|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SLD_DR_CHM_CSO : 37|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_SLD_DR_CHM_CSO : 38|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FLSH_LMP_SLDR_CSO : 40|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SPEED_WARNING_CSO : 41|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LDW_ON_CSO : 43|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PRK_ASST_TYPE_CSO : 44|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EPB_ON_CSO : 45|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AIRBAG_ON_CSO : 46|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RDY_DRV_CSO : 55|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TEEN_PRK_ASST_BRK_CSO : 51|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PCS_CSO : 52|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FCW_WARN_BRK_CSO : 49|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DOORS_OFF_ACC_DLY_CSO : 50|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BSM_TRLR_CSO : 53|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_SS_CSO : 54|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MOTORIZED_SEATBELT_CSO : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LKA_CSO : 48|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BLIND_SPOT_WARNING_CSO : 58|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ABSD_WARNING_CSO : 60|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ABSD_STRN_CSO : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ABSD_SENS_CSO : 61|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ABSD_HAPTIC_CSO : 63|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ABSD_CSO : 59|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MOTORIZED_SEATBELT_STRN_CS : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 956 NAV_DATA: 8 CBC
+ SG_ NAV_GrpNum : 4|4@1+ (1,1) [1|16] "Group" SGW,IC
+ SG_ NAV_GrpTyp : 8|6@1+ (1,0) [1|40] "Text" SGW,IC
+ SG_ NAV_HiGrpMark : 14|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ NAV_TEXT : 23|48@0+ (1,0) [0|0] "" SGW,IC
+
+BO_ 969 AMB_TEMP_DISP: 4 CBC
+ SG_ AMB_TEMP_AVG_F : 0|8@1+ (1,-40) [-40|210] "°F" FTM,SGW,IC
+ SG_ AMB_TEMP_AVG_C : 8|8@1+ (1,-40) [-40|210] "°C" FTM,SGW,IC
+
+BO_ 974 GW_Dev: 5 CBC
+ SG_ FT_HVAC_BLW_FN_SP : 0|7@1+ (1,0) [0|100] "Bars" SGW,PCM,ECM
+ SG_ DRV_TEMP_DR_POS : 16|7@1+ (1,0) [0|100] "%" SGW,PCM,ECM
+
+BO_ 977 TCM_CFG: 4 TCM
+ SG_ TransTyp : 0|8@1+ (1,0) [0|0] "" SGW,DTCM
+
+BO_ 979 EcuCfg14: 8 CBC
+ SG_ EC_ECUCfg14_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC14A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC14B : 15|56@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 980 EcuCfg13: 8 CBC
+ SG_ EC_ECUCfg13_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC13A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC13B : 15|56@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 981 EcuCfg12: 8 CBC
+ SG_ EC_ECUCfg12_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ EC_Cluster5A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Cluster5B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Cluster5C : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 982 EcuCfg11: 8 CBC
+ SG_ EC_ECUCfg11_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC10A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC10B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC11 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 983 EcuCfg10: 8 CBC
+ SG_ EC_ECUCfg10_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ EC_Cluster3A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Cluster3B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Cluster4 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 984 EcuCfg9: 8 CBC
+ SG_ EC_ECUCfg9_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC9A1 : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC9A2 : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC9B : 39|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_ITM : 55|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 985 EcuBuCfg14: 8 RF_HUB
+ SG_ EC_BU_ECUCfg14_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC14A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC14B : 15|56@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 986 EcuBuCfg13: 8 RF_HUB
+ SG_ EC_BU_ECUCfg13_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC13A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC13B : 15|56@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 987 EcuBuCfg12: 8 RF_HUB
+ SG_ EC_BU_ECUCfg12_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster5A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster5B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster5C : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 988 EcuBuCfg11: 8 RF_HUB
+ SG_ EC_BU_ECUCfg11_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC10A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC10B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC11 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 989 EcuBuCfg10: 8 RF_HUB
+ SG_ EC_BU_ECUCfg10_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster3A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster3B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster4 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 991 EcuBuCfg9: 8 RF_HUB
+ SG_ EC_BU_ECUCfg9_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC9A1 : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC9A2 : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC9B : 39|16@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_ITM : 55|16@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 993 ENG_CFG: 7 ECM
+ SG_ DISPLACEMENT : 0|8@1+ (0.1,0) [0|25] "liters" IRCM,SGW,ETM,ESC,CBC,ASCM
+ SG_ NUM_CYL : 8|4@1+ (1,0) [0|14] "cylinders" IRCM,SGW,IC,ETM,ESC
+ SG_ SpStPrsnt : 12|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ ENG_ASP : 13|3@1+ (1,0) [0|0] "" IRCM,SGW,ETM,ESC
+ SG_ FUEL_TYPE : 16|3@1+ (1,0) [0|0] "" FTM,IRCM,SGW,ITBM,TCM,IC,ETM,ESC,CBC,ASCM
+ SG_ ECM_Vehi_Type : 19|2@1+ (1,0) [0|0] "" SGW
+ SG_ Manufacture : 21|3@1+ (1,0) [0|0] "" SGW
+ SG_ NUM_VALVE : 24|3@1+ (1,0) [0|6] "valve-per-cylinder" IRCM,SGW
+ SG_ ETC_PRSNT : 27|1@1+ (1,0) [0|0] "" SGW
+ SG_ TRANS_TYPE : 28|1@1+ (1,0) [0|0] "" SGW,VSIM,IC,ETM,DTCM,CBC,ASCM
+ SG_ EngStyle : 29|3@1+ (1,0) [0|0] "" SGW,TCM,ESC,CBC
+
+BO_ 995 NET_CFG_INT: 8 CBC
+ SG_ NET_CFG_STAT_INT : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,VSIM,RF_HUB,PTS,IC,ASCM
+ SG_ NetCfg_RBSS : 2|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_BSM : 3|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,IC
+ SG_ NetCfg_CBC_IN : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_CSWM : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DCM_DR : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DCM_PASS : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DCM_RL : 8|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DCM_RR : 9|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_HVAC : 10|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_MSM : 11|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_PLG : 12|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_VTM : 13|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_PSD_LT : 14|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_PSD_RT : 15|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_FSM : 16|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_PTCM : 17|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_RBC : 18|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DTV : 19|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_TGW : 20|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_CLOCK : 21|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_VSIM : 22|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ITM : 23|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_AMP_I : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DVD_CDM : 25|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_HFM_CTM : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ICS_I : 27|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_VES2_I : 28|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_VES3_I : 29|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_CRSM : 30|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_HVAC_R : 31|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DCSD : 37|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_TBM : 38|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_CVPM : 32|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_TMM : 33|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ICS_R : 34|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_MSM_PASS : 35|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_VRM : 36|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ANC_I : 39|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_TTM : 47|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_UPFM : 46|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_PSSM : 45|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+
+BO_ 996 NET_CFG_PT: 8 CBC
+ SG_ NET_CFG_STAT_PT : 0|2@1+ (1,0) [0|0] "" ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ NetCfg_ACC : 2|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB
+ SG_ NetCfg_ADCM : 3|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_AHLM : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_VSIM_C : 5|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ NetCfg_ASCM : 6|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,IC,ESC
+ SG_ NetCfg_CBC_PT : 7|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,ORC,ECM
+ SG_ NetCfg_DTCM : 8|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,IC,ESC,ECM,ASCM
+ SG_ NetCfg_ECM : 9|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,ORC,ECM
+ SG_ NetCfg_EPS : 10|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ NetCfg_ESM : 11|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ NetCfg_ESC : 12|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,ECM
+ SG_ NetCfg_EPB : 13|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ NetCfg_RF_HUB : 14|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,RF_HUB,ECM
+ SG_ NetCfg_IC : 15|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,ECM
+ SG_ NetCfg_DASM : 16|1@1+ (1,0) [0|0] "" IRCM,SGW,ITBM,PCM,TCM,RF_HUB,IC,ESC,ECM
+ SG_ NetCfg_FDCM : 17|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ NetCfg_EPPM : 18|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ORC
+ SG_ NetCfg_ORC : 19|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,RF_HUB,ECM
+ SG_ NetCfg_PTS : 20|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ NetCfg_SCCM : 23|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,ORC,ECM
+ SG_ NetCfg_ELSD : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ESC
+ SG_ NetCfg_TCM : 25|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,RF_HUB,ESM,ESC,ECM
+ SG_ NetCfg_TPM : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ORC
+ SG_ NetCfg_PASS_PT : 27|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_AFLS : 28|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ NetCfg_ITBM : 29|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,PTS,IC
+ SG_ NetCfg_OCM : 30|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ORC
+ SG_ NetCfg_HaLF : 31|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ANC : 39|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_HCP : 38|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ESL : 37|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_BSMO : 36|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_SGW : 34|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_DPDM : 33|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ASBS : 35|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_ATMM : 32|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ NetCfg_SWSM : 57|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ NetCfg_MSBD : 56|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 998 BU_NET_CFG_INT: 8 RF_HUB
+ SG_ BU_NET_CFG_STAT_INT : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_RBSS : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_BSM : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_CBC_IN : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_CSWM : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DCM_DR : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DCM_PASS : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DCM_RL : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DCM_RR : 9|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_HVAC : 10|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_MSM : 11|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PLG : 12|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_VTM : 13|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PSD_LT : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PSD_RT : 15|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_FSM : 16|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PTCM : 17|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_RBC : 18|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DTV : 19|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_TGW : 20|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_CLOCK : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_VSIM : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ITM : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_AMP_I : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DVD_CDM : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_HFM_CTM : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ICS_I : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_VES2_I : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_VES3_I : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_CRSM : 30|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_HVAC_R : 31|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DCSD : 37|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_TBM : 38|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_CVPM : 32|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_TMM : 33|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ICS_R : 34|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_MSM_PASS : 35|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_VRM : 36|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ANC_I : 39|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_TTM : 47|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_UPFM : 46|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PSSM : 45|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 999 BU_NET_CFG_PT: 8 RF_HUB
+ SG_ BU_NET_CFG_STAT_PT : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ACC : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ADCM : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_AHLM : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_VSIM_C : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ASCM : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_CBC_PT : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DTCM : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ECM : 9|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_EPS : 10|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ESM : 11|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ESC : 12|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_EPB : 13|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_RF_HUB : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_IC : 15|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DASM : 16|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_FDCM : 17|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_EPPM : 18|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ORC : 19|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PTS : 20|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_SCCM : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ELSD : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_TCM : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_TPM : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_PASS_PT : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_AFLS : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ITBM : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_OCM : 30|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_HaLF : 31|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ANC : 39|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_HCP : 38|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ESL : 37|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_BSMO : 36|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_SGW : 34|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_DPDM : 33|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ASBS : 35|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_ATMM : 32|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_SWSM : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BU_NetCfg_MSBD : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1000 VehCfg1: 8 CBC
+ SG_ VC_VehCfg1_Stat : 0|2@1+ (1,0) [0|0] "" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ VC_MODEL_YEAR : 2|6@1+ (1,2000) [2000|2062] "model-year" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ VC_VEH_LINE : 8|8@1+ (1,0) [0|0] "" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ VC_COUNTRY : 16|5@1+ (1,0) [0|0] "" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ VC_LHD_RHD : 21|2@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,ORC,IC,ETM,DTCM
+ SG_ VC_RemStPrsnt : 23|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB,IC
+ SG_ VC_XWD : 24|2@1+ (1,0) [0|0] "" ATMM,IRCM,SGW,PCM,TCM,RF_HUB,ESC,ECM,DTCM,ASCM
+ SG_ VC_EmodePrsnt : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AUTO_HB : 27|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB
+ SG_ VC_BODY_STYLE : 28|4@1+ (1,0) [0|0] "" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ VC_MAX_VEH_SPD : 32|8@1+ (2,0) [0|506] "kph" SGW,RF_HUB
+ SG_ VC_ShftrTyp : 40|4@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB,IC
+ SG_ VC_PTS_DispTyp : 44|3@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PP_Prsnt : 47|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SpecialPKG : 48|8@1+ (1,0) [1|254] "" SGW,RF_HUB
+ SG_ VC_HdRstPrsnt : 56|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SCR_Prsnt : 57|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,IC,ECM
+ SG_ VC_PTS_Config : 58|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_RVCM_Prsnt : 60|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_CHMCM_Prsnt : 61|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HDC_Prsnt : 62|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,IC,ESC
+ SG_ VC_SSC_Prsnt : 63|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1001 VehCfg2: 8 CBC
+ SG_ VC_VehCfg2_Stat : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,SCCM,RF_HUB,ORC,IC,ESM,ESC,ECM,ASCM
+ SG_ VC_PwrIvtrTyp : 2|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ThatchamPrsnt : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RunFlatTirePrsnt : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_MaseratiMd : 6|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PADS_Prsnt : 8|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RainSnsPrsnt : 9|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SKIM_PRSNT : 10|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AC_Prsnt : 11|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_CRUISE_PRSNT : 12|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,SCCM,RF_HUB,IC,ECM
+ SG_ VC_FG_PRSNT : 13|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FULL_SPARE : 14|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_OffRoad : 15|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SpecialPKG_IC : 16|8@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_ECO_Indicator : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DRVMD_Prsnt : 25|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_MemoryDRVMD_Prsnt : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ESCDrvMd_Prsnt : 27|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_EngPowerDrvMd_Prsnt : 28|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SecPrkPrsnt : 29|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ShftInd_Prsnt : 30|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_MaxLdPressRrTr : 32|8@1+ (1,0) [0|126] "psi" SGW,RF_HUB,IC
+ SG_ VC_MaxLdPressFtTr : 40|8@1+ (1,0) [0|126] "psi" SGW,RF_HUB,IC
+ SG_ VC_LgtLdPressRrTr : 48|8@1+ (1,0) [0|126] "psi" SGW,RF_HUB
+ SG_ VC_LgtLdPressFtTr : 56|8@1+ (1,0) [0|126] "psi" SGW,RF_HUB
+
+BO_ 1002 VehCfg3: 8 CBC
+ SG_ VC_VehCfg3_Stat : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ESM,ESC,ECM,DTCM
+ SG_ VC_POLICE : 2|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PWR_LFT_GT : 3|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PWR_RT_SLDR : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PWR_LT_SLDR : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RKE_PRSNT : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SunShade_Present : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TcaseTyp : 8|4@1+ (1,0) [0|0] "" SGW,RF_HUB,ESC,ECM,DTCM
+ SG_ VC_WHL_BASE : 12|2@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,IC
+ SG_ VC_FOBIKsafeENBL : 14|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ELV_Prsnt : 15|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FUEL_CAP : 16|8@1+ (1,36) [36|290] "liters" SGW,VSIM,RF_HUB,IC
+ SG_ VC_WIN_EXPR_FEAT : 24|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ADJ_PDL_PRSNT : 26|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AUTO_HL : 27|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DrAlrPrsnt : 28|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DualFuelSens : 29|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,IC,ECM
+ SG_ VC_SRT_PRSNT : 30|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DSBL_CLK_DISP : 31|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ChassisType : 32|7@1+ (1,0) [0|126] "" SGW,RF_HUB,ORC,ESC,DTCM
+ SG_ VC_TEMP_DISP : 39|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_HVAC_Config : 40|4@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_VEH_BRAND : 44|4@1+ (1,0) [0|0] "" SGW,RF_HUB,PTS
+ SG_ VC_CMP_DISP : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_IntEC_MIRR : 49|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ESCL_PRSNT : 50|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HID_HL : 51|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SecLkPrsnt : 52|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Liftgate_Trunk : 53|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_CMS : 55|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,ESC
+ SG_ VC_FCW : 56|1@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,ESC
+ SG_ VC_Base_TPM : 57|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_Prem_TPM : 58|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PDDL_PRSNT : 59|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB
+ SG_ VC_SPORT_PRSNT : 60|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AutoParkPrsnt : 61|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PE_Prsnt : 62|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_KG_Prsnt : 63|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB,IC
+
+BO_ 1003 VehCfg4: 8 CBC
+ SG_ VC_TCASE_HI_RATIO : 5|14@0+ (0.001,0) [0|16.382] "" SGW,TCM,RF_HUB,ESC
+ SG_ VC_VehCfg4_Stat : 6|2@1+ (1,0) [0|0] "" IRCM,SGW,FDCM,PCM,TCM,RF_HUB,PTS,ORC,ESC,ECM,DTCM
+ SG_ VC_AXLE_RATIO : 23|16@0+ (0.001,0) [0|65.534] "" IRCM,SGW,TCM,RF_HUB,ESC,DTCM
+ SG_ VC_TCASE_LO_RATIO : 39|16@0+ (0.001,0) [0|65.534] "" SGW,TCM,RF_HUB,ESC
+ SG_ VC_TIRE_CIRCUMF : 55|16@0+ (1,0) [0|65534] "mm" IRCM,SGW,TCM,RF_HUB,ORC,ESC,DTCM
+
+BO_ 1004 VehCfgBu1: 8 RF_HUB
+ SG_ VC_BU_VehCfg1_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MODEL_YEAR : 2|6@1+ (1,2000) [2000|2062] "model-year" SGW,CBC
+ SG_ VC_BU_VEH_LINE : 8|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_COUNTRY : 16|5@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LHD_RHD : 21|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RemStPrsnt : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_XWD : 24|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EmodePrsnt : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_HB : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BODY_STYLE : 28|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MAX_VEH_SPD : 32|8@1+ (2,0) [0|506] "kph" SGW,CBC
+ SG_ VC_BU_ShftrTyp : 40|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PTS_DispTyp : 44|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PP_Prsnt : 47|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SpecialPKG : 48|8@1+ (1,0) [1|254] "" SGW,CBC
+ SG_ VC_BU_HdRstPrsnt : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SCR_Prsnt : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PTS_Config : 58|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RVCM_Prsnt : 60|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CHMCM_Prsnt : 61|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HDC_Prsnt : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SSC_Prsnt : 63|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1005 VehCfgBu2: 8 RF_HUB
+ SG_ VC_BU_VehCfg2_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PwrIvtrTyp : 2|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ThatchamPrsnt : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RunFlatTirePrsnt : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MaseratiMd : 6|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PADS_Prsnt : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RainSnsPrsnt : 9|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SKIM_PRSNT : 10|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AC_Prsnt : 11|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CRUISE_PRSNT : 12|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FG_PRSNT : 13|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FULL_SPARE : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_OffRoad : 15|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SpecialPKG_IC : 16|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ECO_Indicator : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DRVMD_Prsnt : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MemoryDRVMD_Prsnt : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ESCDrvMd_Prsnt : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EngPowerDrvMd_Prsnt : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SecPrkPrsnt : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ShftInd_Prsnt : 30|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MaxLdPressRrTr : 32|8@1+ (1,0) [0|126] "psi" SGW,CBC
+ SG_ VC_BU_MaxLdPressFtTr : 40|8@1+ (1,0) [0|126] "psi" SGW,CBC
+ SG_ VC_BU_LgtLdPressRrTr : 48|8@1+ (1,0) [0|126] "psi" SGW,CBC
+ SG_ VC_BU_LgtLdPressFtTr : 56|8@1+ (1,0) [0|126] "psi" SGW,CBC
+
+BO_ 1006 VehCfgBu3: 8 RF_HUB
+ SG_ VC_BU_VehCfg3_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_POLICE : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PWR_LFT_GT : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PWR_RT_SLDR : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PWR_LT_SLDR : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RKE_PRSNT : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SunShade_Present : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TcaseTyp : 8|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_WHL_BASE : 12|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FOBIKsafeENBL : 14|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ELV_PRSNT : 15|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FUEL_CAP : 16|8@1+ (1,36) [36|290] "liters" SGW,CBC
+ SG_ VC_BU_WIN_EXPR_FEAT : 24|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ADJ_PDL_PRSNT : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_HL : 27|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DrAlrPrsnt : 28|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DualFuelSens : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SRT_PRSNT : 30|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DSBL_CLK_DISP : 31|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ChassisType : 32|7@1+ (1,0) [0|126] "" SGW,CBC
+ SG_ VC_BU_TEMP_DISP : 39|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HVAC_Config : 40|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_VEH_BRAND : 44|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CMP_DISP : 48|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_IntEC_MIRR : 49|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ESCL_Prsnt : 50|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HID_HL : 51|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SecLkPrsnt : 52|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Liftgate_Trunk : 53|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CMS : 55|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FCW : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Base_TPM : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Prem_TPM : 58|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PDDL_PRSNT : 59|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SPORT_PRSNT : 60|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AutoParkPrsnt : 61|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PE_Prsnt : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_KG_Prsnt : 63|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1007 VehCfgBu4: 8 RF_HUB
+ SG_ VC_BU_TCASE_HI_RATIO : 5|14@0+ (0.001,0) [0|16.382] "" SGW,CBC
+ SG_ VC_BU_VehCfg4_Stat : 6|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AXLE_RATIO : 23|16@0+ (0.001,0) [0|65.534] "" SGW,CBC
+ SG_ VC_BU_TCASE_LO_RATIO : 39|16@0+ (0.001,0) [0|65.534] "" SGW,CBC
+ SG_ VC_BU_TIRE_CIRCUMF : 55|16@0+ (1,0) [0|65534] "mm" SGW,CBC
+
+BO_ 1008 EcuCfg1: 8 CBC
+ SG_ EC_ECUCfg1_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC1A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC1B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC2 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1009 EcuCfg2: 8 CBC
+ SG_ EC_ECUCfg2_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC3A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC3B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC4 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1010 EcuCfg3: 8 CBC
+ SG_ EC_ECUCfg3_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_AudTel1A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_AudTel1B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_AudTel2 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1011 EcuCfg4: 8 CBC
+ SG_ EC_ECUCfg4_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ EC_Cluster1A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ EC_Cluster1B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ EC_Cluster2 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB,IC
+
+BO_ 1012 EcuCfg5: 8 CBC
+ SG_ EC_ECUCfg5_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_WirelessA : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_WirelessB : 15|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Doors : 31|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_Memory : 55|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1013 EcuCfg6: 8 CBC
+ SG_ EC_ECUCfg6_Stat : 0|2@1+ (1,0) [0|0] "" SGW,PCM,TCM,RF_HUB,PTS,ORC,ESC,ECM
+ SG_ EC_BrakesA : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB,ESC
+ SG_ EC_BrakesB : 8|8@1+ (1,0) [0|0] "" SGW,RF_HUB,ESC
+ SG_ EC_Steering : 23|16@0+ (1,0) [0|0] "" SGW,RF_HUB,ESC
+ SG_ EC_Powertrain : 39|16@0+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ EC_Safety : 55|16@0+ (1,0) [0|0] "" SGW,RF_HUB,ORC
+
+BO_ 1014 EcuCfg7: 8 CBC
+ SG_ EC_ECUCfg7_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC5A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC5B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC6 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1015 EcuCfg8: 8 CBC
+ SG_ EC_ECUCfg8_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC7A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC7B : 15|24@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC8 : 39|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1016 EcuBuCfg1: 8 RF_HUB
+ SG_ EC_BU_ECUCfg1_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC1A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC1B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC2 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1017 EcuBuCfg2: 8 RF_HUB
+ SG_ EC_BU_ECUCfg2_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC3A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC3B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC4 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1018 EcuBuCfg3: 8 RF_HUB
+ SG_ EC_BU_ECUCfg3_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_AudTel1A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_AudTel1B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_AudTel2 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1019 EcuBuCfg4: 8 RF_HUB
+ SG_ EC_BU_ECUCfg4_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster1A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster1B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Cluster2 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1020 EcuBuCfg5: 8 RF_HUB
+ SG_ EC_BU_ECUCfg5_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_WirelessA : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_WirelessB : 15|16@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Doors : 31|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Memory : 55|16@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1021 EcuBuCfg6: 8 RF_HUB
+ SG_ EC_BU_ECUCfg6_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_BrakesA : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_BrakesB : 8|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Steering : 23|16@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Powertrain : 39|16@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_Safety : 55|16@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1022 EcuBuCfg7: 8 RF_HUB
+ SG_ EC_BU_ECUCfg7_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC5A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC5B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC6 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1023 EcuBuCfg8: 8 RF_HUB
+ SG_ EC_BU_ECUCfg8_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC7A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC7B : 15|24@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC8 : 39|32@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1024 NM_RF_HUB: 8 RF_HUB
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "g" _
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "4" 0
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1025 NM_CBC: 8 CBC
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "g" _
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" C
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1026 NM_IC: 8 IC
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "g" _
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" I
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1031 NM_ESC: 8 ESC
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "d" w
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" E
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1033 NM_SBWM: 8 ESM
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "3" 6
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" S
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1059 NM_SCCM: 8 SCCM
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "S" w
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" S
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1089 DG_RQ_GLOBAL_UDS: 8 DIAGNOST
+ SG_ DG_RQ_GLOBAL_UDS : 7|64@0+ (1,0) [0|0] "" TTPM,ATMM,IRCM,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,CBC,ASCM,AFLS
+
+BO_ 1098 VehCfg5: 8 CBC
+ SG_ VC_VehCfg5_Stat : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,SCCM,RF_HUB,PTS,ORC,IC,ESC,ECM
+ SG_ VC_LUCI_PRSNT : 2|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RR_DuallyPrsnt : 3|1@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB,PTS,IC,ESC
+ SG_ VC_NonReg_TPIS : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_WTS_Prsnt : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AmbTempLct : 6|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Strng_Rt_0 : 8|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_pls1 : 16|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_pls2 : 24|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_pls3 : 32|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_pls4 : 40|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_pls5 : 48|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_RearDoorLocks2DCM : 56|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SpdLmt_PRSNT : 57|1@1+ (1,0) [0|0] "" SGW,PCM,SCCM,RF_HUB,ECM
+ SG_ VC_SBR_Prsnt : 58|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ChildDisp_Prsnt : 59|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_OffRoadPg : 60|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AmbLtgPrsnt : 61|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PPPA_Prsnt : 62|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ VC_ParkStopPrsnt : 63|1@1+ (1,0) [0|0] "" SGW,RF_HUB,ESC
+
+BO_ 1099 VehCfgBu5: 8 RF_HUB
+ SG_ VC_BU_VehCfg5_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LUCI_PRSNT : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RR_DuallyPrsnt : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_NonReg_TPIS : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_WTS_Prsnt : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AmbTempLct : 6|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_0 : 8|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_pls1 : 16|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_pls2 : 24|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_pls3 : 32|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_pls4 : 40|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_pls5 : 48|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_RearDoorLocks2DCM : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SpdLmt_PRSNT : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SBR_Prsnt : 58|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ChildDisp_Prsnt : 59|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_OffRoadPg : 60|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AmbLtgPrsnt : 61|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PPPA_Prsnt : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ParkStopPrsnt : 63|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1100 VehCfg6: 8 CBC
+ SG_ VC_VehCfg6_Stat : 0|2@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,RF_HUB,ORC,IC,ESC,ECM
+ SG_ VC_AnlgDrSnsr : 2|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BrkTyp : 4|3@1+ (1,0) [0|0] "" SGW,TCM,RF_HUB
+ SG_ VC_AQS_Prsnt : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Strng_Rt_Mns1 : 8|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_Mns2 : 16|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_Mns3 : 24|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_Mns4 : 32|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_Strng_Rt_Mns5 : 40|8@1+ (0.1,0) [0|25.4] "" SGW,RF_HUB,ESC
+ SG_ VC_TireCircumfFT : 55|16@0+ (1,0) [0|65534] "mm" SGW,TCM,RF_HUB,ORC,ESC
+
+BO_ 1101 VehCfgBu6: 8 RF_HUB
+ SG_ VC_BU_VehCfg6_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AnlgDrSnsr : 2|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BrkTyp : 4|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AQS_Prsnt : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_Mns1 : 8|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_Mns2 : 16|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_Mns3 : 24|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_Mns4 : 32|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_Strng_Rt_Mns5 : 40|8@1+ (0.1,0) [0|25.4] "" SGW,CBC
+ SG_ VC_BU_TireCircumfFT : 55|16@0+ (1,0) [0|65534] "mm" SGW,CBC
+
+BO_ 1216 D_RS_RF_HUB: 8 RF_HUB
+ SG_ D_RS_RF_HUB : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1218 D_RS_IC: 8 IC
+ SG_ D_RS_IC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1220 D_RS_ORC: 8 ORC
+ SG_ D_RS_ORC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1223 D_RS_ESC: 8 ESC
+ SG_ D_RS_ESC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1225 D_RS_ESM: 8 ESM
+ SG_ D_RS_ESM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1235 D_RS_DASM: 8 IRCM
+ SG_ D_RS_DASM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1250 D_RS_PTS: 8 PTS
+ SG_ D_RS_PTS : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM
+
+BO_ 1251 D_RS_SCCM: 8 SCCM
+ SG_ D_RS_SCCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1284 D_RS_CBC: 8 CBC
+ SG_ D_RS_CBC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1408 ECU_APPL_RF_HUB: 8 RF_HUB
+ SG_ ECU_APPL_RF_HUB : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1409 ECU_APPL_CBC: 8 CBC
+ SG_ ECU_APPL_CBC : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1410 ECU_APPL_IC: 8 IC
+ SG_ ECU_APPL_IC : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1412 ECU_APPL_ORC: 8 ORC
+ SG_ ECU_APPL_ORC : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1415 ECU_APPL_ESC: 8 ESC
+ SG_ ECU_APPL_ESC : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1417 ECU_APPL_ESM: 8 ESM
+ SG_ ECU_APPL_ESM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1427 ECU_APPL_DASM: 8 IRCM
+ SG_ ECU_APPL_DASM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1442 ECU_APPL_PTS: 8 PTS
+ SG_ ECU_APPL_PTS : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1443 ECU_APPL_SCCM: 8 SCCM
+ SG_ ECU_APPL_SCCM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1464 ECU_APPL_ECM: 8 ECM
+ SG_ ECU_APPL_ECM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1465 ECU_APPL_TCM: 8 TCM
+ SG_ ECU_APPL_TCM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1536 SD_RS_RF_HUB: 8 RF_HUB
+ SG_ SD_RS_RF_HUB : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1537 SD_RS_CBC: 8 CBC
+ SG_ SD_RS_CBC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1538 SD_RS_IC: 8 IC
+ SG_ SD_RS_IC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1540 SD_RS_ORC: 8 ORC
+ SG_ SD_RS_ORC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1543 SD_RS_ESC: 8 ESC
+ SG_ SD_RS_ESC : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1545 SD_RS_ESM: 8 ESM
+ SG_ SD_RS_ESM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1555 SD_RS_DASM: 8 IRCM
+ SG_ SD_RS_DASM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1568 D_RQ_CBC: 8 DIAGNOST
+ SG_ D_RQ_CBC : 7|64@0+ (1,0) [0|0] "" CBC
+
+BO_ 1570 SD_RS_PTS: 8 PTS
+ SG_ SD_RS_PTS : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1571 SD_RS_SCCM: 8 SCCM
+ SG_ SD_RS_SCCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1592 SD_RS_ECM: 8 ECM
+ SG_ SD_RS_ECM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1593 SD_RS_TCM: 8 TCM
+ SG_ SD_RS_TCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1728 APPL_ECU_RF_HUB: 8 DIAGNOST
+ SG_ APPL_ECU_RF_HUB : 7|64@0+ (1,0) [0|0] "" RF_HUB
+
+BO_ 1729 APPL_ECU_CBC: 8 DIAGNOST
+ SG_ APPL_ECU_CBC : 7|64@0+ (1,0) [0|0] "" CBC
+
+BO_ 1730 APPL_ECU_IC: 8 DIAGNOST
+ SG_ APPL_ECU_IC : 7|64@0+ (1,0) [0|0] "" IC
+
+BO_ 1732 APPL_ECU_ORC: 8 DIAGNOST
+ SG_ APPL_ECU_ORC : 7|64@0+ (1,0) [0|0] "" ORC
+
+BO_ 1735 APPL_ECU_ESC: 8 DIAGNOST
+ SG_ APPL_ECU_ESC : 7|64@0+ (1,0) [0|0] "" ESC
+
+BO_ 1737 APPL_ECU_ESM: 8 DIAGNOST
+ SG_ APPL_ECU_ESM : 7|64@0+ (1,0) [0|0] "" ESM
+
+BO_ 1747 APPL_ECU_DASM: 8 DIAGNOST
+ SG_ APPL_ECU_DASM : 7|64@0+ (1,0) [0|0] "" IRCM
+
+BO_ 1762 APPL_ECU_PTS: 8 DIAGNOST
+ SG_ APPL_ECU_PTS : 7|64@0+ (1,0) [0|0] "" PTS
+
+BO_ 1763 APPL_ECU_SCCM: 8 DIAGNOST
+ SG_ APPL_ECU_SCCM : 7|64@0+ (1,0) [0|0] "" SCCM
+
+BO_ 1784 APPL_ECU_ECM: 8 DIAGNOST
+ SG_ APPL_ECU_ECM : 7|64@0+ (1,0) [0|0] "" PCM,ECM
+
+BO_ 1785 APPL_ECU_TCM: 8 DIAGNOST
+ SG_ APPL_ECU_TCM : 7|64@0+ (1,0) [0|0] "" TCM
+
+BO_ 1856 D_RQ_RF_HUB: 8 DIAGNOST
+ SG_ D_RQ_RF_HUB : 7|64@0+ (1,0) [0|0] "" RF_HUB
+
+BO_ 1858 D_RQ_IC: 8 DIAGNOST
+ SG_ D_RQ_IC : 7|64@0+ (1,0) [0|0] "" IC
+
+BO_ 1860 D_RQ_ORC: 8 DIAGNOST
+ SG_ D_RQ_ORC : 7|64@0+ (1,0) [0|0] "" ORC
+
+BO_ 1863 D_RQ_ESC: 8 DIAGNOST
+ SG_ D_RQ_ESC : 7|64@0+ (1,0) [0|0] "" ESC
+
+BO_ 1865 D_RQ_ESM: 8 DIAGNOST
+ SG_ D_RQ_ESM : 7|64@0+ (1,0) [0|0] "" ESM
+
+BO_ 1875 D_RQ_DASM: 8 DIAGNOST
+ SG_ D_RQ_DASM : 7|64@0+ (1,0) [0|0] "" IRCM,DIAGNOST
+
+BO_ 1890 D_RQ_PTS: 8 DIAGNOST
+ SG_ D_RQ_PTS : 7|64@0+ (1,0) [0|0] "" PTS
+
+BO_ 1891 D_RQ_SCCM: 8 DIAGNOST
+ SG_ D_RQ_SCCM : 7|64@0+ (1,0) [0|0] "" SCCM
+
+BO_ 2015 DG_RQ_GLOBAL: 8 DIAGNOST
+ SG_ DG_RQ_GLOBAL : 7|64@0+ (1,0) [0|0] "" PCM,ECM
+
+BO_ 2016 D_RQ_ECM: 8 DIAGNOST
+ SG_ D_RQ_ECM : 7|64@0+ (1,0) [0|0] "" PCM,ECM
+
+BO_ 2017 D_RQ_TCM: 8 DIAGNOST
+ SG_ D_RQ_TCM : 7|64@0+ (1,0) [0|0] "" TCM
+
+BO_ 2024 D_RS_ECM: 8 ECM
+ SG_ D_RS_ECM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 2025 D_RS_TCM: 8 TCM
+ SG_ D_RS_TCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 362 DTCM_A2: 8 DTCM
+ SG_ CRC_DTCM_A2 : 56|8@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ DrvLnMinTrqMd : 7|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ DrvLnTrqRq : 0|9@0+ (2,0) [0|1020] "Nm" SGW,PCM,ECM
+ SG_ MC_DTCM_A2 : 52|4@1+ (1,0) [0|15] "" SGW,PCM,ECM
+
+BO_ 640 MEM_D_POS: 1 CBC
+ SG_ Mem_D_Pos_Rq : 0|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Mem_D_Rc_Rq : 2|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Mem_D_Sv_Rq : 3|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 752 MSM_A1: 2 CBC
+ SG_ MEM_RC_STAT : 3|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ MSMD_PDL_LKOUT : 8|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ EASY_EXIT : 1|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RKE_MEM : 0|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 847 RFHUB_A4: 1 RF_HUB
+ SG_ RF_FobNum : 1|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ RFMemRq : 0|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 916 VSIM_C2: 6 VSIM
+ SG_ AudioMuteRq : 5|1@1+ (1,0) [0|0] "" SGW
+ SG_ FtWigWagRq : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ RrWigWagRq : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ SupHrnRq : 1|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ SprtRearLtg : 15|1@1+ (1,0) [0|0] "" SGW
+ SG_ R_AC_Enable : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DsblTurnLmpFlt : 14|1@1+ (1,0) [0|0] "" SGW
+ SG_ DoorUnlkAllRq : 17|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DoorLkAllRq : 18|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1227 D_RS_DTCM: 8 DTCM
+ SG_ D_RS_DTCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1265 D_RS_VSIM: 8 VSIM
+ SG_ D_RS_VSIM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1419 ECU_APPL_DTCM: 8 DTCM
+ SG_ ECU_APPL_DTCM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1457 ECU_APPL_VSIM: 8 VSIM
+ SG_ ECU_APPL_VSIM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1547 SD_RS_DTCM: 8 DTCM
+ SG_ SD_RS_DTCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1585 SD_RS_VSIM: 8 VSIM
+ SG_ SD_RS_VSIM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1739 APPL_ECU_DTCM: 8 DIAGNOST
+ SG_ APPL_ECU_DTCM : 7|64@0+ (1,0) [0|0] "" DTCM
+
+BO_ 1777 APPL_ECU_VSIM: 8 DIAGNOST
+ SG_ APPL_ECU_VSIM : 7|64@0+ (1,0) [0|0] "" VSIM
+
+BO_ 1867 D_RQ_DTCM: 8 DIAGNOST
+ SG_ D_RQ_DTCM : 7|64@0+ (1,0) [0|0] "" DTCM
+
+BO_ 1905 D_RQ_VSIM: 8 DIAGNOST
+ SG_ D_RQ_VSIM : 7|64@0+ (1,0) [0|0] "" VSIM
+
+BO_ 806 AFLS_A1: 2 AFLS
+ SG_ AFLS_ENBL : 0|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ AFLS_Stat : 1|2@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 1256 D_RS_AFLS: 8 AFLS
+ SG_ D_RS_AFLS : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1448 ECU_APPL_AFLS: 8 AFLS
+ SG_ ECU_APPL_AFLS : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1768 APPL_ECU_AFLS: 8 DIAGNOST
+ SG_ APPL_ECU_AFLS : 7|64@0+ (1,0) [0|0] "" AFLS
+
+BO_ 1896 D_RQ_AFLS: 8 DIAGNOST
+ SG_ D_RQ_AFLS : 7|64@0+ (1,0) [0|0] "" AFLS
+
+BO_ 530 ECM_DIESEL: 8 ECM
+ SG_ Adblue_FL_LVL : 40|8@1+ (1,0) [0|100] "%" FTM,SGW,VSIM,IC,ETM
+ SG_ Adblue_Stat : 32|6@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ AdblueRemainDist : 55|16@0+ (1,0) [0|65534] "" SGW,IC
+ SG_ DEF_LOW : 0|2@1+ (1,0) [0|0] "" FTM,SGW,IC
+ SG_ ECM_HMI_Timer_RQ : 16|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ EngChmRq : 15|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PFW_Stat : 4|4@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ PrcntCplt : 8|4@1+ (10,0) [0|100] "%" FTM,SGW,IC
+ SG_ PreHtIndLmp_On_Rq : 19|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+ SG_ PTC_REL1_RQ : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTC_REL2_RQ : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ PTC_REL3_RQ : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ RemainDistUnt : 38|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ WtrFuelIndLmp_On_Rq : 30|1@1+ (1,0) [0|0] "" FTM,SGW,IC,ETM
+
+BO_ 625 DAS_A5: 8 IRCM
+ SG_ DsrSpeed_KPH : 24|8@1+ (1,0) [0|250] "km/h" SGW,PCM,TCM
+ SG_ FCWSetting : 3|2@1+ (1,0) [0|0] "" SGW,ORC,IC,CBC
+ SG_ FCWState : 2|1@1+ (1,0) [0|0] "" SGW,ORC,IC,CBC
+
+BO_ 671 PTS_StrCtrl: 8 PTS
+ SG_ CRC_29Fh : 56|8@1+ (1,0) [0|0] "" SGW
+ SG_ MC_29Fh : 52|4@1+ (1,0) [0|15] "" SGW
+
+BO_ 684 CBC_PT10: 8 CBC
+ SG_ INV_CARGO_OnState : 51|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ GateOnOffSts : 49|2@1+ (1,0) [0|0] "" SGW
+ SG_ SM_Rear_Guidance_Lgt : 20|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Snow_Plow_Presence : 53|1@1+ (1,0) [0|0] "" IRCM,SGW,PTS,IC
+ SG_ RR_DR_UNLKD : 18|1@1+ (1,0) [0|0] "" SGW,VSIM
+
+BO_ 705 GW_LIN_I_C5: 8 CBC
+ SG_ VEH_INT_TEMP : 31|16@0+ (0.01,-40) [-40|85] "°C" SGW
+ SG_ SwayBarBtnRq : 14|2@1+ (1,0) [0|0] "" SGW,FDCM
+
+BO_ 709 EcuCfg16: 8 CBC
+ SG_ EC_AudTel3B : 15|56@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_ECUCfg16_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_AudTel3A : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 710 EcuCfg17: 8 CBC
+ SG_ EC_ECUCfg17_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,PTS
+ SG_ EC_PTS : 56|8@1+ (1,0) [0|0] "" SGW,RF_HUB,PTS
+ SG_ EC_SeatsB : 15|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_SeatsA : 2|6@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_HVAC2 : 32|8@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_HVAC1 : 24|8@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ EC_CBC17 : 47|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 714 EcuBuCfg16: 8 RF_HUB
+ SG_ EC_BU_AudTel3B : 15|56@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_ECUCfg16_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_AudTel3A : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 715 EcuBuCfg17: 8 RF_HUB
+ SG_ EC_BU_ECUCfg17_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_PTS : 56|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_SeatsB : 15|16@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_SeatsA : 2|6@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_HVAC2 : 32|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_HVAC1 : 24|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EC_BU_CBC17 : 47|16@0+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 773 TPM_A2: 8 RF_HUB
+ SG_ Tire_FL : 8|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ Tire_FR : 10|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ Tire_RL : 14|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ Tire_RR : 12|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ Tire_Spr : 16|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TirePrssFL : 24|8@1+ (1,0) [0|126] "psi" FTM,SGW,ORC,IC,ETM
+ SG_ TirePrssFR : 32|8@1+ (1,0) [0|126] "psi" FTM,SGW,ORC,IC,ETM
+ SG_ TirePrssRL : 40|8@1+ (1,0) [0|126] "psi" FTM,SGW,ORC,IC,ETM
+ SG_ TirePrssRR : 48|8@1+ (1,0) [0|126] "psi" FTM,SGW,ORC,IC,ETM
+ SG_ TirePrssSpr : 56|8@1+ (1,0) [0|126] "psi" SGW,IC,ETM
+ SG_ TPM_ChimeRq : 2|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TPM_IndLmpOnRq : 0|2@1+ (1,0) [0|0] "" FTM,SGW,ORC,IC,ETM
+ SG_ TPM_SysStat : 5|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TPMHornChirp : 19|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TPMHazardFlash : 21|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+
+BO_ 778 ECM_DIESEL2: 8 ECM
+ SG_ TrboBstPress : 48|8@1+ (1,0) [0|250] "kPaG" SGW,IC
+ SG_ EngBrkStat : 33|2@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ WTS_CntDnTmr : 0|8@1+ (1,0) [0|254] "sec" SGW,IC
+ SG_ Man_PFW_Stat : 12|4@1+ (1,0) [0|0] "" SGW,IC
+ SG_ IdleShutDwnAppl : 30|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ EngDerate : 35|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ EB_Stat3 : 21|3@1+ (1,0) [0|0] "" FTM,SGW,IC,CBC
+ SG_ EB_Pwr : 56|8@1+ (1,0) [0|250] "kW" SGW,IC
+ SG_ EB_ACC_AVLBL : 11|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ DPF_Man_Stat : 8|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ SRV_AIR_FLTR : 24|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ SRV_CCV_FLTR : 25|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ DrtdTrqMd : 28|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Rapid_Cabin_Warmup_Stat : 26|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 831 ASCM_1: 6 ASCM
+ SG_ FL_Lvl_Adj : 32|1@1+ (1,0) [0|0] "" IRCM,SGW,CBC
+ SG_ FR_Lvl_Adj : 33|1@1+ (1,0) [0|0] "" IRCM,SGW,CBC
+ SG_ LvlCalCmplt : 36|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ RL_Lvl : 16|8@1+ (1,-100) [-100|153] "mm" IRCM,SGW,IC,CBC
+ SG_ RL_Lvl_Adj : 34|1@1+ (1,0) [0|0] "" IRCM,SGW
+ SG_ RR_Lvl : 24|8@1+ (1,-100) [-100|153] "mm" IRCM,SGW,IC,CBC
+ SG_ RR_Lvl_Adj : 35|1@1+ (1,0) [0|0] "" IRCM,SGW
+
+BO_ 844 ASCM_2: 5 ASCM
+ SG_ ASCM_Exit_Rq : 30|2@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ ASCM_HMI_Stat : 8|4@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ASCM_Srv : 12|1@1+ (1,0) [0|0] "" SGW,ORC,IC,CBC
+ SG_ ASCM_Stat : 0|4@1+ (1,0) [0|0] "" FTM,IRCM,SGW,ORC,IC,ESC,CBC
+ SG_ ASCM_StatDisp : 4|4@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ASCM_SysFail : 13|1@1+ (1,0) [0|0] "" SGW,ORC,IC,CBC
+ SG_ ASCM_TJM : 14|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ ASCM_WarnOnly : 34|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ Loading_Lv : 19|3@1+ (1,0) [0|0] "" SGW,IC,ESC
+ SG_ LvlAdjStat : 35|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Tgt_Level : 16|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TM_Enbl : 37|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ WAL_Enbl : 33|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+
+BO_ 1062 NM_ASCM: 8 ASCM
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "g" _
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" A
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1254 D_RS_ASCM: 8 ASCM
+ SG_ D_RS_ASCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1446 ECU_APPL_ASCM: 8 ASCM
+ SG_ ECU_APPL_ASCM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1574 SD_RS_ASCM: 8 ASCM
+ SG_ SD_RS_ASCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1576 SD_RS_AFLS: 8 AFLS
+ SG_ SD_RS_AFLS : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1766 APPL_ECU_ASCM: 8 DIAGNOST
+ SG_ APPL_ECU_ASCM : 7|64@0+ (1,0) [0|0] "" ASCM
+
+BO_ 1894 D_RQ_ASCM: 8 DIAGNOST
+ SG_ D_RQ_ASCM : 7|64@0+ (1,0) [0|0] "" ASCM
+
+BO_ 294 ORC_YRS_DATA: 8 ORC
+ SG_ LatAcceleration : 3|12@0+ (0.02,-40.96) [-40.96|40.92] "m/s²" SGW,ETM,ESC
+ SG_ AXSStat : 4|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ AYSStat : 6|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ LongAcceleration : 19|12@0+ (0.02,-40.96) [-40.96|40.92] "m/s²" SGW,ITBM,ETM,ESC
+ SG_ YRSStat : 20|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ InternalError : 22|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ VoltageError : 23|1@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ YawRate : 35|12@0+ (0.08,-163.84) [-163.84|163.68] "°/s" SGW,ESC
+ SG_ MC_ORC_YRS_DATA : 52|4@1+ (1,0) [0|15] "" SGW,ESC
+ SG_ CRC_ORC_YRS_DATA : 56|8@1+ (1,0) [0|0] "" SGW,ESC
+
+BO_ 516 IMMO_CODE_RESPONSE: 7 CBC
+ SG_ ControlEncodingRsp : 0|8@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ MKKey1org21 : 8|8@1+ (1,0) [0|255] "" SGW,PCM,ECM
+ SG_ MKKey2org22 : 16|8@1+ (1,0) [0|255] "" SGW,PCM,ECM
+ SG_ MKKey_3 : 24|8@1+ (1,0) [0|255] "" SGW,PCM,ECM
+ SG_ MKKey_4 : 32|8@1+ (1,0) [0|255] "" SGW,PCM,ECM
+ SG_ MKKey_5 : 40|8@1+ (1,0) [0|255] "" SGW,PCM,ECM
+ SG_ MKKey_6 : 48|8@1+ (1,0) [0|255] "" SGW,PCM,ECM
+
+BO_ 517 IMMO_CODE_REQUEST: 7 ECM
+ SG_ ControlEncodingRq : 0|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ rnd_1 : 8|8@1+ (1,0) [0|255] "" SGW,CBC
+ SG_ rnd_2 : 16|8@1+ (1,0) [0|255] "" SGW,CBC
+ SG_ rnd_3 : 24|8@1+ (1,0) [0|255] "" SGW,CBC
+ SG_ rnd_4 : 32|8@1+ (1,0) [0|255] "" SGW,CBC
+ SG_ f1_1 : 40|8@1+ (1,0) [0|255] "" SGW,CBC
+ SG_ f1_2 : 48|8@1+ (1,0) [0|255] "" SGW,CBC
+
+BO_ 524 BCM_CODE_TRM_REQUEST: 8 CBC
+ SG_ ControlEncodingBCM : 0|8@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ MiniCryptFCode : 15|16@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ MiniCrypt_Rnd : 31|32@0+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ TxpReadRequest : 62|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ TxpAuthRequest : 63|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 525 BCM_MINICRYPT_ACK: 1 CBC
+ SG_ MinicryptReceptionSts : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 526 TRM_CODE_RESPONSE: 6 RF_HUB
+ SG_ MiniCryptGCode : 15|16@0+ (1,0) [0|0] "" SGW,CBC
+ SG_ ControlEncoding : 0|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ CodeCheckSts : 24|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ProgrammedSts : 26|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TxpID : 27|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TxpFound : 31|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 527 TRM_MKP_KEY: 8 RF_HUB
+ SG_ FrameNumber : 0|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TotalFrameNumber : 4|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA1 : 8|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA2 : 16|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA3 : 24|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA4 : 32|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA5 : 40|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA6 : 48|8@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DATA7 : 56|8@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 542 ORC_YRS_INFO: 8 ORC
+ SG_ BlockOffset : 0|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ PTRInfo : 8|4@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ CLUType : 12|4@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Character5 : 16|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Character4 : 24|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Character3 : 32|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Character2 : 40|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Character1 : 48|8@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ Character0 : 56|8@1+ (1,0) [0|0] "" SGW,ESC
+
+BO_ 669 EPB_A1: 3 ESC
+ SG_ MC_EPB_A1 : 12|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,TCM,PTS,ECM
+ SG_ CRC_EPB_A1 : 16|8@1+ (1,0) [0|0] "" IRCM,SGW,PCM,TCM,PTS,ECM
+
+BO_ 770 EPB_1: 8 ESC
+ SG_ MC_EPB_1 : 52|4@1+ (1,0) [0|15] "" IRCM,SGW,IC
+ SG_ CRC_EPB_1 : 56|8@1+ (1,0) [0|0] "" IRCM,SGW,IC
+
+BO_ 782 IC_A5: 8 IC
+ SG_ Gas_Range : 1|10@0+ (1,0) [0|1022] "km" FTM,SGW,ETM
+ SG_ EngHour : 39|16@0+ (1,0) [0|65535] "Hours" SGW,VSIM
+ SG_ CFG_Manual_DPF : 3|2@1+ (1,0) [0|0] "" SGW,ECM
+
+BO_ 938 IC_TripData_1: 8 IC
+ SG_ A_MPG : 1|10@0+ (0.1,0) [0|99.9] "MPG" FTM,SGW,ETM
+
+BO_ 939 IC_TripData_2: 8 IC
+ SG_ A_KMpL : 1|10@0+ (0.1,0) [0|99.9] "kmpl" FTM,SGW,ETM
+
+BO_ 940 IC_TripData_3: 8 IC
+ SG_ A_Total_Dist_Miles : 23|24@0+ (0.1,0) [0|9999.9] "Mile" FTM,SGW,ETM
+ SG_ A_Total_Dist_Kilometers : 47|24@0+ (0.1,0) [0|16093.3] "km" FTM,SGW,ETM
+
+BO_ 941 IC_TripData_4: 8 IC
+ SG_ B_MPG : 1|10@0+ (0.1,0) [0|99.9] "MPG" FTM,SGW,ETM
+
+BO_ 942 IC_TripData_5: 8 IC
+ SG_ B_KMpL : 1|10@0+ (0.1,0) [0|99.9] "kmpl" FTM,SGW,ETM
+
+BO_ 943 IC_TripData_6: 8 IC
+ SG_ B_Total_Dist_Miles : 23|24@0+ (0.1,0) [0|9999.9] "Mile" FTM,SGW,ETM
+ SG_ B_Total_Dist_Kilometers : 47|24@0+ (0.1,0) [0|16093.3] "km" FTM,SGW,ETM
+
+BO_ 55 TCM_EngTrq2_2: 8 TCM
+ SG_ CRC_TCM_EngTrq2_2 : 56|8@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ EngTrqRq_2 : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,ESC,ECM
+ SG_ MaxTrqDes_2 : 36|13@0+ (0.25,-500) [-500|1547.5] "Nm" SGW,ECM
+ SG_ MC_TCM_EngTrq2_2 : 52|4@1+ (1,0) [0|15] "" SGW,ECM
+ SG_ TrnsTrqReqSlow_2 : 20|13@0+ (0.25,-500) [-500|1547.5] "Nm" FTM,SGW,ETM
+ SG_ TrqCtrlModeRq_2 : 5|3@1+ (1,0) [0|0] "" SGW,ESC,ECM
+
+BO_ 1073 NM_VSIM_C: 8 VSIM
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "g" _
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" V
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 973 IPC_LMPS: 8 IC
+ SG_ WATER_IN_FUEL_STAT : 28|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TIRE_PRESSURE_STAT : 12|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ STOP_START_STAT : 20|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ SERVICE_STAT : 34|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ SERVICE_ACC_STAT : 26|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ OVER_TEMP_STAT : 18|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ OIL_TEMP_STAT : 32|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ OIL_PRESSURE_STAT : 4|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ LANE_SENSE_STAT : 42|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FOUR_WD_SERVICE_STAT : 40|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FCW_SYSTEM_STAT : 24|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ETC_CONTROL_STAT : 14|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EPS_STAT : 22|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ EPB_WARN_STAT : 46|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ENGINE_TEMP_STAT : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ENGINE_MIL_STAT : 10|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ELEC_STAB_STAT : 16|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DEF_STAT : 30|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ DAMPING_SYSTEM_STAT : 36|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BRK_IND_STAT : 6|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BRAKE_PAD_STAT : 38|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ BATTERY_CHARGE_STAT : 2|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AWD_SERVICE_STAT : 44|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ABS_IND_STAT : 8|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ WINDSHIELD_FLUID_STAT : 52|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ OIL_LEVEL_STAT : 56|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FUEL_CAP_STAT : 50|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ COOLENT_LEVEL_STAT : 54|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TORQUE_STAT : 60|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ ELECTRIC_WRENCH_STAT : 58|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ CATALYST_TEMP_STAT : 48|2@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 754 IC_A6: 8 IC
+ SG_ Inst_Fuel_Econ : 49|10@0+ (0.05,0) [0|50] "kmpl" SGW,VSIM,CBC
+ SG_ Avg_Fuel_Econ : 33|10@0+ (0.05,0) [0|50] "kmpl" SGW,CBC
+
+BO_ 910 GW_LIN_I_C6: 8 CBC
+ SG_ IBS3_TempFailStatus : 21|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ IBS3_T_BATT : 32|8@1+ (1,-40) [-40|105] "°C" FTM,SGW,PCM,ETM,ECM
+ SG_ IBS3_SOH_Q_Accuracy : 47|1@1+ (1,0) [0|0] "" SGW
+ SG_ IBS3_SOH_Q : 40|7@1+ (2,0) [0|252] "Ah" SGW
+ SG_ IBS3_SOF_VC : 56|7@1+ (0.05,5) [5|11.3] "V" SGW
+ SG_ IBS3_SOF_V_Accuracy : 63|1@1+ (1,0) [0|0] "" SGW
+ SG_ IBS3_SOF_Q_Accuracy : 22|1@1+ (1,0) [0|0] "" SGW
+ SG_ IBS3_SOF_Q : 24|8@1+ (1,0) [0|254] "Ah" SGW
+ SG_ IBS3_SOC_Accuracy : 55|1@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ IBS3_SOC : 48|7@1+ (1,0) [0|100] "%" FTM,SGW,ORC,ETM
+ SG_ IBS3_FLAG_DISCONNECT : 23|1@1+ (1,0) [0|0] "" SGW
+ SG_ Ft_RrAxleLckr_Rq : 9|2@1+ (1,0) [0|0] "" SGW,FDCM
+
+BO_ 579 GW_LIN_I_C4: 8 CBC
+ SG_ AxleLckrOFF_SW : 6|2@1+ (1,0) [0|0] "" SGW,FDCM
+ SG_ TGW_AUD_MD2_CAB_DR : 24|6@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Phone_Popup_setting_active : 55|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 1151 D_RS_SGW: 8 SGW
+ SG_ D_RS_SGW : 7|64@0+ (1,0) [0|0] "" FTM,ETM,DIAGNOST
+
+BO_ 1150 D_RQ_SGW: 8 DIAGNOST
+ SG_ D_RQ_SGW : 7|64@0+ (1,0) [0|0] "" SGW
+
+BO_ 683 CBC_PT9: 8 CBC
+ SG_ VoltBattFailStatus : 36|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ RsErrIBS3 : 38|1@1+ (1,0) [0|0] "" SGW
+ SG_ IBS3_Vbatt : 32|9@0+ (0.025,5) [5|17.75] "V" FTM,SGW,PCM,ORC,ETM,ECM,ASCM
+ SG_ IBS3_Ibatt : 23|16@0+ (0.02,-1000) [-1000|310.68] "A" FTM,SGW,ETM
+ SG_ IBS3_Error_Internal : 37|1@1+ (1,0) [0|0] "" SGW
+ SG_ CurrBattFailStatus : 35|1@1+ (1,0) [0|0] "" SGW
+
+BO_ 685 CBC_CFG2: 8 CBC
+ SG_ Cfg_Aux_PTO : 16|3@1+ (1,0) [0|0] "" SGW
+ SG_ CBC_AUX4_Type : 3|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX4_PWRMD : 8|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX4_HLEnbl : 13|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX3_Type : 2|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX3_PWRMD : 7|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX3_HLEnbl : 12|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX2_Type : 1|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX2_PWRMD : 6|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX2_HLEnbl : 11|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX1_Type : 0|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX1_PWRMD : 5|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX1_HLEnbl : 10|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX5_Type : 4|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX5_PWRMD : 9|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX5_HLEnbl : 14|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX6_Type : 39|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX6_PWRMD : 23|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CBC_AUX6_HLEnbl : 38|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 881 ASBS_1: 8 FDCM
+ SG_ SwayBarEVICDisplay : 4|4@1+ (1,0) [0|0] "" SGW,IC
+ SG_ SwayBar_Sts : 0|2@1+ (1,0) [0|0] "" SGW
+ SG_ SwayBar_LEDRq : 8|2@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 739 ECM_CNG1: 8 ECM
+ SG_ CNG_GaLvl : 0|8@1+ (1,0) [0|100] "%" SGW,ETM
+ SG_ CNG_LO : 8|1@1+ (1,0) [0|0] "" SGW,ETM
+ SG_ EngRunFuelTyp : 9|3@1+ (1,0) [0|0] "" SGW,ETM
+
+BO_ 570 SCCM_CRS_CTRL: 3 SCCM
+ SG_ AUS : 0|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ESC,ECM
+ SG_ WA : 1|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ECM
+ SG_ S_PLUS_B : 2|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,VSIM,ESC,ECM
+ SG_ S_MINUS_B : 3|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,VSIM,ESC,ECM
+ SG_ WH_UP : 5|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ESC,ECM
+ SG_ CRUISE_TGL : 6|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,VSIM,ESC,ECM
+ SG_ ACC_MODE : 7|1@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ESC,ECM
+ SG_ MC_SCCM_CRS_CTRL : 12|4@1+ (1,0) [0|15] "" IRCM,SGW,PCM,ESC,ECM
+ SG_ CRC_SCCM_CRS_CTRL : 16|8@1+ (1,0) [0|0] "" IRCM,SGW,PCM,ESC,ECM
+
+BO_ 914 VSIM_C1: 8 VSIM
+ SG_ PTO_IdleSpd1 : 0|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ PTO_IdleSpd2 : 1|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ PTO_IdleSpd3 : 2|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ PosEngdSwStat : 3|1@1+ (1,0) [0|0] "" SGW,TCM,ECM
+ SG_ MC_VSIM_C1 : 52|4@1+ (1,0) [0|15] "" SGW,PCM,TCM,ECM
+ SG_ CRC_VSIM_C1 : 56|8@1+ (1,0) [0|0] "" SGW,PCM,TCM,ECM
+ SG_ IdleShutDown_Disable : 6|1@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ VSIMEngineOffRequest : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ J1939_RPM_RQ : 31|16@0+ (1,0) [0|0] "" SGW,ECM
+
+BO_ 676 ECM_B11: 8 ECM
+ SG_ MAP_4_Bar : 0|9@0+ (0.8,0) [0|408] "kPa" FTM,SGW,ORC,ETM
+ SG_ ECM_WARN_EXT : 24|5@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TransWarmup_Min_RPM : 32|8@1+ (25,0) [0|6350] "rpm" SGW,TCM
+ SG_ TransWarmup_Enbl_Rq : 20|1@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ MC_ECM_B11 : 52|4@1+ (1,0) [0|15] "" SGW,TCM
+ SG_ CRC_ECM_B11 : 56|8@1+ (1,0) [0|0] "" SGW,TCM
+
+BO_ 2047 WAKE_SGW: 1 SGW
+ SG_ WAKE_SGW_Signal : 0|8@1+ (1,0) [0|0] "" Vector__XXX
+
+BO_ 963 VehCfgCSM3_BU: 8 RF_HUB
+ SG_ VC_BU_VehCfgCSO3_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TIRE_FILL_ALERT_CSO : 60|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_POWER_SIDE_STEP_CSO : 61|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TRAILER_LENGTH_BLIND_SPOT_ : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TSI_CSO : 59|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TRUNK_UNLOCK_ENABLE_CSO : 55|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SPEED_THRESHOLD_CSO : 52|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SEIU_RPM_CSO : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SEIU_INPUT_WIRE_CSO : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RVC_CVPM_SGRID_CSO : 50|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RVC_CVPM_DGRID_CSO : 49|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RR_CARGO_GUIDE_LGT_CSO : 3|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PEB_CSO : 51|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LKA_WARNING_CSO : 56|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LKA_STRN_CSO : 58|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LKA_SENS_CSO : 57|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FFC_GRIDLINES_CSO : 48|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_EXTERNAL_LIGHT_SENSOR_CSO : 53|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BUZZER_VOLUME_LEVEL_CSO : 54|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BACKUP_ALARM_CSO : 2|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AUTO_STOP_START_CSO : 63|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AL_OR_PLUS_CSO : 41|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AL_FFC_OR_PLUS_CSO : 40|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TSR_WARNING_MODE_CSO : 42|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_RR_PK_LOOSE_SHIP_CSO : 9|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HWRSS_CSO : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_FT_PK_LOOSE_SHIP_CSO : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CHMSL_DYN_CNTR_CSO : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TSR_WARNING_MODE_OFFSET_CS : 43|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 962 VehCfgCSM3: 8 CBC
+ SG_ VC_VehCfgCSO3_Stat : 0|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TRAILER_LENGTH_BLIND_SPOT_CSO : 62|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TIRE_FILL_ALERT_CSO : 60|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_POWER_SIDE_STEP_CSO : 61|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TSI_CSO : 59|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TRUNK_UNLOCK_ENABLE_CSO : 55|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SPEED_THRESHOLD_CSO : 52|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SEIU_RPM_CSO : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_SEIU_INPUT_WIRE_CSO : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_RVC_CVPM_SGRID_CSO : 50|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RVC_CVPM_DGRID_CSO : 49|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RR_CARGO_GUIDE_LGT_CSO : 3|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_PEB_CSO : 51|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LKA_WARNING_CSO : 56|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LKA_STRN_CSO : 58|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LKA_SENS_CSO : 57|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_FFC_GRIDLINES_CSO : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_EXTERNAL_LIGHT_SENSOR_CSO : 53|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BUZZER_VOLUME_LEVEL_CSO : 54|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BACKUP_ALARM_CSO : 2|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_AUTO_STOP_START_CSO : 63|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AL_OR_PLUS_CSO : 41|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AL_FFC_OR_PLUS_CSO : 40|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TSR_WARNING_MODE_OFFSET_CSO : 43|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TSR_WARNING_MODE_CSO : 42|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_RR_PK_LOOSE_SHIP_CSO : 9|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HWRSS_CSO : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_FT_PK_LOOSE_SHIP_CSO : 8|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_CHMSL_DYN_CNTR_CSO : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 907 VehCfgBu8: 8 RF_HUB
+ SG_ VC_BU_VehCfg8_Stat : 0|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Steering_Cfactor : 2|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Trans_Brake_PRSNT : 8|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_LineLock_PRSNT : 4|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_HighOctane_PRSNT : 7|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_CHILLER_PRSNT : 6|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_ARC_PRSNT : 5|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Speedometer_Tolerance : 9|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Increasing_Speed_Constant : 13|3@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_WHL_BASE_LENGTH : 56|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_OHC_TYPE : 60|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_SBL_FBL_CORNERING_PRSNT : 17|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PPPAHardBtn : 24|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_PEB_PRSNT : 62|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_OFFroad_Camera : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_OFFRoadModePrsnt : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_DBL_PRSNT : 20|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_BEAM_SHAPING_PRSNT : 19|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_AVAC_PRSNT : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_OvertakingBan : 16|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TrailerTPM_Prsnt : 52|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TFA_Prsnt : 51|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_TACHO_TYPE : 54|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_STFA_Prsnt : 53|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_MARKET_HEADLAMP : 49|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Dgtl_CHMSL_Cam_Prsnt : 25|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_WRSS_Prsnt : 29|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Trlr_Rev_Guidance_Prsnt : 48|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Box_Delete : 30|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ VC_BU_Aux_Trailer_Cam_Prsnt : 40|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 906 VehCfg8: 8 CBC
+ SG_ VC_VehCfg8_Stat : 0|2@1+ (1,0) [0|0] "" ATMM,IRCM,SGW,PCM,RF_HUB,PTS,IC,ESC,ECM,AFLS
+ SG_ VC_Steering_Cfactor : 2|2@1+ (1,0) [0|0] "" IRCM,SGW,RF_HUB,AFLS
+ SG_ VC_Trans_Brake_PRSNT : 8|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_LineLock_PRSNT : 4|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_HighOctane_PRSNT : 7|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_CHILLER_PRSNT : 6|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_ARC_PRSNT : 5|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Speedometer_Tolerance : 9|4@1+ (1,0) [0|0] "" IRCM,SGW,PCM,RF_HUB,IC,ECM
+ SG_ VC_Increasing_Speed_Constant : 13|3@1+ (1,0) [0|0] "" IRCM,SGW,PCM,RF_HUB,IC,ECM
+ SG_ VC_WHL_BASE_LENGTH : 56|4@1+ (1,0) [0|0] "" ATMM,IRCM,SGW,RF_HUB,PTS,AFLS
+ SG_ VC_OHC_TYPE : 60|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_SBL_FBL_CORNERING_PRSNT : 17|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PPPAHardBtn : 24|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_PEB_PRSNT : 62|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_OvertakingBan : 16|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_OFFroad_Camera : 23|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_OFFRoadModePrsnt : 22|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_DBL_PRSNT : 20|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_BEAM_SHAPING_PRSNT : 19|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_AVAC_PRSNT : 21|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TrailerTPM_Prsnt : 52|1@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ VC_TFA_Prsnt : 51|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_TACHO_TYPE : 54|2@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,IC,ECM
+ SG_ VC_STFA_Prsnt : 53|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_MARKET_HEADLAMP : 49|2@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Dgtl_CHMSL_Cam_Prsnt : 25|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_WRSS_Prsnt : 29|1@1+ (1,0) [0|0] "" SGW,PCM,RF_HUB,ECM
+ SG_ VC_Trlr_Rev_Guidance_Prsnt : 48|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Box_Delete : 30|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+ SG_ VC_Aux_Trailer_Cam_Prsnt : 40|1@1+ (1,0) [0|0] "" SGW,RF_HUB
+
+BO_ 1556 SD_RS_ITBM: 8 ITBM
+ SG_ SD_RS_ITBM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1590 SD_RS_ATMM: 8 ATMM
+ SG_ SD_RS_ATMM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 687 ITBM_A2: 8 ITBM
+ SG_ TrlrTripDist : 15|24@0+ (0.1,0) [0|1677720] "km" SGW,IC
+ SG_ TrlrStyle_4 : 56|5@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TrlrStyle_3 : 48|5@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TrlrStyle_2 : 40|5@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TrlrStyle_1 : 32|5@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ SelTrlrStyle : 3|5@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ SelTrlrNum : 0|3@1+ (1,0) [0|0] "" SGW,IC,CBC
+
+BO_ 1428 ECU_APPL_ITBM: 8 ITBM
+ SG_ ECU_APPL_ITBM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1462 ECU_APPL_ATMM: 8 ATMM
+ SG_ ECU_APPL_ATMM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 629 DAS_A6: 8 IRCM
+ SG_ IRCM_AHB_On : 47|1@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1236 D_RS_ITBM: 8 ITBM
+ SG_ D_RS_ITBM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1270 D_RS_ATMM: 8 ATMM
+ SG_ D_RS_ATMM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1876 D_RQ_ITBM: 8 DIAGNOST
+ SG_ D_RQ_ITBM : 7|64@0+ (1,0) [0|0] "" ITBM
+
+BO_ 1910 D_RQ_ATMM: 8 DIAGNOST
+ SG_ D_RQ_ATMM : 7|64@0+ (1,0) [0|0] "" ATMM
+
+BO_ 875 ATMM_1: 2 ATMM
+ SG_ ATMM_PopUpRqst : 6|2@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 1748 APPL_ECU_ITBM: 8 DIAGNOST
+ SG_ APPL_ECU_ITBM : 7|64@0+ (1,0) [0|0] "" ITBM
+
+BO_ 1782 APPL_ECU_ATMM: 8 DIAGNOST
+ SG_ APPL_ECU_ATMM : 7|64@0+ (1,0) [0|0] "" ATMM
+
+BO_ 924 RFHUB_A3: 8 RF_HUB
+ SG_ MsgFobBattLow : 0|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ MsgFobNotFnd : 4|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ MsgNotInPark : 6|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ MsgKG1 : 12|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ FOB_SrchRslt : 16|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FOB_SrchFLT : 18|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FOBinTRUNK : 19|1@1+ (1,0) [0|0] "" SGW
+ SG_ FOBinINT : 20|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FOB_ExtRT : 21|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FOB_ExtLT : 22|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ FOB_ExtRR : 23|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ MsgKG2 : 14|2@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 818 HVAC_INFO: 8 CBC
+ SG_ A2D_DRV_TEMP_DR_POS : 1|10@0+ (0.00489237,0) [0|5] "V" SGW,PCM,ECM
+ SG_ Blower_Speed : 32|9@0+ (1,0) [0|350] "Hz" SGW,PCM,ECM
+ SG_ Blower_Diagnostics : 49|10@0+ (0.1,0) [0|100] "%" SGW,PCM,ECM
+
+BO_ 650 GW_I_C2: 8 CBC
+ SG_ Radio_Theme : 48|8@1+ (1,0) [0|0] "" SGW,IC
+ SG_ CSOPSSAutoStowSts : 58|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 181 ECM_ENG_TRQ2: 8 ECM
+ SG_ TrqRq_SlowFast : 2|11@0+ (1,-500) [-500|1546] "Nm" SGW,TCM
+ SG_ EngRPM_Tach : 23|16@0+ (1,0) [0|65534] "RPM" SGW,IC
+ SG_ CRC_ECM_ENG_TRQ2 : 56|8@1+ (1,0) [0|0] "" SGW,TCM
+ SG_ MC_ECM_ENG_TRQ2 : 52|4@1+ (1,0) [0|15] "" SGW,TCM
+
+BO_ 179 TCM_ENG_SPD: 8 TCM
+ SG_ TargetTime : 1|10@0+ (10,0) [0|10230] "ms" SGW,ECM
+ SG_ MC_TCM_ENG_SPD : 52|4@1+ (1,0) [0|15] "" SGW,ECM
+ SG_ CRC_TCM_ENG_SPD : 56|8@1+ (1,0) [0|0] "" SGW,ECM
+ SG_ TransLosses : 33|10@0+ (1,-500) [-500|500] "Nm" SGW,ECM
+ SG_ OutputSpeed_2 : 23|16@0+ (1,0) [0|65534] "rpm" SGW,ECM
+
+BO_ 774 TPM_A3: 4 RF_HUB
+ SG_ Tire_RR2 : 0|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Tire_RL2 : 2|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TirePrssRR2 : 16|8@1+ (1,0) [0|126] "psi" SGW,ORC,IC,ETM
+ SG_ TirePrssRL2 : 8|8@1+ (1,0) [0|126] "psi" SGW,ORC,IC,ETM
+
+BO_ 960 TCM_500: 4 TCM
+ SG_ TrqC_Temp : 0|8@1+ (1,-50) [-50|204] "°C" SGW,ECM
+
+BO_ 1548 SD_RS_FDCM: 8 FDCM
+ SG_ SD_RS_FDCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 302 Radio_A4: 8 CBC
+ SG_ STFARrAlertPress : 8|8@1+ (1,0) [0|126] "psi" SGW,RF_HUB
+ SG_ STFAFtAlertPress : 0|8@1+ (1,0) [0|126] "psi" SGW,RF_HUB
+ SG_ TrlTPMSetPress : 32|8@1+ (1,0) [0|254] "" TTPM,SGW
+ SG_ Stop_TPM_Programming : 41|1@1+ (1,0) [0|0] "" TTPM,SGW
+ SG_ Start_TPM_Programming : 40|1@1+ (1,0) [0|0] "" TTPM,SGW
+ SG_ SelectedTPMTrailer_Number : 21|3@1+ (1,0) [0|0] "" TTPM,SGW
+ SG_ Program_Single_TPM : 27|4@1+ (1,0) [0|0] "" TTPM,SGW
+ SG_ Number_of_Trl_Tires : 18|3@1+ (1,0) [0|0] "" TTPM,SGW
+ SG_ Number_of_Trl_Axles : 42|3@1+ (1,0) [0|0] "" TTPM,SGW
+ SG_ Clear_Trailer_TPM_Settings : 24|3@1+ (1,0) [0|0] "" TTPM,SGW
+
+BO_ 903 ITBM_A1: 5 ITBM
+ SG_ ITBM_WarnRq : 4|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ ITBM_TrlrStat : 0|2@1+ (1,0) [0|0] "" FTM,IRCM,SGW,PCM,PTS,IC,ECM,CBC
+ SG_ ITBM_OP_PWR : 8|8@1+ (0.5,0) [0|100] "%" SGW,ORC,IC
+ SG_ ITBM_GAIN_STAT : 19|5@1+ (0.5,0) [0|10] "" FTM,IRCM,SGW,ORC,IC
+ SG_ ITBM_DSP_RQ : 28|4@1+ (1,0) [0|0] "" SGW,PCM,ORC,IC,ECM
+ SG_ ITBM_BrkStyle : 2|2@1+ (1,0) [0|0] "" FTM,IRCM,SGW,ORC,IC,CBC
+ SG_ ITBM_BRK_SW : 16|2@1+ (1,0) [0|0] "" IRCM,SGW,IC,ETM,CBC
+ SG_ ITBM_CHM_RQ : 18|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 1420 ECU_APPL_FDCM: 8 FDCM
+ SG_ ECU_APPL_FDCM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 341 ECM_B12: 8 ECM
+ SG_ SEIU_Sts : 32|4@1+ (1,0) [0|0] "" SGW,IC
+ SG_ SEIU_RPM : 8|8@1+ (25,600) [600|6950] "rpm" SGW,IC
+ SG_ SEIU_Enbl : 3|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTO_Target_Gear : 29|3@1+ (1,0) [0|0] "" SGW,TCM,IC
+ SG_ PTO_Remote_RPM_Method : 37|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTO_Ramp_Rate : 24|5@1+ (1,0) [0|0] "rpm" SGW,IC
+ SG_ PTO_Park_Brk_Required : 5|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTO_High_Idle_RPM : 16|8@1+ (25,600) [600|6950] "rpm" SGW,IC
+ SG_ PTO_High_Idle_Enable : 2|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ PTO_Active : 6|2@1+ (1,0) [0|0] "" IRCM,SGW,VSIM,CBC
+ SG_ PTO_Acc_Intlk : 1|1@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 1271 D_RS_VGT: 8 ECM
+ SG_ D_RS_VGT : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM
+
+BO_ 1228 D_RS_FDCM: 8 FDCM
+ SG_ D_RS_FDCM : 7|64@0+ (1,0) [0|0] "" FTM,SGW,ETM,DIAGNOST
+
+BO_ 1911 D_RQ_VGT: 8 SGW
+ SG_ D_RQ_VGT : 7|64@0+ (1,0) [0|0] "" PCM,ECM
+
+BO_ 1868 D_RQ_FDCM: 8 DIAGNOST
+ SG_ D_RQ_FDCM : 7|64@0+ (1,0) [0|0] "" FDCM
+
+BO_ 564 CBC_PT7: 8 CBC
+ SG_ AM_ECM_Trace : 22|2@1+ (1,0) [0|0] "" SGW,PCM,ECM
+
+BO_ 664 ASCM_3: 8 ASCM
+ SG_ BDL_Enbl : 4|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ ASCM_HMI_Stat2 : 0|4@1+ (1,0) [0|0] "" SGW
+
+BO_ 1740 APPL_ECU_FDCM: 8 DIAGNOST
+ SG_ APPL_ECU_FDCM : 7|64@0+ (1,0) [0|0] "" FDCM
+
+BO_ 703 ECM_B7: 8 ECM
+ SG_ DrvAway_Alert : 7|1@1+ (1,0) [0|0] "" SGW,ORC,IC
+ SG_ DrvAway_Inhibit : 15|1@1+ (1,0) [0|0] "" SGW,PTS,IC
+
+BO_ 811 FDCM_1: 6 FDCM
+ SG_ AxlLckrSts : 4|2@1+ (1,0) [0|0] "" SGW,ESC
+ SG_ AxleLockerEVICDisplay : 8|4@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RrAxleLockerIndRq : 20|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ Ft_RrAxleLockerIndRq : 18|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AxleUnlockIndRq : 16|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ AXLE_LCKR_SRV_RQ : 38|2@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 560 HVAC_A2: 8 CBC
+ SG_ AC_RQ : 0|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ AC_SEL : 1|1@1+ (1,0) [0|0] "" SGW,PCM,VSIM,ECM
+ SG_ DEFROST_SEL : 2|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ AC_PT_Demand : 5|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ EVAP_TEMP : 8|8@1+ (0.5,-20) [-20|107] "°C" SGW,PCM,ECM
+ SG_ EvapTempTar : 16|8@1+ (0.5,-20) [-20|107] "°C" SGW,PCM,ECM
+ SG_ PTC_Enbl : 3|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+
+BO_ 821 TPM_A6: 8 TTPM
+ SG_ TrlTPM_ServiceReq : 14|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTPMSetPress_TTPM : 0|8@1+ (1,0) [0|254] "psi" SGW,IC
+ SG_ Trailer_Sensor_Mismatch : 27|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Trailer_Not_Configured : 30|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ Trailer_Configured : 15|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ TPM_Programming_Complete : 13|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TPM_Prog_Not_Complete : 12|1@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TPMTrailer_Number : 16|3@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ TPMSensor_Programmed : 8|4@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ TPMLearnHornChirp : 22|2@1+ (1,0) [0|0] "" SGW,CBC
+ SG_ Number_of_Trl_Tires_TTPM : 19|3@1+ (1,0) [0|0] "" SGW,IC
+ SG_ Number_of_Trl_Axles_TTPM : 24|3@1+ (1,0) [0|0] "" SGW,IC
+
+BO_ 813 TPM_A5: 8 TTPM
+ SG_ TrlTire9_Stat : 12|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire8_Stat : 10|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire7_Stat : 8|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire12_Stat : 2|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire11_Stat : 0|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire10_Stat : 14|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrailerTirePress9 : 40|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress8 : 48|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress7 : 56|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress12 : 16|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress11 : 24|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress10 : 32|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+
+BO_ 812 TPM_A4: 8 TTPM
+ SG_ TrlTire6_Stat : 2|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire5_Stat : 0|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire4_Stat : 14|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire3_Stat : 12|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire2_Stat : 10|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrlTire1_Stat : 8|2@1+ (1,0) [0|0] "" SGW,IC
+ SG_ TrailerTirePress6 : 16|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress5 : 24|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress4 : 32|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress3 : 40|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress2 : 48|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+ SG_ TrailerTirePress1 : 56|8@1+ (1,0) [0|254] "psi" SGW,ORC,IC
+
+BO_ 1560 SD_RS_TTPM: 8 TTPM
+ SG_ SD_RS_TTPM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 388 RFHUB_A1: 8 RF_HUB
+ SG_ CustKeyInIgn : 0|2@1+ (1,0) [0|0] "" SGW,ETM,CBC
+ SG_ IgnPos : 2|3@1+ (1,0) [0|0] "" SGW,ETM,CBC
+ SG_ ValImmKey : 5|2@1+ (1,0) [0|0] "" SGW
+ SG_ WRSS_ENABLE : 7|1@1+ (1,0) [0|0] "" SGW,IC
+ SG_ RFHUBEngineOffRequest : 48|1@1+ (1,0) [0|0] "" SGW,IC,CBC
+ SG_ MC_RFHUB_A1 : 52|4@1+ (1,0) [0|15] "" SGW,CBC
+ SG_ CRC_RFHUB_A1 : 56|8@1+ (1,0) [0|0] "" SGW,CBC
+
+BO_ 1048 NM_TTPM: 8 TTPM
+ SG_ NM_Mode : 0|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Successor : 8|8@1+ (1,0) [0|63] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Ud_Launch : 16|6@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ack : 22|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ NM_Sleep_Ind : 23|1@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+ SG_ N : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "2" 4
+ SG_ A : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "g" _
+ SG_ W : NaN|NaN@0+ (NaN,NaN) [NaN|NaN] "_" T
+ SG_ Nw_Id : 56|8@1+ (1,0) [0|0] "" TTPM,SGW,VSIM,SCCM,RF_HUB,IC,ESM,ESC,CBC,ASCM
+
+BO_ 1432 ECU_APPL_TTPM: 8 TTPM
+ SG_ ECU_APPL_TTPM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1240 D_RS_TTPM: 8 TTPM
+ SG_ D_RS_TTPM : 7|64@0+ (1,0) [0|0] "" SGW,DIAGNOST
+
+BO_ 1880 D_RQ_TTPM: 8 DIAGNOST
+ SG_ D_RQ_TTPM : 7|64@0+ (1,0) [0|0] "" TTPM
+
+BO_ 1874 D_RQ_DCU: 8 DIAGNOST
+ SG_ D_RQ_DCU : 7|64@0+ (1,0) [0|0] "" PCM,ECM
+
+BO_ 274 CBC_PT2: 8 CBC
+ SG_ CmdIgnStat : 0|3@1+ (1,0) [0|0] "" TTPM,ATMM,IRCM,SGW,ITBM,FDCM,PCM,VSIM,TCM,SCCM,RF_HUB,PTS,ORC,IC,ETM,ESM,ESC,ECM,DTCM,ASCM,AFLS
+ SG_ StTyp : 3|3@1+ (1,0) [0|0] "" SGW,RF_HUB,DTCM
+ SG_ RemStActv : 6|1@1+ (1,0) [0|0] "" SGW,PCM,TCM,RF_HUB,IC,ECM,DTCM
+ SG_ KeyInIgn : 8|2@1+ (1,0) [0|0] "" SGW,RF_HUB,IC
+ SG_ StartRelayBCMSts : 13|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ StartRelayBCMFault : 14|1@1+ (1,0) [0|0] "" SGW,PCM,ECM
+ SG_ OD_SW_PSD : 10|1@1+ (1,0) [0|0] "" SGW,PCM,TCM
+
+BO_ 1752 APPL_ECU_TTPM: 8 DIAGNOST
+ SG_ APPL_ECU_TTPM : 7|64@0+ (1,0) [0|0] "" TTPM
+
+BO_TX_BU_ 992 : PCM,ECM;
+BO_TX_BU_ 257 : PCM,ECM;
+BO_TX_BU_ 264 : PCM,ECM;
+BO_TX_BU_ 280 : PCM,ECM;
+BO_TX_BU_ 288 : PCM,ECM;
+BO_TX_BU_ 308 : PCM,ECM;
+BO_TX_BU_ 324 : PCM,TCM;
+BO_TX_BU_ 352 : DTCM,CBC;
+BO_TX_BU_ 368 : PCM,TCM;
+BO_TX_BU_ 376 : PCM,TCM;
+BO_TX_BU_ 384 : PCM,ECM;
+BO_TX_BU_ 416 : PCM,TCM;
+BO_TX_BU_ 559 : PCM,ECM;
+BO_TX_BU_ 632 : PCM,ECM;
+BO_TX_BU_ 672 : PCM,ECM;
+BO_TX_BU_ 680 : PCM,TCM;
+BO_TX_BU_ 698 : SGW,ETM;
+BO_TX_BU_ 760 : PCM,ECM;
+BO_TX_BU_ 761 : PCM,TCM;
+BO_TX_BU_ 764 : PCM,ECM;
+BO_TX_BU_ 766 : PCM,ECM;
+BO_TX_BU_ 779 : PCM,ECM;
+BO_TX_BU_ 810 : PCM,ECM;
+BO_TX_BU_ 850 : SGW,DIAGNOST;
+BO_TX_BU_ 863 : PCM,ECM;
+BO_TX_BU_ 864 : PCM,ECM;
+BO_TX_BU_ 872 : PCM,TCM;
+BO_TX_BU_ 880 : PCM,ECM;
+BO_TX_BU_ 888 : PCM,TCM;
+BO_TX_BU_ 896 : PCM,ECM;
+BO_TX_BU_ 904 : PCM,TCM;
+BO_TX_BU_ 912 : PCM,ECM;
+BO_TX_BU_ 920 : PCM,TCM;
+BO_TX_BU_ 928 : PCM,ECM;
+BO_TX_BU_ 936 : PCM,ECM;
+BO_TX_BU_ 944 : SGW,DIAGNOST;
+BO_TX_BU_ 945 : PCM,TCM;
+BO_TX_BU_ 946 : PCM,TCM;
+BO_TX_BU_ 993 : PCM,ECM;
+BO_TX_BU_ 1089 : SGW,DIAGNOST;
+BO_TX_BU_ 1464 : PCM,ECM;
+BO_TX_BU_ 1568 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1592 : PCM,ECM;
+BO_TX_BU_ 1728 : SGW,DIAGNOST;
+BO_TX_BU_ 1729 : SGW,DIAGNOST;
+BO_TX_BU_ 1730 : SGW,DIAGNOST;
+BO_TX_BU_ 1732 : SGW,DIAGNOST;
+BO_TX_BU_ 1735 : SGW,DIAGNOST;
+BO_TX_BU_ 1737 : SGW,DIAGNOST;
+BO_TX_BU_ 1747 : SGW,DIAGNOST;
+BO_TX_BU_ 1762 : SGW,DIAGNOST;
+BO_TX_BU_ 1763 : SGW,DIAGNOST;
+BO_TX_BU_ 1784 : SGW,DIAGNOST;
+BO_TX_BU_ 1785 : SGW,DIAGNOST;
+BO_TX_BU_ 1856 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1858 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1860 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1863 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1865 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1875 : FTM,SGW,PCM,ETM,ECM,DIAGNOST;
+BO_TX_BU_ 1890 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1891 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 2015 : SGW,DIAGNOST;
+BO_TX_BU_ 2016 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 2017 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 2024 : PCM,ECM;
+BO_TX_BU_ 2025 : PCM,TCM;
+BO_TX_BU_ 1739 : SGW,DIAGNOST;
+BO_TX_BU_ 1777 : SGW,DIAGNOST;
+BO_TX_BU_ 1867 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1905 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1768 : SGW,DIAGNOST;
+BO_TX_BU_ 1896 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 530 : PCM,ECM;
+BO_TX_BU_ 778 : PCM,ECM;
+BO_TX_BU_ 1766 : SGW,DIAGNOST;
+BO_TX_BU_ 1894 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 517 : PCM,ECM;
+BO_TX_BU_ 55 : PCM,TCM;
+BO_TX_BU_ 1150 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 676 : PCM,ECM;
+BO_TX_BU_ 1876 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1910 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1748 : SGW,DIAGNOST;
+BO_TX_BU_ 1782 : SGW,DIAGNOST;
+BO_TX_BU_ 181 : PCM,ECM;
+BO_TX_BU_ 179 : PCM,TCM;
+BO_TX_BU_ 341 : PCM,ECM;
+BO_TX_BU_ 1271 : PCM,ECM;
+BO_TX_BU_ 1911 : ETM,FTM,SGW;
+BO_TX_BU_ 1868 : FTM,SGW,ETM,DIAGNOST;
+BO_TX_BU_ 1740 : SGW,DIAGNOST;
+BO_TX_BU_ 1880 : SGW,DIAGNOST;
+BO_TX_BU_ 1874 : SGW,DIAGNOST;
+BO_TX_BU_ 1752 : SGW,DIAGNOST;
+
+
+CM_ SG_ 992 VIN_MSG "VIN Message Information";
+CM_ SG_ 992 VIN_DATA "VIN Digits (8 bit ascii encoded) - see Signal Description Doc for details";
+CM_ SG_ 257 CARB_Temp "CARB warmup criteria is true [1]";
+CM_ SG_ 257 Inp_GD_Fail "Inputs to the general denominator are in a pend or MIL fault.";
+CM_ SG_ 257 InpICC_Fail "Inputs to the Ign Cycle Cntr are in a Pend or MIL cond.";
+CM_ SG_ 257 CARB_PERM "CARB permanent fault code drive cycle";
+CM_ SG_ 257 OBD_GnrlDenCond_Stat "General denominator conditions are met [1].";
+CM_ SG_ 257 IgnCntrTrue "Ignition cycle counter is true [1]";
+CM_ SG_ 257 ENGINE_RESET "ECM Reset Notification";
+CM_ SG_ 257 ECM_SKIM_STAT "ECM Skim Status";
+CM_ SG_ 257 EngLoad_OBD "Load value for OBD (ISO 15031-5.4 PID 4)";
+CM_ SG_ 257 AccelPdlPosn_OBD "Pedal value for OBD (ISO 15031-5.4 PID 49)";
+CM_ SG_ 257 RAD_FAN1_STAT "Low speed or single radiator fan requested duty cycle";
+CM_ SG_ 258 LRW "Steering wheel angle";
+CM_ SG_ 258 LRW_PLRTY "Steering angle polarity (0=ISO 8855 Polarity and CCW = Positive)";
+CM_ SG_ 258 VLRW "Delta steering wheel angle";
+CM_ SG_ 258 LRWS_ST "Steering wheel angle sensor status";
+CM_ SG_ 258 Pad_Shft "Paddle Shift";
+CM_ SG_ 258 MC_STW_Angle_STAT "Message counter";
+CM_ SG_ 258 CRC_STW_Angle_STAT "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 264 EngRPM "Engine revolutions per minute";
+CM_ SG_ 264 EngTrqStatic "Static engine torque / Effective engine torque";
+CM_ SG_ 264 ExpEngTrq "Expected Engine Torque based on target engine speed";
+CM_ SG_ 264 MC_ECM_A1 "Message counter";
+CM_ SG_ 264 CRC_ECM_A1 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 264 ECM_LHOM_Trans "Torque Accuracy Information for Transmission";
+CM_ SG_ 268 EngTrq_Rq_ESC "Engine torque request";
+CM_ SG_ 268 DAS_Enbl_Rq "Enable DAS request; True = [1]";
+CM_ SG_ 268 EngTrqMax_Rq_ESC "Engine torque request maximum";
+CM_ SG_ 268 EngTrqMin_Rq_ESC "Engine torque request minimum";
+CM_ SG_ 268 EngTrq_Rq_As "Engine torque request";
+CM_ SG_ 268 ASRActive "Traction control is active";
+CM_ SG_ 268 EngTrqMax_Rq_AS "Engine torque request maximum; True = [1]";
+CM_ SG_ 268 BrkBstrVac "Brake Booster Vacuum Level";
+CM_ SG_ 268 PrefillActive "Brake prefill is active - True = [1]";
+CM_ SG_ 268 TrlrBrkRq "Trailor brake request percentage";
+CM_ SG_ 268 DsblFuelShutOff "Disable fuel shutoff; True = [1]";
+CM_ SG_ 268 DAS_RqActv "DAS request active";
+CM_ SG_ 268 Brk_Jrk_Rsp "Brake jerk response; True = [1]";
+CM_ SG_ 268 MC_ENG_RQ_ESC "Message counter";
+CM_ SG_ 268 CRC_ENG_RQ_ESC "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 280 EngTrqMax "Maximum engine torque";
+CM_ SG_ 280 ANL_LFT "Starter motor running (Cranking)";
+CM_ SG_ 280 Clutch_Disengg "Clutch upstop position:  Upstop=[0]; partial=[1]";
+CM_ SG_ 280 ClutchInterLk "Clutch interlock switch, clutch depressed = [0]";
+CM_ SG_ 280 EngTrqMin "Minimum engine torque";
+CM_ SG_ 280 MdsAct "MDS Active";
+CM_ SG_ 280 FullOFC_Actv "Cylinder cut-out";
+CM_ SG_ 280 CYL_CUT_POSS "Cylinder cut-out conditions fulfilled";
+CM_ SG_ 280 StartRelayBCMCmd "Engine restart request for StopStart function";
+CM_ SG_ 280 MC_ECM_ENG_TRQ "Message counter";
+CM_ SG_ 280 CRC_ECM_ENG_TRQ "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 280 MdsActforANC "MDS active for ANC; Active = [1]";
+CM_ SG_ 280 ECM_WTS_Inhbt "Wait to start inhibit";
+CM_ SG_ 284 VehSpSts "Vehicle is stopped status signal";
+CM_ SG_ 284 VEH_SPEED "Vehicle speed";
+CM_ SG_ 284 MC_VEH_SPEED "Message counter";
+CM_ SG_ 284 CRC_VEH_SPEED "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 284 BrkTrq_D "Brake torque requested by driver";
+CM_ SG_ 284 BrkTrq "Actual brake torque";
+CM_ SG_ 288 EngTrqSel_D_TTC "Corrected (substitute) driver torque demand";
+CM_ SG_ 288 EngTrq_Enbl_Rq_AS "Allow LCM torque requests";
+CM_ SG_ 288 EngTrq_Enbl_Rq_ESC "Allow ESC torque request";
+CM_ SG_ 288 EngTrq_Enbl_Rq_TCM "Allow TRANS torque request";
+CM_ SG_ 288 AccelPdlPosn "Throttle Pedal Position (Calculated)";
+CM_ SG_ 288 EngTrq_DrvReqMod "Driver requested engine torque modifed";
+CM_ SG_ 288 ECM_LHOM "Engine in limp home mode";
+CM_ SG_ 288 AccelPdlPosnSens_Flt "Accelerator pedal position sensor fault";
+CM_ SG_ 288 CRUISE_OVERRIDE "Driver is over-riding cruise set speed";
+CM_ SG_ 288 RPMOverRev "RPM Overrev condition has occurred";
+CM_ SG_ 288 LV12PwrFreeRq "Level 1 or 2 power free request - engine controller has depowered the throttle body";
+CM_ SG_ 288 MC_ECM_A2 "Message counter";
+CM_ SG_ 288 CRC_ECM_A2 "CRC-checksum byte 1 to 6 according to SAE J1850";
+CM_ SG_ 288 ESS_RqShftPark "ESS Request shift to Park.  1 = True, 0 = False";
+CM_ SG_ 290 KickDnSw_Psd "kick-down (change-over scenario open!)";
+CM_ SG_ 290 TxAC_EMCC_rq "Transmission  AC converter clutch slip request; [1] = True";
+CM_ SG_ 290 EngTrqMaxCorrFctr "Factor of reduction from max. torque";
+CM_ SG_ 290 GrMin_Rq_ECM "Target gear lower limit (ECM requested limit)";
+CM_ SG_ 290 GrMax_Rq_ECM "Target gear upper limit (ECM requested limit)";
+CM_ SG_ 290 NMOTS "Target idle speed";
+CM_ SG_ 290 EngTrq_Ack_ECM "Acknowledge TRANS torque request";
+CM_ SG_ 292 WhlPlsCnt_FL "Wheel pulse counter front left (96 per rotation)";
+CM_ SG_ 292 WhlPlsCnt_FR "Wheel pulse counter front right (96 per rotation)";
+CM_ SG_ 292 WhlPlsCnt_RL "Wheel pulse counter rear left (96 per rotation)";
+CM_ SG_ 292 WhlPlsCnt_RR "Wheel pulse counter rear right (96 per rotation)";
+CM_ SG_ 292 CENT_DIFF_ESP_RQ "ESP Requested Center  Differential State";
+CM_ SG_ 292 R_DIFF_ESP_RQ "ESP Requested Rear Differential State";
+CM_ SG_ 292 CENT_DIFF_TRQ_RQ "Desired Torque for Center Diff";
+CM_ SG_ 308 CRUISE_EGD "Cruise system is controlling speed";
+CM_ SG_ 308 CRUISE_ON "Cruise control system 'on'";
+CM_ SG_ 308 V_MAX_TM "Max. or cruise control set speed";
+CM_ SG_ 308 MAP_ENG "Intake manifold pressure, extended rangeEDR ONLY - Intake manifold pressure";
+CM_ SG_ 308 BARO_ENG "Ambient air pressure (barometric pressure)";
+CM_ SG_ 308 Rel_Thrt_ENG "Relative throttle value";
+CM_ SG_ 308 Rel_Pdl_ENG "Relative pedal value";
+CM_ SG_ 308 MC_134h "Message counter";
+CM_ SG_ 320 Brk_Stat "Brake state";
+CM_ SG_ 320 BrkPdl_Stat "Brake pedal state";
+CM_ SG_ 320 BrkPdl_Flt "Brake Pedal Fault is active, 1=Faulted";
+CM_ SG_ 320 BrkIntrvntn_Actv_ESP "Brake intervention by ESP active";
+CM_ SG_ 320 BrkIntrvntn_Actv_AS "Brake intervention by assistance system active";
+CM_ SG_ 320 BrkIntrvntn_Enbl "Brake intervention enabled";
+CM_ SG_ 320 EmgBrk_Actv "Emergency braking";
+CM_ SG_ 320 FullBrk_Actv "Maximum (hard) braking (ALS controls all wheels)";
+CM_ SG_ 320 ESP_Sys_Stat "ESP system state";
+CM_ SG_ 320 ABS_BrkEvt "Any ABS brake event";
+CM_ SG_ 320 DTR_CC_Engaged "ACC is engaged; True = [1]";
+CM_ SG_ 320 GrMin_Rq_ESC "Requested gear, lower limit";
+CM_ SG_ 320 GrMax_Rq_ESC "Requested gear, upper limit";
+CM_ SG_ 320 GrMinMax_Rq_DTR "Gear limit request from DTR";
+CM_ SG_ 320 DTR_CC_Enabled "ACC is enabled; True = [1]";
+CM_ SG_ 320 Brk_Thermdl "Brake thermal over target";
+CM_ SG_ 320 ShftChrDsp_Rq_ESC "Shift characteristic displacement request";
+CM_ SG_ 320 RollTestMd_Actv "Roller test bench mode active";
+CM_ SG_ 320 REF_VEH_SPEED "Reference vehicle actual speed";
+CM_ SG_ 320 SPCR_AS_Off_Rq "Assistance system off request";
+CM_ SG_ 320 MC_Brk_Stat "Message counter";
+CM_ SG_ 320 CRC_Brk_Stat "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 324 K_STO_B "Conf. (torque converter lock-up) clutch 'starts to open'";
+CM_ SG_ 324 EngSt_Enbl_Rq_TCM "Enable engine start request";
+CM_ SG_ 324 Gr "Current Gear";
+CM_ SG_ 324 Gr_Target "Target Gear";
+CM_ SG_ 324 K_G_B "Conf. (torque converter lock-up) clutch 'closed'";
+CM_ SG_ 324 K_O_B "Conf. (torque converter lock-up) clutch 'open'";
+CM_ SG_ 324 K_S_B "Conf. (torque converter lock-up) clutch 'slip'";
+CM_ SG_ 324 Trns_EMCC_Achvd "Trans A/C Converter Clutch Slipping; [1] = True";
+CM_ SG_ 324 OUTPUT_SPEED "Output Shaft Speed";
+CM_ SG_ 324 N_Turb "Unfiltered turbine speed (n_t_v)";
+CM_ SG_ 324 OutputSpdPolarity "Output shaft speed polarity";
+CM_ SG_ 324 TCM_TmpManMd "Transmission in temporary manual mode";
+CM_ SG_ 324 TCM_ManMd "Transmission in manual mode";
+CM_ SG_ 324 DrvRst_Hi "Drive resistance high/Grade detection";
+CM_ SG_ 324 GearSwitchActiveSts "Transmission shift in progress";
+CM_ SG_ 324 KS "Garage shift torque demand";
+CM_ SG_ 324 TRNS_SPD_MC "TRNS_SPD message counter";
+CM_ SG_ 324 Ups_Inh_Act "Upshift inhibit active";
+CM_ SG_ 324 OD_OFF "Overdrive lock out";
+CM_ SG_ 324 EngBrkCanRq "Engine braking cancel request";
+CM_ SG_ 324 PTO_Enbl "PTO Enabled";
+CM_ SG_ 331 BrkPrss_TMC "Master cylinder pressure";
+CM_ SG_ 331 HSA_BrkPrss "Hill start assist brake pressure";
+CM_ SG_ 331 BrkBstrVac_OBD "Brake booster vacuum level, raw";
+CM_ SG_ 331 MC_ESP_A3 "Message counter";
+CM_ SG_ 331 CRC_ESP_A3 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 332 VehYawRate_Raw "Vehicle yaw rate unfiltered/unadjusted (+ means left)";
+CM_ SG_ 332 VehYawRate_Offset "Offset of vehicle yaw rate unfiltered/unadjusted (+ means left)";
+CM_ SG_ 332 VehAccel_X_Offset "Offset of vehicle longitudinal acceleration (+ means forward)";
+CM_ SG_ 332 VehAccel_X "Vehicle longitudinal acceleration (+ means forward)";
+CM_ SG_ 332 VehAccel_Y "Vehicle lateral acceleration (+ means left, specific to center of gravity, offset-corrected )";
+CM_ SG_ 332 MC_VEH_DYN_STAT "Message counter";
+CM_ SG_ 332 VehAccel_Y_Offset "Offset of vehicle lateral acceleration (+ means left)";
+CM_ SG_ 344 WhlRPM_FL "Wheel rpm front left";
+CM_ SG_ 344 WhlDir_FL_Stat "Direction of rotation of front left wheel";
+CM_ SG_ 344 WhlRPM_FR "Wheel rpm front right";
+CM_ SG_ 344 WhlDir_FR_Stat "Direction of rotation of front right wheel";
+CM_ SG_ 344 WhlRPM_RL "Wheel rpm rear left";
+CM_ SG_ 344 WhlDir_RL_Stat "Direction of rotation of rear left wheel";
+CM_ SG_ 344 WhlRPM_RR "Wheel rpm rear right";
+CM_ SG_ 344 WhlDir_RR_Stat "Direction of rotation of rear right wheel";
+CM_ SG_ 352 TCASE_STAT "Transfer Case Status";
+CM_ SG_ 352 ACT_CNT_DIF_TRQ "Actual center differential torque lock";
+CM_ SG_ 352 DES_CNT_DIF_TRQ "Desired center differential torque lock";
+CM_ SG_ 352 SHFT_ABRT "Shift has been abortet";
+CM_ SG_ 368 PRND_STAT "PRND Status";
+CM_ SG_ 368 EngStEnblRqTCM "Engine start enable request from the transmission";
+CM_ SG_ 368 SHFT_PROG "Driving program display code";
+CM_ SG_ 368 PRNDL_DISP "PRNDL display request";
+CM_ SG_ 368 SHFT_LOCK "Shiftlock state locked; false = [1]";
+CM_ SG_ 368 PRNDL_Blink "Request gear shift display indicator blink";
+CM_ SG_ 368 MC_TRNS_STAT "Message counter";
+CM_ SG_ 368 CRC_TRNS_STAT "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 368 APCM_Rq "Auto position correction mode request";
+CM_ SG_ 376 MIL_OnRq_TCM "MIL on request from the transmission";
+CM_ SG_ 376 GS_NOTL "TRANS in limp home mode";
+CM_ SG_ 376 TxTemp_Excess "Excessive transmission temperature";
+CM_ SG_ 376 FAN_RQ "Cooling fan request";
+CM_ SG_ 376 TX_TEMP "Transmission fluid temperature";
+CM_ SG_ 376 TX_WARN "Transmission warning";
+CM_ SG_ 376 TX_FAULT "Transmission fault";
+CM_ SG_ 384 IntkAirTemp "Engine Intake Air Temperature";
+CM_ SG_ 384 EngCoolTemp "Engine coolant temperature";
+CM_ SG_ 384 AirPress_Outsd "Ambient air pressure (barometric pressure)";
+CM_ SG_ 384 SysVolt "Engine system voltage";
+CM_ SG_ 384 R134a_Press_Stat "Refrigerant pressure (R134a or R1234YF)";
+CM_ SG_ 384 CHRG_FAIL "Charging system Failure (battery indicator request)";
+CM_ SG_ 384 AM_ECM_Prsnt "Aftermarket ECM present";
+CM_ SG_ 384 AC_CLTCH_EGD "AC clutch engauged";
+CM_ SG_ 416 Trans_Trq_Ratio "Transmission torque ratio";
+CM_ SG_ 416 TxIdleRq "Transmission idle speed request";
+CM_ SG_ 416 EngTrq_Rq_TCM "Engine torque request";
+CM_ SG_ 416 EngTrqMax_Rq_TCM "Engine torque request maximum";
+CM_ SG_ 416 EngTrqMin_Rq_TCM "Engine torque request minimum";
+CM_ SG_ 416 MC_TCM_ENG_TRQ "Message counter";
+CM_ SG_ 416 CRC_TCM_ENG_TRQ "CRC-checksum byte 1 to 6 according to SAE J1850";
+CM_ SG_ 448 RFFuncReq "Basic request (RKE, PE, Remstart)";
+CM_ SG_ 448 RFReq "Who's asking for the request";
+CM_ SG_ 448 RFCfgReq "Change customer programmable items by RKE";
+CM_ SG_ 448 RFFobNum "FOB number making the request";
+CM_ SG_ 448 PE_ENABLE "Passive entry feature enabled; [1] = True";
+CM_ SG_ 448 TFASts "Tire fill alert status; Disabled = [0], Enabled = [1]";
+CM_ SG_ 456 VTA_STAT "VTA status";
+CM_ SG_ 464 SRS_IndLmp_Rq "SRS indication lamp request";
+CM_ SG_ 464 DRV_SEATBELT "Drivers seat belt status";
+CM_ SG_ 464 PSG_SEATBELT "Passengers seat belt status";
+CM_ SG_ 464 PSG_ODS_STAT "Passenger Occupant Detection Sensor Status";
+CM_ SG_ 464 ORC_A1_Par "ORC_A1 even parity bit";
+CM_ SG_ 464 ORC_A1_Tog "ORC_A1 toggle bit";
+CM_ SG_ 464 DrvSbltUnFltr "Drivers seat belt fault status - unfiltered";
+CM_ SG_ 466 IMPACT_B "EARS Rear Event; actuate = [1]; do_not_actuate = [0]";
+CM_ SG_ 466 Impact_F "EARS lower severity front event; actuate = [1]; do_not_actuate = [0]";
+CM_ SG_ 466 Impact_Tgl "Toggle bit for all impact events; See Signal Description Document";
+CM_ SG_ 466 IMPACT_I "EARS Rollover Event; actuate = [1]; do_not_actuate = [0]";
+CM_ SG_ 466 IMPACT_L "EARS Side Event; actuate = [1]; do_not_actuate = [0]";
+CM_ SG_ 466 IMPACT_X "Any impact event; actuate = [1]; do_not_actuate = [0]";
+CM_ SG_ 500 EngTrqRq_DAS "Requested engine torque";
+CM_ SG_ 500 EngTrqMaxRq_DAS "Engine torque request maximum; True = [1]";
+CM_ SG_ 500 DAS_ACCEL_Rq "DASM acceleration request";
+CM_ SG_ 500 ACC_Enbl "ACC cruise control enabled; True = [1]";
+CM_ SG_ 500 ACC_Engd "ACC engaged; True = [1]";
+CM_ SG_ 500 DsblFuelShutOff_ACC "Disable fuel shutoff; True = [1]";
+CM_ SG_ 500 GrMax_RqDAS "Requested gear, upper limit";
+CM_ SG_ 500 DAS_Rq_ID "DAS request ID";
+CM_ SG_ 500 DAS_Sts "DASM fault status";
+CM_ SG_ 500 Brk_Jrk_Rq "Brake jerk request; True = [1]";
+CM_ SG_ 500 Brk_PreFill_Rq "Brakes pre-fill request; True = [1]";
+CM_ SG_ 500 As_DispRq "Assistance system display request (priority)";
+CM_ SG_ 500 MC_DAS_A3 "Message counter";
+CM_ SG_ 500 CRC_DAS_A3 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 500 ACC_Drive_Cmd "ACC drive off commanded; True = [1]";
+CM_ SG_ 500 ACC_Still_Cmd "ACC stop commanded; True = [1]";
+CM_ SG_ 501 HMI_Screens "HMI screens";
+CM_ SG_ 501 SetSpeed_KPH "Desired set speed in kilometers per hour";
+CM_ SG_ 501 SetSpeed_MPH "Desired set speed in miles per hour";
+CM_ SG_ 501 FCW_Error "Forward collision warning error";
+CM_ SG_ 501 ACCOnOff "ACC on off status";
+CM_ SG_ 501 Sm_ICON_Dspl "Small graphic display";
+CM_ SG_ 501 RadarBlocked "ACC FCW not available: clean radar snsr; True = [1]";
+CM_ SG_ 501 ACConlyNA_DASMSts "ACC only not available: vehicle system error; True = [1]";
+CM_ SG_ 501 NCConlyNA_DASMSts "NCC only not available: vehicle system error; True = [1]";
+CM_ SG_ 501 ACCFaulted "ACC faulted; True = [1]";
+CM_ SG_ 501 FCWonlyNA_DASMSts "FCW only not available: vehicle system error; True = [1]";
+CM_ SG_ 501 ACCNA_DASMSts "ACC/FCW not avail: vehicle system error; True = [1]";
+CM_ SG_ 501 NCCNA_DASMSts "NCC/FCW not avail: vehicle system error; True = [1]";
+CM_ SG_ 501 ObjIntrstDist "Object of interest distance";
+CM_ SG_ 501 CameraBlocked "ACC FCW limited functionality: camera blocked; True = [1]";
+CM_ SG_ 501 CameraFailure "ACC/FCW limited functionality: camera failure; True = [1]";
+CM_ SG_ 501 CIPV_Fused "Closest in-path vehicle is fused; True = [1]";
+CM_ SG_ 501 FCW_BrkOn "FCW braking is on; true = [1]";
+CM_ SG_ 501 FCWBrakingOff "FCW autobraking disabled; True = [1]";
+CM_ SG_ 501 ACC_EB_Req "Request for exhaust break;1='On'";
+CM_ SG_ 512 AirTemp_Outsd "Outside air temperature";
+CM_ SG_ 512 AMB_TEMP_AVG "Averaged ambient temperature";
+CM_ SG_ 512 AMB_TEMP_VOLT "Ambient Temp Sensor A/D Voltage";
+CM_ SG_ 512 FUEL_VOLT "Fuel level A/D Voltage (Single tank OR Primary on Saddle/Dual Tank)";
+CM_ SG_ 512 FUEL_VOLT2 "Sub Side Fuel level sensor A/D Voltage (saddle/Dual tank)";
+CM_ SG_ 512 BATT_VOLT "System voltage";
+CM_ SG_ 514 BrkPdlRawStat "Brake pedal state raw value";
+CM_ SG_ 520 AC_OutptCurrStat "AC output current status";
+CM_ SG_ 520 BrkPdlStat_CBC "Brake pedal state reported by CBC";
+CM_ SG_ 557 HrnSwPsd "Horn switch pressed (1=pressed)";
+CM_ SG_ 559 ActlAccelPdlPosn "Throttle Pedal Position (actual)";
+CM_ SG_ 559 MC_ECM_A5 "Message counter";
+CM_ SG_ 559 CRC_ECM_A5 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 559 ECM_WARN_BTO "Status of the BTO failure is transmitted from ECM to cluster, appropriate EVIC message will be displayed by cluster";
+CM_ SG_ 584 PN14_LS_Actv "14 V powernet Load Shed active";
+CM_ SG_ 584 Batt_ST_Crit "Battery reached critical state";
+CM_ SG_ 608 CRC_PTS_2 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 608 MC_PTS_2 "Message counter";
+CM_ SG_ 608 PTS_FT_TEMP_NA "ParkSense front system temporarily not available; True = [1]";
+CM_ SG_ 608 PTS_Off_Status "ParkSense system on/off status indication";
+CM_ SG_ 608 PTS_PopUpRqst "ParkSense HMI pop-up message request";
+CM_ SG_ 608 PTS_RR_TEMP_NA "ParkSense rear system temporarily not available; True = [1]";
+CM_ SG_ 608 PTS_STAT_Front "Front park assist system - LED control status";
+CM_ SG_ 608 LooseShip_Rear "Rear LooseShip customer setting confirmation. Enabled = [1]";
+CM_ SG_ 608 LooseShip_Front "Front LooseShip customer setting confirmation. Enabled = [1]";
+CM_ SG_ 624 EngineOffTimer "Engine off timer - engine off ignition NOT lock.";
+CM_ SG_ 624 PNC_ALM_ACT "Panic alarm active; [1] = True";
+CM_ SG_ 624 Gate_Req_PE "Gate passive entry requested; True = [1]";
+CM_ SG_ 624 FuelTxfrSts "Fuel transfer relay status";
+CM_ SG_ 624 HAZARD_STATUS "Hazard lamps; active = [1]";
+CM_ SG_ 632 CC_SetSpdDspl "Cruise control set speed for display (kmph only)";
+CM_ SG_ 632 EVPmpStat "Electric vacuum pump status";
+CM_ SG_ 632 CC_SetSpdDsplMPH "Cruise control set speed for display in miles per hour";
+CM_ SG_ 632 IdleShutDwnApply "Idle Shut down applied; 1 = True";
+CM_ SG_ 632 EnblFuelTxfr "Enable fuel transfer; True = [1]";
+CM_ SG_ 639 IBS_Q_received "LifeTime charge received";
+CM_ SG_ 639 IBS_Q_released "Lifetime charge released";
+CM_ SG_ 639 IBS_Tm_Lst_Reset_Sec "Accumulated time since last reset in seconds";
+CM_ SG_ 639 IBS_Tm_Lst_Reset_Days "Accumulated time since last reset in days";
+CM_ SG_ 656 UConnSeed1 "Character 1";
+CM_ SG_ 656 UConnSeed2 "Character 2";
+CM_ SG_ 656 UConnSeed3 "Character 3";
+CM_ SG_ 656 UConnSeed4 "Character 4";
+CM_ SG_ 660 MC_294h "Message counter";
+CM_ SG_ 660 CRC_294h "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 660 BrkPrss_One "Brake Pressure One (P1)";
+CM_ SG_ 660 BrkPrss_Two "Brake Pressure Two (P2 if supported)";
+CM_ SG_ 660 SyncPos "Signal P2 sync position";
+CM_ SG_ 672 MIL_OnRq "MIL on request from the engine";
+CM_ SG_ 672 MIL_IND_BLINK "Request MIL blink (OBD II)";
+CM_ SG_ 672 ETC_IND_LMP "ETC faulty, indicator lamp request";
+CM_ SG_ 672 OIL_IND_LMP_FLSH "Oil indicator lamp flash (for in plant use)";
+CM_ SG_ 672 EngOilIndLmp_On_Rq "Request oil level/oil pressure indicator lamp";
+CM_ SG_ 672 OIL_TEMP_IND_RQ "Engine oil overtemp. indicator request";
+CM_ SG_ 672 ChkFuelCap "Check fuel cap";
+CM_ SG_ 672 OIL_PRESS "Oil pressure";
+CM_ SG_ 672 EngOilTemp "Oil temperature";
+CM_ SG_ 672 FuelCons "Fuel consumption";
+CM_ SG_ 672 DefFuelEcon "Default fuel economy";
+CM_ SG_ 672 EngRun_Stat "Engine running state";
+CM_ SG_ 672 CoolLo "Engine coolant is low";
+CM_ SG_ 680 EngTrgtSpdCtrl "Engine target speed control";
+CM_ SG_ 680 EngShutOffRq_TCM "TCM request engine shut off";
+CM_ SG_ 680 EngTrgtSpdCtrl_Active "Engine target speed control active";
+CM_ SG_ 680 CurrentGear "Current Gear";
+CM_ SG_ 680 CurrentGearForDisplay "Current Gear for display";
+CM_ SG_ 680 TargetGear "Target Gear - protected";
+CM_ SG_ 680 TX_WARN2 "Transmission warning #2";
+CM_ SG_ 680 MC_TCM_A7 "Message counter";
+CM_ SG_ 680 CRC_TCM_A7 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 698 UConnReq "Basic Uconnect request";
+CM_ SG_ 698 UConnReqAuthCode "Authorization for requests";
+CM_ SG_ 698 UConnReqFOBNum "FOB number making the request";
+CM_ SG_ 706 EC_ECUCfg15_Stat "ECU Configuration messages status 15";
+CM_ SG_ 706 EC_CBC15A "CBC ecu configuration 15A";
+CM_ SG_ 706 EC_CBC15B "CBC ecu configuration 15B";
+CM_ SG_ 706 EC_Suspension "Suspension ecu configuration";
+CM_ SG_ 707 EC_BU_ECUCfg15_Stat "Backup for ECU Configuration messages status 15";
+CM_ SG_ 707 EC_BU_CBC15A "Backup for CBC ecu configuration 15A";
+CM_ SG_ 707 EC_BU_CBC15B "Backup for CBC ecu configuration 15B";
+CM_ SG_ 707 EC_BU_Suspension "Backup for Suspension ecu configuration";
+CM_ SG_ 719 PTS_DBD "Park assist system disabled; System_Disabled = [1]";
+CM_ SG_ 720 BSM_CFG_STAT "BSM configuration status";
+CM_ SG_ 720 BSM_SRV_RQ "BSM service warning request; 1= service request";
+CM_ SG_ 720 BSM_OPR_STAT "BSM operation status; 1= operational failure";
+CM_ SG_ 720 BSM_Blind_RQ "Sensor blinded request from BSM; 1= sensor blocked request";
+CM_ SG_ 720 BSM_LT_WRN "Blind spot detection left side warning";
+CM_ SG_ 720 BSM_RT_WRN "Blind spot detection Right side warning";
+CM_ SG_ 736 LT_DIST "Distance Traveled by Left Wheel";
+CM_ SG_ 736 RT_DIST "Distance Traveled by Right Wheel";
+CM_ SG_ 736 YRS_DataRq "Request from ESC for YRS information";
+CM_ SG_ 736 HSA_EN "Hill Start Assist enabled (1=enabled)";
+CM_ SG_ 736 ESP_DSBL "ESP feature is completely disabled = [1]";
+CM_ SG_ 736 HILL_DES_STAT "Hill descent feature status";
+CM_ SG_ 736 ESP_Off_IndLmp_On_Rq "ESP-OFF indication lamp on request";
+CM_ SG_ 736 ESC_CtrlLmp_Info "ESC control lamp information";
+CM_ SG_ 736 ABS_IndLmp_On_Rq "ABS indication lamp on request";
+CM_ SG_ 736 BrkIndLmp_On_Rq_ESC "Brake indication lamp (red) on request";
+CM_ SG_ 736 SelSpdLmp "Select speed lamp status";
+CM_ SG_ 746 DrvRqShftROT "Driver requested gear shift position";
+CM_ SG_ 746 ShftSensFltROT "Shift sensor single fault - rotary shifter, 1=fault";
+CM_ SG_ 746 ShftDispFltROT "Gear shifter display/trigger fault status - rotary shifter, 1=fault";
+CM_ SG_ 746 ShftLkFltROT "Shift lock fault - rotary shifter, 1=fault";
+CM_ SG_ 746 MC_SBW_ROT1 "Message counter";
+CM_ SG_ 746 CRC_SBW_ROT1 "CRC-checksum byte 1 to 4 according to SAE J1850";
+CM_ SG_ 746 APCM_Stat "Auto position correction mode status";
+CM_ SG_ 746 RackFlt "Rack / detent sensor fault, 1=fault";
+CM_ SG_ 760 EngTrqTgt_SEM "Target Torque  - trans trq. request";
+CM_ SG_ 760 EngTrqStatic_SEM "Static engine torque - trans trq request";
+CM_ SG_ 760 TRANS_CLU_SLIP_MODE "Clutch Slip Request Mode";
+CM_ SG_ 760 ThrmlMngActv "Indicates ECM RPM Limitation Status, Active = 1";
+CM_ SG_ 760 EngMaxRPM "Engine maximum RPM";
+CM_ SG_ 760 MC_ECM_A3 "Message counter";
+CM_ SG_ 760 CRC_ECM_A3 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 761 MC_TCM_EngTrq2 "Message counter";
+CM_ SG_ 761 CRC_TCM_EngTrq2 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 764 ApplyTrq "EDR ONLY - Torque may be applied to the wheels";
+CM_ SG_ 764 BrkSw1Stat "EDR ONLY - Brake switch1 status, off = [0]";
+CM_ SG_ 764 ESP_TrqRqEnabl "EDR ONLY - ESP torque requests are allowed = [1]";
+CM_ SG_ 764 ETC_LmpFlash "EDR ONLY - ETC lamp is flashing";
+CM_ SG_ 764 ETC_LmpOn "EDR ONLY - ETC lamp is on";
+CM_ SG_ 764 Lv1CrsCtrlOff "EDR ONLY - Level is requested cruise off";
+CM_ SG_ 764 CruiseEGD "EDR ONLY - Cruise system is engaged";
+CM_ SG_ 764 RawPVS1 "EDR ONLY - Raw pedal value sensor #1";
+CM_ SG_ 764 RawPVS2 "EDR ONLY - Raw pedal value sensor #2";
+CM_ SG_ 764 RawTPS1 "EDR ONLY - Raw throttle position sensor #1";
+CM_ SG_ 764 RawTPS2 "EDR ONLY - Raw throttle position sensor #2";
+CM_ SG_ 764 RelativePdl "EDR ONLY - Relative pedal value";
+CM_ SG_ 764 RelativeThrt "EDR ONLY - Relative throttle value";
+CM_ SG_ 764 MAP "EDR ONLY - Intake manifold pressure";
+CM_ SG_ 766 VVT_ExhCam1Pos "EDR ONLY - Centerline position for exhaust cam on bank 1";
+CM_ SG_ 766 VVT_ExhCam2Pos "EDR ONLY - Centerline position for exhaust cam on bank 2";
+CM_ SG_ 766 VVT_IntCam1Pos "EDR ONLY - Centerline position for intake cam on bank 1";
+CM_ SG_ 766 VVT_IntCam2Pos "EDR ONLY - Centerline position for intake cam on bank 2";
+CM_ SG_ 766 GF_Charge "EDR ONLY - Port flow per cylinder per stroke";
+CM_ SG_ 766 RelativeThrtPct "EDR ONLY - Relative throttle percent";
+CM_ SG_ 776 CNT_DIFF_MOD "Actual mode of center differential";
+CM_ SG_ 776 DTCM_HMI_Rq "DTCM AWD / 4WD HMI display request";
+CM_ SG_ 776 TCASE_FAIL "T Case System Fault (Limp in)";
+CM_ SG_ 776 TCASE_SRV_RQ "Transfer case service indicator request";
+CM_ SG_ 776 TcaseAWD "Transfer case High range / AWD LED status";
+CM_ SG_ 776 TCASE_INHBT "All wheel drive mode inhibited";
+CM_ SG_ 776 Tcase4Low "Transfer case low range LED status";
+CM_ SG_ 776 TcaseNtrlStat "Transfer case neutral LED status";
+CM_ SG_ 776 Tcase4Lock "Transfer case 4WD locked status";
+CM_ SG_ 776 Tcase2WD_Stat "Transfer case 2 wheel drive status";
+CM_ SG_ 779 DisOilLifeRst "Distance since last oil life reset";
+CM_ SG_ 779 OilLifeLeft "Oil life left";
+CM_ SG_ 779 MntncSts "Maintenance reminder status";
+CM_ SG_ 779 OilLifeLeftRst "Oil life remaining has been reset";
+CM_ SG_ 779 HoursOilLifeRst "Hours since last oil life reset";
+CM_ SG_ 779 FuelFltrRq "Fuel filter reminder request";
+CM_ SG_ 779 FuelFltrLeft "Fuel filter life left";
+CM_ SG_ 779 FuelFltrAck "Fuel filter reset acknowledge";
+CM_ SG_ 784 AvgFuelLvl "Average filtered fuel level in liters";
+CM_ SG_ 784 SRS_LMP_STAT "Airbag indicator lamp status";
+CM_ SG_ 784 FuelLvlLow "Fuel level low";
+CM_ SG_ 784 OilChgRst "Oil change reminder reset request";
+CM_ SG_ 784 ODO "Odometer";
+CM_ SG_ 784 WTS_LmpRqOn "Wait to start lamp requested on; true = [1]";
+CM_ SG_ 784 Trailer_Trp_Rst "Trailer Trip Reset Request";
+CM_ SG_ 784 FuelFltrRst "Fuel filter maintenance reminder reset";
+CM_ SG_ 784 FuelSavDispEnbl "Fuel saver display indicator status (1=enabled)";
+CM_ SG_ 788 CFG_FEATURE "Configurable feature";
+CM_ SG_ 788 CFG_STAT_RQ "Configurable feature status request";
+CM_ SG_ 788 CFG_SET "Specific setting or value (see reference)";
+CM_ SG_ 790 CFG_FEATURE_C "Configurable feature";
+CM_ SG_ 790 CFG_STAT_RQ_C "Configurable feature status request";
+CM_ SG_ 790 CFG_SET_C "Specific setting or value (see reference)";
+CM_ SG_ 792 TurnIndLvr_Stat "Turn indicator lever state";
+CM_ SG_ 792 HiBmLvr_Stat "High beam lever state";
+CM_ SG_ 792 WprWashSw_Psd "Front wiper switch pressed";
+CM_ SG_ 792 WprSw6Posn "Wiper switch (6 stages) position";
+CM_ SG_ 792 VOL "Volume up/down";
+CM_ SG_ 792 Up_Arw_Rq "Up Arrow Request / Step";
+CM_ SG_ 792 StW_TempSens_Flt "Steering wheel temperature sensor fault";
+CM_ SG_ 792 StW_Temp "Steering wheel temperature";
+CM_ SG_ 792 SEEK "Seek up/down";
+CM_ SG_ 792 RT_ARW_RST_RQ "Right Arrow Reset Request";
+CM_ SG_ 792 PRESET_CFG "Preset Configuration";
+CM_ SG_ 792 MENU_RQ "Menu Switch Request / Back";
+CM_ SG_ 792 HrnSw_Psd "Horn switch pressed (1=pressed)";
+CM_ SG_ 792 DN_ARW_STEP_RQ "Down Arrow Request / Odometer Trip Reset";
+CM_ SG_ 792 CELL_VR "Cell Phone/Voice Recognition Request";
+CM_ SG_ 792 AUD_MODE_ADV "Audio-mode advance";
+CM_ SG_ 799 IBS_R_Batt "Calculated battery resistance";
+CM_ SG_ 799 IBS_R_Batt_25 "Batt resistance at 100% SOC and 25 degC";
+CM_ SG_ 799 RainSensorFailSts "Fail present = 1";
+CM_ SG_ 799 TGW_AUD_MD_CAB_DR "TGW audio mode for Cabin/Driver";
+CM_ SG_ 799 PSS_Display "Power side step display";
+CM_ SG_ 804 TurnLmp_FL_Flt "Turn indication lamp front left fault";
+CM_ SG_ 804 TurnLmp_FR_Flt "Turn indication lamp front right fault";
+CM_ SG_ 804 TurnLmp_RL_Flt "Turn indication lamp rear left fault";
+CM_ SG_ 804 TurnLmp_RR_Flt "Turn indication lamp rear right fault";
+CM_ SG_ 804 ACC_DLY_ACT "Accessory Delay Active";
+CM_ SG_ 804 RemSt_Inhibit "Remote start inhibit";
+CM_ SG_ 804 WPR_SYS_OFF "Wiper system off; [1] = switch is OFF";
+CM_ SG_ 804 WPR_SYS_LOW "Wiper system low; [1] = switch is LOW";
+CM_ SG_ 804 WPR_SYS_HIGH "Wiper system high; [1] = switch is HIGH";
+CM_ SG_ 804 WPR_SYS_INT "Wiper system intermittent; [1] = switch is INT";
+CM_ SG_ 804 WPR_SYS_AUTO "Wiper system auto; [1] = Auto wipers equipped";
+CM_ SG_ 804 WPR_SYS_MIST "Wiper system mist; [1] = mist request";
+CM_ SG_ 804 WPR_SYS_WASH "Wiper system wash; [1] = wash request";
+CM_ SG_ 804 WPR_SYS_FLT "Wiper system fault present; [1] = fault present";
+CM_ SG_ 804 AirSusp_DnSw "Air suspension down (Trailer) switch status";
+CM_ SG_ 804 HdAjar "Hood latch ajar, left or single (1=ajar)";
+CM_ SG_ 804 CargoLampOn "Cargo lamp is on";
+CM_ SG_ 804 WTS_Active "Indicates WTS feature is active";
+CM_ SG_ 804 CBC_WTS_AS "WTS automatic start is active";
+CM_ SG_ 808 TGW_GrpNum_IC "TGW group number to IC";
+CM_ SG_ 808 TGW_GrpTyp_IC "Group type to send text data from TGW to IC";
+CM_ SG_ 808 TGW_HiGrpMark_IC "TGW high group mark to IC; [0] = Not True, [1] = True";
+CM_ SG_ 808 TGW_TEXT_IC "TGW text string information to IC";
+CM_ SG_ 810 PTO_Md "PTO mode selected";
+CM_ SG_ 810 PTO_MaxVehSpd "PTO maximum vehicle speed";
+CM_ SG_ 810 PTO_AutoRsm "PTO - resume on ignition on";
+CM_ SG_ 810 PTO_TYPES "PTO type selected";
+CM_ SG_ 810 PTO_ENGD_RQ "Power takeoff engage request";
+CM_ SG_ 810 PTO_Incab "Power takeoff - in cab switch status; On = [1]";
+CM_ SG_ 810 PTO_HornRq "Power ake Off HORN ON Request; On = 1";
+CM_ SG_ 810 PTO_SingleRPM "PTO single set RPM";
+CM_ SG_ 810 PTO_RPM1 "PTO preset 1 RPM setting";
+CM_ SG_ 810 PTO_RPM2 "PTO preset 2 RPM setting";
+CM_ SG_ 810 PTO_RPM3 "PTO preset 3 RPM setting";
+CM_ SG_ 810 PTO_Sts "PTO warning status";
+CM_ SG_ 810 FuelTransSts "Fuel transfer status";
+CM_ SG_ 816 TRAC_PSD "Traction on/off button pressed; [0] = Not Pressed, [1] = Pressed";
+CM_ SG_ 816 HILL_DES_RQ "Hill descent or select speed status";
+CM_ SG_ 816 AHB_ENBL "Auto highbeam enable";
+CM_ SG_ 816 phone_pop_up_active "Phone pop up is active; True = [1]";
+CM_ SG_ 816 TILT_IN_REV_D "Tilt in reverese feature enabled; [0] = no, [1] = yes";
+CM_ SG_ 816 RemStNrmlStEnbl_DCS "Driver comfort system remote & normal start status; [0] = Off, [1] = On";
+CM_ SG_ 816 RemStEnbl_DCS "Driver comfort system remote start status; [0] = Off, [1] = On";
+CM_ SG_ 816 EB_SW_PSD "Exhaust brake switch pressed (1=pressed)";
+CM_ SG_ 820 FT_FOG_RQ "Front fog request; off=[0], on=[1]";
+CM_ SG_ 820 REV_GEAR "Reverse Gear (manual trans)";
+CM_ SG_ 820 DR_LK_STAT "Door lock status";
+CM_ SG_ 820 FOB_SrchRq "FOB search request";
+CM_ SG_ 820 AHB_ACT "Automatic high beam active";
+CM_ SG_ 820 PARK_LMP_ON "Parklamps are on; off=[0], on=[1]";
+CM_ SG_ 820 DRV_AJAR "Driver door ajar (1 = Door Ajar)";
+CM_ SG_ 820 PSG_AJAR "Passenger door ajar";
+CM_ SG_ 820 L_R_AJAR "Left rear door ajar";
+CM_ SG_ 820 R_R_AJAR "Right rear door ajar";
+CM_ SG_ 820 TLG_AJAR "Trunk/Liftgate ajar";
+CM_ SG_ 820 PARK_BRK_EGD "Park brake switch engaged";
+CM_ SG_ 820 IGN_OFF_TIME_LNG "Time since last ignition on (long)";
+CM_ SG_ 820 SHIP_STAT "Shipping status";
+CM_ SG_ 820 TurnInd_LT_ON "Turn indication left is on";
+CM_ SG_ 820 TurnInd_RT_ON "Turn indication right is on";
+CM_ SG_ 820 DAY_LGT_MD "Day light brightness mode; Night=[0], Day=[1]";
+CM_ SG_ 820 PANEL_INTS "Panel-/display intensity";
+CM_ SG_ 820 FT_WPR_NOT_PRK "Front wiper outside park position";
+CM_ SG_ 820 LOBEAM_ON "Low beam is on; off=[0], on=[1]";
+CM_ SG_ 820 HIBEAM_ON "High beam is on; off=[0], on=[1]";
+CM_ SG_ 820 BRK_FLUID_LO "Low brake fluid warning; low = [1]";
+CM_ SG_ 820 WASH_FLUID_LO "Low washer fluid warning (1=Fluid is low)";
+CM_ SG_ 820 R_FOG_RQ "Rear fog request; [0] = off, [1] = on";
+CM_ SG_ 820 PTC_REL1_STAT "PTC Relay # 1 Status (diesel only)";
+CM_ SG_ 820 PTC_REL2_STAT "PTC Relay # 2 Status (diesel only)";
+CM_ SG_ 820 PTC_REL3_STAT "PTC Relay # 3 Status (diesel only)";
+CM_ SG_ 820 PoliceStlthMdAct "Police stealth mode active; true = [1]";
+CM_ SG_ 825 PTS_RR_CHIME_RQ "PTS right rear chime on request; True = [1]";
+CM_ SG_ 825 PTS_LR_CHIME_RQ "PTS left rear chime on request; True = [1]";
+CM_ SG_ 825 PTS_CHIME_TYPE "PTS chime type";
+CM_ SG_ 825 PTS_CHIME_REP_RATE "PTS chime repetition rate";
+CM_ SG_ 825 PTS_RR_VOL "PTS Rear Volume Setting";
+CM_ SG_ 825 PTS_FT_VOL "PTS Front Volume Setting";
+CM_ SG_ 825 PTS_LF_CHIME_RQ "PTS left front chime on request; True = [1]";
+CM_ SG_ 825 PTS_RF_CHIME_RQ "PTS right front chime on request; True = [1]";
+CM_ SG_ 826 PTS_RR_NA "Rear park assist not available - blinded sensor; True = [1]";
+CM_ SG_ 826 PTS_SRV_RQ "PTS service warning request; True = [1]";
+CM_ SG_ 826 PTS_AlrRL "PTS alert rear left";
+CM_ SG_ 826 PTS_GraphicRL "PTS graphic flash rate rear left";
+CM_ SG_ 826 PTS_AlrRR "PTS alert rear right";
+CM_ SG_ 826 PTS_GraphicRR "PTS graphic flash rate rear right";
+CM_ SG_ 826 PTS_AlrRC "PTS alert rear center";
+CM_ SG_ 826 PTS_GraphicRC "PTS graphic flash rate rear center";
+CM_ SG_ 826 PTS_RR_SRV "Rear PTS sensor service request; True = [1]";
+CM_ SG_ 826 PTS_STAT "Park Assist System - LED control status";
+CM_ SG_ 826 PTS_AlrFC "PTS alert front center";
+CM_ SG_ 826 PTS_AlrFL "PTS alert front left";
+CM_ SG_ 826 PTS_AlrFR "PTS alert front right";
+CM_ SG_ 826 PTS_FT_NA "Front park assist not available - blinded sensor; True = [1]";
+CM_ SG_ 826 PTS_FT_SRV "Front PTS sensor service request; True = [1]";
+CM_ SG_ 826 PTS_GraphicFC "PTS graphic flash rate front center";
+CM_ SG_ 826 PTS_GraphicFL "PTS graphic flash rate front left";
+CM_ SG_ 826 PTS_GraphicFR "PTS graphic flash rate front right";
+CM_ SG_ 832 VehSpd_MPH "Vehicle speed signal is in miles per hour format";
+CM_ SG_ 832 VehSpdDisp "Vehicle speed - displayed";
+CM_ SG_ 832 xtended_AvgFuelLvl "Epanded average filtered fuel level in liters";
+CM_ SG_ 838 AS_RF_CHIME_RQ "AS right front chime on request; True = [1]";
+CM_ SG_ 838 AS_LF_CHIME_RQ "AS left front chime on request; True = [1]";
+CM_ SG_ 838 AS_CHIME_TYPE "AS chime type";
+CM_ SG_ 838 AS_CHIME_REP_RATE "AS chime repetition rate";
+CM_ SG_ 840 FailSafeError "Fail safe error";
+CM_ SG_ 848 DateTmSec "Time of day: SECONDS";
+CM_ SG_ 848 DateTmMinute "Time of day: MINUTES";
+CM_ SG_ 848 DateTmHour "Time of day: HOURS";
+CM_ SG_ 848 DateTmYear "Date year";
+CM_ SG_ 848 DateTmMonth "Month";
+CM_ SG_ 848 DateTmDay "Day";
+CM_ SG_ 848 DateTmFormat "Date and Time Format";
+CM_ SG_ 850 ECM_APPL2 "Application";
+CM_ SG_ 853 RrAxleLckr_Rq "Rear axle locker request";
+CM_ SG_ 853 TCASE_NEUT_RQ "Transfer case neutral request";
+CM_ SG_ 853 TcaseSwTyp "Transfer case LIN switch type";
+CM_ SG_ 853 TcaseAWD_Rq "Transfer case all wheel drive request";
+CM_ SG_ 853 Tcase4Low_Rq "Transfer case 4 wheel low request";
+CM_ SG_ 853 Tcase4Lock_Rq "Transfer case 4 wheel lock request";
+CM_ SG_ 853 Tcase2WD_Rq "Transfer case 2 wheel drive request";
+CM_ SG_ 853 PARK_ASST_RQ "Park Assist Request";
+CM_ SG_ 853 FT_PARK_ASST_RQ "Front park assist request";
+CM_ SG_ 853 CLS_UnlkSw_Psd_P "Central locking system unlock switch pressed - passenger side";
+CM_ SG_ 853 CLS_UnlkSw_Psd_D "Central locking system unlock switch pressed - driver side";
+CM_ SG_ 853 CLS_LkSw_Psd_P "Central locking system lock switch pressed - passenger side";
+CM_ SG_ 853 CLS_LkSw_Psd_D "Central locking system lock switch pressed - driver side";
+CM_ SG_ 853 ASBM_AUX6_On "Aux Switch 6 Status ON;ON=1";
+CM_ SG_ 856 CMP_DIR "Compass direction (WK/LX)";
+CM_ SG_ 856 VAR_VAL "RCM Variance Value";
+CM_ SG_ 856 CMP_DIR_RAW "Compass direction raw";
+CM_ SG_ 856 IN_CAL_MD "In Calibration Mode";
+CM_ SG_ 860 DIST_TO_TURN "Numeric distance to next turn";
+CM_ SG_ 860 UNITS "Unit of measure";
+CM_ SG_ 860 T_BY_T_ON "Turn by turn on";
+CM_ SG_ 860 TURN_COMP "Turn complete";
+CM_ SG_ 860 NAV_ARROW "Navigation arrow type";
+CM_ SG_ 860 NAVPrsnt "A navigation system module is present";
+CM_ SG_ 863 RevOilLifeRst "Engine revolutions since last oil life reset";
+CM_ SG_ 864 ECM_APPL1 "Application";
+CM_ SG_ 872 TCM_HSA "Manual control at test bench";
+CM_ SG_ 880 ECM_APPL3 "CCP synchronous - TDC event DAQ";
+CM_ SG_ 882 TorqueUnit "Torque units; Foot Pounds (ft-lb) = [1]";
+CM_ SG_ 882 LANG_C "Language preference (5 bit)";
+CM_ SG_ 882 PowerUnit "Power units";
+CM_ SG_ 882 PressureUnit "Pressure units";
+CM_ SG_ 882 CapacityUnit "Fuel capacity units";
+CM_ SG_ 882 DistanceUnit "Distance (odometer) units; Miles = [1]";
+CM_ SG_ 882 SpeedUnit "Speed (speedometer) units; Miles = [1]";
+CM_ SG_ 882 TemperatureUnit "Temperature units; Farenheit = [1]";
+CM_ SG_ 882 ConsumptionUnit "Fuel consumption units";
+CM_ SG_ 882 UNIT_SET_CSO "Unit set status enable/disable";
+CM_ SG_ 888 TCM_HSB "Manual control at test bench";
+CM_ SG_ 896 ECM_APPL4 "CCP 5ms DAQ  (from ENGINE to external tool)";
+CM_ SG_ 897 VC_VehCfg7_Stat "Configuration messages status 7";
+CM_ SG_ 897 VC_LDW "Lane Departure Warning present; present = [1]";
+CM_ SG_ 897 VC_TrnsDrvMdPrsnt "Transmission drive mode feature; present = [1]";
+CM_ SG_ 897 VC_PdlsMdPrsnt "Paddles lock-out feature; present = [1]";
+CM_ SG_ 897 VC_DST_Present "Dynamic steering torque present; True = [1]";
+CM_ SG_ 897 VC_STP_PRSNT "Super trac pack present; True = [1]";
+CM_ SG_ 897 VC_eShifter_Prsnt "e-shifter present; present = [1]";
+CM_ SG_ 897 VC_TransType "Automatic transmission type";
+CM_ SG_ 897 VC_AS_ERS "Shift feature autostick / electronic range select status";
+CM_ SG_ 897 VC_FullSpeedRange_FCW "Full speed range forward collision warning plus system present; Present = 1";
+CM_ SG_ 897 VC_ACC_Type "Type of adaptive cruise control (ACC) system present";
+CM_ SG_ 897 VC_SuspPrsnt "NetCfg_ASCM contains suspension; present = [1]";
+CM_ SG_ 897 VC_DampingPrsnt "NetCfg_ASCM contains active damping; present = [1]";
+CM_ SG_ 897 VC_AxleLockerPrsnt "Axle locker configuration";
+CM_ SG_ 897 VC_PBTyp "Park brake type";
+CM_ SG_ 897 VC_RedKey "RedKey feature is present; Present = [1]";
+CM_ SG_ 897 VC_TeenKey "TeenKey feature is present; Present = [1]";
+CM_ SG_ 897 VC_TPMS_Configuration "TPMS configuration";
+CM_ SG_ 897 VC_Trans_Equipped "Transmission equipped: 0 = Automatic & 1 = Manual";
+CM_ SG_ 897 VC_TSBM_Prsnt "TSBM LIN slave is present; True = [1]";
+CM_ SG_ 897 VC_SVC_Prsnt "Surround view camera; present = [1]";
+CM_ SG_ 897 VC_Trans_N_Hold_Prsnt "Transmission neutral hold feature; present = [1]";
+CM_ SG_ 897 VC_ABSM "Active Blind Spot present; present = [1]";
+CM_ SG_ 897 VC_HybridType "Identify the kind of hybrid vehicle";
+CM_ SG_ 897 VC_SUNR_Prsnt "Sunroof is present; True = 1";
+CM_ SG_ 897 VC_Temp_Display_Resolution "Toggle between 0.5degC and 1degC temperature display";
+CM_ SG_ 897 VC_Suspension_Type "Suspension type";
+CM_ SG_ 897 VC_SmartAlternator "Smart alternator is present; True = [1]";
+CM_ SG_ 897 VC_PTCPrsnt "PTC Present/Absent;  Present = 1";
+CM_ SG_ 897 VC_MOC_Type "Motor on caliper type";
+CM_ SG_ 897 VC_Glovebox "Glovebox control; Present = 1";
+CM_ SG_ 897 VC_Brake_Type "Brake type";
+CM_ SG_ 897 VC_AGSprsnt "AGS Present/Absent;  Present = 1";
+CM_ SG_ 897 VC_ADR_PRSNT "ADR feature present; True = [1]";
+CM_ SG_ 897 VC_GlareFree_Prsnt "Glare Free Present";
+CM_ SG_ 897 VC_Vehicle_Package "Vehicle Package Content";
+CM_ SG_ 897 VC_TrafficSignInfo "Traffic Sign Information Feature";
+CM_ SG_ 897 VC_PAD_Lamp_Ctrl "ECU Controlling PAD Lamp";
+CM_ SG_ 897 VC_LDW_Audio "LDW without Haptic Feedback feature";
+CM_ SG_ 897 VC_LaneCentering "Lane Centering / HAS feature";
+CM_ SG_ 898 VC_BU_VehCfg7_Stat "Backup for Configuration messages status 7";
+CM_ SG_ 898 VC_BU_LDW "Lane departure warning present; present = [1]";
+CM_ SG_ 898 VC_BU_TrnsDrvMdPrsnt "Backup for transmission drive mode feature; present = [1]";
+CM_ SG_ 898 VC_BU_PdlsMdPrsnt "Backup for paddles lock-out feature; present = [1]";
+CM_ SG_ 898 VC_BU_DST_Present "Backup for dynamic steering torque present; True = [1]";
+CM_ SG_ 898 VC_BU_STP_PRSNT "Backup for super trac pack present; True = [1]";
+CM_ SG_ 898 VC_BU_eShifter_Prsnt "Backup for e-shifter present; present = [1]";
+CM_ SG_ 898 VC_BU_TransType "Backup for automatic transmission type";
+CM_ SG_ 898 VC_BU_AS_ERS "Backup for shift feature autostick / electronic range select status";
+CM_ SG_ 898 VC_BU_FullSpeedRange_FCW "Backup for full speed range forward collision warning plus system present; Present = 1";
+CM_ SG_ 898 VC_BU_ACC_Type "Backup for type of adaptive cruise control (ACC) system present";
+CM_ SG_ 898 VC_BU_SuspPrsnt "backup for ASCM contains suspension; present = [1]";
+CM_ SG_ 898 VC_BU_DampingPrsnt "Backup for ASCM contains active damping; present = [1]";
+CM_ SG_ 898 VC_BU_AxleLockerPrsnt "Backup for axle locker configuration";
+CM_ SG_ 898 VC_BU_PBTyp "Backup for park brake type";
+CM_ SG_ 898 VC_BU_RedKey "Backup for RedKey feature is present; Present = [1]";
+CM_ SG_ 898 VC_BU_TeenKey "Backup for teenKey feature is present; Present = [1]";
+CM_ SG_ 898 VC_BU_TPMS_Configuration "Backup for TPMS configuration";
+CM_ SG_ 898 VC_BU_Trans_Equipped "Backup for Transmission equipped: 0 = Automatic & 1 = Manual";
+CM_ SG_ 898 VC_BU_TSBM_Prsnt "Backup for TSBM LIN slave is present; True = [1]";
+CM_ SG_ 898 VC_BU_SVC_Prsnt "Backup for surround view camera; present = [1]";
+CM_ SG_ 898 VC_BU_Trans_N_Hold_Prsnt "Backup for Transmission neutral hold feature; present = [1]";
+CM_ SG_ 898 VC_BU_ABSM "Backup for Active Blind Spot present; present = [1]";
+CM_ SG_ 898 VC_BU_HybridType "Backup for identify the kind of hybrid vehicle";
+CM_ SG_ 898 VC_BU_SUNR_Prsnt "Backup for sunroof is present; True = 1";
+CM_ SG_ 898 VC_BU_Temp_Display_Resolution "Backup for toggle between 0.5degC and 1degC temperature display";
+CM_ SG_ 898 VC_BU_Suspension_Type "Backup for suspension type";
+CM_ SG_ 898 VC_BU_SmartAlternator "Backup for smart alternator is present; True = [1]";
+CM_ SG_ 898 VC_BU_PTCPrsnt "Backup for PTC present/absent config signal;  Present = 1";
+CM_ SG_ 898 VC_BU_MOC_Type "Backup for motor on caliper type";
+CM_ SG_ 898 VC_BU_Glovebox "Backup for Glovebox control; Present = 1";
+CM_ SG_ 898 VC_BU_Brake_Type "Backup for brake type";
+CM_ SG_ 898 VC_BU_AGSprsnt "Backup for AGS present/absent config signal;  Present = 1";
+CM_ SG_ 898 VC_BU_ADR_PRSNT "Backup for ADR feature present; True = [1]";
+CM_ SG_ 898 VC_BU_Vehicle_Package "Vehicle Package Content";
+CM_ SG_ 898 VC_BU_TrafficSignInfo "Backup for Traffic Sign Information Feature";
+CM_ SG_ 898 VC_BU_PAD_Lamp_Ctrl "ECU Controlling PAD Lamp";
+CM_ SG_ 898 VC_BU_GlareFree_Prsnt "Glare Free Present";
+CM_ SG_ 898 VC_BU_LDW_Audio "LDW without Haptic Feedback feature";
+CM_ SG_ 898 VC_BU_LaneCentering "Lane Centering / HAS feature";
+CM_ SG_ 904 TCM_HSC "Manual control at test bench";
+CM_ SG_ 912 ECM_APPL5 "CCP 10ms DAQ  (from ENGINE to external tool)";
+CM_ SG_ 920 TCM_HSD "Manual control at test bench";
+CM_ SG_ 928 ECM_APPL6 "CCP 80ms DAQ  (from ENGINE to external tool)";
+CM_ SG_ 936 ECM_APPL7 "Application";
+CM_ SG_ 937 SOUND_LK "Sound horn on lock; no = [0], yes = [1]";
+CM_ SG_ 937 FLASH_LK "Flash lamps with lock; no = [0], yes = [1]";
+CM_ SG_ 937 HL_WPR "Headlamp on with wiper; no = [0], yes =[1]";
+CM_ SG_ 937 CFG_AUTO_WPR "Auto wiper configuration; no = [0], yes =[1]";
+CM_ SG_ 937 ILL_APRCH_TIME "Illuminated approach time";
+CM_ SG_ 937 HL_DLY_TIME "Headlamp delay time";
+CM_ SG_ 937 ACC_DLY_TIME "Power accessory delay time";
+CM_ SG_ 937 DRL_ON "Daytime running lamps on; enabled = [1]";
+CM_ SG_ 937 SOUND_RS "Sound horn on Remote Start ; no = [0], yes = [1]";
+CM_ SG_ 937 SOUND_LK_1ST_2ND "Sound horn on lock status";
+CM_ SG_ 937 AUTO_LK "Auto lock; enabled = [1]";
+CM_ SG_ 937 AUTO_UNLK "Auto unlock; enabled = [1]";
+CM_ SG_ 937 RKE_ONE_PRESS_ENBL "Unlck all doors on 1st press; yes = [0], no = [1]";
+CM_ SG_ 937 R_G_LGT_STS "Rear Guidance Lights status information, Enable= 1";
+CM_ SG_ 937 Backup_Alarm "Backup Alarm; enabled = [1]";
+CM_ SG_ 944 TCM_APPL2 "CCP to transmission";
+CM_ SG_ 945 TCM_APPL1 "CCP from transmission";
+CM_ SG_ 946 TCM_APPL3 "CCP from transmission";
+CM_ SG_ 947 VC_VehCfgCSO1_Stat "Configuration message CSO1 status";
+CM_ SG_ 947 VC_PRK_AST_CSO "Park assist customer settings menu";
+CM_ SG_ 947 VC_PRK_AST_BRK_CSO "Park assist brake customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PRK_FT_VOL_CSO "Park assist front volume customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PRK_RR_VOL_CSO "Park assist rear volume customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_EPS_CSO "Electric power steering customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_FCW_CSO "Forward collision warning customer settings menu";
+CM_ SG_ 947 VC_FCW_BRK_CSO "Forward collision mitigation braking customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_HRN_RMT_LK_CSO "Sound horn with remote lock customer settings menu";
+CM_ SG_ 947 VC_HRN_RMT_ST_CSO "Sound horn with remote start customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_HRN_RMT_LWR_CSO "Sound horn with remote lower customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_CHMSL_LINE_CSO "CHMSL line menu; Present = [1]";
+CM_ SG_ 947 VC_DCS_CSO "Auto on driver comfort customer settings menu";
+CM_ SG_ 947 VC_AUX_SWS_CSO "Auxiliary switches customer settings menu";
+CM_ SG_ 947 VC_CMRA_GRDLNS_CSO "Rear view camera gridlines customer settings menu";
+CM_ SG_ 947 VC_ACC_DLY_CSO "Power accessory delay customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_AFLS_CSO "Adaptive front light system customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_AMB_DMR_CSO "Ambient dimmer customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_ASCM_TJ_CSO "Tire jack mode customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_ASCM_WRN_CSO "Air suspension warning customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_AUTO_AERO_CSO "Automatic aero mode customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_AUTO_HB_CSO "Auto high beam customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_AUTO_PRK_CSO "Auto park customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_BLIND_SPOT_CSO "Blind spot alert customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_CAPACITY_CSO "Capacity unit customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_CLK_DSP_CSO "Clock display customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_CMP_CAL_CSO "Compass calibration customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_CMP_VAR_CSO "Compass variance customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_CONS_CSO "Consumption unit customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_DISTANCE_CSO "Distance unit customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_DR_LK_CSO "Auto door lock customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_DR_UNLK_CSO "Auto door unlock customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_DRL_CSO "Daytime running lights customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_EASY_EXIT_CSO "Easy exit seat customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_ENTRY_EXIT_CSO "Auto entry exit mode customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_EPB_SERV_CSO "EPB service mode customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_FLSH_LMP_LK_CSO "Flash lamps with lock customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_HL_DRP_CSO "Headlamp drop customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_HL_OFF_DLY_CSO "Headlamp off delay customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_HL_WPR_CSO "Headlamps on with wiper customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_HSA_CSO "Hill start assist customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_ILL_APPRCH_CSO "Illuminated approach customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_LDW_TRQ_CSO "Lane departure torque customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_LDW_WRN_CSO "Lane departure warning customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_LGHT_RMT_LWR_CSO "Flash lights with remote lower customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_NAV_TRN_CSO "Nav turn by turn customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PE_CSO "Passive entry customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PER_SHFT_ENBL_CSO "Performance shift enable customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PER_SHFT_RPM_CSO "Performance shift rpm customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PLG_CHM_CSO "Power liftgate chime customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_POWER_CSO "Power unit customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PRESSURE_CSO "Pressure unit customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_PTO_CSO "Power take off customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_RAIN_WPR_CSO "Rain sensitive wipers customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_REAR_CMRA_CSO "Rear camera customer settings menu; Present = [1]";
+CM_ SG_ 947 VC_POLICE_PE_CSO "Police passive entry settings menu; Present = [1]";
+CM_ SG_ 947 VC_UNIT_SET_CSO "Unit set customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_VehCfgCSO2_Stat "Configuration message CSO2 status";
+CM_ SG_ 948 VC_REAR_CMRA_DLY_CSO "Rear view camera delay customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_RKE_MEM_CSO "RKE linked to memory customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_RKE_UNLK_CSO "RKE unlock customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_SPEED_CSO "Speed unit customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_TLT_MRR_CSO "Tilt mirror in reverse customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_TORQUE_CSO "Torque unit customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_TRLR_CSO "Trailer selected customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_TRLR_NAME_CSO "Trailer name customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_TRLR_TYPE_CSO "Trailer type customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_TRNS_MD_CSO "Transport mode customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_US_METRIC_CSO "US metric customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_WHL_ALGN_CSO "Wheel alignment customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_FUEL_SAV_CSO "Fuel Saver settings menu; Present = [1]";
+CM_ SG_ 948 VC_TEMP_CSO "Temperature Unit settings menu; Present = [1]";
+CM_ SG_ 948 VC_FCW_SW_CSO "FCW Switch customer setting menu present.  Present = 1";
+CM_ SG_ 948 VC_PADDLE_SHIFT_CSO "Paddle shifter customer setting menu present.  Present = [1]";
+CM_ SG_ 948 VC_PWR_FLD_MRR_CSO "Power folding mirror customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_FCW_BRK_CSO "Teen key FCW braking customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_FCW_SENS_CSO "Teen key FCW sensitivity customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_MAX_SPEED_CSO "Teen key max speed customer setting menu: Present = 1";
+CM_ SG_ 948 VC_HOLD_N_GO_CSO "Hold and go customer setting menu: Present = 1";
+CM_ SG_ 948 VC_HANDS_FREE_LFT_CSO "Hands free liftgate customer setting menu: Present = 1";
+CM_ SG_ 948 VC_HANDS_FREE_SLDR_CSO "Hands free sliding door customer setting menu: Present = 1";
+CM_ SG_ 948 VC_SVC_GRIDLINES_CSO "Surround view camera gridlines customer setting menu: Present = 1";
+CM_ SG_ 948 VC_SVC_DELAY_CSO "Surround view camera delay customer setting menu: Present = 1";
+CM_ SG_ 948 VC_SLD_DR_ALRT_CSO "Sliding door alert customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_PRK_ASST_CSO "Teen key park assist customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_FT_PRK_VOL_CSO "Teen key front park assist chime volume customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_RR_PRK_VOL_CSO "Teen key rear park assist chime volume customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_FUEL_WRN_CSO "Teen key early fuel warning customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_FUEL_POPUP_CSO "Teen key fuel pop-up customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_BLIND_SPOT_CSO "Teen key blind spot customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_RAIN_WPR_CSO "Teen key rain sensitive wiper customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_AUTO_HB_CSO "Teen key automatic highbeam customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_LGHT_WPR_CSO "Teen key lights on with wipers customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_SLD_DR_ALRT_CSO "Teen key sliding door alert customer setting menu: Present = 1";
+CM_ SG_ 948 VC_TEEN_PLG_CHIME_CSO "Teen key power lift gate chime customer setting menu: Present = 1";
+CM_ SG_ 948 VC_SLD_DR_CHM_CSO "Sliding door chime customer setting menu present: Present = 1";
+CM_ SG_ 948 VC_TEEN_SLD_DR_CHM_CSO "Teen key sliding door chime customer setting menu present: Present = 1";
+CM_ SG_ 948 VC_FLSH_LMP_SLDR_CSO "Flash lamps with sliding door customer settings menu; Present = [1]";
+CM_ SG_ 948 VC_SPEED_WARNING_CSO "Speed warning  customer setting";
+CM_ SG_ 948 VC_LDW_ON_CSO "LDW on/off customer setting menu present.  Present = 1.";
+CM_ SG_ 948 VC_PRK_ASST_TYPE_CSO "Park assist type customer setting menu present. Present = 1.";
+CM_ SG_ 948 VC_EPB_ON_CSO "EPB on/off customer setting menu present. Present = 1.";
+CM_ SG_ 948 VC_AIRBAG_ON_CSO "Passenger airbag on/off customer setting menu present. Present = 1.";
+CM_ SG_ 948 VC_RDY_DRV_CSO "Disable ready to drive popup customer settings menu. Present = 1";
+CM_ SG_ 948 VC_TEEN_PRK_ASST_BRK_CSO "Teen key park assist brake customer settings menu.  Present = 1";
+CM_ SG_ 948 VC_PCS_CSO "Auto on passenger comfort customer settings menu. Present = 1";
+CM_ SG_ 948 VC_FCW_WARN_BRK_CSO "FCW single setting (warning and brake) customer setting menu.  Present = 1";
+CM_ SG_ 948 VC_DOORS_OFF_ACC_DLY_CSO "Doors & engine off power delay customer settings menu backup. Present = 1";
+CM_ SG_ 948 VC_BSM_TRLR_CSO "Blind spot with trailer customer settings menu. Present = 1";
+CM_ SG_ 948 VC_AUTO_SS_CSO "Automatic side step customer settings menu. Present = 1";
+CM_ SG_ 948 VC_MOTORIZED_SEATBELT_STRN_CSO "Motorized Seatbelt Strength customer settings menu";
+CM_ SG_ 948 VC_MOTORIZED_SEATBELT_CSO "Motorized Seatbelt Enable/Disable customer settings menu";
+CM_ SG_ 948 VC_LKA_CSO "Lane Keep Assist Enable/Disable customer settings menu";
+CM_ SG_ 948 VC_BLIND_SPOT_WARNING_CSO "Blind Spot Warning Mode customer settings menu";
+CM_ SG_ 948 VC_ABSD_WARNING_CSO "Active Blind Spot Warning Mode customer settings menu";
+CM_ SG_ 948 VC_ABSD_STRN_CSO "Active Blind Spot Strength customer settings menu";
+CM_ SG_ 948 VC_ABSD_SENS_CSO "Active Blind Spot Sensitivity customer settings menu";
+CM_ SG_ 948 VC_ABSD_HAPTIC_CSO "Active Blind Spot Haptic customer settings menu";
+CM_ SG_ 948 VC_ABSD_CSO "Active Blind Spot Enable/Disable customer settings menu";
+CM_ SG_ 949 VC_BU_VehCfgCSO1_Stat "Backup for Configuration message CSO1 status";
+CM_ SG_ 949 VC_BU_PRK_AST_CSO "Backup for park assist customer settings menu";
+CM_ SG_ 949 VC_BU_PRK_AST_BRK_CSO "Backup for park assist brake customer settings menu";
+CM_ SG_ 949 VC_BU_PRK_FT_VOL_CSO "Backup for park assist front volume customer settings menu";
+CM_ SG_ 949 VC_BU_PRK_RR_VOL_CSO "Backup for park assist rear volume customer settings menu";
+CM_ SG_ 949 VC_BU_EPS_CSO "Backup for electric power steering customer settings menu";
+CM_ SG_ 949 VC_BU_FCW_CSO "Backup for Forward collision warning customer settings menu";
+CM_ SG_ 949 VC_BU_FCW_BRK_CSO "Backup for Forward collision mitigation braking customer settings menu";
+CM_ SG_ 949 VC_BU_HRN_RMT_LK_CSO "Backup for Sound horn with remote lock customer settings menu";
+CM_ SG_ 949 VC_BU_HRN_RMT_ST_CSO "Backup for Sound horn with remote start customer settings menu";
+CM_ SG_ 949 VC_BU_HRN_RMT_LWR_CSO "Backup for Sound horn with remote lower customer settings menu";
+CM_ SG_ 949 VC_BU_CHMSL_LINE_CSO "Backup for CHMSL line customer settings menu";
+CM_ SG_ 949 VC_BU_DCS_CSO "Backup for Auto on driver comfort customer settings menu";
+CM_ SG_ 949 VC_BU_AUX_SWS_CSO "Backup for Auxiliary switches customer settings menu";
+CM_ SG_ 949 VC_BU_CMRA_GRDLNS_CSO "Backup for Rear view camera gridlines customer settings menu";
+CM_ SG_ 949 VC_BU_ACC_DLY_CSO "Backup for Power accessory delay customer settings menu";
+CM_ SG_ 949 VC_BU_AFLS_CSO "Backup for Adaptive front light system customer settings menu";
+CM_ SG_ 949 VC_BU_AMB_DMR_CSO "Backup for Ambient dimmer customer settings menu";
+CM_ SG_ 949 VC_BU_ASCM_TJ_CSO "Backup for Tire jack mode customer settings menu";
+CM_ SG_ 949 VC_BU_ASCM_WRN_CSO "Backup for Air suspension warning customer settings menu";
+CM_ SG_ 949 VC_BU_AUTO_AERO_CSO "Backup for Automatic aero mode customer settings menu";
+CM_ SG_ 949 VC_BU_AUTO_HB_CSO "Backup for Auto high beam customer settings menu";
+CM_ SG_ 949 VC_BU_AUTO_PRK_CSO "Backup for Auto park customer settings menu";
+CM_ SG_ 949 VC_BU_BLIND_SPOT_CSO "Backup for Blind spot alert customer settings menu";
+CM_ SG_ 949 VC_BU_CAPACITY_CSO "Backup for Capacity unit customer settings menu";
+CM_ SG_ 949 VC_BU_CLK_DSP_CSO "Backup for Clock display customer settings menu";
+CM_ SG_ 949 VC_BU_CMP_CAL_CSO "Backup for Compass calibration customer settings menu";
+CM_ SG_ 949 VC_BU_CMP_VAR_CSO "Backup for Compass variance customer settings menu";
+CM_ SG_ 949 VC_BU_CONS_CSO "Backup for Consumption unit customer settings menu";
+CM_ SG_ 949 VC_BU_DISTANCE_CSO "Backup for Distance unit customer settings menu";
+CM_ SG_ 949 VC_BU_DR_LK_CSO "Backup for Auto door lock customer settings menu";
+CM_ SG_ 949 VC_BU_DR_UNLK_CSO "Backup for Auto door unlock customer settings menu";
+CM_ SG_ 949 VC_BU_DRL_CSO "Backup for Daytime running lights customer settings menu";
+CM_ SG_ 949 VC_BU_EASY_EXIT_CSO "Backup for Easy exit seat customer settings menu";
+CM_ SG_ 949 VC_BU_ENTRY_EXIT_CSO "Backup for Auto entry exit mode customer settings menu";
+CM_ SG_ 949 VC_BU_EPB_SERV_CSO "Backup for EPB service mode customer settings menu";
+CM_ SG_ 949 VC_BU_FLSH_LMP_LK_CSO "Backup for Flash lamps with lock customer settings menu";
+CM_ SG_ 949 VC_BU_HL_DRP_CSO "Backup for Headlamp drop customer settings menu";
+CM_ SG_ 949 VC_BU_HL_OFF_DLY_CSO "Backup for Headlamp off delay customer settings menu";
+CM_ SG_ 949 VC_BU_HL_WPR_CSO "Backup for Headlamps on with wiper customer settings menu";
+CM_ SG_ 949 VC_BU_HSA_CSO "Backup for Hill start assist customer settings menu";
+CM_ SG_ 949 VC_BU_ILL_APPRCH_CSO "Backup for Illuminated approach customer settings menu";
+CM_ SG_ 949 VC_BU_LDW_TRQ_CSO "Backup for Lane departure torque customer settings menu";
+CM_ SG_ 949 VC_BU_LDW_WRN_CSO "Backup for Lane departure warning customer settings menu";
+CM_ SG_ 949 VC_BU_LGHT_RMT_LWR_CSO "Backup for Flash lights with remote lower customer settings menu";
+CM_ SG_ 949 VC_BU_NAV_TRN_CSO "Backup for Nav turn by turn customer settings menu";
+CM_ SG_ 949 VC_BU_PE_CSO "Backup for Passive entry customer settings menu";
+CM_ SG_ 949 VC_BU_PER_SHFT_ENBL_CSO "Backup for Performance shift enable customer settings menu";
+CM_ SG_ 949 VC_BU_PER_SHFT_RPM_CSO "Backup for Performance shift rpm customer settings menu";
+CM_ SG_ 949 VC_BU_PLG_CHM_CSO "Backup for Power liftgate chime customer settings menu";
+CM_ SG_ 949 VC_BU_POWER_CSO "Backup for Power unit customer settings menu";
+CM_ SG_ 949 VC_BU_PRESSURE_CSO "Backup for Pressure unit customer settings menu";
+CM_ SG_ 949 VC_BU_PTO_CSO "Backup for Power take off customer settings menu";
+CM_ SG_ 949 VC_BU_RAIN_WPR_CSO "Backup for Rain sensitive wipers customer settings menu";
+CM_ SG_ 949 VC_BU_REAR_CMRA_CSO "Backup for Rear camera customer settings menu";
+CM_ SG_ 949 VC_BU_POLICE_PE_CSO "Backup for police passive entry settings menu; Present = [1]";
+CM_ SG_ 949 VC_BU_UNIT_SET_CSO "Backup for unit set customer settings menu; Present = [1]";
+CM_ SG_ 950 VC_BU_VehCfgCSO2_Stat "Backup for Configuration message CSO2 status";
+CM_ SG_ 950 VC_BU_REAR_CMRA_DLY_CSO "Backup for Rear view camera delay customer settings menu";
+CM_ SG_ 950 VC_BU_RKE_MEM_CSO "Backup for RKE linked to memory customer settings menu";
+CM_ SG_ 950 VC_BU_RKE_UNLK_CSO "Backup for RKE unlock customer settings menu";
+CM_ SG_ 950 VC_BU_SPEED_CSO "Backup for Speed unit customer settings menu";
+CM_ SG_ 950 VC_BU_TLT_MRR_CSO "Backup for Tilt mirror in reverse customer settings menu";
+CM_ SG_ 950 VC_BU_TORQUE_CSO "Backup for Torque unit customer settings menu";
+CM_ SG_ 950 VC_BU_TRLR_CSO "Backup for Trailer selected customer settings menu";
+CM_ SG_ 950 VC_BU_TRLR_NAME_CSO "Backup for Trailer name customer settings menu";
+CM_ SG_ 950 VC_BU_TRLR_TYPE_CSO "Backup for Trailer type customer settings menu";
+CM_ SG_ 950 VC_BU_TRNS_MD_CSO "Backup for Transport mode customer settings menu";
+CM_ SG_ 950 VC_BU_US_METRIC_CSO "Backup for US metric customer settings menu";
+CM_ SG_ 950 VC_BU_WHL_ALGN_CSO "Backup for Wheel alignment customer settings menu";
+CM_ SG_ 950 VC_BU_FUEL_SAV_CSO "Backup for Fuel Saver settings menu; Present = [1]";
+CM_ SG_ 950 VC_BU_TEMP_CSO "Backup for Temperature Unit settings menu; Present = [1]";
+CM_ SG_ 950 VC_BU_FCW_SW_CSO "Backup for FCW Switch customer setting menu present.  Present = 1";
+CM_ SG_ 950 VC_BU_PADDLE_SHIFT_CSO "Backup for paddle shifter customer setting menu present.  Present = [1]";
+CM_ SG_ 950 VC_BU_PWR_FLD_MRR_CSO "Backup for Power folding mirror customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_FCW_BRK_CSO "Backup for Teen key FCW braking customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_FCW_SENS_CSO "Backup for Teen key FCW sensitivity customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_MAX_SPEED_CSO "Backup for Teen key max speed customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_HOLD_N_GO_CSO "Backup for Hold and go customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_HANDS_FREE_LFT_CSO "Backup for Hands free liftgate customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_HANDS_FREE_SLDR_CSO "Backup for Hands free sliding door customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_SVC_GRIDLINES_CSO "Backup for Surround view camera gridlines customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_SVC_DELAY_CSO "Backup for Surround view camera delay customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_SLD_DR_ALRT_CSO "Backup for Sliding door alert customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_PRK_ASST_CSO "Backup for Teen key park assist customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_FT_PRK_VOL_CSO "Backup for Teen key front park assist chime volume customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_RR_PRK_VOL_CSO "Backup for Teen key rear park assist chime volume customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_FUEL_WRN_CSO "Backup for Teen key early fuel warning customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_FUEL_POPUP_CSO "Backup for Teen key fuel pop-up customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_BLIND_SPOT_CSO "Backup for Teen key blind spot customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_RAIN_WPR_CSO "Backup for Teen key rain sensitive wiper customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_AUTO_HB_CSO "Backup for Teen key automatic highbeam customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_LGHT_WPR_CSO "Backup for Teen key lights on with wipers customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_SLD_DR_ALRT_CSO "Backup for Teen key sliding door alert customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_PLG_CHIME_CSO "Backup for Teen key power lift gate chime customer setting menu: Present = 1";
+CM_ SG_ 950 VC_BU_SLD_DR_CHM_CSO "Backup for Sliding door chime customer setting menu present: Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_SLD_DR_CHM_CSO "Backup for Teen key sliding door chime customer setting menu present: Present = 1";
+CM_ SG_ 950 VC_BU_FLSH_LMP_SLDR_CSO "Backup for flash lamps with sliding door customer settings menu; Present = [1]";
+CM_ SG_ 950 VC_BU_SPEED_WARNING_CSO "Backup for Speed warning  customer setting";
+CM_ SG_ 950 VC_BU_LDW_ON_CSO "Backup for LDW on/off customer setting menu present.  Present = 1.";
+CM_ SG_ 950 VC_BU_PRK_ASST_TYPE_CSO "Backup for Park assist type customer setting menu present. Present = 1.";
+CM_ SG_ 950 VC_BU_EPB_ON_CSO "Backup for EPB on/off customer setting menu present. Present = 1.";
+CM_ SG_ 950 VC_BU_AIRBAG_ON_CSO "Backup for Passenger airbag on/off customer setting menu present. Present = 1.";
+CM_ SG_ 950 VC_BU_RDY_DRV_CSO "Backup for disable ready to drive popup customer settings menu.  Present = 1";
+CM_ SG_ 950 VC_BU_TEEN_PRK_ASST_BRK_CSO "Backup teen key park assist brake customer settings menu.  Present = 1";
+CM_ SG_ 950 VC_BU_PCS_CSO "Backup for Auto on passenger comfort customer settings menu. Present = 1";
+CM_ SG_ 950 VC_BU_FCW_WARN_BRK_CSO "Backup for FCW single setting (warning and brake) customer setting menu.  Present = 1";
+CM_ SG_ 950 VC_BU_DOORS_OFF_ACC_DLY_CSO "Backup for Doors & engine off power delay customer settings menu backup. Present = 1";
+CM_ SG_ 950 VC_BU_BSM_TRLR_CSO "Backup for Blind spot with trailer customer settings menu. Present = 1.";
+CM_ SG_ 950 VC_BU_AUTO_SS_CSO "Backup for Automatic side step customer settings menu. Present = 1";
+CM_ SG_ 950 VC_BU_MOTORIZED_SEATBELT_CSO "Motorized Seatbelt Enable/Disable customer settings menu";
+CM_ SG_ 950 VC_BU_LKA_CSO "Lane Keep Assist Enable/Disable customer settings menu";
+CM_ SG_ 950 VC_BU_BLIND_SPOT_WARNING_CSO "Blind Spot Warning Mode customer settings menu";
+CM_ SG_ 950 VC_BU_ABSD_WARNING_CSO "Active Blind Spot Warning Mode customer settings menu";
+CM_ SG_ 950 VC_BU_ABSD_STRN_CSO "Active Blind Spot Strength customer settings menu";
+CM_ SG_ 950 VC_BU_ABSD_SENS_CSO "Active Blind Spot Warning Mode customer settings menu";
+CM_ SG_ 950 VC_BU_ABSD_HAPTIC_CSO "Active Blind Spot Haptic customer settings menu";
+CM_ SG_ 950 VC_BU_ABSD_CSO "Active Blind Spot Enable/Disable customer settings menu";
+CM_ SG_ 950 VC_BU_MOTORIZED_SEATBELT_STRN_CS "Motorized Seatbelt Strength customer settings menu";
+CM_ SG_ 956 NAV_GrpNum "NAV group number";
+CM_ SG_ 956 NAV_GrpTyp "NAV group type";
+CM_ SG_ 956 NAV_HiGrpMark "NAV high group mark";
+CM_ SG_ 956 NAV_TEXT "NAV data field";
+CM_ SG_ 969 AMB_TEMP_AVG_F "Ambient temperature average - in degrees Fahrenheit";
+CM_ SG_ 969 AMB_TEMP_AVG_C "Ambient temperature average - in degrees Celsius";
+CM_ SG_ 974 FT_HVAC_BLW_FN_SP "Front HVAC blower fan speed status in 'bars'";
+CM_ SG_ 974 DRV_TEMP_DR_POS "Driver temperature door postion";
+CM_ SG_ 977 TransTyp "Transmission type";
+CM_ SG_ 979 EC_ECUCfg14_Stat "ECU Configuration messages status 14";
+CM_ SG_ 979 EC_CBC14A "CBC ecu configuration 14A";
+CM_ SG_ 979 EC_CBC14B "CBC ecu configuration 14B";
+CM_ SG_ 980 EC_ECUCfg13_Stat "ECU Configuration messages status 13";
+CM_ SG_ 980 EC_CBC13A "CBC ecu configuration 13A";
+CM_ SG_ 980 EC_CBC13B "CBC ecu configuration 13B";
+CM_ SG_ 981 EC_ECUCfg12_Stat "ECU Configuration messages status 12";
+CM_ SG_ 981 EC_Cluster5A "Instrument cluster ecu configuration 5A";
+CM_ SG_ 981 EC_Cluster5B "Instrument cluster ecu configuration 5B";
+CM_ SG_ 981 EC_Cluster5C "Instrument cluster ecu configuration 5C";
+CM_ SG_ 982 EC_ECUCfg11_Stat "ECU Configuration messages status 11";
+CM_ SG_ 982 EC_CBC10A "CBC ecu configuration 10A";
+CM_ SG_ 982 EC_CBC10B "CBC ecu configuration 10B";
+CM_ SG_ 982 EC_CBC11 "CBC ecu configuration 11";
+CM_ SG_ 983 EC_ECUCfg10_Stat "ECU Configuration messages status 10";
+CM_ SG_ 983 EC_Cluster3A "Instrument cluster ecu configuration 3A";
+CM_ SG_ 983 EC_Cluster3B "Instrument cluster ecu configuration 3B";
+CM_ SG_ 983 EC_Cluster4 "Instrument cluster ecu configuration 4";
+CM_ SG_ 984 EC_ECUCfg9_Stat "ECU Configuration messages status 9";
+CM_ SG_ 984 EC_CBC9A1 "CBC configuration 9A1";
+CM_ SG_ 984 EC_CBC9A2 "CBC configuration 9A2";
+CM_ SG_ 984 EC_CBC9B "CBC configuration 9B";
+CM_ SG_ 984 EC_ITM "ITM ecu configuration";
+CM_ SG_ 985 EC_BU_ECUCfg14_Stat "Backup for ECU Configuration messages status 14";
+CM_ SG_ 985 EC_BU_CBC14A "Backup for CBC ecu configuration 14A";
+CM_ SG_ 985 EC_BU_CBC14B "Backup for CBC ecu configuration 14B";
+CM_ SG_ 986 EC_BU_ECUCfg13_Stat "Backup for ECU Configuration messages status 13";
+CM_ SG_ 986 EC_BU_CBC13A "Backup for CBC ecu configuration 13A";
+CM_ SG_ 986 EC_BU_CBC13B "Backup for CBC ecu configuration 13B";
+CM_ SG_ 987 EC_BU_ECUCfg12_Stat "Backup for ECU Configuration messages status 12";
+CM_ SG_ 987 EC_BU_Cluster5A "Backup for Instrument cluster ecu configuration 5A";
+CM_ SG_ 987 EC_BU_Cluster5B "Backup for Instrument cluster ecu configuration 5B";
+CM_ SG_ 987 EC_BU_Cluster5C "Backup for Instrument cluster ecu configuration 5C";
+CM_ SG_ 988 EC_BU_ECUCfg11_Stat "Backup for ECU Configuration messages status 11";
+CM_ SG_ 988 EC_BU_CBC10A "Backup for CBC ecu configuration 10A";
+CM_ SG_ 988 EC_BU_CBC10B "Backup for CBC ecu configuration 10B";
+CM_ SG_ 988 EC_BU_CBC11 "Backup for CBC ecu configuration 11";
+CM_ SG_ 989 EC_BU_ECUCfg10_Stat "Backup for ECU Configuration messages status 10";
+CM_ SG_ 989 EC_BU_Cluster3A "Backup for Instrument cluster ecu configuration 3A";
+CM_ SG_ 989 EC_BU_Cluster3B "Backup for Instrument cluster ecu configuration 3B";
+CM_ SG_ 989 EC_BU_Cluster4 "Backup for Instrument cluster ecu configuration 4";
+CM_ SG_ 991 EC_BU_ECUCfg9_Stat "Backup for ECU Configuration messages status 9";
+CM_ SG_ 991 EC_BU_CBC9A1 "Backup for CBC configuration 9A1";
+CM_ SG_ 991 EC_BU_CBC9A2 "Backup for CBC configuration 9A2";
+CM_ SG_ 991 EC_BU_CBC9B "Backup for CBC configuration 9B";
+CM_ SG_ 991 EC_BU_ITM "Backup for ITM ecu configuration";
+CM_ SG_ 993 DISPLACEMENT "Engine displacement";
+CM_ SG_ 993 NUM_CYL "Number of engine cylinders";
+CM_ SG_ 993 SpStPrsnt "Stop start feature present";
+CM_ SG_ 993 ENG_ASP "Engine aspiration method";
+CM_ SG_ 993 FUEL_TYPE "Fuel type";
+CM_ SG_ 993 ECM_Vehi_Type "Engine vehicle type";
+CM_ SG_ 993 Manufacture "Engine manufacture";
+CM_ SG_ 993 NUM_VALVE "Number of valves per cylinder";
+CM_ SG_ 993 ETC_PRSNT "Electronic throttle control";
+CM_ SG_ 993 TRANS_TYPE "Transmission type; [0] = manual, [1] = automatic";
+CM_ SG_ 993 EngStyle "Engine output version";
+CM_ SG_ 995 NET_CFG_STAT_INT "Network configuration status";
+CM_ SG_ 995 NetCfg_RBSS "Right Blind-Spot Module (1=present)";
+CM_ SG_ 995 NetCfg_BSM "Blind-Spot Module (1=present)";
+CM_ SG_ 995 NetCfg_CBC_IN "Common Body Controller Int Bus (1=present)";
+CM_ SG_ 995 NetCfg_CSWM "Comfot Seats and Wheel Module (1=present)";
+CM_ SG_ 995 NetCfg_DCM_DR "Door Control Module Driver (1=present)";
+CM_ SG_ 995 NetCfg_DCM_PASS "Door Control Module Passenger (1=present)";
+CM_ SG_ 995 NetCfg_DCM_RL "Door Control Module Rear Left (1=present)";
+CM_ SG_ 995 NetCfg_DCM_RR "Door Control Module Rear Right (1=present)";
+CM_ SG_ 995 NetCfg_HVAC "Heating Ventilation Air Conditioning (1=present)";
+CM_ SG_ 995 NetCfg_MSM "Memory Seat Module (1=present)";
+CM_ SG_ 995 NetCfg_PLG "Power Liftgate Module (1=present)";
+CM_ SG_ 995 NetCfg_VTM "Vehicle theft / tax module (1=present)";
+CM_ SG_ 995 NetCfg_PSD_LT "Power Sliding Door Left Module (1=present)";
+CM_ SG_ 995 NetCfg_PSD_RT "Power Sliding Door Right Module (1=present)";
+CM_ SG_ 995 NetCfg_FSM "Folding Seat Module (1=present)";
+CM_ SG_ 995 NetCfg_PTCM "Power Top Control Module (1=present)";
+CM_ SG_ 995 NetCfg_RBC "Rear Body Controller Module (1=present)";
+CM_ SG_ 995 NetCfg_DTV "Digital TV Module (1=present)";
+CM_ SG_ 995 NetCfg_TGW "Telematics gateway (1=present)";
+CM_ SG_ 995 NetCfg_CLOCK "CAN I Clock Module (1=present)";
+CM_ SG_ 995 NetCfg_VSIM "Vehicle System Interface Module (1=present)";
+CM_ SG_ 995 NetCfg_ITM "Intrusion module (1=present)";
+CM_ SG_ 995 NetCfg_AMP_I "CAN I Amplifier Module (1=present)";
+CM_ SG_ 995 NetCfg_DVD_CDM "CAN I in-dash disc player module (1=present)";
+CM_ SG_ 995 NetCfg_HFM_CTM "Convergence Telematics Module (1=present)";
+CM_ SG_ 995 NetCfg_ICS_I "CAN I Integrated Center Stack Module (1=present)";
+CM_ SG_ 995 NetCfg_VES2_I "CAN I Video Ent. System screen 2 Module (1=present)";
+CM_ SG_ 995 NetCfg_VES3_I "CAN I Video Ent. System screen 1 Module (1=present)";
+CM_ SG_ 995 NetCfg_CRSM "CAN I Comfort Rear Seat Module (1=present)";
+CM_ SG_ 995 NetCfg_HVAC_R "CAN I Rear Heating Ventilation Air Conditioning (1=present)";
+CM_ SG_ 995 NetCfg_DCSD "Disassociated Center Stack Display Module (1=present)";
+CM_ SG_ 995 NetCfg_TBM "Telematics Box Module (1=present)";
+CM_ SG_ 995 NetCfg_CVPM "CAN I Central Vision Processing Module (1=present)";
+CM_ SG_ 995 NetCfg_TMM "CAN I Track Mapping Module (1=present)";
+CM_ SG_ 995 NetCfg_ICS_R "CAN I Integrated rear Center Stack Module (1=present)";
+CM_ SG_ 995 NetCfg_MSM_PASS "CAN I Memory Seat Module Passenger (1=present)";
+CM_ SG_ 995 NetCfg_VRM "Video Routing Module (1=present)";
+CM_ SG_ 995 NetCfg_ANC_I "Active Noise Cancellation interior (1=present)";
+CM_ SG_ 995 NetCfg_TTM "0= Not Present;  1= Present";
+CM_ SG_ 995 NetCfg_UPFM "CAN I Upfitter Module (1=present)";
+CM_ SG_ 995 NetCfg_PSSM "NetCfg PSSM";
+CM_ SG_ 996 NET_CFG_STAT_PT "Network configuration status";
+CM_ SG_ 996 NetCfg_ACC "Active Cruise Control (1=present)";
+CM_ SG_ 996 NetCfg_ADCM "Active Damping Control Module (1=present)";
+CM_ SG_ 996 NetCfg_AHLM "Automatic Headlamp Leveling Module (1=present)";
+CM_ SG_ 996 NetCfg_VSIM_C "Vehicle System Interface Module (1=present)";
+CM_ SG_ 996 NetCfg_ASCM "Air Suspension Control Module (1=present)";
+CM_ SG_ 996 NetCfg_CBC_PT "Common Body Controller PT Bus (1=present)";
+CM_ SG_ 996 NetCfg_DTCM "Drivetrain Control Module (1=present)";
+CM_ SG_ 996 NetCfg_ECM "Engine Control Module (1=present)";
+CM_ SG_ 996 NetCfg_EPS "Electric Power Steering (1=present)";
+CM_ SG_ 996 NetCfg_ESM "Electronic Shift Module (1=present)";
+CM_ SG_ 996 NetCfg_ESC "Electronic Stability Module / Anti-Lock Brake (1=present)";
+CM_ SG_ 996 NetCfg_EPB "Electric Park Brake Module (1=present)";
+CM_ SG_ 996 NetCfg_RF_HUB "RF Hub Node (1=present)";
+CM_ SG_ 996 NetCfg_IC "Instrument Cluster (1=present)";
+CM_ SG_ 996 NetCfg_DASM "Driver Assistance System Module (1=present)";
+CM_ SG_ 996 NetCfg_FDCM "Final Drive Control Module (1=present)";
+CM_ SG_ 996 NetCfg_EPPM "Elect. Pedestrian protection module (1=present)";
+CM_ SG_ 996 NetCfg_ORC "Occupant Restraint Controller (1=present)";
+CM_ SG_ 996 NetCfg_PTS "Parktronics System (1=present)";
+CM_ SG_ 996 NetCfg_SCCM "Steering Column Control Module (1=present)";
+CM_ SG_ 996 NetCfg_ELSD "Electric Limited Slip Differential (1=present)";
+CM_ SG_ 996 NetCfg_TCM "Automatic Transmission Controller (1=present)";
+CM_ SG_ 996 NetCfg_TPM "Tire Pressure Monitor (1=present)";
+CM_ SG_ 996 NetCfg_PASS_PT "Personal Assistant Safety System Module PT Bus (1=present)";
+CM_ SG_ 996 NetCfg_AFLS "Advanced Front Lighting System (1=present)";
+CM_ SG_ 996 NetCfg_ITBM "Integrated Trailer Brake Module (1=present)";
+CM_ SG_ 996 NetCfg_OCM "Occupant Classification Module (1=present)";
+CM_ SG_ 996 NetCfg_HaLF "Haptic Lane Feedback module (1=present)";
+CM_ SG_ 996 NetCfg_ANC "Active Noise Cancellation (1=present)";
+CM_ SG_ 996 NetCfg_HCP "Hybrid Control Processor (1=present)";
+CM_ SG_ 996 NetCfg_ESL "Electric Steering Lock (1=present)";
+CM_ SG_ 996 NetCfg_BSMO "Brake System Module - OBD (1=present)";
+CM_ SG_ 996 NetCfg_SGW "Security GateWay (1=present)";
+CM_ SG_ 996 NetCfg_DPDM "Driver Presence Detection Module (1=present)";
+CM_ SG_ 996 NetCfg_ASBS "Automatic Sway Bar System Module (Present = 1, Not Present = 0)";
+CM_ SG_ 996 NetCfg_ATMM "Active Tuned Mass Module (Present = 1, Not Present = 0)";
+CM_ SG_ 996 NetCfg_SWSM "Steering wheel sensor module (HOD)";
+CM_ SG_ 996 NetCfg_MSBD "Motorized Seatbelt Module (1=present)";
+CM_ SG_ 998 BU_NET_CFG_STAT_INT "Backup for network configuration status";
+CM_ SG_ 998 BU_NetCfg_RBSS "Backup for Right Blind-Spot Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_BSM "Backup for Blind-Spot Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_CBC_IN "Backup for Common Body Controller Int Bus (1=present)";
+CM_ SG_ 998 BU_NetCfg_CSWM "Backup for Comfot Seats and Wheel Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_DCM_DR "Backup for Door Control Module Driver (1=present)";
+CM_ SG_ 998 BU_NetCfg_DCM_PASS "Backup for Door Control Module Passenger (1=present)";
+CM_ SG_ 998 BU_NetCfg_DCM_RL "Backup for Door Control Module Rear Left (1=present)";
+CM_ SG_ 998 BU_NetCfg_DCM_RR "Backup for Door Control Module Rear Right (1=present)";
+CM_ SG_ 998 BU_NetCfg_HVAC "Backup for Heating Ventilation Air Conditioning (1=present)";
+CM_ SG_ 998 BU_NetCfg_MSM "Backup for Memory Seat Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_PLG "Backup for Power Liftgate Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_VTM "Backup for vehicle theft / tax module (1=present)";
+CM_ SG_ 998 BU_NetCfg_PSD_LT "Backup for Power Sliding Door Left Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_PSD_RT "Backup for Power Sliding Door Right Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_FSM "Backup for Folding Seat Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_PTCM "Backup for Power Top Control Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_RBC "Backup for Rear Body Controller Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_DTV "Backup for Digital TV Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_TGW "Backup for Telematics gateway (1=present)";
+CM_ SG_ 998 BU_NetCfg_CLOCK "Backup for CAN I Clock Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_VSIM "Backup for Vehicle System Interface Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_ITM "Backup for Intrusion module (1=present)";
+CM_ SG_ 998 BU_NetCfg_AMP_I "Backup for CAN I Amplifier Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_DVD_CDM "Backup for CAN I in-dash disc player module (1=present)";
+CM_ SG_ 998 BU_NetCfg_HFM_CTM "Backup for Convergence Telematics Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_ICS_I "Backup for CAN I Integrated Center Stack Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_VES2_I "Backup for CAN I Video Ent. System screen 2 Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_VES3_I "Backup for CAN I Video Ent. System screen 1 Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_CRSM "Backup for CAN I Comfort Rear Seat Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_HVAC_R "Backup for CAN I Rear Heating Ventilation Air Conditioning (1=present)";
+CM_ SG_ 998 BU_NetCfg_DCSD "Backup for Disassociated Center Stack Display Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_TBM "Backup for Telematics Box Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_CVPM "Backup for CAN I Central Vision Processing Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_TMM "Backup for CAN I Track Mapping Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_ICS_R "Backup for CAN I Integrated rear Center Stack Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_MSM_PASS "Backup for CAN I Memory Seat Module Passenger (1=present)";
+CM_ SG_ 998 BU_NetCfg_VRM "Backup for Video Routing Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_ANC_I "Backup for Active Noise Cancellation interior (1=present)";
+CM_ SG_ 998 BU_NetCfg_TTM "0= Not Present;  1= Present";
+CM_ SG_ 998 BU_NetCfg_UPFM "Backup for Upfitter Module (1=present)";
+CM_ SG_ 998 BU_NetCfg_PSSM "NetCfg PSSM";
+CM_ SG_ 999 BU_NET_CFG_STAT_PT "Backup for network configuration status";
+CM_ SG_ 999 BU_NetCfg_ACC "Backup for Active Cruise Control (1=present)";
+CM_ SG_ 999 BU_NetCfg_ADCM "Backup for Active Damping Control Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_AHLM "Backup for Automatic Headlamp Leveling Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_VSIM_C "Backup for Vehicle System Interface Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ASCM "Backup for Air Suspension Control Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_CBC_PT "Backup for Common Body Controller PT Bus (1=present)";
+CM_ SG_ 999 BU_NetCfg_DTCM "Backup for Drivetrain Control Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ECM "Backup for Engine Control Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_EPS "Backup for Electric Power Steering (1=present)";
+CM_ SG_ 999 BU_NetCfg_ESM "Backup for Electronic Shift Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ESC "Backup for Electronic Stability Module / Anti-Lock Brake (1=present)";
+CM_ SG_ 999 BU_NetCfg_EPB "Backup for Electric Park Brake Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_RF_HUB "Backup for RF HUB Node (1=present)";
+CM_ SG_ 999 BU_NetCfg_IC "Backup for Instrument Cluster (1=present)";
+CM_ SG_ 999 BU_NetCfg_DASM "Backup for Driver Assistance System Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_FDCM "Backup for Final Drive Control Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_EPPM "Backup for  Elect. Pedestrian protection module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ORC "Backup for Occupant Restraint Controller (1=present)";
+CM_ SG_ 999 BU_NetCfg_PTS "Backup for Parktronics System (1=present)";
+CM_ SG_ 999 BU_NetCfg_SCCM "Backup for Steering Column Control Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ELSD "Backup for Electric Limited Slip Differential (1=present)";
+CM_ SG_ 999 BU_NetCfg_TCM "Backup for Automatic Transmission Controller (1=present)";
+CM_ SG_ 999 BU_NetCfg_TPM "Backup for Tire Pressure Monitor (1=present)";
+CM_ SG_ 999 BU_NetCfg_PASS_PT "Backup for Personal Assistant Safety System Module PT Bus (1=present)";
+CM_ SG_ 999 BU_NetCfg_AFLS "Backup for Advanced Front Lighting System (1=present)";
+CM_ SG_ 999 BU_NetCfg_ITBM "Backup for Integrated Trailer Brake Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_OCM "Backup for Occupant Classification Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_HaLF "Backup for Haptic Lane Feedback module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ANC "Backup for Active Noise Cancellation (1=present)";
+CM_ SG_ 999 BU_NetCfg_HCP "Backup for Hybrid Control Processor (1=present)";
+CM_ SG_ 999 BU_NetCfg_ESL "Backup for Electric Steering Lock (1=present)";
+CM_ SG_ 999 BU_NetCfg_BSMO "Backup for Brake System Module - OBD (1=present)";
+CM_ SG_ 999 BU_NetCfg_SGW "Backup for Security GateWay (1=present)";
+CM_ SG_ 999 BU_NetCfg_DPDM "Backup for Driver Presence Detection Module (1=present)";
+CM_ SG_ 999 BU_NetCfg_ASBS "Automatic Sway Bar System Module (Present = 1, Not Present = 0)";
+CM_ SG_ 999 BU_NetCfg_ATMM "Backup Active Tuned Mass Module (Present = 1, Not Present = 0)";
+CM_ SG_ 999 BU_NetCfg_SWSM "Steering wheel sensor module (HOD)";
+CM_ SG_ 999 BU_NetCfg_MSBD "Motorized Seatbelt Module (1=present)";
+CM_ SG_ 1000 VC_VehCfg1_Stat "Configuration messages status 1";
+CM_ SG_ 1000 VC_MODEL_YEAR "Model year";
+CM_ SG_ 1000 VC_VEH_LINE "Vehicle line";
+CM_ SG_ 1000 VC_COUNTRY "Country Code";
+CM_ SG_ 1000 VC_LHD_RHD "Left/right hand drive";
+CM_ SG_ 1000 VC_RemStPrsnt "Remote start present; present = [1]";
+CM_ SG_ 1000 VC_XWD "Drive configuration";
+CM_ SG_ 1000 VC_EmodePrsnt "E-Mode feature present; True = [1]";
+CM_ SG_ 1000 VC_AUTO_HB "Auto Highbeam feature present; present = [1]";
+CM_ SG_ 1000 VC_BODY_STYLE "Body style";
+CM_ SG_ 1000 VC_MAX_VEH_SPD "Maximum vehicle speed";
+CM_ SG_ 1000 VC_ShftrTyp "Shifter type";
+CM_ SG_ 1000 VC_PTS_DispTyp "PTS display type and location";
+CM_ SG_ 1000 VC_PP_Prsnt "Performance Pages Present (1=present)";
+CM_ SG_ 1000 VC_SpecialPKG "Special sales code package";
+CM_ SG_ 1000 VC_HdRstPrsnt "Headrest present; present = [1]";
+CM_ SG_ 1000 VC_SCR_Prsnt "Urea/SCR system present; present = [1]";
+CM_ SG_ 1000 VC_PTS_Config "Parktronics system configuration";
+CM_ SG_ 1000 VC_RVCM_Prsnt "Rear view camera (1=present)";
+CM_ SG_ 1000 VC_CHMCM_Prsnt "CHMSL camera (1=present)";
+CM_ SG_ 1000 VC_HDC_Prsnt "Hill descent feature is present; present = [1]";
+CM_ SG_ 1000 VC_SSC_Prsnt "Select speed control feature is present; present = [1]";
+CM_ SG_ 1001 VC_VehCfg2_Stat "Configuration messages status 2";
+CM_ SG_ 1001 VC_PwrIvtrTyp "Power inverter type";
+CM_ SG_ 1001 VC_ThatchamPrsnt "Thatcham present; present = [1]";
+CM_ SG_ 1001 VC_RunFlatTirePrsnt "Run flat tires present; present = [1]";
+CM_ SG_ 1001 VC_MaseratiMd "Maserati vehicle mode";
+CM_ SG_ 1001 VC_PADS_Prsnt "Pass. airbag disable switch present; present = [1]";
+CM_ SG_ 1001 VC_RainSnsPrsnt "Rain sensor present; present = [1]";
+CM_ SG_ 1001 VC_SKIM_PRSNT "SKIM system present; present = [1]";
+CM_ SG_ 1001 VC_AC_Prsnt "Vehicle is equipped with air conditioning; present = [1]";
+CM_ SG_ 1001 VC_CRUISE_PRSNT "Cruise feature is present; present = [1]";
+CM_ SG_ 1001 VC_FG_PRSNT "Flipper glass present; present = [1]";
+CM_ SG_ 1001 VC_FULL_SPARE "Full size spare; present = [1]";
+CM_ SG_ 1001 VC_OffRoad "Off road capable; present = [1]";
+CM_ SG_ 1001 VC_SpecialPKG_IC "Special sales code package";
+CM_ SG_ 1001 VC_ECO_Indicator "ECO Indicator present on vehicle; True = [1]";
+CM_ SG_ 1001 VC_DRVMD_Prsnt "Drive mode feature configuration (1 = Present)";
+CM_ SG_ 1001 VC_MemoryDRVMD_Prsnt "Memory drive mode sub-feature configuration (1 = Present)";
+CM_ SG_ 1001 VC_ESCDrvMd_Prsnt "ESC drive mode sub-feature configuration (1 = Present)";
+CM_ SG_ 1001 VC_EngPowerDrvMd_Prsnt "ECM drive mode sub-feature configuration (1 = Present)";
+CM_ SG_ 1001 VC_SecPrkPrsnt "Secure park feature present; present = [1]";
+CM_ SG_ 1001 VC_ShftInd_Prsnt "Configuration for performance & gear shift indication";
+CM_ SG_ 1001 VC_MaxLdPressRrTr "Max Load Inflation Pressure Rear Tire";
+CM_ SG_ 1001 VC_MaxLdPressFtTr "Max Load Inflation Pressure Front Tire";
+CM_ SG_ 1001 VC_LgtLdPressRrTr "Light Load Inflation Pressure Rear Tire";
+CM_ SG_ 1001 VC_LgtLdPressFtTr "Light Load Inflation Pressure Front Tire";
+CM_ SG_ 1002 VC_VehCfg3_Stat "Configuration messages status 3";
+CM_ SG_ 1002 VC_POLICE "Police lighting feature; present = [1]";
+CM_ SG_ 1002 VC_PWR_LFT_GT "Power lift gate present; present = [1]";
+CM_ SG_ 1002 VC_PWR_RT_SLDR "Power right sliding door present; present = [1]";
+CM_ SG_ 1002 VC_PWR_LT_SLDR "Power left sliding door present; present = [1]";
+CM_ SG_ 1002 VC_RKE_PRSNT "RKE system present; present = [1]";
+CM_ SG_ 1002 VC_SunShade_Present "Vehicle equipped w/SunShade (1=present)";
+CM_ SG_ 1002 VC_TcaseTyp "Tcase type";
+CM_ SG_ 1002 VC_WHL_BASE "Wheel base";
+CM_ SG_ 1002 VC_FOBIKsafeENBL "Feature FOBIK safe is enabled; present = [1]";
+CM_ SG_ 1002 VC_ELV_Prsnt "ELV system present; enabled=[1], disabled=[0]";
+CM_ SG_ 1002 VC_FUEL_CAP "Fuel capacity";
+CM_ SG_ 1002 VC_WIN_EXPR_FEAT "Window express feature configuration";
+CM_ SG_ 1002 VC_ADJ_PDL_PRSNT "Adjustable pedal system present (non-memory); present = [1]";
+CM_ SG_ 1002 VC_AUTO_HL "Auto headlamp feature present; present = [1]";
+CM_ SG_ 1002 VC_DrAlrPrsnt "Door alert feature present; present = [1]";
+CM_ SG_ 1002 VC_DualFuelSens "Vehicle equipped with two fuel sending units; present = [1]";
+CM_ SG_ 1002 VC_SRT_PRSNT "Vehicle is an SRT; present = [1]";
+CM_ SG_ 1002 VC_DSBL_CLK_DISP "Disable display of radio clock; 1 = clock display disabled";
+CM_ SG_ 1002 VC_ChassisType "Chassis type (including suspension, brakes, and tires)";
+CM_ SG_ 1002 VC_TEMP_DISP "Display outside temperature present; present = [1]";
+CM_ SG_ 1002 VC_HVAC_Config "HVAC Configuration";
+CM_ SG_ 1002 VC_VEH_BRAND "Vehicle brand type";
+CM_ SG_ 1002 VC_CMP_DISP "Display compass heading present; present = [1]";
+CM_ SG_ 1002 VC_IntEC_MIRR "Vehicle is equipped with an interior EC mirror; present = [1]";
+CM_ SG_ 1002 VC_ESCL_PRSNT "ESCL system present; enabled=[1], disabled=[0]";
+CM_ SG_ 1002 VC_HID_HL "High intensity discharge head lamps; present = [1]";
+CM_ SG_ 1002 VC_SecLkPrsnt "Secondary Lock Present; [1] = True";
+CM_ SG_ 1002 VC_Liftgate_Trunk "Liftgate or trunk";
+CM_ SG_ 1002 VC_CMS "Collision Mitigation System present; present = [1]";
+CM_ SG_ 1002 VC_FCW "Forward Collision Warning present; present = [1]";
+CM_ SG_ 1002 VC_Base_TPM "Base TPM system present; present = [1]";
+CM_ SG_ 1002 VC_Prem_TPM "Premium TPM system present; present = [1]";
+CM_ SG_ 1002 VC_PDDL_PRSNT "Paddle shift feature is present; present = [1]";
+CM_ SG_ 1002 VC_SPORT_PRSNT "Sport mode is present; present = [1]";
+CM_ SG_ 1002 VC_AutoParkPrsnt "Automatic transmission parking feature is present; present = [1]";
+CM_ SG_ 1002 VC_PE_Prsnt "Feature passive entry is present; present = [1]";
+CM_ SG_ 1002 VC_KG_Prsnt "Feature keyless go is present; present = [1]";
+CM_ SG_ 1003 VC_TCASE_HI_RATIO "Transfer case high ratio";
+CM_ SG_ 1003 VC_VehCfg4_Stat "Configuration messages status 4";
+CM_ SG_ 1003 VC_AXLE_RATIO "Axle ratio";
+CM_ SG_ 1003 VC_TCASE_LO_RATIO "Transfer case low range reduction ratio";
+CM_ SG_ 1003 VC_TIRE_CIRCUMF "Dynamic tire circumference (all or rear)";
+CM_ SG_ 1004 VC_BU_VehCfg1_Stat "Backup for Configuration messages status 1";
+CM_ SG_ 1004 VC_BU_MODEL_YEAR "Backup for Model year";
+CM_ SG_ 1004 VC_BU_VEH_LINE "Backup for Vehicle line";
+CM_ SG_ 1004 VC_BU_COUNTRY "Backup for Country Code";
+CM_ SG_ 1004 VC_BU_LHD_RHD "Backup for Left/right hand drive";
+CM_ SG_ 1004 VC_BU_RemStPrsnt "Backup for Remote start present; present = [1]";
+CM_ SG_ 1004 VC_BU_XWD "Backup for Drive configuration";
+CM_ SG_ 1004 VC_BU_EmodePrsnt "Backup for E-Mode feature present; True = [1]";
+CM_ SG_ 1004 VC_BU_AUTO_HB "Backup for Auto Highbeam feature present; present = [1]";
+CM_ SG_ 1004 VC_BU_BODY_STYLE "Backup for Body style";
+CM_ SG_ 1004 VC_BU_MAX_VEH_SPD "Backup for Maximum vehicle speed";
+CM_ SG_ 1004 VC_BU_ShftrTyp "Shifter type";
+CM_ SG_ 1004 VC_BU_PTS_DispTyp "PTS display type and location";
+CM_ SG_ 1004 VC_BU_PP_Prsnt "Backup for Performance Pages Present (1=present)";
+CM_ SG_ 1004 VC_BU_SpecialPKG "Special sales code package";
+CM_ SG_ 1004 VC_BU_HdRstPrsnt "Backup for headrest present; present = [1]";
+CM_ SG_ 1004 VC_BU_SCR_Prsnt "Backup for Urea/SCR system present; present = [1]";
+CM_ SG_ 1004 VC_BU_PTS_Config "Backup for Parktronics system configuration";
+CM_ SG_ 1004 VC_BU_RVCM_Prsnt "Backup for rear view camera (1=present)";
+CM_ SG_ 1004 VC_BU_CHMCM_Prsnt "Backup for CHMSL camera (1=present)";
+CM_ SG_ 1004 VC_BU_HDC_Prsnt "Backup for Hill descent feature is present; present = [1]";
+CM_ SG_ 1004 VC_BU_SSC_Prsnt "Backup for Select speed control feature is present; present = [1]";
+CM_ SG_ 1005 VC_BU_VehCfg2_Stat "Backup for Configuration messages status 2";
+CM_ SG_ 1005 VC_BU_PwrIvtrTyp "Backup for power inverter type";
+CM_ SG_ 1005 VC_BU_ThatchamPrsnt "Backup for thatcham present; present = [1]";
+CM_ SG_ 1005 VC_BU_RunFlatTirePrsnt "Backup for run flat tires present; present = [1]";
+CM_ SG_ 1005 VC_BU_MaseratiMd "Backup for Maserati vehicle mode";
+CM_ SG_ 1005 VC_BU_PADS_Prsnt "Backup for Pass. airbag disable switch present; present = [1]";
+CM_ SG_ 1005 VC_BU_RainSnsPrsnt "Backup for Rain sensor present; present = [1]";
+CM_ SG_ 1005 VC_BU_SKIM_PRSNT "Backup for SKIM system present; present = [1]";
+CM_ SG_ 1005 VC_BU_AC_Prsnt "Backup for Vehicle is equipped with air conditioning; present = [1]";
+CM_ SG_ 1005 VC_BU_CRUISE_PRSNT "Backup for Cruise feature is present; present = [1]";
+CM_ SG_ 1005 VC_BU_FG_PRSNT "Backup for Flipper glass present; present = [1]";
+CM_ SG_ 1005 VC_BU_FULL_SPARE "Backup for Full size spare; present = [1]";
+CM_ SG_ 1005 VC_BU_OffRoad "Backup for Off road capable; present = [1]";
+CM_ SG_ 1005 VC_BU_SpecialPKG_IC "Special sales code package";
+CM_ SG_ 1005 VC_BU_ECO_Indicator "Backup for ECO Indicator present on vehicle; True = [1]";
+CM_ SG_ 1005 VC_BU_DRVMD_Prsnt "Backup for drive mode feature configuration (1 = Present)";
+CM_ SG_ 1005 VC_BU_MemoryDRVMD_Prsnt "Backup for memory drive mode sub-feature configuration (1 = Present)";
+CM_ SG_ 1005 VC_BU_ESCDrvMd_Prsnt "Backup for ESC drive mode sub-feature configuration (1 = Present)";
+CM_ SG_ 1005 VC_BU_EngPowerDrvMd_Prsnt "Backup for ECM drive mode sub-feature configuration (1 = Present)";
+CM_ SG_ 1005 VC_BU_SecPrkPrsnt "Backup for secure park feature present; present = [1]";
+CM_ SG_ 1005 VC_BU_ShftInd_Prsnt "Backup for configuration for performance & gear shift indication";
+CM_ SG_ 1005 VC_BU_MaxLdPressRrTr "Backup for Max Load Inflation Pressure Rear Tire";
+CM_ SG_ 1005 VC_BU_MaxLdPressFtTr "Backup for Max Load Inflation Pressure Front Tire";
+CM_ SG_ 1005 VC_BU_LgtLdPressRrTr "Backup for Light Load Inflation Pressure Rear Tire";
+CM_ SG_ 1005 VC_BU_LgtLdPressFtTr "Backup for Light Load Inflation Pressure Front Tire";
+CM_ SG_ 1006 VC_BU_VehCfg3_Stat "Backup for Configuration messages status 3";
+CM_ SG_ 1006 VC_BU_POLICE "Backup for Police lighting feature; present = [1]";
+CM_ SG_ 1006 VC_BU_PWR_LFT_GT "Backup for Power lift gate present; present = [1]";
+CM_ SG_ 1006 VC_BU_PWR_RT_SLDR "Backup for Power right sliding door present; present = [1]";
+CM_ SG_ 1006 VC_BU_PWR_LT_SLDR "Backup for Power left sliding door present; present = [1]";
+CM_ SG_ 1006 VC_BU_RKE_PRSNT "Backup for RKE system present; present = [1]";
+CM_ SG_ 1006 VC_BU_SunShade_Present "Backup for Vehicle equipped w/SunShade (1=present)";
+CM_ SG_ 1006 VC_BU_TcaseTyp "Backup for Tcase type";
+CM_ SG_ 1006 VC_BU_WHL_BASE "Backup for Wheel base";
+CM_ SG_ 1006 VC_BU_FOBIKsafeENBL "Backup for FOBIK safe feature; present = [1]";
+CM_ SG_ 1006 VC_BU_ELV_PRSNT "Backup for ELV system present; enabled=[1], disabled=[0]";
+CM_ SG_ 1006 VC_BU_FUEL_CAP "Backup for Fuel capacity";
+CM_ SG_ 1006 VC_BU_WIN_EXPR_FEAT "Backup for Window express feature configuration";
+CM_ SG_ 1006 VC_BU_ADJ_PDL_PRSNT "Backup for Adjustable pedal system present (non-memory); present = [1]";
+CM_ SG_ 1006 VC_BU_AUTO_HL "Backup for Auto headlamp feature present; present = [1]";
+CM_ SG_ 1006 VC_BU_DrAlrPrsnt "Backup for Door alert feature present; present = [1]";
+CM_ SG_ 1006 VC_BU_DualFuelSens "Backup for Vehicle equipped with two fuel sending units; present = [1]";
+CM_ SG_ 1006 VC_BU_SRT_PRSNT "Backup for Vehicle is an SRT; present = [1]";
+CM_ SG_ 1006 VC_BU_DSBL_CLK_DISP "Backup of Disable display of radio clock; 1 = clock display disabled";
+CM_ SG_ 1006 VC_BU_ChassisType "Backup for chassis type (including suspension, brakes, and tires)";
+CM_ SG_ 1006 VC_BU_TEMP_DISP "Backup for display outside temperature present; present = [1]";
+CM_ SG_ 1006 VC_BU_HVAC_Config "Backup for HVAC Configuration";
+CM_ SG_ 1006 VC_BU_VEH_BRAND "Backup for Vehicle brand type";
+CM_ SG_ 1006 VC_BU_CMP_DISP "Backup for display compass heading present; present = [1]";
+CM_ SG_ 1006 VC_BU_IntEC_MIRR "Backup for vehicle is equipped with an interior EC mirror; present = [1]";
+CM_ SG_ 1006 VC_BU_ESCL_Prsnt "Backup for ESCL system present; enabled=[1], disabled=[0]";
+CM_ SG_ 1006 VC_BU_HID_HL "Backup for High intensity discharge head lamps; present = [1]";
+CM_ SG_ 1006 VC_BU_SecLkPrsnt "Backup for Secondary Lock Present; [1] = True";
+CM_ SG_ 1006 VC_BU_Liftgate_Trunk "Backup for Liftgate or trunk";
+CM_ SG_ 1006 VC_BU_CMS "Backup for Collision Mitigation System present; present = [1]";
+CM_ SG_ 1006 VC_BU_FCW "Backup for Forward Collision Warning present; present = [1]";
+CM_ SG_ 1006 VC_BU_Base_TPM "Backup for Base TPM system present; present = [1]";
+CM_ SG_ 1006 VC_BU_Prem_TPM "Backup for Premium TPM system present; present = [1]";
+CM_ SG_ 1006 VC_BU_PDDL_PRSNT "backup for Paddle shift feature is present; present = [1]";
+CM_ SG_ 1006 VC_BU_SPORT_PRSNT "Backup for Sport mode is present; present = [1]";
+CM_ SG_ 1006 VC_BU_AutoParkPrsnt "Backup for automatic transmission parking feature is present; present = [1]";
+CM_ SG_ 1006 VC_BU_PE_Prsnt "Backup for passive entry is present; present = [1]";
+CM_ SG_ 1006 VC_BU_KG_Prsnt "Backup for keyless go is present; present = [1]";
+CM_ SG_ 1007 VC_BU_TCASE_HI_RATIO "Backup for Transfer case high ratio";
+CM_ SG_ 1007 VC_BU_VehCfg4_Stat "Backup for Configuration messages status 4";
+CM_ SG_ 1007 VC_BU_AXLE_RATIO "Backup for Axle ratio";
+CM_ SG_ 1007 VC_BU_TCASE_LO_RATIO "Backup for Transfer case low range reduction ratio";
+CM_ SG_ 1007 VC_BU_TIRE_CIRCUMF "Backup for Dynamic tire circumference (all or rear)";
+CM_ SG_ 1008 EC_ECUCfg1_Stat "ECU Configuration messages status 1";
+CM_ SG_ 1008 EC_CBC1A "CBC ecu configuration 1A";
+CM_ SG_ 1008 EC_CBC1B "CBC ecu configuration 1B";
+CM_ SG_ 1008 EC_CBC2 "CBC ecu configuration 2";
+CM_ SG_ 1009 EC_ECUCfg2_Stat "ECU Configuration messages status 2";
+CM_ SG_ 1009 EC_CBC3A "CBC ecu configuration 3A";
+CM_ SG_ 1009 EC_CBC3B "CBC ecu configuration 3B";
+CM_ SG_ 1009 EC_CBC4 "CBC ecu configuration 4";
+CM_ SG_ 1010 EC_ECUCfg3_Stat "ECU Configuration messages status 3";
+CM_ SG_ 1010 EC_AudTel1A "Audio and telematics ecu configuration 1A";
+CM_ SG_ 1010 EC_AudTel1B "Audio and telematics ecu configuration 1B";
+CM_ SG_ 1010 EC_AudTel2 "Audio and telematics ecu configuration 2";
+CM_ SG_ 1011 EC_ECUCfg4_Stat "ECU Configuration messages status 4";
+CM_ SG_ 1011 EC_Cluster1A "Instrument cluster ecu configuration 1A";
+CM_ SG_ 1011 EC_Cluster1B "Instrument cluster ecu configuration 1B";
+CM_ SG_ 1011 EC_Cluster2 "Instrument cluster ecu configuration 2";
+CM_ SG_ 1012 EC_ECUCfg5_Stat "ECU Configuration messages status 5";
+CM_ SG_ 1012 EC_WirelessA "Wireless ecu configurationA";
+CM_ SG_ 1012 EC_WirelessB "Wireless ecu configurationB";
+CM_ SG_ 1012 EC_Doors "Doors ecu configuration";
+CM_ SG_ 1012 EC_Memory "Memory ecu configuration";
+CM_ SG_ 1013 EC_ECUCfg6_Stat "ECU Configuration messages status 6";
+CM_ SG_ 1013 EC_BrakesA "Brake system ecu configurationA";
+CM_ SG_ 1013 EC_BrakesB "Brake system ecu configurationB";
+CM_ SG_ 1013 EC_Steering "Steering ecu configuration";
+CM_ SG_ 1013 EC_Powertrain "Powertrain ecu configuration";
+CM_ SG_ 1013 EC_Safety "Safety ecu configuration";
+CM_ SG_ 1014 EC_ECUCfg7_Stat "ECU Configuration messages status 7";
+CM_ SG_ 1014 EC_CBC5A "CBC ecu configuration 5A";
+CM_ SG_ 1014 EC_CBC5B "CBC ecu configuration 5B";
+CM_ SG_ 1014 EC_CBC6 "CBC ecu configuration 6";
+CM_ SG_ 1015 EC_ECUCfg8_Stat "ECU Configuration messages status 8";
+CM_ SG_ 1015 EC_CBC7A "CBC ecu configuration 7A";
+CM_ SG_ 1015 EC_CBC7B "CBC ecu configuration 7B";
+CM_ SG_ 1015 EC_CBC8 "CBC ecu configuration 8";
+CM_ SG_ 1016 EC_BU_ECUCfg1_Stat "Backup for ECU Configuration messages status 1";
+CM_ SG_ 1016 EC_BU_CBC1A "Backup for CBC ecu configuration 1A";
+CM_ SG_ 1016 EC_BU_CBC1B "Backup for CBC ecu configuration 1B";
+CM_ SG_ 1016 EC_BU_CBC2 "Backup for CBC ecu configuration 2";
+CM_ SG_ 1017 EC_BU_ECUCfg2_Stat "Backup for ECU Configuration messages status 2";
+CM_ SG_ 1017 EC_BU_CBC3A "Backup for CBC ecu configuration 3A";
+CM_ SG_ 1017 EC_BU_CBC3B "Backup for CBC ecu configuration 3B";
+CM_ SG_ 1017 EC_BU_CBC4 "Backup for CBC ecu configuration 4";
+CM_ SG_ 1018 EC_BU_ECUCfg3_Stat "Backup for ECU Configuration messages status 3";
+CM_ SG_ 1018 EC_BU_AudTel1A "Backup for Audio and telematics ecu configuration 1A";
+CM_ SG_ 1018 EC_BU_AudTel1B "Backup for Audio and telematics ecu configuration 1B";
+CM_ SG_ 1018 EC_BU_AudTel2 "Backup for Audio and telematics ecu configuration 2";
+CM_ SG_ 1019 EC_BU_ECUCfg4_Stat "Backup for ECU Configuration messages status 4";
+CM_ SG_ 1019 EC_BU_Cluster1A "Backup for Instrument cluster ecu configuration 1A";
+CM_ SG_ 1019 EC_BU_Cluster1B "Backup for Instrument cluster ecu configuration 1B";
+CM_ SG_ 1019 EC_BU_Cluster2 "Backup for Instrument cluster ecu configuration 2";
+CM_ SG_ 1020 EC_BU_ECUCfg5_Stat "Backup for ECU Configuration messages status 5";
+CM_ SG_ 1020 EC_BU_WirelessA "Backup for Wireless ecu configurationA";
+CM_ SG_ 1020 EC_BU_WirelessB "Backup for Wireless ecu configurationB";
+CM_ SG_ 1020 EC_BU_Doors "Backup for Doors ecu configuration";
+CM_ SG_ 1020 EC_BU_Memory "Backup for Memory ecu configuration";
+CM_ SG_ 1021 EC_BU_ECUCfg6_Stat "Backup for ECU Configuration messages status 6";
+CM_ SG_ 1021 EC_BU_BrakesA "Backup for Brake system ecu configurationA";
+CM_ SG_ 1021 EC_BU_BrakesB "Backup for Brake system ecu configurationB";
+CM_ SG_ 1021 EC_BU_Steering "Backup for steering ecu configuration";
+CM_ SG_ 1021 EC_BU_Powertrain "Backup for Powertrain ecu configuration";
+CM_ SG_ 1021 EC_BU_Safety "Backup for Safety ecu configuration";
+CM_ SG_ 1022 EC_BU_ECUCfg7_Stat "Backup for ECU Configuration messages status 7";
+CM_ SG_ 1022 EC_BU_CBC5A "Backup for CBC ecu configuration 5A";
+CM_ SG_ 1022 EC_BU_CBC5B "Backup for CBC ecu configuration 5B";
+CM_ SG_ 1022 EC_BU_CBC6 "Backup for CBC ecu configuration 6";
+CM_ SG_ 1023 EC_BU_ECUCfg8_Stat "Backup for ECU Configuration messages status 8";
+CM_ SG_ 1023 EC_BU_CBC7A "Backup for CBC ecu configuration 7A";
+CM_ SG_ 1023 EC_BU_CBC7B "Backup for CBC ecu configuration 7B";
+CM_ SG_ 1023 EC_BU_CBC8 "Backup for CBC ecu configuration 8";
+CM_ SG_ 1024 NM_Mode "Network management mode";
+CM_ SG_ 1024 NM_Successor "Network management logical successor";
+CM_ SG_ 1024 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1024 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1024 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1024 Nw_Id "Network identification no.";
+CM_ SG_ 1025 NM_Mode "Network management mode";
+CM_ SG_ 1025 NM_Successor "Network management logical successor";
+CM_ SG_ 1025 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1025 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1025 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1025 Nw_Id "Network identification no.";
+CM_ SG_ 1026 NM_Mode "Network management mode";
+CM_ SG_ 1026 NM_Successor "Network management logical successor";
+CM_ SG_ 1026 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1026 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1026 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1026 Nw_Id "Network identification no.";
+CM_ SG_ 1031 NM_Mode "Network management mode";
+CM_ SG_ 1031 NM_Successor "Network management logical successor";
+CM_ SG_ 1031 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1031 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1031 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1031 Nw_Id "Network identification no.";
+CM_ SG_ 1033 NM_Mode "Network management mode";
+CM_ SG_ 1033 NM_Successor "Network management logical successor";
+CM_ SG_ 1033 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1033 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1033 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1033 Nw_Id "Network identification no.";
+CM_ SG_ 1059 NM_Mode "Network management mode";
+CM_ SG_ 1059 NM_Successor "Network management logical successor";
+CM_ SG_ 1059 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1059 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1059 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1059 Nw_Id "Network identification no.";
+CM_ SG_ 1089 DG_RQ_GLOBAL_UDS "Diagnostic-Request";
+CM_ SG_ 1098 VC_VehCfg5_Stat "Configuration messages status 5";
+CM_ SG_ 1098 VC_LUCI_PRSNT "Luci feature present; present = [1]";
+CM_ SG_ 1098 VC_RR_DuallyPrsnt "Vehicle is equipped with rear duals; present = [1]";
+CM_ SG_ 1098 VC_NonReg_TPIS "Non-regulated tire pressure indicator system; True = 1";
+CM_ SG_ 1098 VC_WTS_Prsnt "Wait to start feature is present; present = [1]";
+CM_ SG_ 1098 VC_AmbTempLct "Ambient temperature sensor location";
+CM_ SG_ 1098 VC_Strng_Rt_0 "Steering Ratio at zero";
+CM_ SG_ 1098 VC_Strng_Rt_pls1 "Steering Ratio at positve angle 1";
+CM_ SG_ 1098 VC_Strng_Rt_pls2 "Steering Ratio at positve angle 2";
+CM_ SG_ 1098 VC_Strng_Rt_pls3 "Steering Ratio at positve angle 3";
+CM_ SG_ 1098 VC_Strng_Rt_pls4 "Steering Ratio at positve angle 4";
+CM_ SG_ 1098 VC_Strng_Rt_pls5 "Steering Ratio at positve angle 5";
+CM_ SG_ 1098 VC_RearDoorLocks2DCM "Rear door lock switch present; present = [1]";
+CM_ SG_ 1098 VC_SpdLmt_PRSNT "Speed limiter is present; present = [1]";
+CM_ SG_ 1098 VC_SBR_Prsnt "Seat belt reminder module is present; True = 1";
+CM_ SG_ 1098 VC_ChildDisp_Prsnt "Child display feature is present; True = 1";
+CM_ SG_ 1098 VC_OffRoadPg "Off road pages present; True = [1]";
+CM_ SG_ 1098 VC_AmbLtgPrsnt "Ambient lighting feature is present; True = [1]";
+CM_ SG_ 1098 VC_PPPA_Prsnt "Semi automatic parking system present; present = [1]";
+CM_ SG_ 1098 VC_ParkStopPrsnt "Park with stop is present; True = 1";
+CM_ SG_ 1099 VC_BU_VehCfg5_Stat "Backup for Configuration messages status 5";
+CM_ SG_ 1099 VC_BU_LUCI_PRSNT "Backup for Luci feature present; present = [1]";
+CM_ SG_ 1099 VC_BU_RR_DuallyPrsnt "Backup for vehicle is equipped with rear duals; present = [1]";
+CM_ SG_ 1099 VC_BU_NonReg_TPIS "Backup for non-regulated tire pressure indicator system; True = 1";
+CM_ SG_ 1099 VC_BU_WTS_Prsnt "Backup for wait to start feature is present; present = [1]";
+CM_ SG_ 1099 VC_BU_AmbTempLct "Backup for ambient temperature sensor location";
+CM_ SG_ 1099 VC_BU_Strng_Rt_0 "Backup for Steering Ratio at zero";
+CM_ SG_ 1099 VC_BU_Strng_Rt_pls1 "Backup for Steering Ratio at positve angle 1";
+CM_ SG_ 1099 VC_BU_Strng_Rt_pls2 "Backup for Steering Ratio at positve angle 2";
+CM_ SG_ 1099 VC_BU_Strng_Rt_pls3 "Backup for Steering Ratio at positve angle 3";
+CM_ SG_ 1099 VC_BU_Strng_Rt_pls4 "Backup for Steering Ratio at positve angle 4";
+CM_ SG_ 1099 VC_BU_Strng_Rt_pls5 "Backup for Steering Ratio at positve angle 5";
+CM_ SG_ 1099 VC_BU_RearDoorLocks2DCM "Backup for Rear door lock switch present; present = [1]";
+CM_ SG_ 1099 VC_BU_SpdLmt_PRSNT "Backup for Speed limiter is present; present = [1]";
+CM_ SG_ 1099 VC_BU_SBR_Prsnt "Backup for seat belt reminder module is present; True = 1";
+CM_ SG_ 1099 VC_BU_ChildDisp_Prsnt "Backup for child display feature is present; True = 1";
+CM_ SG_ 1099 VC_BU_OffRoadPg "Backup for off road pages present; True = [1]";
+CM_ SG_ 1099 VC_BU_AmbLtgPrsnt "Backup for ambient lighting feature is present; True = 1";
+CM_ SG_ 1099 VC_BU_PPPA_Prsnt "Backup for semi automatic parking system present; True = 1";
+CM_ SG_ 1099 VC_BU_ParkStopPrsnt "Backup for park with stop is present; True = 1";
+CM_ SG_ 1100 VC_VehCfg6_Stat "Configuration messages status 6";
+CM_ SG_ 1100 VC_AnlgDrSnsr "Analog door sensor configuration";
+CM_ SG_ 1100 VC_BrkTyp "Brake type configuration (M156/7)";
+CM_ SG_ 1100 VC_AQS_Prsnt "Air quality sensor present; present = [1]";
+CM_ SG_ 1100 VC_Strng_Rt_Mns1 "Steering Ratio at negative angle 1";
+CM_ SG_ 1100 VC_Strng_Rt_Mns2 "Steering Ratio at negative angle 2";
+CM_ SG_ 1100 VC_Strng_Rt_Mns3 "Steering Ratio at negative angle 3";
+CM_ SG_ 1100 VC_Strng_Rt_Mns4 "Steering Ratio at negative angle 4";
+CM_ SG_ 1100 VC_Strng_Rt_Mns5 "Steering Ratio at negative angle 5";
+CM_ SG_ 1100 VC_TireCircumfFT "Dynamic tire circumference - front only";
+CM_ SG_ 1101 VC_BU_VehCfg6_Stat "Backup for Configuration messages status 6";
+CM_ SG_ 1101 VC_BU_AnlgDrSnsr "Analog door sensor configuration backup";
+CM_ SG_ 1101 VC_BU_BrkTyp "Backup for brake type configuration (M156/7)";
+CM_ SG_ 1101 VC_BU_AQS_Prsnt "Backup for air quality sensor present; present = [1]";
+CM_ SG_ 1101 VC_BU_Strng_Rt_Mns1 "Backup for Steering Ratio at negative angle 1";
+CM_ SG_ 1101 VC_BU_Strng_Rt_Mns2 "Backup for Steering Ratio at negative angle 2";
+CM_ SG_ 1101 VC_BU_Strng_Rt_Mns3 "Backup for Steering Ratio at negative angle 3";
+CM_ SG_ 1101 VC_BU_Strng_Rt_Mns4 "Backup for Steering Ratio at negative angle 4";
+CM_ SG_ 1101 VC_BU_Strng_Rt_Mns5 "Backup for Steering Ratio at negative angle 5";
+CM_ SG_ 1101 VC_BU_TireCircumfFT "Backup for Dynamic tire circumference - front only";
+CM_ SG_ 1216 D_RS_RF_HUB "Diagnostic-Response";
+CM_ SG_ 1218 D_RS_IC "Diagnostic-Response";
+CM_ SG_ 1220 D_RS_ORC "Diagnostic-Response";
+CM_ SG_ 1223 D_RS_ESC "Diagnostic-Response";
+CM_ SG_ 1225 D_RS_ESM "Diagnostic-Response";
+CM_ SG_ 1235 D_RS_DASM "Diagnostic-Response";
+CM_ SG_ 1250 D_RS_PTS "Diagnostic-Response";
+CM_ SG_ 1251 D_RS_SCCM "Diagnostic-Response";
+CM_ SG_ 1284 D_RS_CBC "Diagnostic-Response";
+CM_ SG_ 1408 ECU_APPL_RF_HUB "ECU to External Application";
+CM_ SG_ 1409 ECU_APPL_CBC "ECU to External Application";
+CM_ SG_ 1410 ECU_APPL_IC "ECU to External Application";
+CM_ SG_ 1412 ECU_APPL_ORC "ECU to External Application";
+CM_ SG_ 1415 ECU_APPL_ESC "ECU to External Application";
+CM_ SG_ 1417 ECU_APPL_ESM "ECU to External Application";
+CM_ SG_ 1427 ECU_APPL_DASM "ECU to External Application";
+CM_ SG_ 1442 ECU_APPL_PTS "ECU to External Application";
+CM_ SG_ 1443 ECU_APPL_SCCM "ECU to External Application";
+CM_ SG_ 1464 ECU_APPL_ECM "ECU to External Application";
+CM_ SG_ 1465 ECU_APPL_TCM "ECU to External Application";
+CM_ SG_ 1536 SD_RS_RF_HUB "Response on Event - light";
+CM_ SG_ 1537 SD_RS_CBC "Response on Event - light";
+CM_ SG_ 1538 SD_RS_IC "Response on Event - light";
+CM_ SG_ 1540 SD_RS_ORC "Response on Event - light";
+CM_ SG_ 1543 SD_RS_ESC "Response on Event - light";
+CM_ SG_ 1545 SD_RS_ESM "Response on Event - light";
+CM_ SG_ 1555 SD_RS_DASM "Response on Event - light";
+CM_ SG_ 1568 D_RQ_CBC "Diagnostic-Request";
+CM_ SG_ 1570 SD_RS_PTS "Response on Event - light";
+CM_ SG_ 1571 SD_RS_SCCM "Response on Event - light";
+CM_ SG_ 1592 SD_RS_ECM "Response on Event - light";
+CM_ SG_ 1593 SD_RS_TCM "Response on Event - light";
+CM_ SG_ 1728 APPL_ECU_RF_HUB "External Application to ECU";
+CM_ SG_ 1729 APPL_ECU_CBC "External Application to ECU";
+CM_ SG_ 1730 APPL_ECU_IC "External Application to ECU";
+CM_ SG_ 1732 APPL_ECU_ORC "External Application to ECU";
+CM_ SG_ 1735 APPL_ECU_ESC "External Application to ECU";
+CM_ SG_ 1737 APPL_ECU_ESM "External Application to ECU";
+CM_ SG_ 1747 APPL_ECU_DASM "External Application to ECU";
+CM_ SG_ 1762 APPL_ECU_PTS "External Application to ECU";
+CM_ SG_ 1763 APPL_ECU_SCCM "External Application to ECU";
+CM_ SG_ 1784 APPL_ECU_ECM "External Application to ECU";
+CM_ SG_ 1785 APPL_ECU_TCM "External Application to ECU";
+CM_ SG_ 1856 D_RQ_RF_HUB "Diagnostic-Request";
+CM_ SG_ 1858 D_RQ_IC "Diagnostic-Request";
+CM_ SG_ 1860 D_RQ_ORC "Diagnostic-Request";
+CM_ SG_ 1863 D_RQ_ESC "Diagnostic-Request";
+CM_ SG_ 1865 D_RQ_ESM "Diagnostic-Request";
+CM_ SG_ 1875 D_RQ_DASM "Diagnostic-Request";
+CM_ SG_ 1890 D_RQ_PTS "Diagnostic-Request";
+CM_ SG_ 1891 D_RQ_SCCM "Diagnostic-Request";
+CM_ SG_ 2015 DG_RQ_GLOBAL "Diagnostic-Request";
+CM_ SG_ 2016 D_RQ_ECM "Diagnostic-Request";
+CM_ SG_ 2017 D_RQ_TCM "Diagnostic-Request";
+CM_ SG_ 2024 D_RS_ECM "Diagnostic-Response";
+CM_ SG_ 2025 D_RS_TCM "Diagnostic-Response";
+CM_ SG_ 362 CRC_DTCM_A2 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 362 DrvLnMinTrqMd "Drive line engine torque request: min.-mode";
+CM_ SG_ 362 DrvLnTrqRq "Drive line requested engine torque";
+CM_ SG_ 362 MC_DTCM_A2 "Message counter";
+CM_ SG_ 640 Mem_D_Pos_Rq "Memory driver - position request";
+CM_ SG_ 640 Mem_D_Rc_Rq "Memory driver - recall position";
+CM_ SG_ 640 Mem_D_Sv_Rq "Memory driver - save position";
+CM_ SG_ 752 MEM_RC_STAT "Memory recall status";
+CM_ SG_ 752 MSMD_PDL_LKOUT "Adjustable pedal lockout";
+CM_ SG_ 752 EASY_EXIT "Easy exit seat state";
+CM_ SG_ 752 RKE_MEM "Remote linked to memory; [0] = NO, [1] = YES";
+CM_ SG_ 847 RF_FobNum "FOB number making the request";
+CM_ SG_ 847 RFMemRq "RF memory request; [1] = True";
+CM_ SG_ 916 AudioMuteRq "Audio mute request; Audio mute = [1]";
+CM_ SG_ 916 FtWigWagRq "Front wig wag request";
+CM_ SG_ 916 RrWigWagRq "Rear wig wag request";
+CM_ SG_ 916 SupHrnRq "Suppress horn request";
+CM_ SG_ 916 SprtRearLtg "Separate rear lighting";
+CM_ SG_ 916 R_AC_Enable "Rear A/C enable request; On = [1]";
+CM_ SG_ 916 DsblTurnLmpFlt "Disable rear turn lamp fault";
+CM_ SG_ 916 DoorUnlkAllRq "Request to unlock all doors; No request active = 0, Request active = 1";
+CM_ SG_ 916 DoorLkAllRq "Request to lock all doors; No request active = 0, Request active = 1";
+CM_ SG_ 1227 D_RS_DTCM "Diagnostic-Response";
+CM_ SG_ 1265 D_RS_VSIM "Diagnostic-Response";
+CM_ SG_ 1419 ECU_APPL_DTCM "ECU to External Application";
+CM_ SG_ 1457 ECU_APPL_VSIM "ECU to External Application";
+CM_ SG_ 1547 SD_RS_DTCM "Response on Event - light";
+CM_ SG_ 1585 SD_RS_VSIM "Response on Event - light";
+CM_ SG_ 1739 APPL_ECU_DTCM "External Application to ECU";
+CM_ SG_ 1777 APPL_ECU_VSIM "External Application to ECU";
+CM_ SG_ 1867 D_RQ_DTCM "Diagnostic-Request";
+CM_ SG_ 1905 D_RQ_VSIM "Diagnostic-Request";
+CM_ SG_ 806 AFLS_ENBL "Advanced lighting enabled; [0] = no, [1] = yes";
+CM_ SG_ 806 AFLS_Stat "AFLS fault status";
+CM_ SG_ 1256 D_RS_AFLS "Diagnostic-Response";
+CM_ SG_ 1448 ECU_APPL_AFLS "ECU to External Application";
+CM_ SG_ 1768 APPL_ECU_AFLS "External Application to ECU";
+CM_ SG_ 1896 D_RQ_AFLS "Diagnostic-Request";
+CM_ SG_ 530 Adblue_FL_LVL "Adblue fluid level";
+CM_ SG_ 530 Adblue_Stat "Adblue status";
+CM_ SG_ 530 AdblueRemainDist "Adblue remaining distance";
+CM_ SG_ 530 DEF_LOW "DEF Low Indicator request";
+CM_ SG_ 530 ECM_HMI_Timer_RQ "DEF and DPF warning re-launch timer request";
+CM_ SG_ 530 EngChmRq "Engine chime request";
+CM_ SG_ 530 PFW_Stat "Particulate filter warning status";
+CM_ SG_ 530 PrcntCplt "Percent complete";
+CM_ SG_ 530 PreHtIndLmp_On_Rq "Request glow-plug (wait to start) lamp";
+CM_ SG_ 530 PTC_REL1_RQ "Activate PTC Relay # 1 (diesel only)";
+CM_ SG_ 530 PTC_REL2_RQ "Activate PTC Relay # 2 (diesel only)";
+CM_ SG_ 530 PTC_REL3_RQ "Activate PTC Relay # 3 (diesel only)";
+CM_ SG_ 530 RemainDistUnt "Adblue distance counter unit; miles = [0], km = [1]";
+CM_ SG_ 530 WtrFuelIndLmp_On_Rq "Request water in fuel lamp (diesel only)";
+CM_ SG_ 625 DsrSpeed_KPH "Desired speed in kilometers per hour";
+CM_ SG_ 625 FCWSetting "Forward collision warning sensitivity setting";
+CM_ SG_ 625 FCWState "FCW system operating state; On = [1]";
+CM_ SG_ 671 CRC_29Fh "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 671 MC_29Fh "Message counter";
+CM_ SG_ 684 INV_CARGO_OnState "01 =cargo outlet is disabledt, 10 = cargo outlet is enabled";
+CM_ SG_ 684 SM_Rear_Guidance_Lgt "Side Mirror Rear Guidance Light On/ Off , ON = 1";
+CM_ SG_ 684 Snow_Plow_Presence "Snowplow is present; True = [1]";
+CM_ SG_ 684 RR_DR_UNLKD "Rear door hatch / lift gate is unlocked";
+CM_ SG_ 705 VEH_INT_TEMP "Vehicle interior temperature";
+CM_ SG_ 705 SwayBarBtnRq "Sway bar disconnect switch request";
+CM_ SG_ 709 EC_AudTel3B "Audio and telematics ecu configuration 3B";
+CM_ SG_ 709 EC_ECUCfg16_Stat "ECU Configuration messages status 16";
+CM_ SG_ 709 EC_AudTel3A "Audio and telematics ecu configuration 3A";
+CM_ SG_ 710 EC_ECUCfg17_Stat "ECU Configuration messages status 17";
+CM_ SG_ 710 EC_PTS "Park assist ecu configuration";
+CM_ SG_ 710 EC_SeatsB "Heated seats ecu configuration - B";
+CM_ SG_ 710 EC_SeatsA "Heated seats ecu configuration - A";
+CM_ SG_ 710 EC_HVAC2 "HVAC ECU Configurations - 2";
+CM_ SG_ 710 EC_HVAC1 "HVAC ECU Configurations - 1";
+CM_ SG_ 710 EC_CBC17 "CBC ECU Config 17";
+CM_ SG_ 714 EC_BU_AudTel3B "Backup for audio and telematics ecu configuration 3B";
+CM_ SG_ 714 EC_BU_ECUCfg16_Stat "Backup for ECU Configuration messages status 16";
+CM_ SG_ 714 EC_BU_AudTel3A "Backup for audio and telematics ecu configuration 3A";
+CM_ SG_ 715 EC_BU_ECUCfg17_Stat "Backup for ECU Configuration messages status 17";
+CM_ SG_ 715 EC_BU_PTS "Backup for park assist ecu configuration";
+CM_ SG_ 715 EC_BU_SeatsB "Backup for heated seats ecu configuration";
+CM_ SG_ 715 EC_BU_SeatsA "Backup for heated seats ecu configuration";
+CM_ SG_ 715 EC_BU_HVAC2 "Backup for HVAC ECU Configurations - 2";
+CM_ SG_ 715 EC_BU_HVAC1 "Backup for HVAC ECU Configurations - 1";
+CM_ SG_ 715 EC_BU_CBC17 "CBC ECU Config 17 Backup";
+CM_ SG_ 773 Tire_FL "Tire front left";
+CM_ SG_ 773 Tire_FR "Tire front right";
+CM_ SG_ 773 Tire_RL "Tire rear left";
+CM_ SG_ 773 Tire_RR "Tire rear right";
+CM_ SG_ 773 Tire_Spr "Spare tire";
+CM_ SG_ 773 TirePrssFL "Tire pressure front left";
+CM_ SG_ 773 TirePrssFR "Tire pressure front right";
+CM_ SG_ 773 TirePrssRL "Tire pressure rear left";
+CM_ SG_ 773 TirePrssRR "Tire pressure rear right";
+CM_ SG_ 773 TirePrssSpr "Tire pressure spare tire";
+CM_ SG_ 773 TPM_ChimeRq "TPM chime request";
+CM_ SG_ 773 TPM_IndLmpOnRq "Tire pressure indication request";
+CM_ SG_ 773 TPM_SysStat "TPM system localization status";
+CM_ SG_ 773 TPMHornChirp "TPM horn chirp";
+CM_ SG_ 773 TPMHazardFlash "TPM hazard flash;  true = [1]";
+CM_ SG_ 778 TrboBstPress "Turbo boost pressure";
+CM_ SG_ 778 EngBrkStat "Engine braking status";
+CM_ SG_ 778 WTS_CntDnTmr "Wait to start count down timer (sec)";
+CM_ SG_ 778 Man_PFW_Stat "Manual Regen Particulate filter warning status";
+CM_ SG_ 778 IdleShutDwnAppl "Idle Shut down applied";
+CM_ SG_ 778 EngDerate "Engine derate mode";
+CM_ SG_ 778 EB_Stat3 "Exhaust brake status - 3 bit";
+CM_ SG_ 778 EB_Pwr "Exhaust brake Power";
+CM_ SG_ 778 EB_ACC_AVLBL "If the ACC is engaged, exhaust brake can be used to decelerate the vehicle;1='In Range'";
+CM_ SG_ 778 DPF_Man_Stat "Manual Regeneration status";
+CM_ SG_ 778 SRV_AIR_FLTR "Service air Filter";
+CM_ SG_ 778 SRV_CCV_FLTR "Service CCV Filter";
+CM_ SG_ 778 DrtdTrqMd "Derated torque mode";
+CM_ SG_ 778 Rapid_Cabin_Warmup_Stat "EB is aiding in cabin warmup.  TRUE = [1].";
+CM_ SG_ 831 FL_Lvl_Adj "Front left level adjust (1=adjusting)";
+CM_ SG_ 831 FR_Lvl_Adj "Front right level adjust (1=adjusting)";
+CM_ SG_ 831 LvlCalCmplt "Level calibration complete";
+CM_ SG_ 831 RL_Lvl "Rear left level";
+CM_ SG_ 831 RL_Lvl_Adj "Rear left level adjust (1=adjusting)";
+CM_ SG_ 831 RR_Lvl "Rear right level";
+CM_ SG_ 831 RR_Lvl_Adj "Rear right level adjust (1=adjusting)";
+CM_ SG_ 844 ASCM_Exit_Rq "Request for exit (Trailer_ HD) indicator";
+CM_ SG_ 844 ASCM_HMI_Stat "ASCM HMI status";
+CM_ SG_ 844 ASCM_Srv "Service air suspension; 1 = True";
+CM_ SG_ 844 ASCM_Stat "Air suspension status";
+CM_ SG_ 844 ASCM_StatDisp "Air suspension status for display";
+CM_ SG_ 844 ASCM_SysFail "Loss of function - system fault; 1 = True";
+CM_ SG_ 844 ASCM_TJM "Tire jack mode; 1 = True";
+CM_ SG_ 844 ASCM_WarnOnly "ASCM warning messages only; 1 = True";
+CM_ SG_ 844 Loading_Lv "Loading level";
+CM_ SG_ 844 LvlAdjStat "Level adjustment status";
+CM_ SG_ 844 Tgt_Level "Target Level";
+CM_ SG_ 844 TM_Enbl "Transport mode enabled; 1 = True";
+CM_ SG_ 844 WAL_Enbl "Wheel alignment level enabled; 1 = True";
+CM_ SG_ 1062 NM_Mode "Network management mode";
+CM_ SG_ 1062 NM_Successor "Network management logical successor";
+CM_ SG_ 1062 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1062 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1062 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1062 Nw_Id "Network identification no.";
+CM_ SG_ 1254 D_RS_ASCM "Diagnostic-Response";
+CM_ SG_ 1446 ECU_APPL_ASCM "ECU to External Application";
+CM_ SG_ 1574 SD_RS_ASCM "Response on Event - light";
+CM_ SG_ 1576 SD_RS_AFLS "Response on Event - light";
+CM_ SG_ 1766 APPL_ECU_ASCM "External Application to ECU";
+CM_ SG_ 1894 D_RQ_ASCM "Diagnostic-Request";
+CM_ SG_ 294 LatAcceleration "Raw lateral acceleration";
+CM_ SG_ 294 AXSStat "Longitudinal signal status";
+CM_ SG_ 294 AYSStat "Latitudinal signal status";
+CM_ SG_ 294 LongAcceleration "Raw longitudinal acceleration";
+CM_ SG_ 294 YRSStat "Yaw rate signal status";
+CM_ SG_ 294 InternalError "ORC ESC internal error; True = [1]";
+CM_ SG_ 294 VoltageError "ORC ESC voltage error; True = [1]";
+CM_ SG_ 294 YawRate "Raw yaw acceleration";
+CM_ SG_ 294 MC_ORC_YRS_DATA "Message counter";
+CM_ SG_ 294 CRC_ORC_YRS_DATA "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 516 ControlEncodingRsp "Control encoding - response";
+CM_ SG_ 516 MKKey1org21 "Mini kript key 1 or G2_1";
+CM_ SG_ 516 MKKey2org22 "Mini kript key 2 or G2_2";
+CM_ SG_ 516 MKKey_3 "Mini kript key 3";
+CM_ SG_ 516 MKKey_4 "Mini kript key 4";
+CM_ SG_ 516 MKKey_5 "Mini kript key 5";
+CM_ SG_ 516 MKKey_6 "Mini kript key 6";
+CM_ SG_ 517 ControlEncodingRq "Control encoding - request";
+CM_ SG_ 517 rnd_1 "Random number 1";
+CM_ SG_ 517 rnd_2 "Random number 2";
+CM_ SG_ 517 rnd_3 "Random number 3";
+CM_ SG_ 517 rnd_4 "Random number 4";
+CM_ SG_ 517 f1_1 "F code 1_1";
+CM_ SG_ 517 f1_2 "F code 1_2";
+CM_ SG_ 524 ControlEncodingBCM "Fob authentication or presence query";
+CM_ SG_ 524 MiniCryptFCode "MiniCrypt 'F' code output";
+CM_ SG_ 524 MiniCrypt_Rnd "MiniCrypt input random number";
+CM_ SG_ 524 TxpReadRequest "Transponder reading request; Request = [0]";
+CM_ SG_ 524 TxpAuthRequest "Transponder authentication request; Request = [0]";
+CM_ SG_ 525 MinicryptReceptionSts "Acknowledge message reception; Received = [1]";
+CM_ SG_ 526 MiniCryptGCode "MiniCrypt 'G' code output";
+CM_ SG_ 526 ControlEncoding "Response type UC/TEN/PVA";
+CM_ SG_ 526 CodeCheckSts "Code check status";
+CM_ SG_ 526 ProgrammedSts "TRM programmed status; Programmed = [1]";
+CM_ SG_ 526 TxpID "Transponder authentication";
+CM_ SG_ 526 TxpFound "Transponder found; Absent = [1]";
+CM_ SG_ 527 FrameNumber "MiniCrypt key frame number";
+CM_ SG_ 527 TotalFrameNumber "MiniCrypt key total number of frames";
+CM_ SG_ 527 DATA1 "MiniCrypt key data byte 1";
+CM_ SG_ 527 DATA2 "MiniCrypt key data byte 2";
+CM_ SG_ 527 DATA3 "MiniCrypt key data byte 3";
+CM_ SG_ 527 DATA4 "MiniCrypt key data byte 4";
+CM_ SG_ 527 DATA5 "MiniCrypt key data byte 5";
+CM_ SG_ 527 DATA6 "MiniCrypt key data byte 6";
+CM_ SG_ 527 DATA7 "MiniCrypt key data byte 7";
+CM_ SG_ 542 BlockOffset "Part number block offset";
+CM_ SG_ 542 PTRInfo "Part number PTR information";
+CM_ SG_ 542 CLUType "Part number CLU type";
+CM_ SG_ 542 Character5 "Part number character 5";
+CM_ SG_ 542 Character4 "Part number character 4";
+CM_ SG_ 542 Character3 "Part number character 3";
+CM_ SG_ 542 Character2 "Part number character 2";
+CM_ SG_ 542 Character1 "Part number character 1";
+CM_ SG_ 542 Character0 "Part number character 0";
+CM_ SG_ 669 MC_EPB_A1 "Message counter";
+CM_ SG_ 669 CRC_EPB_A1 "CRC-checksum byte 1 to 2 according to SAE J1850";
+CM_ SG_ 770 MC_EPB_1 "Message counter";
+CM_ SG_ 770 CRC_EPB_1 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 782 Gas_Range "Gas range or DTE";
+CM_ SG_ 782 EngHour "Total Engine Hours";
+CM_ SG_ 782 CFG_Manual_DPF "Manual DPF initiation by driver";
+CM_ SG_ 938 A_MPG "Trip A Combined fuel economy in US MPG";
+CM_ SG_ 939 A_KMpL "Trip A Combined fuel economy in Km/L";
+CM_ SG_ 940 A_Total_Dist_Miles "Trip A total distance in US miles";
+CM_ SG_ 940 A_Total_Dist_Kilometers "Trip A total distance in kilometers";
+CM_ SG_ 941 B_MPG "Trip B Combined fuel economy in US MPG";
+CM_ SG_ 942 B_KMpL "Trip B Combined fuel economy in Km/L";
+CM_ SG_ 943 B_Total_Dist_Miles "Trip B total distance in US miles";
+CM_ SG_ 943 B_Total_Dist_Kilometers "Trip B total distance in kilometers";
+CM_ SG_ 55 CRC_TCM_EngTrq2_2 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 55 EngTrqRq_2 "Requested engine torque";
+CM_ SG_ 55 MaxTrqDes_2 "Maximum engine torque desired";
+CM_ SG_ 55 MC_TCM_EngTrq2_2 "Message counter";
+CM_ SG_ 55 TrnsTrqReqSlow_2 "Slow path desired engine torque request from the trans";
+CM_ SG_ 55 TrqCtrlModeRq_2 "Torque control mode request";
+CM_ SG_ 1073 NM_Mode "Network management mode";
+CM_ SG_ 1073 NM_Successor "Network management logical successor";
+CM_ SG_ 1073 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1073 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1073 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1073 Nw_Id "Network identification no.";
+CM_ SG_ 973 WATER_IN_FUEL_STAT "Water in fuel indicator status";
+CM_ SG_ 973 TIRE_PRESSURE_STAT "Tire pressure indicator status";
+CM_ SG_ 973 STOP_START_STAT "Stop start indicator status";
+CM_ SG_ 973 SERVICE_STAT "Service indicator status";
+CM_ SG_ 973 SERVICE_ACC_STAT "Service ACC indicator status";
+CM_ SG_ 973 OVER_TEMP_STAT "Over temperature indicator status";
+CM_ SG_ 973 OIL_TEMP_STAT "Oil temperature indicator status";
+CM_ SG_ 973 OIL_PRESSURE_STAT "Oil pressure indicator status";
+CM_ SG_ 973 LANE_SENSE_STAT "Lane sense indicator status";
+CM_ SG_ 973 FOUR_WD_SERVICE_STAT "Service indicator status";
+CM_ SG_ 973 FCW_SYSTEM_STAT "FCW system indicator status";
+CM_ SG_ 973 ETC_CONTROL_STAT "ETC control indicator status";
+CM_ SG_ 973 EPS_STAT "EPS indicator status";
+CM_ SG_ 973 EPB_WARN_STAT "EPB warn indicator status";
+CM_ SG_ 973 ENGINE_TEMP_STAT "Engine temperature indicator status";
+CM_ SG_ 973 ENGINE_MIL_STAT "Engine MIL indicator status";
+CM_ SG_ 973 ELEC_STAB_STAT "Electronic stability indicator status";
+CM_ SG_ 973 DEF_STAT "DEF indicator status";
+CM_ SG_ 973 DAMPING_SYSTEM_STAT "Damping system indicator status";
+CM_ SG_ 973 BRK_IND_STAT "Brake indicator status";
+CM_ SG_ 973 BRAKE_PAD_STAT "Brake pad indicator status";
+CM_ SG_ 973 BATTERY_CHARGE_STAT "Battery charge indicator status";
+CM_ SG_ 973 AWD_SERVICE_STAT "AWD service indicator status";
+CM_ SG_ 973 ABS_IND_STAT "ABS indicator status";
+CM_ SG_ 973 WINDSHIELD_FLUID_STAT "Windshield Water Fluid";
+CM_ SG_ 973 OIL_LEVEL_STAT "Oil Level";
+CM_ SG_ 973 FUEL_CAP_STAT "Fuel Cap Unfastened";
+CM_ SG_ 973 COOLENT_LEVEL_STAT "Low Coolent Level";
+CM_ SG_ 973 TORQUE_STAT "Torque Limited";
+CM_ SG_ 973 ELECTRIC_WRENCH_STAT "Electric Wrench";
+CM_ SG_ 973 CATALYST_TEMP_STAT "Catalyst Overtemp";
+CM_ SG_ 754 Inst_Fuel_Econ "Instantaneous fuel economy";
+CM_ SG_ 754 Avg_Fuel_Econ "Average fuel economy";
+CM_ SG_ 910 IBS3_TempFailStatus "Failure of ASIC Temperature meas. (internal defect)";
+CM_ SG_ 910 IBS3_T_BATT "Battery temperature";
+CM_ SG_ 910 IBS3_SOH_Q_Accuracy "SOH_Q accuracy status";
+CM_ SG_ 910 IBS3_SOH_Q "State of health related to capacity (energy)";
+CM_ SG_ 910 IBS3_SOF_VC "Predicted initial battery voltage dip during cranking (old CG spec)";
+CM_ SG_ 910 IBS3_SOF_V_Accuracy "SOF_V accuracy; Data reliable = [0], unreliable = [1]";
+CM_ SG_ 910 IBS3_SOF_Q_Accuracy "SOF_Q accuracy status";
+CM_ SG_ 910 IBS3_SOF_Q "Residual battery charge in Ah";
+CM_ SG_ 910 IBS3_SOC_Accuracy "SOC accuracy status";
+CM_ SG_ 910 IBS3_SOC "State of charge";
+CM_ SG_ 910 IBS3_FLAG_DISCONNECT "Battery disconnection flag";
+CM_ SG_ 910 Ft_RrAxleLckr_Rq "Front and Rear axle locker request";
+CM_ SG_ 579 AxleLckrOFF_SW "Axle locker deactivation switch";
+CM_ SG_ 579 TGW_AUD_MD2_CAB_DR "TGW additional audio modes for Cabin/Driver";
+CM_ SG_ 579 Phone_Popup_setting_active "Phone call status popup active or not, Active=1";
+CM_ SG_ 1151 D_RS_SGW "Diagnostic-Response";
+CM_ SG_ 1150 D_RQ_SGW "Diagnostic-Request";
+CM_ SG_ 683 VoltBattFailStatus "Failure Status of Voltage meas. (internal defect)";
+CM_ SG_ 683 RsErrIBS3 "Response Error IBS; Error=[1]";
+CM_ SG_ 683 IBS3_Vbatt "Battery voltage measured at the terminals";
+CM_ SG_ 683 IBS3_Ibatt "Battery current";
+CM_ SG_ 683 IBS3_Error_Internal "Error in IBS calibration data; No Error = [0], Error = [1]";
+CM_ SG_ 683 CurrBattFailStatus "Failure Status of Current meas. (internal defect)";
+CM_ SG_ 685 Cfg_Aux_PTO "AUX Switches Configuration";
+CM_ SG_ 685 CBC_AUX4_Type "Aux switch 4 behavior; Latching = [0], Momentary = [1]";
+CM_ SG_ 685 CBC_AUX4_PWRMD "Aux switch 4 power mode; ignition = [0], battery = [1]";
+CM_ SG_ 685 CBC_AUX4_HLEnbl "Aux switch 4 enable holding last state; enabled = [1]";
+CM_ SG_ 685 CBC_AUX3_Type "Aux switch 3 behavior; Latching = [0], Momentary = [1]";
+CM_ SG_ 685 CBC_AUX3_PWRMD "Aux switch 3 power mode; ignition = [0], battery = [1]";
+CM_ SG_ 685 CBC_AUX3_HLEnbl "Aux switch 3 enable holding last state; enabled = [1]";
+CM_ SG_ 685 CBC_AUX2_Type "Aux switch 2 behavior; Latching = [0], Momentary = [1]";
+CM_ SG_ 685 CBC_AUX2_PWRMD "Aux switch 2 power mode; ignition = [0], battery = [1]";
+CM_ SG_ 685 CBC_AUX2_HLEnbl "Aux switch 2 enable holding last state; enabled = [1]";
+CM_ SG_ 685 CBC_AUX1_Type "Aux switch 1 behavior; Latching = [0], Momentary = [1]";
+CM_ SG_ 685 CBC_AUX1_PWRMD "Aux switch 1 power mode; ignition = [0], battery = [1]";
+CM_ SG_ 685 CBC_AUX1_HLEnbl "Aux switch 1 enable holding last state; enabled = [1]";
+CM_ SG_ 685 CBC_AUX5_Type "Aux switch 5 behavior; Latching = [0], Momentary = [1]";
+CM_ SG_ 685 CBC_AUX5_PWRMD "Aux switch 5 power mode; ignition = [0], battery = [1]";
+CM_ SG_ 685 CBC_AUX5_HLEnbl "Aux switch 5 enable holding last state; enabled = [1]";
+CM_ SG_ 685 CBC_AUX6_Type "Aux switch 6 behavior; Latching = [0], Momentary = [1]";
+CM_ SG_ 685 CBC_AUX6_PWRMD "Aux switch 6 power mode; ignition = [0], battery = [1]";
+CM_ SG_ 685 CBC_AUX6_HLEnbl "Aux switch 6 enable holding last state; enabled = [1]";
+CM_ SG_ 881 SwayBarEVICDisplay "Sway Bar HMI display request";
+CM_ SG_ 881 SwayBar_Sts "Swaybar status";
+CM_ SG_ 881 SwayBar_LEDRq "Sway Bar disconnect switch LED request";
+CM_ SG_ 739 CNG_GaLvl "CNG gauge level";
+CM_ SG_ 739 CNG_LO "CNG is low";
+CM_ SG_ 739 EngRunFuelTyp "Engine running fuel type";
+CM_ SG_ 570 AUS "Cruise Switch: Cancel Pressed";
+CM_ SG_ 570 WA "Cruise Switch: distance / launch mode pressed";
+CM_ SG_ 570 S_PLUS_B "Cruise Switch: Resume/Accel Pressed";
+CM_ SG_ 570 S_MINUS_B "Cruise Switch: Coast or Set/Decel Pressed";
+CM_ SG_ 570 WH_UP "Cruise Switch: Implausible State=1";
+CM_ SG_ 570 CRUISE_TGL "Cruise Switch: On/Off  Pressed";
+CM_ SG_ 570 ACC_MODE "Cruise Switch: ACC or ESC mode pressed";
+CM_ SG_ 570 MC_SCCM_CRS_CTRL "Message counter";
+CM_ SG_ 570 CRC_SCCM_CRS_CTRL "CRC-checksum byte 1 to 2 according to SAE J1850";
+CM_ SG_ 914 PTO_IdleSpd1 "Power takeoff idle speed 1 selected";
+CM_ SG_ 914 PTO_IdleSpd2 "Power takeoff idle speed 2 selected";
+CM_ SG_ 914 PTO_IdleSpd3 "Power takeoff idle speed 3 selected";
+CM_ SG_ 914 PosEngdSwStat "Positive engagement switch status; On = [1]";
+CM_ SG_ 914 MC_VSIM_C1 "Message counter";
+CM_ SG_ 914 CRC_VSIM_C1 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 914 IdleShutDown_Disable "5 Minute Idle shut down feature disabled signal ;True =1";
+CM_ SG_ 914 VSIMEngineOffRequest "This signal informs the RF_HUB that VSIM Emergency Stop wire is activated; ACTIVE= 1";
+CM_ SG_ 914 J1939_RPM_RQ "Engine RPM requested through J1939";
+CM_ SG_ 676 MAP_4_Bar "Engine manifold pressure (4 bar range)";
+CM_ SG_ 676 ECM_WARN_EXT "HMI extended warnings";
+CM_ SG_ 676 TransWarmup_Min_RPM "Minimal engine rpm request for transmission warm up feature";
+CM_ SG_ 676 TransWarmup_Enbl_Rq "Enable and disable flag for transmission warm up feature, 0h = WarmUp_NOT_Enabled 1h = WarmUp_Enabled";
+CM_ SG_ 676 MC_ECM_B11 "Message counter";
+CM_ SG_ 676 CRC_ECM_B11 "CRC-Checksum Byte 1 - 7 according to SAE J1850";
+CM_ SG_ 2047 WAKE_SGW_Signal "This signal is used to wakeup networks";
+CM_ SG_ 963 VC_BU_VehCfgCSO3_Stat "Backup for Configuration message CSO3 status";
+CM_ SG_ 963 VC_BU_TIRE_FILL_ALERT_CSO "Tire Fill Alert Enable/Disable customer settings menu. 1 - Present";
+CM_ SG_ 963 VC_BU_POWER_SIDE_STEP_CSO "Power Side Step Enable/Disable customer settings menu, 1 - Present.";
+CM_ SG_ 963 VC_BU_TRAILER_LENGTH_BLIND_SPOT_ "Backup for Trailer Length Blind Spot Enable/Disable customer settings menu. 1 - Present";
+CM_ SG_ 963 VC_BU_TSI_CSO "Traffic Sign Information Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_TRUNK_UNLOCK_ENABLE_CSO "Trunk Unlock Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_SPEED_THRESHOLD_CSO "Vehicle Speed Threshold Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_SEIU_RPM_CSO "Back up for SEIU RPM Enable/Disable customer settings menu;Present=1";
+CM_ SG_ 963 VC_BU_SEIU_INPUT_WIRE_CSO "Back up fpr SEIU Input Wire Enable/Disable customer settings menu;Present=1";
+CM_ SG_ 963 VC_BU_RVC_CVPM_SGRID_CSO "Backup for Rear CVPM Camera Static Gridlines, Present = 1";
+CM_ SG_ 963 VC_BU_RVC_CVPM_DGRID_CSO "Backup for Rear CVPM Camera Dynamic Gridlines, Present = 1";
+CM_ SG_ 963 VC_BU_RR_CARGO_GUIDE_LGT_CSO "Back up for Rear Cargo Guidance Lights Enable/Disable customer settings menu;Present=1";
+CM_ SG_ 963 VC_BU_PEB_CSO "Pedestrian Emergency Brake Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_LKA_WARNING_CSO "Lane Keep Assist Warning Mode customer settings menu";
+CM_ SG_ 963 VC_BU_LKA_STRN_CSO "Lane Keep Assist Strength customer settings menu";
+CM_ SG_ 963 VC_BU_FFC_GRIDLINES_CSO "Backup for Forward Facing Camera Gridlines, Present = 1";
+CM_ SG_ 963 VC_BU_EXTERNAL_LIGHT_SENSOR_CSO "External Light Sensor Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_BUZZER_VOLUME_LEVEL_CSO "Buzzer Volume Level Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_BACKUP_ALARM_CSO "Backup for Back Up Alarm Enable/Disable customer settings menu;Present=1";
+CM_ SG_ 963 VC_BU_AUTO_STOP_START_CSO "Auto Stop Start Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_AL_OR_PLUS_CSO "BACKUP Auto Launch Off Road Plus customer settings menu";
+CM_ SG_ 963 VC_BU_AL_FFC_OR_PLUS_CSO "BACKUP Auto Launch Forward Facing Camera Off Road Plus customer settings menu";
+CM_ SG_ 963 VC_BU_TSR_WARNING_MODE_CSO "Backup TSR Warning Mode customer setting menu, Present = 1";
+CM_ SG_ 963 VC_BU_RR_PK_LOOSE_SHIP_CSO "Back up for Rear Park Sense Loose Ship Enable/Disable customer settings menu;0 - Absent 1 - Present";
+CM_ SG_ 963 VC_BU_HWRSS_CSO "Back up for HWRSS Enable/Disable customer settings menu;Present=1";
+CM_ SG_ 963 VC_BU_FT_PK_LOOSE_SHIP_CSO "Back up for Front Park Sense Loose Ship Enable/Disable customer settings menu;0 - Absent 1 - Present";
+CM_ SG_ 963 VC_BU_CHMSL_DYN_CNTR_CSO "BACKUP CHMSL Dynamic Centerline Enable/Disable customer settings menu";
+CM_ SG_ 963 VC_BU_TSR_WARNING_MODE_OFFSET_CS "Backup TSR Warning Mode Offset customer setting menu, Present = 1";
+CM_ SG_ 962 VC_VehCfgCSO3_Stat "Configuration message CSO3 status";
+CM_ SG_ 962 VC_TRAILER_LENGTH_BLIND_SPOT_CSO "Trailer Length Blind Spot Enable/Disable customer settings menu. 1 - Present";
+CM_ SG_ 962 VC_TIRE_FILL_ALERT_CSO "Tire Fill Alert Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_POWER_SIDE_STEP_CSO "Power Side Step Enable/Disable customer settings menu, 1 - Present.";
+CM_ SG_ 962 VC_TSI_CSO "Traffic Sign Information Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_TRUNK_UNLOCK_ENABLE_CSO "Trunk Unlock Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_SPEED_THRESHOLD_CSO "Vehicle Speed Threshold Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_SEIU_RPM_CSO "SEIU RPM Enable/Disable customer settings menu,Present =1 ";
+CM_ SG_ 962 VC_SEIU_INPUT_WIRE_CSO "SEIU Input Wire Enable/Disable customer settings menu,Present =1 ";
+CM_ SG_ 962 VC_RVC_CVPM_SGRID_CSO "Rear CVPM Camera Static Gridlines, Present = 1";
+CM_ SG_ 962 VC_RVC_CVPM_DGRID_CSO "Rear CVPM Camera Dynamic Gridlines, Present = 1";
+CM_ SG_ 962 VC_RR_CARGO_GUIDE_LGT_CSO "Rear Cargo Guidance Lights Enable/Disable customer settings menu, Present = 1";
+CM_ SG_ 962 VC_PEB_CSO "Pedestrian Emergency Brake Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_LKA_WARNING_CSO "Lane Keep Assist Warning Mode customer settings menu";
+CM_ SG_ 962 VC_LKA_STRN_CSO "Lane Keep Assist Strength customer settings menu";
+CM_ SG_ 962 VC_LKA_SENS_CSO "Lane Keep Assist Sensitivity customer settings menu";
+CM_ SG_ 962 VC_FFC_GRIDLINES_CSO "Forward Facing Camera Gridlines, Present = 1";
+CM_ SG_ 962 VC_EXTERNAL_LIGHT_SENSOR_CSO "External Light Sensor Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_BUZZER_VOLUME_LEVEL_CSO "Buzzer Volume Level Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_BACKUP_ALARM_CSO "Backup Alarm Enable/Disable customer settings menu, Present = 1";
+CM_ SG_ 962 VC_AUTO_STOP_START_CSO "Auto Stop Start Enable/Disable customer settings menu";
+CM_ SG_ 962 VC_AL_OR_PLUS_CSO "Auto Launch Off Road Plus customer settings menu";
+CM_ SG_ 962 VC_AL_FFC_OR_PLUS_CSO "Auto Launch Forward Facing Camera Off Road Plus customer settings menu";
+CM_ SG_ 962 VC_TSR_WARNING_MODE_OFFSET_CSO "TSR Warning Mode Offset customer setting menu, Present = 1";
+CM_ SG_ 962 VC_TSR_WARNING_MODE_CSO "TSR Warning Mode customer setting menu, Present = 1";
+CM_ SG_ 962 VC_RR_PK_LOOSE_SHIP_CSO "Rear Park Sense Loose Ship Enable/Disable customer settings menu;0 - Absent 1 - Present";
+CM_ SG_ 962 VC_HWRSS_CSO "HWRSS Enable/Disable customer settings menu,Present =1";
+CM_ SG_ 962 VC_FT_PK_LOOSE_SHIP_CSO "Front Park Sense Loose Ship Enable/Disable customer settings menu;0 - Absent 1 - Present";
+CM_ SG_ 962 VC_CHMSL_DYN_CNTR_CSO "CHMSL Dynamic Centerline Enable/Disable customer settings menu";
+CM_ SG_ 907 VC_BU_VehCfg8_Stat "Backup for Configuration messages status 8";
+CM_ SG_ 907 VC_BU_Steering_Cfactor "Backup for Steering Cfactor feature";
+CM_ SG_ 907 VC_BU_Trans_Brake_PRSNT "Backup for Transmission Brake feature present; True = [1]";
+CM_ SG_ 907 VC_BU_LineLock_PRSNT "Backup for Line Lock feature present; True = [1]";
+CM_ SG_ 907 VC_BU_HighOctane_PRSNT "Backup for High Octane feature present; True = [1]";
+CM_ SG_ 907 VC_BU_CHILLER_PRSNT "Backup for Chiller present; True = [1]";
+CM_ SG_ 907 VC_BU_ARC_PRSNT "Backup for After Run Cooling (Race Cool Down) feature present; True = [1]";
+CM_ SG_ 907 VC_BU_Speedometer_Tolerance "Backup for Speedometer Tolerance Percentage (Gain for Speedometer Biasing)";
+CM_ SG_ 907 VC_BU_Increasing_Speed_Constant "Backup for Increasing Speed Constant (Offset for Speedometer Biasing)";
+CM_ SG_ 907 VC_BU_WHL_BASE_LENGTH "Back up Wheel Base Length";
+CM_ SG_ 907 VC_BU_SBL_FBL_CORNERING_PRSNT "Configuration messages status 8";
+CM_ SG_ 907 VC_BU_PPPAHardBtn "PPPA Hard button present; Present = [1]";
+CM_ SG_ 907 VC_BU_PEB_PRSNT "Vehicle config to learn the presence of PEB";
+CM_ SG_ 907 VC_BU_OFFroad_Camera "OFF Road Camera Present, Present = 1";
+CM_ SG_ 907 VC_BU_OFFRoadModePrsnt "OFF ROAD MODE Present BackUp Configuration, Present = 1";
+CM_ SG_ 907 VC_BU_DBL_PRSNT "Present = 1";
+CM_ SG_ 907 VC_BU_BEAM_SHAPING_PRSNT "Present = 1";
+CM_ SG_ 907 VC_BU_AVAC_PRSNT "Present = 1";
+CM_ SG_ 907 VC_BU_OvertakingBan "Backup for Overtaking Ban present; present = [1]";
+CM_ SG_ 907 VC_BU_TrailerTPM_Prsnt "Back up for Trailer TPM Present; True = [1] ";
+CM_ SG_ 907 VC_BU_TFA_Prsnt "Back up for Tire Fill Alert Present; True = [1] ";
+CM_ SG_ 907 VC_BU_TACHO_TYPE "Backup Vehicle Configuration 8 Packet";
+CM_ SG_ 907 VC_BU_STFA_Prsnt "Back up for Selectable Tire Fill Alert Present; True = [1] ";
+CM_ SG_ 907 VC_BU_MARKET_HEADLAMP "Headlamp led intensity configuration referred to market homologation";
+CM_ SG_ 907 VC_BU_Dgtl_CHMSL_Cam_Prsnt "Digital CHMSL Camera Present Backup;Present = 1";
+CM_ SG_ 907 VC_BU_WRSS_Prsnt "Wired Remote Start Stop Feature Backup;0 = Not Set, 1 = Set";
+CM_ SG_ 907 VC_BU_Trlr_Rev_Guidance_Prsnt "Back up for Trailer Reverse Guidance Present; 0 = Not Set, 1 = Set";
+CM_ SG_ 907 VC_BU_Box_Delete "Pickup Box Delete Backup;0 = Not Set, 1 = Set";
+CM_ SG_ 907 VC_BU_Aux_Trailer_Cam_Prsnt "Back up for Auxiliary Trailer Camera Present; 0 = Not Set, 1 = Set";
+CM_ SG_ 906 VC_VehCfg8_Stat "Configuration messages status 8";
+CM_ SG_ 906 VC_Steering_Cfactor "Steering Cfactor feature";
+CM_ SG_ 906 VC_Trans_Brake_PRSNT "Transmission Brake feature present; True = [1]";
+CM_ SG_ 906 VC_LineLock_PRSNT "Line Lock feature present; True = [1]";
+CM_ SG_ 906 VC_HighOctane_PRSNT "High Octane feature present; True = [1]";
+CM_ SG_ 906 VC_CHILLER_PRSNT "Chiller present; True = [1]";
+CM_ SG_ 906 VC_ARC_PRSNT "After Run Cooling (Race Cool Down) feature present; True = [1]";
+CM_ SG_ 906 VC_Speedometer_Tolerance "Speedometer Tolerance Percentage (Gain for Speedometer Biasing)";
+CM_ SG_ 906 VC_Increasing_Speed_Constant "Increasing Speed Constant (Offset for Speedometer Biasing)";
+CM_ SG_ 906 VC_WHL_BASE_LENGTH "Wheel Base Length";
+CM_ SG_ 906 VC_OHC_TYPE "Type of OHC";
+CM_ SG_ 906 VC_SBL_FBL_CORNERING_PRSNT "Configuration messages status 8";
+CM_ SG_ 906 VC_PPPAHardBtn "PPPA Hard button present, Present = 1";
+CM_ SG_ 906 VC_PEB_PRSNT "Vehicle config to learn the presence of PEB";
+CM_ SG_ 906 VC_OvertakingBan "Overtaking Ban present; present = [1]";
+CM_ SG_ 906 VC_OFFroad_Camera "OFF Road Camera Present, Present = 1";
+CM_ SG_ 906 VC_OFFRoadModePrsnt "OFF ROAD MODE Present, Present = 1";
+CM_ SG_ 906 VC_DBL_PRSNT "Present = 1";
+CM_ SG_ 906 VC_BEAM_SHAPING_PRSNT "Present = 1";
+CM_ SG_ 906 VC_AVAC_PRSNT "Present = 1";
+CM_ SG_ 906 VC_TrailerTPM_Prsnt "Trailer TPM Present; True = [1] ";
+CM_ SG_ 906 VC_TFA_Prsnt "Tire Fill Alert Present; True = [1] ";
+CM_ SG_ 906 VC_TACHO_TYPE "CBC VC Config of Tachometer Type";
+CM_ SG_ 906 VC_STFA_Prsnt "Selectable Tire Fill Alert Present; True = [1] ";
+CM_ SG_ 906 VC_MARKET_HEADLAMP "Headlamp led intensity configuration referred to market homologation";
+CM_ SG_ 906 VC_Dgtl_CHMSL_Cam_Prsnt "Digital CHMSL Camera Present;Present = 1";
+CM_ SG_ 906 VC_WRSS_Prsnt "Wired Remote Start Stop Feature Present;0 = Not Set, 1 = Set";
+CM_ SG_ 906 VC_Trlr_Rev_Guidance_Prsnt "Trailer Reverse Guidance Present; 0 = Not Set, 1 = Set";
+CM_ SG_ 906 VC_Box_Delete "Pickup Box Delete;0 = Not Set, 1 = Set";
+CM_ SG_ 906 VC_Aux_Trailer_Cam_Prsnt "Auxiliary Trailer Camera Present; 0 = Not Set, 1 = Set";
+CM_ SG_ 1556 SD_RS_ITBM "Response on Event - light";
+CM_ SG_ 1590 SD_RS_ATMM "Response on Event - light";
+CM_ SG_ 687 TrlrTripDist "Trip distance of the curent Trailer";
+CM_ SG_ 687 TrlrStyle_4 "Trailer 4 style";
+CM_ SG_ 687 TrlrStyle_3 "Trailer 3 style";
+CM_ SG_ 687 TrlrStyle_2 "Trailer 2 style";
+CM_ SG_ 687 TrlrStyle_1 "Trailer 1 style";
+CM_ SG_ 687 SelTrlrStyle "Selected trailer style";
+CM_ SG_ 687 SelTrlrNum "Selected trailer number";
+CM_ SG_ 1428 ECU_APPL_ITBM "ECU to External Application";
+CM_ SG_ 1462 ECU_APPL_ATMM "ECU to External Application";
+CM_ SG_ 629 IRCM_AHB_On "Auto high beam on request from the IRCM ECU";
+CM_ SG_ 1236 D_RS_ITBM "Diagnostic-Response";
+CM_ SG_ 1270 D_RS_ATMM "Diagnostic-Response";
+CM_ SG_ 1876 D_RQ_ITBM "Diagnostic-Request";
+CM_ SG_ 1910 D_RQ_ATMM "Diagnostic-Request";
+CM_ SG_ 875 ATMM_PopUpRqst "ATMM HMI Display Request";
+CM_ SG_ 1748 APPL_ECU_ITBM "External Application to ECU";
+CM_ SG_ 1782 APPL_ECU_ATMM "External Application to ECU";
+CM_ SG_ 924 MsgFobBattLow "Indicates battery low on FOBIK last used for RKE purposes";
+CM_ SG_ 924 MsgFobNotFnd "FOB Not Detected.";
+CM_ SG_ 924 MsgNotInPark "Vehicle was not in Park.";
+CM_ SG_ 924 MsgKG1 "Place holder for future.";
+CM_ SG_ 924 FOB_SrchRslt "FOB search result";
+CM_ SG_ 924 FOB_SrchFLT "FOB search fault";
+CM_ SG_ 924 FOBinTRUNK "FOB is in zone trunk";
+CM_ SG_ 924 FOBinINT "FOB is in zone interior";
+CM_ SG_ 924 FOB_ExtRT "FOB is in zone exterior right";
+CM_ SG_ 924 FOB_ExtLT "FOB is in zone exterior left";
+CM_ SG_ 924 FOB_ExtRR "FOB is in zone exterior rear";
+CM_ SG_ 924 MsgKG2 "Place holder for future.";
+CM_ SG_ 818 A2D_DRV_TEMP_DR_POS "Transmit raw A/D driver temp door position to ECM to make OBD model more robust";
+CM_ SG_ 818 Blower_Speed "Frequency Feedback received from the Blower";
+CM_ SG_ 818 Blower_Diagnostics "Duty cycle Feedback received from the Blower";
+CM_ SG_ 650 Radio_Theme "Radio Theme";
+CM_ SG_ 650 CSOPSSAutoStowSts "Power side step Auto/Stow status; Auto = [0], Stow = [1]";
+CM_ SG_ 181 TrqRq_SlowFast "Final torque between fast path and slow path calculated for Speed Control";
+CM_ SG_ 181 EngRPM_Tach "Engine revolutions per minute for indication";
+CM_ SG_ 181 CRC_ECM_ENG_TRQ2 "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 181 MC_ECM_ENG_TRQ2 "Message counter";
+CM_ SG_ 179 TargetTime "Time to achieve Trans Target Speed";
+CM_ SG_ 179 MC_TCM_ENG_SPD "Message counter   TCM_ENG_SPD";
+CM_ SG_ 179 CRC_TCM_ENG_SPD "CRC-checksum byte 1 to 7 according to SAE J1850";
+CM_ SG_ 179 TransLosses "Transmission Drag torques";
+CM_ SG_ 179 OutputSpeed_2 "Output Shaft Speed from 0 - 65534 RPM with 1 RPM resolution.  ";
+CM_ SG_ 774 Tire_RR2 "Tire rear right inside on dually";
+CM_ SG_ 774 Tire_RL2 "Tire rear left inside on dually";
+CM_ SG_ 774 TirePrssRR2 "Tire pressure rear right inside on dually";
+CM_ SG_ 774 TirePrssRL2 "Tire pressure rear left inside on dually";
+CM_ SG_ 960 TrqC_Temp "Filtered torque converter temperature";
+CM_ SG_ 1548 SD_RS_FDCM "Response on Event - light";
+CM_ SG_ 302 STFARrAlertPress "Selectable Tire Fill Alert Rear Alert Pressure";
+CM_ SG_ 302 STFAFtAlertPress "Selectable Tire Fill Alert Front Alert Pressure";
+CM_ SG_ 302 TrlTPMSetPress "Trailer TPM set pressure";
+CM_ SG_ 302 Stop_TPM_Programming "Stop the TPM sensor ID programming;Stop would be set to '1' to stop programming";
+CM_ SG_ 302 Start_TPM_Programming "Start the TPM sensor ID programming;Start would be set to '1' to start programming";
+CM_ SG_ 302 SelectedTPMTrailer_Number "TPM Trailer Number Selected";
+CM_ SG_ 302 Program_Single_TPM "Program a single TPM sensor ID";
+CM_ SG_ 302 Number_of_Trl_Tires "Number of Trailer Tires";
+CM_ SG_ 302 Number_of_Trl_Axles "Number of Trailer Axles";
+CM_ SG_ 302 Clear_Trailer_TPM_Settings "Clear trailer TPM settings";
+CM_ SG_ 903 ITBM_WarnRq "ITBM warning request";
+CM_ SG_ 903 ITBM_TrlrStat "Trailer connection status";
+CM_ SG_ 903 ITBM_OP_PWR "ITBM brake output value (PWM)";
+CM_ SG_ 903 ITBM_GAIN_STAT "Set gain";
+CM_ SG_ 903 ITBM_DSP_RQ "ITBM display request";
+CM_ SG_ 903 ITBM_BrkStyle "Trailer brake style";
+CM_ SG_ 903 ITBM_BRK_SW "Brake light activation";
+CM_ SG_ 903 ITBM_CHM_RQ "ITBM fault chime request";
+CM_ SG_ 1420 ECU_APPL_FDCM "ECU to External Application";
+CM_ SG_ 341 SEIU_Sts "SEIU Status";
+CM_ SG_ 341 SEIU_RPM "PTO SEIU RPM ";
+CM_ SG_ 341 SEIU_Enbl "SEIU feature enable bit: enabled=[1]";
+CM_ SG_ 341 PTO_Target_Gear "PTO Target Gear";
+CM_ SG_ 341 PTO_Remote_RPM_Method "Remote RPM method selection signal";
+CM_ SG_ 341 PTO_Ramp_Rate "PTO RPM Ramp rate";
+CM_ SG_ 341 PTO_Park_Brk_Required "Park brake is required to enable PTO: YES=[1]";
+CM_ SG_ 341 PTO_High_Idle_RPM "PTO High Idle Set RPM";
+CM_ SG_ 341 PTO_High_Idle_Enable "PTO High Idle feature enable bit: enabled=[1]";
+CM_ SG_ 341 PTO_Active "PTO indication for ASBM: Default is OFF";
+CM_ SG_ 341 PTO_Acc_Intlk "PTO Accelerator Interlock feature enable: enabled=[1]";
+CM_ SG_ 1271 D_RS_VGT "Diagnostic-Response";
+CM_ SG_ 1228 D_RS_FDCM "Diagnostic-Response";
+CM_ SG_ 1911 D_RQ_VGT "Diagnostic-Request";
+CM_ SG_ 1868 D_RQ_FDCM "Diagnostic-Request";
+CM_ SG_ 564 AM_ECM_Trace "Aftermarket ECM trace";
+CM_ SG_ 664 BDL_Enbl "Bed Lowering Mode enabled; 1 = True";
+CM_ SG_ 664 ASCM_HMI_Stat2 "ASCM HMI status2";
+CM_ SG_ 1740 APPL_ECU_FDCM "External Application to ECU";
+CM_ SG_ 703 DrvAway_Alert "Drive Away Alert; True = [1]";
+CM_ SG_ 703 DrvAway_Inhibit "Drive Away Inhibit; True = [1]";
+CM_ SG_ 811 AxlLckrSts "Axle locker status";
+CM_ SG_ 811 AxleLockerEVICDisplay "Axle locker HMI display request";
+CM_ SG_ 811 RrAxleLockerIndRq "Rear Axle Locker Indication Request";
+CM_ SG_ 811 Ft_RrAxleLockerIndRq "Front and Rear Axle Locker Indication Request";
+CM_ SG_ 811 AxleUnlockIndRq "Axle Unlock Indication Request";
+CM_ SG_ 811 AXLE_LCKR_SRV_RQ "Axle locker service indicator request";
+CM_ SG_ 560 AC_RQ "A/C clutch request; [1] = A/C Clutch requested; 0 = A/C Clutch not requested";
+CM_ SG_ 560 AC_SEL "Customer has selected A/C; [1] = A/C selected; 0 = A/C not selected";
+CM_ SG_ 560 DEFROST_SEL "Defrost select switch";
+CM_ SG_ 560 AC_PT_Demand "Maximum A/C demand to powertrain";
+CM_ SG_ 560 EVAP_TEMP "AC evaporator temperature";
+CM_ SG_ 560 EvapTempTar "Evaporator temperature target";
+CM_ SG_ 560 PTC_Enbl "PTC heater enable; [1] = enable";
+CM_ SG_ 821 TrlTPM_ServiceReq "Trailer TPM Service Required ; FALSE =0 ,TRUE =1";
+CM_ SG_ 821 TrlTPMSetPress_TTPM "Trailer TPM set pressure";
+CM_ SG_ 821 Trailer_Sensor_Mismatch "TPM sensor IDs mismatched to trailer number";
+CM_ SG_ 821 Trailer_Not_Configured "Trailer Not Configured;FALSE =0 ,TRUE =1";
+CM_ SG_ 821 Trailer_Configured "Trailer Configured;FALSE =0 ,TRUE =1";
+CM_ SG_ 821 TPM_Programming_Complete "TPM Programming Complete; FALSE =0 ,TRUE =1";
+CM_ SG_ 821 TPM_Prog_Not_Complete "Trailer programming not complete; FALSE =0 ,TRUE =1";
+CM_ SG_ 821 TPMTrailer_Number "Trailer Number Selected";
+CM_ SG_ 821 TPMSensor_Programmed "TPM sensor programmed";
+CM_ SG_ 821 TPMLearnHornChirp "TPM sensor learn horn chirp";
+CM_ SG_ 821 Number_of_Trl_Tires_TTPM "Number of Trailer Tires";
+CM_ SG_ 821 Number_of_Trl_Axles_TTPM "Number of Trailer Axles";
+CM_ SG_ 813 TrlTire9_Stat "Trailer Tire 9 Status";
+CM_ SG_ 813 TrlTire8_Stat "Trailer Tire 8 Status";
+CM_ SG_ 813 TrlTire7_Stat "Trailer Tire 7 Status";
+CM_ SG_ 813 TrlTire12_Stat "Trailer Tire 12 Status";
+CM_ SG_ 813 TrlTire11_Stat "Trailer Tire 11 Status";
+CM_ SG_ 813 TrlTire10_Stat "Trailer Tire 10 Status";
+CM_ SG_ 813 TrailerTirePress9 "Trailer Tire Pressure 9";
+CM_ SG_ 813 TrailerTirePress8 "Trailer Tire Pressure 8";
+CM_ SG_ 813 TrailerTirePress7 "Trailer Tire Pressure 7";
+CM_ SG_ 813 TrailerTirePress12 "Trailer Tire Pressure 12";
+CM_ SG_ 813 TrailerTirePress11 "Trailer Tire Pressure 11";
+CM_ SG_ 813 TrailerTirePress10 "Trailer Tire Pressure 10";
+CM_ SG_ 812 TrlTire6_Stat "Trailer Tire 6 Status";
+CM_ SG_ 812 TrlTire5_Stat "Trailer Tire 5 Status";
+CM_ SG_ 812 TrlTire4_Stat "Trailer Tire 4 Status";
+CM_ SG_ 812 TrlTire3_Stat "Trailer Tire 3 Status";
+CM_ SG_ 812 TrlTire2_Stat "Trailer Tire 2 Status";
+CM_ SG_ 812 TrlTire1_Stat "Trailer Tire 1 Status";
+CM_ SG_ 812 TrailerTirePress6 "Trailer Tire Pressure 6";
+CM_ SG_ 812 TrailerTirePress5 "Trailer Tire Pressure 5";
+CM_ SG_ 812 TrailerTirePress4 "Trailer Tire Pressure 4";
+CM_ SG_ 812 TrailerTirePress3 "Trailer Tire Pressure 3";
+CM_ SG_ 812 TrailerTirePress2 "Trailer Tire Pressure 2";
+CM_ SG_ 812 TrailerTirePress1 "Trailer Tire Pressure 1";
+CM_ SG_ 1560 SD_RS_TTPM "Response on Event - light";
+CM_ SG_ 388 CustKeyInIgn "Driver's request, key-in-ignition";
+CM_ SG_ 388 IgnPos "Drivers request, ignition position";
+CM_ SG_ 388 ValImmKey "Drivers request, immobilizer results";
+CM_ SG_ 388 WRSS_ENABLE "Passive entry feature enabled; [1] = True";
+CM_ SG_ 388 RFHUBEngineOffRequest "This signal informs the CBC that RF_HUB is requesting an Emergency Stop; ACTIVE= 1";
+CM_ SG_ 388 MC_RFHUB_A1 "Message Counter";
+CM_ SG_ 388 CRC_RFHUB_A1 "CRC-Checksum Byte 1 - 7 according to SAE J1850";
+CM_ SG_ 1048 NM_Mode "Network management mode";
+CM_ SG_ 1048 NM_Successor "Network management logical successor";
+CM_ SG_ 1048 NM_Ud_Launch "Network management userdata launch type";
+CM_ SG_ 1048 NM_Sleep_Ack "Network management sleep acknowledge; True = [1]";
+CM_ SG_ 1048 NM_Sleep_Ind "Network management sleep indication; True = [1]";
+CM_ SG_ 1048 Nw_Id "Network identification no.";
+CM_ SG_ 1432 ECU_APPL_TTPM "ECU to External Application";
+CM_ SG_ 1240 D_RS_TTPM "Diagnostic-Response";
+CM_ SG_ 1880 D_RQ_TTPM "Diagnostic-Request";
+CM_ SG_ 1874 D_RQ_DCU "Diagnostic-Request";
+CM_ SG_ 274 CmdIgnStat "Commanded ignition switch status";
+CM_ SG_ 274 StTyp "Type of start being requested";
+CM_ SG_ 274 RemStActv "Ignition run active for remote start (0=not active, 1=active)";
+CM_ SG_ 274 KeyInIgn "Key in ignition status";
+CM_ SG_ 274 StartRelayBCMSts "CBC starter relay status; [1] = ON";
+CM_ SG_ 274 StartRelayBCMFault "CBC starter relay fault detected";
+CM_ SG_ 274 OD_SW_PSD "Overdrive Switch Pressed; [0] = not pressed, [1] = pressed";
+CM_ SG_ 1752 APPL_ECU_TTPM "External Application to ECU";
+VAL_ 992 VIN_MSG 0 "VIN_LO" 1 "VIN_MID" 2 "VIN_HI" 3 "SNA" ;
+VAL_ 257 ECM_SKIM_STAT 0 "OK" 1 "KILL" 2 "RUN" 3 "SNA" ;
+VAL_ 257 RAD_FAN1_STAT 255 "SNA" ;
+VAL_ 258 LRW 16383 "SNA" ;
+VAL_ 258 VLRW 16383 "SNA" ;
+VAL_ 258 LRWS_ST 0 "OK" 1 "INI" 2 "ERR" 3 "ERR_INI" ;
+VAL_ 258 Pad_Shft 0 "PS_OFF" 1 "PS_RIGHT" 2 "PS_LEFT" 3 "PS_BOTH" 7 "SNA" ;
+VAL_ 264 EngRPM 65535 "SNA" ;
+VAL_ 264 EngTrqStatic 8191 "SNA" ;
+VAL_ 264 ExpEngTrq 8191 "SNA" ;
+VAL_ 264 ECM_LHOM_Trans 0 "LH_NOT_ACTIVE" 1 "NO_RDN_TRQ" 2 "PRECISE_TRQ" 3 "IMPRECISE_TRQ" ;
+VAL_ 268 EngTrq_Rq_ESC 8191 "SNA" ;
+VAL_ 268 EngTrq_Rq_As 8191 "SNA" ;
+VAL_ 268 BrkBstrVac 255 "SNA" ;
+VAL_ 268 TrlrBrkRq 63 "SNA" ;
+VAL_ 268 DAS_RqActv 0 "IDLE" 1 "ACC" 2 "CMS" 3 "ABA" 4 "LSCM" 5 "CMS_XTD" 6 "PEB" 7 "SNA" ;
+VAL_ 280 EngTrqMax 8191 "SNA" ;
+VAL_ 280 EngTrqMin 8191 "SNA" ;
+VAL_ 280 StartRelayBCMCmd 0 "SNA" ;
+VAL_ 280 ECM_WTS_Inhbt 0 "INHIBIT" 1 "GRID_HEATER_OFF" 2 "GRID_HEATER_ON" 3 "SNA" ;
+VAL_ 284 VEH_SPEED 65535 "SNA" ;
+VAL_ 284 BrkTrq_D 16383 "SNA" ;
+VAL_ 284 BrkTrq 16383 "SNA" ;
+VAL_ 288 EngTrqSel_D_TTC 8191 "SNA" ;
+VAL_ 288 AccelPdlPosn 255 "SNA" ;
+VAL_ 288 EngTrq_DrvReqMod 8191 "SNA" ;
+VAL_ 290 EngTrqMaxCorrFctr 255 "SNA" ;
+VAL_ 290 GrMin_Rq_ECM 0 "PASSIVE" 1 "G1" 2 "G2" 3 "G3" 4 "G4" 5 "G5" 6 "G6" 7 "G7" ;
+VAL_ 290 GrMax_Rq_ECM 0 "PASSIVE" 1 "G1" 2 "G2" 3 "G3" 4 "G4" 5 "G5" 6 "G6" 7 "G7" ;
+VAL_ 290 NMOTS 65535 "SNA" ;
+VAL_ 292 WhlPlsCnt_FL 255 "SNA" ;
+VAL_ 292 WhlPlsCnt_FR 255 "SNA" ;
+VAL_ 292 WhlPlsCnt_RL 255 "SNA" ;
+VAL_ 292 WhlPlsCnt_RR 255 "SNA" ;
+VAL_ 292 CENT_DIFF_ESP_RQ 0 "FREE" 1 "HOLD" 2 "OPEN" 3 "SNA" ;
+VAL_ 292 R_DIFF_ESP_RQ 0 "FREE" 1 "HOLD" 2 "OPEN" 3 "SNA" ;
+VAL_ 292 CENT_DIFF_TRQ_RQ 255 "SNA" ;
+VAL_ 308 CRUISE_EGD 0 "SNA" ;
+VAL_ 308 CRUISE_ON 0 "SNA" ;
+VAL_ 308 V_MAX_TM 255 "SNA" ;
+VAL_ 308 MAP_ENG 255 "SNA" ;
+VAL_ 308 BARO_ENG 255 "SNA" ;
+VAL_ 308 Rel_Thrt_ENG 255 "SNA" ;
+VAL_ 308 Rel_Pdl_ENG 255 "SNA" ;
+VAL_ 320 Brk_Stat 0 "IDLE" 1 "BRAKING" 2 "NDEF2" 3 "SNA" ;
+VAL_ 320 BrkPdl_Stat 0 "UPSTOP" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 320 ESP_Sys_Stat 0 "ABSERR" 1 "NORM" 2 "HALF" 3 "ABGAS" ;
+VAL_ 320 DTR_CC_Engaged 0 "SNA" ;
+VAL_ 320 GrMin_Rq_ESC 0 "PASSIVE" 1 "G1" 2 "G2" 3 "G3" 4 "G4" 5 "G5" 6 "G6" 7 "G7" ;
+VAL_ 320 GrMax_Rq_ESC 0 "PASSIVE" 1 "G1" 2 "G2" 3 "G3" 4 "G4" 5 "G5" 6 "G6" 7 "G7" ;
+VAL_ 320 DTR_CC_Enabled 0 "SNA" ;
+VAL_ 320 ShftChrDsp_Rq_ESC 0 "SKL0" 1 "SKL1" 2 "SKL2" 3 "SKL3" 4 "SKL4" 5 "SKL5" 6 "SKL6" 7 "SKL7" 8 "SKL8" 9 "SKL9" 10 "SKL10" 11 "SKL11" 12 "SKL12" 15 "SNA" ;
+VAL_ 320 RollTestMd_Actv 0 "OFF" 1 "ON" 2 "NDEF2" 3 "SNA" ;
+VAL_ 320 REF_VEH_SPEED 1023 "SNA" ;
+VAL_ 320 SPCR_AS_Off_Rq 0 "IDLE" 1 "AS_TMP_OFF" 2 "AS_CNTS_OFF" 3 "SPCR_NA" ;
+VAL_ 324 Gr 0 "N" 1 "D1" 2 "D2" 3 "D3" 4 "D4" 5 "D5" 6 "D6" 7 "D7" 8 "D8" 9 "D2P" 10 "D9" 11 "R" 12 "R2" 13 "P" 14 "KRAFTFREI" 15 "SNA" ;
+VAL_ 324 Gr_Target 0 "N" 1 "D1" 2 "D2" 3 "D3" 4 "D4" 5 "D5" 6 "D6" 7 "D7" 8 "D8" 9 "D2P" 10 "D9" 11 "R" 12 "R2" 13 "P" 14 "ABBRUCH" 15 "SNA" ;
+VAL_ 324 OUTPUT_SPEED 65535 "SNA" ;
+VAL_ 324 N_Turb 65535 "SNA" ;
+VAL_ 324 OutputSpdPolarity 0 "DND" 1 "DF" 2 "DB" 3 "SNA" ;
+VAL_ 324 Ups_Inh_Act 0 "SNA" ;
+VAL_ 324 PTO_Enbl 0 "SNA" ;
+VAL_ 331 BrkPrss_TMC 2047 "SNA" ;
+VAL_ 331 HSA_BrkPrss 63 "SNA" ;
+VAL_ 332 VehYawRate_Raw 65535 "SNA" ;
+VAL_ 332 VehYawRate_Offset 255 "SNA" ;
+VAL_ 332 VehAccel_X_Offset 255 "SNA" ;
+VAL_ 332 VehAccel_X 255 "SNA" ;
+VAL_ 332 VehAccel_Y 255 "SNA" ;
+VAL_ 332 VehAccel_Y_Offset 255 "SNA" ;
+VAL_ 344 WhlRPM_FL 16383 "SNA" ;
+VAL_ 344 WhlDir_FL_Stat 0 "VOID" 1 "FORWARD" 2 "BACKWARD" 3 "SNA" ;
+VAL_ 344 WhlRPM_FR 16383 "SNA" ;
+VAL_ 344 WhlDir_FR_Stat 0 "VOID" 1 "FORWARD" 2 "BACKWARD" 3 "SNA" ;
+VAL_ 344 WhlRPM_RL 16383 "SNA" ;
+VAL_ 344 WhlDir_RL_Stat 0 "VOID" 1 "FORWARD" 2 "BACKWARD" 3 "SNA" ;
+VAL_ 344 WhlRPM_RR 16383 "SNA" ;
+VAL_ 344 WhlDir_RR_Stat 0 "VOID" 1 "FORWARD" 2 "BACKWARD" 3 "SNA" ;
+VAL_ 352 TCASE_STAT 0 "SH_IPG" 1 "4LO" 2 "4HI" 3 "2WD" 4 "N" 5 "AUTO" 6 "PT" 7 "SNA" ;
+VAL_ 352 ACT_CNT_DIF_TRQ 255 "SNA" ;
+VAL_ 352 DES_CNT_DIF_TRQ 255 "SNA" ;
+VAL_ 352 SHFT_ABRT 1 "SNA" ;
+VAL_ 368 PRND_STAT 0 "LVR_P" 1 "LVR_R" 2 "LVR_N" 4 "LVR_D" 5 "NOT_R" 7 "SNA" ;
+VAL_ 368 SHFT_PROG 1 "LOW" 2 "SSC" 3 "HDC" 4 "TRACK" 5 "VALET" 7 "SNOW" 11 "MUD" 12 "SAND" 16 "SKIP_SHFT" 24 "UPSHIFT_IND_RQ" 32 "BLANK" 64 "E_MODE" 65 "A" 77 "M" 83 "S" 87 "W" 249 "TX_RACE" 250 "Sport_Plus" 251 "TX_SPORT" 252 "TX_NORM" 253 "OD_OFF" 254 "TX_TOW" 255 "SNA" ;
+VAL_ 368 PRNDL_DISP 32 "BLANK" 49 "ONE" 50 "TWO" 51 "THREE" 52 "FOUR" 53 "FIVE" 54 "SIX" 55 "SEVEN" 56 "EIGHT" 57 "NINE" 65 "A" 68 "D" 70 "F" 76 "L" 77 "M" 78 "N" 80 "P" 82 "R" 83 "S" 128 "DS" 130 "D2" 131 "D3" 132 "D4" 133 "D5" 135 "SNOW" 254 "NOT_N" 255 "SNA" ;
+VAL_ 368 PRNDL_Blink 0 "NONE" 1 "P" 2 "R" 3 "N" 4 "D" 5 "L" 6 "S" 7 "M_TIP" ;
+VAL_ 368 APCM_Rq 0 "OFF" 1 "ON" 2 "PENDING" 3 "SNA" ;
+VAL_ 376 FAN_RQ 15 "SNA" ;
+VAL_ 376 TX_TEMP 255 "SNA" ;
+VAL_ 376 TX_WARN 0 "None" 1 "WARN_1" 2 "WARN_2" 3 "WARN_3" 4 "WARN_4" 5 "WARN_5" 6 "WARN_6" 7 "WARN_7" 8 "WARN_8" 9 "WARN_9" 10 "WARN_10" 11 "WARN_11" 12 "WARN_12" 13 "WARN_13" 14 "WARN_14" 15 "SNA" ;
+VAL_ 376 TX_FAULT 0 "OK" 1 "TPF" 3 "SNA" ;
+VAL_ 384 IntkAirTemp 255 "SNA" ;
+VAL_ 384 EngCoolTemp 255 "SNA" ;
+VAL_ 384 AirPress_Outsd 255 "SNA" ;
+VAL_ 384 SysVolt 255 "SNA" ;
+VAL_ 384 R134a_Press_Stat 511 "SNA" ;
+VAL_ 384 CHRG_FAIL 1 "SNA" ;
+VAL_ 384 AM_ECM_Prsnt 0 "DEFAULT" 2 "AM_ECM_PRSNT" 3 "SNA" ;
+VAL_ 416 Trans_Trq_Ratio 2047 "SNA" ;
+VAL_ 416 TxIdleRq 255 "SNA" ;
+VAL_ 416 EngTrq_Rq_TCM 8191 "SNA" ;
+VAL_ 448 RFFuncReq 0 "NO_BASIC_REQUEST" 1 "LOCK_REQUEST" 2 "RELOCK_REQUEST" 3 "DRIVER_UNLOCK_REQUEST" 4 "ALL_UNLOCK_REQUEST" 5 "TRUNK_PLG_TOGGLE_REQUEST" 6 "LEFT_SLIDER_TOGGLE_REQUEST" 7 "RIGHT_SLIDER_TOGGLE_REQUEST" 8 "FLIPPER_GLASS_REQUEST" 9 "REMOTE_START_ON" 10 "REMOTE_START_OFF" 11 "GLOBAL_WINDOW_DOWN_REQUEST" 12 "OPEN_CONVERTIBLE_TOP" 13 "CLOSE_CONVERTIBLE_TOP" 14 "PANIC_TOGGLE_REQUEST" 15 "DRIVER_TOGGLE_REQUEST" 16 "PASSENGER_TOGGLE_REQUEST" 17 "ExtLightReq" 18 "AirSuspReq" 19 "AirSuspCancel" 20 "GLBL_WIN_UP_RQ" 21 "CAR_FINDER_REQUEST" 22 "TRUNK_PLG_BTN_PRESSED" 23 "TRUNK_PLG_STOP_REQUEST" 24 "TRUNK_PLG_OPEN_REQUEST" 25 "TRUNK_PLG_CLOSE_REQUEST" 26 "VTA_RQ" 27 "RAP_UNLOCK_REQUEST" 31 "SNA" ;
+VAL_ 448 RFReq 0 "REQUESTOR_DEFAULT" 1 "REQUESTOR_RKE" 2 "REQUESTOR_PE" 3 "REQUESTOR_REMOTESTART" 4 "REQUESTOR_UCONNECT" 5 "REQUESTOR_PE_HANDSFREE" 7 "SNA" ;
+VAL_ 448 RFCfgReq 0 "DEFAULT" 1 "HORN_CHIRP_TOGGLE" 2 "OPTICAL_CHIRP_TOGGLE" 3 "DRIVER_UNLOCK_FIRST_TOGGLE" 7 "SNA" ;
+VAL_ 448 RFFobNum 0 "FOB_DEFAULT" 1 "FOB_1" 2 "FOB_2" 3 "FOB_3" 4 "FOB_4" 5 "FOB_5" 6 "FOB_6" 7 "FOB_7" 8 "FOB_8" 15 "SNA" ;
+VAL_ 456 VTA_STAT 0 "VTA_DISARM" 1 "VTA_PREARM" 2 "VTA_ARM" 3 "VTA_LGT" 4 "VTA_LGT_HORN" 5 "VTA_TAMP" 6 "VTA_ITM_Alarm" 7 "SNA" ;
+VAL_ 464 SRS_IndLmp_Rq 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 464 DRV_SEATBELT 0 "DRV_SEATBELT_OK" 1 "DRV_SEATBELT_NOK" 2 "SEATBELT_FAIL" 3 "SNA" ;
+VAL_ 464 PSG_SEATBELT 0 "PSG_SEATBELT_OK" 1 "PSG_SEATBELT_NOK" 2 "SEATBELT_FAIL" 3 "SNA" ;
+VAL_ 464 PSG_ODS_STAT 0 "ODS_STAT_NOCC" 1 "ODS_STAT_OCC" 2 "ODS_FAULT" 3 "SNA" ;
+VAL_ 464 DrvSbltUnFltr 0 "BUCKLED" 1 "UNBUCKLED" 2 "LOW" 3 "HIGH" 7 "SNA" ;
+VAL_ 500 EngTrqRq_DAS 8191 "SNA" ;
+VAL_ 500 DAS_ACCEL_Rq 4095 "SNA" ;
+VAL_ 500 GrMax_RqDAS 0 "PASSIVE" 1 "G1" 2 "G2" 3 "G3" 4 "G4" 5 "G5" 6 "G6" 7 "G7" 8 "G8" 9 "G9" 10 "G10" 11 "G11" 12 "G12" ;
+VAL_ 500 DAS_Rq_ID 0 "IDLE" 1 "ACC" 2 "CMS" 3 "ABA" 4 "LSCM" 5 "CMS_XTD" 6 "PEB" 7 "SNA" ;
+VAL_ 500 DAS_Sts 0 "OK" 1 "INTERNAL" 2 "EXTERNAL" 3 "SNA" ;
+VAL_ 500 As_DispRq 0 "No_RQ" 1 "ACC" 2 "FCW" 3 "SNA" ;
+VAL_ 501 HMI_Screens 255 "SNA" ;
+VAL_ 501 SetSpeed_KPH 255 "SNA" ;
+VAL_ 501 SetSpeed_MPH 255 "SNA" ;
+VAL_ 501 FCW_Error 0 "No_Error" 1 "FCW_Error" 2 "Limited_FCW" 3 "SNA" ;
+VAL_ 501 ACCOnOff 0 "OFF" 1 "NCC" 2 "NCC_SET" 3 "ACC_ON" 4 "ACC_SET" 7 "SNA" ;
+VAL_ 501 Sm_ICON_Dspl 0 "NONE" 1 "OFF" 2 "READY_TG1" 3 "READY_TG2" 4 "READY_TG3" 5 "READY_TG4" 8 "ACC_E_NT_TG1" 9 "ACC_E_NT_TG2" 10 "ACC_E_NT_TG3" 11 "ACC_E_NT_TG4" 12 "ACC_E_WT_TG1" 13 "ACC_E_WT_TG2" 14 "ACC_E_WT_TG3" 15 "ACC_E_WT_TG4" 33 "NCC_OFF" 34 "NCC_READY" 40 "NCC_ENGAGED" 63 "SNA" ;
+VAL_ 501 ObjIntrstDist 255 "SNA" ;
+VAL_ 512 AirTemp_Outsd 255 "SNA" ;
+VAL_ 512 AMB_TEMP_AVG 65535 "SNA" ;
+VAL_ 512 AMB_TEMP_VOLT 255 "SNA" ;
+VAL_ 512 FUEL_VOLT 255 "SNA" ;
+VAL_ 512 FUEL_VOLT2 255 "SNA" ;
+VAL_ 512 BATT_VOLT 255 "SNA" ;
+VAL_ 520 AC_OutptCurrStat 255 "SNA" ;
+VAL_ 520 BrkPdlStat_CBC 0 "UPSTOP" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 520 CBCEngineOffRequest 0 "Not Active" 1 "Active" ;
+VAL_ 559 ActlAccelPdlPosn 255 "SNA" ;
+VAL_ 608 PTS_PopUpRqst 0 "TM0" 1 "TM1" 2 "TM2" 3 "TM3" 4 "TM4" 5 "TM5" 6 "TM6" 7 "TM7" 8 "TM8" 9 "TM9" 10 "TM10" 11 "TM11" 12 "TM12" 13 "TM13" 14 "TM14" 15 "TM15" 16 "TM16" 17 "TM17" 18 "TM18" 19 "TM19" 20 "TM20" 21 "TM21" 22 "TM22" 23 "TM23" 24 "TM24" 25 "TM25" 26 "TM26" 27 "TM27" 28 "TM28" 29 "TM29" 30 "TM30" 31 "TM31" 32 "TM32" 33 "TM33" 34 "TM34" 35 "TM35" 36 "TM36" 37 "TM37" 38 "TM38" 39 "TM39" 40 "TM40" 41 "TM41" 42 "TM42" 43 "TM43" 44 "TM44" 45 "TM45" 46 "TM46" 47 "TM47" 48 "TM48" 49 "TM49" 50 "TM50" 51 "TM51" 52 "TM52" 53 "TM53" 54 "TM54" 55 "TM55" 56 "TM56" 57 "TM57" 58 "TM58" 59 "TM59" 60 "TM60" 61 "TM61" 62 "TM62" 63 "TM63" 64 "TM64" 65 "TM65" 66 "TM66" 67 "TM67" 68 "TM68" 69 "TM69" 70 "TM70" 71 "TM71" 72 "TM72" 73 "TM73" 74 "TM74" 75 "TM75" 76 "TM76" 77 "TM77" 78 "TM78" 79 "TM79" 80 "TM80" 81 "TM81" 82 "TM82" 83 "TM83" 84 "TM84" 85 "TM85" 86 "TM86" 87 "TM87" 88 "TM88" 89 "TM89" 90 "TM90" 91 "TM91" 92 "TM92" 93 "TM93" 94 "TM94" 95 "TM95" 96 "TM96" 97 "TM97" 98 "TM98" 99 "TM99" 100 "TM100" 255 "SNA" ;
+VAL_ 608 PTS_STAT_Front 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 624 EngineOffTimer 4095 "SNA" ;
+VAL_ 624 Gate_Req_PE 0 "NO_REQ" 1 "HNDL_PE_REQ" 2 "BTN_PE_REQ" 3 "HF_PE_REQ" ;
+VAL_ 624 FuelTxfrSts 0 "OFF" 1 "ON" 2 "FAULT" 3 "SNA" ;
+VAL_ 632 CC_SetSpdDspl 255 "SNA" ;
+VAL_ 632 EVPmpStat 0 "OFF" 1 "ON" 2 "FAULT" 3 "SNA" ;
+VAL_ 632 CC_SetSpdDsplMPH 255 "SNA" ;
+VAL_ 639 IBS_Q_received 65535 "SNA" ;
+VAL_ 639 IBS_Q_released 65535 "SNA" ;
+VAL_ 639 IBS_Tm_Lst_Reset_Sec 65535 "SNA" ;
+VAL_ 639 IBS_Tm_Lst_Reset_Days 4095 "SNA" ;
+VAL_ 660 SyncPos 0 "LOW" 1 "HIGH" 2 "PRESS" 3 "TEMP" 4 "NS" 7 "SNA" ;
+VAL_ 672 ETC_IND_LMP 0 "OFF" 1 "ON" 2 "ON_Flashing" 3 "SNA" ;
+VAL_ 672 EngOilIndLmp_On_Rq 1 "SNA" ;
+VAL_ 672 OIL_TEMP_IND_RQ 0 "IND_LMP_OFF" 1 "IND_LMP_ON" 2 "IND_LMP_FLASH" 3 "SNA" ;
+VAL_ 672 OIL_PRESS 255 "SNA" ;
+VAL_ 672 EngOilTemp 255 "SNA" ;
+VAL_ 672 FuelCons 65535 "SNA" ;
+VAL_ 672 DefFuelEcon 255 "SNA" ;
+VAL_ 672 EngRun_Stat 0 "STOP" 1 "START" 2 "IDLE_UNSTBL" 3 "IDLE_STBL" 4 "UNLIMITED" 5 "LIMITED" 6 "NDEF6" 7 "SNA" ;
+VAL_ 672 CoolLo 0 "SNA" ;
+VAL_ 680 EngTrgtSpdCtrl 4095 "SNA" ;
+VAL_ 680 CurrentGear 0 "N" 1 "D1" 2 "D2" 3 "D3" 4 "D4" 5 "D5" 6 "D6" 7 "D7" 8 "D8" 9 "D2P" 10 "D9" 11 "R" 12 "R2" 13 "P" 14 "KRAFTFREI" 15 "SNA" ;
+VAL_ 680 CurrentGearForDisplay 0 "Initialize" 1 "D1" 2 "D2" 3 "D3" 4 "D4" 5 "D5" 6 "D6" 7 "D7" 8 "D8" 9 "D9" 12 "P" 13 "N" 14 "R" 15 "SNA" ;
+VAL_ 680 TargetGear 0 "N" 1 "D1" 2 "D2" 3 "D3" 4 "D4" 5 "D5" 6 "D6" 7 "D7" 8 "D8" 9 "D2P" 10 "D9" 11 "R" 12 "R2" 13 "P" 14 "ABBRUCH" 15 "SNA" ;
+VAL_ 680 TX_WARN2 0 "None" 1 "WARN_1" 2 "WARN_2" 3 "WARN_3" 4 "WARN_4" 5 "WARN_5" 6 "WARN_6" 7 "WARN_7" 8 "WARN_8" 9 "WARN_9" 10 "WARN_10" 11 "WARN_11" 12 "WARN_12" 13 "WARN_13" 14 "WARN_14" 15 "WARN_15" 17 "WARN_17" 18 "WARN_18" 19 "WARN_19" 20 "WARN_20" 21 "WARN_21" 22 "WARN_22" 23 "WARN_23" 24 "WARN_24" 25 "WARN_25" 31 "WARN_31" 32 "WARN_32" 33 "WARN_33" 34 "WARN_34" 35 "WARN_35" 36 "WARN_36" 37 "WARN_37" 38 "WARN_38" 39 "WARN_39" 40 "WARN_40" 41 "WARN_41" 42 "WARN_42" 43 "WARN_43" 44 "WARN_44" 45 "WARN_45" 46 "WARN_46" 47 "WARN_47" 48 "WARN_48" 49 "WARN_49" 50 "WARN_50" 51 "WARN_51" 52 "WARN_52" 53 "WARN_53" 54 "WARN_54" 55 "WARN_55" 56 "WARN_56" 57 "WARN_57" 58 "WARN_58" 59 "WARN_59" 60 "WARN_60" 61 "WARN_61" 62 "WARN_62" 63 "WARN_63" 64 "WARN_64" 65 "WARN_65" 66 "WARN_66" 67 "WARN_67" 68 "WARN_68" 69 "WARN_69" 70 "WARN_70" 71 "WARN_71" 72 "WARN_72" 255 "SNA" ;
+VAL_ 698 UConnReq 0 "NO_BASIC_REQUEST" 1 "LOCK_REQUEST" 2 "RELOCK_REQUEST" 3 "DRIVER_UNLOCK_REQUEST" 4 "ALL_UNLOCK_REQUEST" 5 "TRUNK_PLG_TOGGLE_REQUEST" 6 "LEFT_SLIDER_TOGGLE_REQUEST" 7 "RIGHT_SLIDER_TOGGLE_REQUEST" 8 "FLIPPER_GLASS_REQUEST" 9 "REMOTE_START_ON" 10 "REMOTE_START_OFF" 11 "GLOBAL_WINDOW_DOWN_REQUEST" 12 "OPEN_CONVERTIBLE_TOP" 13 "CLOSE_CONVERTIBLE_TOP" 14 "PANIC_TOGGLE_REQUEST" 15 "DRIVER_TOGGLE_REQUEST" 16 "PASSENGER_TOGGLE_REQUEST" 17 "ExtLightReq" 18 "AirSuspReq" 19 "AirSuspCancel" 20 "GLBL_WIN_UP_RQ" 21 "CAR_FINDER_REQUEST" 22 "TRUNK_PLG_BTN_PRESSED" 23 "TRUNK_PLG_STOP_REQUEST" 24 "TRUNK_PLG_OPEN_REQUEST" 25 "TRUNK_PLG_CLOSE_REQUEST" 26 "VTA_RQ" 31 "SNA" ;
+VAL_ 698 UConnReqAuthCode 65535 "SNA" ;
+VAL_ 698 UConnReqFOBNum 0 "FOB_DEFAULT" 1 "FOB_1" 2 "FOB_2" 3 "FOB_3" 4 "FOB_4" 5 "FOB_5" 6 "FOB_6" 7 "FOB_7" 8 "FOB_8" 15 "SNA" ;
+VAL_ 706 EC_ECUCfg15_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 707 EC_BU_ECUCfg15_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 720 BSM_CFG_STAT 0 "NT_ENB" 1 "ENB_LED" 2 "ENB_LED_CHM" 3 "SNA" ;
+VAL_ 720 BSM_LT_WRN 0 "NW" 2 "RM_LED" 3 "RBM_LED" 4 "FM_LED" 5 "FBM_LED" 7 "SNA" ;
+VAL_ 720 BSM_RT_WRN 0 "NW" 2 "RM_LED" 3 "RBM_LED" 4 "FM_LED" 5 "FBM_LED" 7 "SNA" ;
+VAL_ 736 LT_DIST 65535 "SNA" ;
+VAL_ 736 RT_DIST 65535 "SNA" ;
+VAL_ 736 HILL_DES_STAT 0 "HDC_UNAVL" 1 "HDC_ACT" 2 "HDC_AVL" 3 "HDC_THRML_DEACT" ;
+VAL_ 736 ESP_Off_IndLmp_On_Rq 0 "SNA" ;
+VAL_ 736 ESC_CtrlLmp_Info 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 736 ABS_IndLmp_On_Rq 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 736 BrkIndLmp_On_Rq_ESC 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 736 SelSpdLmp 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 746 DrvRqShftROT 0 "INIT" 1 "PARK" 2 "REV" 3 "NEUT" 4 "DRIVE" 5 "FIFTH" 7 "SNA" ;
+VAL_ 746 APCM_Stat 0 "OFF" 1 "ON" 2 "PENDING" 3 "SNA" ;
+VAL_ 760 EngTrqTgt_SEM 8191 "SNA" ;
+VAL_ 760 EngTrqStatic_SEM 8191 "SNA" ;
+VAL_ 760 TRANS_CLU_SLIP_MODE 0 "NORMAL" 1 "MDS_RQ" 2 "IDFSO_RQ" 3 "AC_EN_DIS_RQ" 4 "IDFSO_ACTIVE" 5 "MDS_IDFSO_ACT" 7 "SNA" ;
+VAL_ 760 EngMaxRPM 255 "SNA" ;
+VAL_ 764 RawPVS1 255 "SNA" ;
+VAL_ 764 RawPVS2 255 "SNA" ;
+VAL_ 764 RawTPS1 255 "SNA" ;
+VAL_ 764 RawTPS2 255 "SNA" ;
+VAL_ 764 RelativePdl 255 "SNA" ;
+VAL_ 764 RelativeThrt 255 "SNA" ;
+VAL_ 764 MAP 255 "SNA" ;
+VAL_ 766 VVT_ExhCam1Pos 0 "SNA" ;
+VAL_ 766 VVT_ExhCam2Pos 0 "SNA" ;
+VAL_ 766 VVT_IntCam1Pos 0 "SNA" ;
+VAL_ 766 VVT_IntCam2Pos 0 "SNA" ;
+VAL_ 766 GF_Charge 65535 "SNA" ;
+VAL_ 766 RelativeThrtPct 255 "SNA" ;
+VAL_ 776 CNT_DIFF_MOD 0 "FREE" 1 "LM" 2 "ESP" 3 "SNA" ;
+VAL_ 776 DTCM_HMI_Rq 0 "NONE" 1 "SCREEN_1" 2 "SCREEN_2" 3 "SCREEN_3" 4 "SCREEN_4" 5 "SCREEN_5" 6 "SCREEN_6" 7 "SCREEN_7" 8 "SCREEN_8" 9 "SCREEN_9" 10 "SCREEN_10" 11 "SCREEN_11" 12 "SCREEN_12" 13 "SCREEN_13" 14 "SCREEN_14" 15 "SCREEN_15" 16 "SCREEN_16" 17 "SCREEN_17" 18 "SCREEN_18" 19 "SCREEN_19" 20 "SCREEN_20" 21 "SCREEN_21" 22 "SCREEN_22" 23 "SCREEN_23" 24 "SCREEN_24" 25 "SCREEN_25" 26 "SCREEN_26" 27 "SCREEN_27" 28 "SCREEN_28" 29 "SCREEN_29" 30 "SCREEN_30" 31 "SNA" ;
+VAL_ 776 TCASE_SRV_RQ 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 776 TcaseAWD 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 776 Tcase4Low 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 776 TcaseNtrlStat 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 776 Tcase4Lock 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 776 Tcase2WD_Stat 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 779 DisOilLifeRst 65535 "SNA" ;
+VAL_ 779 OilLifeLeft 255 "SNA" ;
+VAL_ 779 MntncSts 0 "NONE" 1 "SOON" 2 "NOW" 3 "SNA" ;
+VAL_ 779 HoursOilLifeRst 4095 "SNA" ;
+VAL_ 779 FuelFltrLeft 255 "SNA" ;
+VAL_ 784 AvgFuelLvl 511 "SNA" ;
+VAL_ 784 SRS_LMP_STAT 0 "SRS_LMP_OFF" 1 "SRS_LMP_ON" 2 "SRS_LMP_ON_IC" 3 "SNA" ;
+VAL_ 784 ODO 16777215 "SNA" ;
+VAL_ 788 CFG_FEATURE 0 "CFG_NONE" 1 "CFG_AUTO_LK" 2 "CFG_AUTO_UNLK" 3 "CFG_DLY_LK" 4 "CFG_DRV_FST" 5 "CFG_SOUND_LK" 6 "CFG_HORN_DUR" 7 "CFG_FLASH_LK" 8 "CFG_DrAlrPrsnt" 9 "CFG_PARK_ASSIST" 10 "CFG_LANG" 11 "CFG_US_METRIC" 12 "CFG_SRV_INTV" 13 "CFG_AUTO_WPR" 14 "CFG_HL_DLY" 15 "CFG_HL_WPR" 16 "CFG_ACC_DLY" 18 "CFG_REM_MEM" 19 "CFG_EASY_EXIT" 20 "CFG_LO_VEH" 21 "CFG_TILT_IN_REV" 22 "CFG_ILL_APRCH" 23 "CFG_ILL_ENTRY" 24 "CFG_GLBL_UP_WIN" 25 "CFG_GLBL_DN_WIN" 26 "CFG_DRL_ON" 27 "CFG_AHB" 28 "REST_FACT_DEF" 29 "CFG_CMP_CAL" 30 "CFG_CMP_VAR" 31 "CFG_VOICE_COMF" 32 "CFG_NAV_TBYT" 33 "CFG_HILL_ST" 34 "CFG_AFS" 35 "CFG_BSD" 36 "CFG_PE" 37 "CFG_WAL" 38 "CFG_DSS" 39 "CFG_SOUND_RS" 40 "CFG_DCS" 41 "CFG_AUTO_RELK" 42 "CFG_CMS" 43 "CFG_FCW" 44 "CFG_PRE_SAFE" 45 "CFG_BELT_SLAK" 46 "CFG_FUEL_SAV" 47 "CFG_FCW_SENS" 48 "CFG_HDLP_DROP" 49 "CFG_ECMM" 50 "PASS_WIN_LKOUT" 51 "AERO" 52 "JACK" 53 "CFG_TRLR" 54 "CFG_ALIGNMENT" 55 "CFG_ASCM_WMO" 57 "CFG_LDW" 58 "OIL" 59 "CFG_NORMAL_DCS" 61 "CFG_TRANSPORT" 62 "CFG_PTO_MODE" 63 "CFG_PTO_SINGLE_RPM" 64 "CFG_PTO_RPM1" 65 "CFG_PTO_RPM2" 66 "CFG_PTO_RPM3" 67 "CFG_PTO_Type" 68 "CFG_PTO_Auto_Resume" 69 "CFG_MAX_PTO_VEH_SPEED" 70 "RVC_GRID" 71 "DIMMER" 72 "RLE_LIGHT" 73 "RLE_HORN" 76 "CFG_TRLR_TYP" 77 "CFG_TRLR_NAME" 81 "CFG_PTS_FT" 82 "CFG_PTS_RR" 83 "CFG_PTS_FT_VOL" 84 "CFG_PTS_RR_VOL" 86 "CFG_PLG" 87 "CFG_AUX1" 88 "CFG_AUX2" 89 "CFG_AUX3" 90 "CFG_AUX4" 91 "CFG_AUX5" 93 "CFG_LDWTRQ" 94 "CFG_PTO_REM_Throttle" 95 "CFG_UNIT_DEFAULT" 96 "CFG_PressureUnit" 97 "CFG_SpeedUnit" 98 "CFG_DistanceUnit" 99 "CFG_ConsumptionUnit" 100 "CFG_CapacityUnit" 101 "CFG_TemperatureUnit" 102 "CFG_PowerUnit" 103 "CFG_TorqueUnit" 104 "CFG_EPS" 105 "CFG_CHMSL_LINES" 106 "CFG_POLICE_PE" 107 "EPB_AUTO_PRK" 108 "EPB_SERVICE" 109 "HOLD_N_GO" 110 "PWR_FLD_MRR" 111 "HANDS_FREE_LFT" 112 "HANDS_FREE_SLDR" 113 "SVC_GRIDLINES" 114 "SVC_DELAY" 115 "SLD_DR_ALRT" 116 "TEEN_FCW_SENS" 117 "TEEN_FCW_BRK" 118 "TEEN_PRK_ASST" 119 "TEEN_PRK_ASST_BRK" 120 "TEEN_FT_PRK_VOL" 121 "TEEN_RR_PRK_VOL" 122 "TEEN_MAX_SPEED" 123 "TEEN_FUEL_WRN" 124 "TEEN_FUEL_POPUP" 125 "TEEN_BLIND_SPOT" 126 "TEEN_RAIN_WPR" 127 "TEEN_AUTO_HB" 128 "TEEN_LGHT_WPR" 129 "TEEN_SLD_DR_ALRT" 130 "TEEN_PLG_CHIME" 131 "SLD_DR_CHM" 132 "TEEN_SLD_DR_CHM" 133 "CFG_ABSM" 134 "CFG_PADDLE_SHIFT" 137 "CFG_PRK_ASST_BRK" 138 "CFG_LDW_ON" 139 "CFG_PRK_ASST_TYPE" 140 "CFG_DR_ALR" 141 "CFG_RDY_DRV" 142 "CFG_PANEL_INTS" 143 "CFG_MOOD_LGT_INTS" 144 "CFG_ML_HDLP_LVL" 145 "CFG_BSM_TRLR" 146 "CFG_AUTO_SS" 147 "CFG_PCS" 148 "CFG_UNIT_SET" 149 "CFG_DOORS_OFF_ACC_DLY" 150 "CFG_MOTORIZED_SEATBELT" 151 "CFG_MOTORIZED_SEATBELT_STRN" 152 "CFG_TSI" 153 "CFG_LKA" 154 "CFG_LKA_SENS" 155 "CFG_LKA_STRN" 156 "CFG_ABSD" 157 "CFG_ABSD_SENS" 158 "CFG_ABSD_STRN" 162 "CFG_TIRE_FILL_ALERT" 163 "CFG_POWER_SIDE_STEP" 164 "CFG_AUTO_STOP_START" 165 "CFG_PEB" 166 "CFG_FFC_GRIDLINES" 167 "CFG_RVC_CVPM_DGRID" 168 "CFG_RVC_CVPM_SGRID" 169 "CFG_SPEED_THRESHOLD_VALUE" 170 "CFG_SPEED_THRESHOLD_CHECK_BOX" 171 "CFG_EXTERNAL_LIGHT_SENSOR" 172 "CFG_BUZZER_VOLUME_LEVEL" 173 "CFG_TRUNK_UNLOCK_ENABLE" 174 "CFG_BACKUP_ALARM" 175 "CFG_RR_CARGO_GUIDE_LGT" 176 "CFG_PTO_HI_IDLE" 177 "CFG_PTO_HI_IDLE_RPM" 178 "CFG_PTO_RMT_RPM_CTRL" 179 "CFG_PTO_SS_GEAR_RATIO" 180 "CFG_PTO_ACC_INT" 181 "CFG_PTO_RAMP_RATE" 182 "CFG_PTO_PB" 183 "CFG_HWRSS" 184 "CFG_SEIU_INPUT_WIRE" 185 "CFG_SEIU_RPM" 186 "CFG_BED_LOWER" 187 "CFG_TSR_WARNING_MODE" 188 "CFG_TSR_WARNING_MODE_OFFSET" 189 "CFG_FT_PK_LOOSE_SHIP" 190 "CFG_RR_PK_LOOSE_SHIP" 191 "CFG_AUX6" 192 "CFG_CHMSL_DYN_CNTR" ;
+VAL_ 788 CFG_STAT_RQ 0 "CFG_DEF" 1 "CFG_DSBL" 2 "CFG_ENBL" 3 "CFG_SPEC" ;
+VAL_ 790 CFG_FEATURE_C 0 "CFG_NONE" 1 "CFG_AUTO_LK" 2 "CFG_AUTO_UNLK" 3 "CFG_DLY_LK" 4 "CFG_DRV_FST" 5 "CFG_SOUND_LK" 6 "CFG_HORN_DUR" 7 "CFG_FLASH_LK" 8 "CFG_DrAlrPrsnt" 9 "CFG_PARK_ASSIST" 10 "CFG_LANG" 11 "CFG_US_METRIC" 12 "CFG_SRV_INTV" 13 "CFG_AUTO_WPR" 14 "CFG_HL_DLY" 15 "CFG_HL_WPR" 16 "CFG_ACC_DLY" 18 "CFG_REM_MEM" 19 "CFG_EASY_EXIT" 20 "CFG_LO_VEH" 21 "CFG_TILT_IN_REV" 22 "CFG_ILL_APRCH" 23 "CFG_ILL_ENTRY" 24 "CFG_GLBL_UP_WIN" 25 "CFG_GLBL_DN_WIN" 26 "CFG_DRL_ON" 27 "CFG_AHB" 28 "REST_FACT_DEF" 29 "CFG_CMP_CAL" 30 "CFG_CMP_VAR" 31 "CFG_VOICE_COMF" 32 "CFG_NAV_TBYT" 33 "CFG_HILL_ST" 34 "CFG_AFS" 35 "CFG_BSD" 36 "CFG_PE" 37 "CFG_WAL" 38 "CFG_DSS" 39 "CFG_SOUND_RS" 40 "CFG_DCS" 41 "CFG_AUTO_RELK" 42 "CFG_CMS" 43 "CFG_FCW" 44 "CFG_PRE_SAFE" 45 "CFG_BELT_SLAK" 46 "CFG_FUEL_SAV" 47 "CFG_FCW_SENS" 48 "CFG_HDLP_DROP" 49 "CFG_ECMM" 50 "PASS_WIN_LKOUT" 51 "AERO" 52 "JACK" 53 "CFG_TRLR" 54 "CFG_ALIGNMENT" 55 "CFG_ASCM_WMO" 57 "CFG_LDW" 58 "OIL" 59 "CFG_NORMAL_DCS" 61 "CFG_TRANSPORT" 62 "CFG_PTO_MODE" 63 "CFG_PTO_SINGLE_RPM" 64 "CFG_PTO_RPM1" 65 "CFG_PTO_RPM2" 66 "CFG_PTO_RPM3" 67 "CFG_PTO_Type" 68 "CFG_PTO_Auto_Resume" 69 "CFG_MAX_PTO_VEH_SPEED" 70 "RVC_GRID" 71 "DIMMER" 72 "RLE_LIGHT" 73 "RLE_HORN" 76 "CFG_TRLR_TYP" 77 "CFG_TRLR_NAME" 81 "CFG_PTS_FT" 82 "CFG_PTS_RR" 83 "CFG_PTS_FT_VOL" 84 "CFG_PTS_RR_VOL" 86 "CFG_PLG" 87 "CFG_AUX1" 88 "CFG_AUX2" 89 "CFG_AUX3" 90 "CFG_AUX4" 91 "CFG_AUX5" 93 "CFG_LDWTRQ" 94 "CFG_PTO_REM_Throttle" 95 "CFG_UNIT_DEFAULT" 96 "CFG_PressureUnit" 97 "CFG_SpeedUnit" 98 "CFG_DistanceUnit" 99 "CFG_ConsumptionUnit" 100 "CFG_CapacityUnit" 101 "CFG_TemperatureUnit" 102 "CFG_PowerUnit" 103 "CFG_TorqueUnit" 104 "CFG_EPS" 105 "CFG_CHMSL_LINES" 106 "CFG_POLICE_PE" 107 "EPB_AUTO_PRK" 108 "EPB_SERVICE" 109 "HOLD_N_GO" 110 "PWR_FLD_MRR" 111 "HANDS_FREE_LFT" 112 "HANDS_FREE_SLDR" 113 "SVC_GRIDLINES" 114 "SVC_DELAY" 115 "SLD_DR_ALRT" 116 "TEEN_FCW_SENS" 117 "TEEN_FCW_BRK" 118 "TEEN_PRK_ASST" 119 "TEEN_PRK_ASST_BRK" 120 "TEEN_FT_PRK_VOL" 121 "TEEN_RR_PRK_VOL" 122 "TEEN_MAX_SPEED" 123 "TEEN_FUEL_WRN" 124 "TEEN_FUEL_POPUP" 125 "TEEN_BLIND_SPOT" 126 "TEEN_RAIN_WPR" 127 "TEEN_AUTO_HB" 128 "TEEN_LGHT_WPR" 129 "TEEN_SLD_DR_ALRT" 130 "TEEN_PLG_CHIME" 131 "SLD_DR_CHM" 132 "TEEN_SLD_DR_CHM" 133 "CFG_ABSM" 134 "CFG_PADDLE_SHIFT" 137 "CFG_PRK_ASST_BRK" 138 "CFG_LDW_ON" 139 "CFG_PRK_ASST_TYPE" 140 "CFG_DR_ALR" 141 "CFG_RDY_DRV" 142 "CFG_PANEL_INTS" 143 "CFG_MOOD_LGT_INTS" 144 "CFG_ML_HDLP_LVL" 145 "CFG_BSM_TRLR" 146 "CFG_AUTO_SS" 147 "CFG_PCS" 148 "CFG_UNIT_SET" 149 "CFG_DOORS_OFF_ACC_DLY" 150 "CFG_MOTORIZED_SEATBELT" 151 "CFG_MOTORIZED_SEATBELT_STRN" 152 "CFG_TSI" 153 "CFG_LKA" 154 "CFG_LKA_SENS" 155 "CFG_LKA_STRN" 156 "CFG_ABSD" 157 "CFG_ABSD_SENS" 158 "CFG_ABSD_STRN" 162 "CFG_TIRE_FILL_ALERT" 163 "CFG_POWER_SIDE_STEP" 164 "CFG_AUTO_STOP_START" 165 "CFG_PEB" 166 "CFG_FFC_GRIDLINES" 167 "CFG_RVC_CVPM_DGRID" 168 "CFG_RVC_CVPM_SGRID" 169 "CFG_SPEED_THRESHOLD_VALUE" 170 "CFG_SPEED_THRESHOLD_CHECK_BOX" 171 "CFG_EXTERNAL_LIGHT_SENSOR" 172 "CFG_BUZZER_VOLUME_LEVEL" 173 "CFG_TRUNK_UNLOCK_ENABLE" 174 "CFG_BACKUP_ALARM" 175 "CFG_RR_CARGO_GUIDE_LGT" 176 "CFG_PTO_HI_IDLE" 177 "CFG_PTO_HI_IDLE_RPM" 178 "CFG_PTO_RMT_RPM_CTRL" 179 "CFG_PTO_SS_GEAR_RATIO" 180 "CFG_PTO_ACC_INT" 181 "CFG_PTO_RAMP_RATE" 182 "CFG_PTO_PB" 183 "CFG_HWRSS" 184 "CFG_SEIU_INPUT_WIRE" 185 "CFG_SEIU_RPM" 186 "CFG_BED_LOWER" 187 "CFG_TSR_WARNING_MODE" 188 "CFG_TSR_WARNING_MODE_OFFSET" 189 "CFG_FT_PK_LOOSE_SHIP" 190 "CFG_RR_PK_LOOSE_SHIP" 191 "CFG_AUX6" 192 "CFG_CHMSL_DYN_CNTR" ;
+VAL_ 790 CFG_STAT_RQ_C 0 "CFG_DEF" 1 "CFG_DSBL" 2 "CFG_ENBL" 3 "CFG_SPEC" ;
+VAL_ 792 TurnIndLvr_Stat 0 "IDLE" 1 "LEFT" 2 "RIGHT" ;
+VAL_ 792 HiBmLvr_Stat 0 "IDLE" 1 "HIBM_ON_PSD" 2 "HIBM_FLSH_ON_PSD" ;
+VAL_ 792 WprWashSw_Psd 0 "NPSD" 1 "MIST" 2 "WASH" ;
+VAL_ 792 WprSw6Posn 0 "OFF" 1 "INTERVAL1" 2 "INTERVAL2" 3 "INTERVAL3" 4 "INTERVAL4" 5 "INTERVAL5" 6 "INTERVAL6" 13 "WPR_LOW" 14 "WPR_HI" 15 "SNA" ;
+VAL_ 792 VOL 0 "VOL_NONE" 1 "VOL_UP" 2 "VOL_DN" 3 "SNA" ;
+VAL_ 792 Up_Arw_Rq 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 792 StW_TempSens_Flt 0 "OK" 1 "SHRT" 2 "OPN" 3 "SNA" ;
+VAL_ 792 StW_Temp 255 "SNA" ;
+VAL_ 792 SEEK 0 "SEEK_NONE" 1 "SEEK_UP" 2 "SEEK_DN" 3 "SNA" ;
+VAL_ 792 RT_ARW_RST_RQ 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 792 PRESET_CFG 0 "PRESET_NONE" 1 "PRESET_UP" 2 "PRESET_DOWN" 3 "SNA" ;
+VAL_ 792 MENU_RQ 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 792 DN_ARW_STEP_RQ 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 792 CELL_VR 0 "CELL_VR_NONE" 1 "CELL_PRESSED" 2 "VR_PRESSED" 3 "SNA" ;
+VAL_ 799 IBS_R_Batt 2047 "SNA" ;
+VAL_ 799 IBS_R_Batt_25 2047 "SNA" ;
+VAL_ 799 TGW_AUD_MD_CAB_DR 0 "AM_SEL" 1 "FM_SEL" 2 "MW_SEL" 3 "LW_SEL" 4 "INT_Disk_SEL" 5 "INT_HDD_SEL" 6 "INT_AUX_SEL" 7 "INT_SLOT_SEL" 8 "USB3_SEL" 9 "SDAR1_SEL" 10 "SW_SEL" 11 "VES_DVD1_SEL" 12 "TMM_SEL" 13 "VES_AUX1_SEL" 14 "VES_AUX2_SEL" 15 "SDARV_SEL" 16 "PPR_SEL" 18 "DAB_SEL" 19 "TGW_USB1_SEL" 20 "ES_SEL" 21 "VES_AUX3_SEL" 22 "VES_AUX4_SEL" 23 "PASS_BT1_SEL" 24 "TV_SEL" 25 "USB2_SEL" 26 "APPS_SEL" 27 "AUD_MUTED" 28 "IR_OFF" 29 "RAD_OFF" 30 "RAD_LOCK" 31 "SNA" ;
+VAL_ 799 PSS_Display 0 "OK" 1 "L_OBS_DET" 2 "R_OBS_DET" 3 "L_STEP_DSBL" 4 "R_STEP_DSBL" 5 "PK" 6 "Reserved" 9 "BOTH_DEPLOYED" 10 "BOTH_RETRACTED" 15 "SNA" ;
+VAL_ 804 RemSt_Inhibit 0 "INHIBIT_DEFAUILT" 1 "TIME_OUT_RUN" 2 "TIME_OUT_CUST_MODE" 3 "KEY_IN_RUN" 4 "DRV_DOOR_AJAR" 5 "PASS_DOOR_AJAR" 6 "LR_DOOR_AJAR" 7 "RR_DOOR_AJAR" 8 "START_COUNTER" 9 "FAIL_COUNTER" 10 "LOW_RPM_SHUTDOWN" 11 "KEY_IN_IGN" 12 "BRAKE_PRESSED" 13 "HAZARD_LAMP_ON" 14 "NOT_IN_PARK" 15 "VEH_SPEED_HIGH" 16 "HOOD_AJAR" 17 "TRUNK_LIFTGATE" 18 "VTA_ALARM" 19 "PANIC_MODE" 20 "BATT_VOLT_HIGH" 21 "BATT_VOLT_LOW" 22 "POWER_LOSS" 23 "MIL_ON" 24 "OIL_PRESSURE_LOW" 25 "COOLANT_TEMP_HIGH" 26 "RPM_HIGH" 27 "CRANK_NO_START" 28 "REMOTE_OFF_RQ" 29 "RS_DISABLED_PREV" 30 "NOT_CONFIGURED" 31 "NO_HOOD_SWITCH" 32 "NO_AUTO_TRANS" 33 "NOT_ENABLED" 34 "INVALID_SKIM_KEY" 35 "IGN_SNA" 36 "IGN_NOT_LOCK" 37 "GLOW_PLUG_TIMEOUT" 38 "LOW_FUEL" 39 "ETC_LAMP_ON" 40 "LOGISTIC_MODE" 41 "COLD_START_LAMP" 42 "ESL_NOT_UNLOCK" 43 "RFHUB_HS_FAIL" 44 "PSA_Not_Active" 255 "SNA" ;
+VAL_ 804 WPR_SYS_OFF 1 "SNA" ;
+VAL_ 804 WPR_SYS_LOW 0 "SNA" ;
+VAL_ 804 WPR_SYS_HIGH 0 "SNA" ;
+VAL_ 804 WPR_SYS_INT 0 "SNA" ;
+VAL_ 804 WPR_SYS_AUTO 0 "SNA" ;
+VAL_ 804 WPR_SYS_MIST 0 "SNA" ;
+VAL_ 804 WPR_SYS_WASH 0 "SNA" ;
+VAL_ 804 WPR_SYS_FLT 0 "SNA" ;
+VAL_ 804 AirSusp_DnSw 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 808 TGW_GrpTyp_IC 0 "NO_TEXT" 63 "SNA" ;
+VAL_ 810 PTO_Md 0 "STANDARD" 2 "MOBILE" 3 "REMOTE" 7 "SNA" ;
+VAL_ 810 PTO_MaxVehSpd 0 "ZERO" 1 "FIVE" 2 "SIX" 3 "SEVEN" 4 "EIGHT" 5 "NINE" 6 "TEN" 7 "ELEVEN" 8 "TWELVE" 9 "THIRTEEN" 10 "FOURTEEN" 11 "FIFTEEN" 12 "SIXTEEN" 13 "SEVENTEEN" 14 "EIGHTEEN" 15 "NINETEEN" 16 "TWENTY" 17 "TWENTY_FIVE" 18 "THIRTY" 19 "THIRTY_FIVE" 20 "FOURTY" 21 "FOURTY_FIVE" 22 "FIFTY" 23 "FIFTY_FIVE" 24 "SIXTY" 25 "SIXTY_FIVE" 26 "SEVENTY" 27 "SEVENTY_FIVE" 28 "EIGHTY" 29 "EIGHTY_FIVE" 30 "NINTY" 31 "SNA" ;
+VAL_ 810 PTO_AutoRsm 0 "DISABLE" 1 "ENABLE" ;
+VAL_ 810 PTO_TYPES 0 "AUX" 1 "SPLIT" 3 "SNA" ;
+VAL_ 810 PTO_SingleRPM 255 "SNA" ;
+VAL_ 810 PTO_RPM1 255 "SNA" ;
+VAL_ 810 PTO_RPM2 255 "SNA" ;
+VAL_ 810 PTO_RPM3 255 "SNA" ;
+VAL_ 810 PTO_Sts 0 "PTO_OFF" 1 "PTO_ON" 2 "SET_BRAKE" 3 "REL_BRAKE" 4 "REL_ACC" 5 "REL_CLUTCH" 6 "PARK" 7 "NEUTRAL" 8 "FB_SWITCH" 9 "TC_2WD" 10 "DRIVE" 11 "SPEED_LT2" 12 "RPM_L1000" 13 "RPM_A900" 14 "COLD" 15 "ECT_HIGH" 16 "EOT_HIGH" 17 "FAULT" 31 "SNA" ;
+VAL_ 810 FuelTransSts 0 "NONE" 1 "M1" 2 "M2" 3 "M3" 4 "M4" 5 "M5" 6 "M6" 7 "M7" ;
+VAL_ 816 HILL_DES_RQ 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 820 DR_LK_STAT 0 "LKD" 1 "DRV_DR_UNLKD" 2 "ALL_DR_UNLKD" 3 "SNA" ;
+VAL_ 820 FOB_SrchRq 0 "NO_ACT" 1 "SEARCH" 2 "RCVD_RSLT" ;
+VAL_ 820 IGN_OFF_TIME_LNG 4095 "SNA" ;
+VAL_ 820 SHIP_STAT 0 "CUST_MD" 1 "ABBRV_MD" 2 "SHIP_MD" 3 "NOT_PROG" ;
+VAL_ 820 PANEL_INTS 255 "SNA" ;
+VAL_ 820 PTC_REL1_STAT 0 "OFF" 1 "ON" 2 "FLT" 3 "SNA" ;
+VAL_ 820 PTC_REL2_STAT 0 "OFF" 1 "ON" 2 "FLT" 3 "SNA" ;
+VAL_ 820 PTC_REL3_STAT 0 "OFF" 1 "ON" 2 "FLT" 3 "SNA" ;
+VAL_ 825 PTS_CHIME_TYPE 0 "NONE" 1 "TYP_1" 2 "TYP_2" 3 "TYP_3" 4 "TYP_4" 5 "TYP_5" 6 "TYP_6" 7 "TYP_7" 8 "TYP_8" 9 "TYP_9" 10 "TYP_10" 11 "TYP_11" 12 "TYP_12" 13 "TYP_13" 14 "TYP_14" 15 "SNA" ;
+VAL_ 825 PTS_RR_VOL 0 "LOW" 1 "MED" 2 "HIGH" 3 "SNA" ;
+VAL_ 825 PTS_FT_VOL 0 "LOW" 1 "MED" 2 "HIGH" 3 "SNA" ;
+VAL_ 826 PTS_AlrRL 0 "PTS_ALR_NOD" 1 "ARC1" 2 "ARC2" 3 "ARC3" 4 "ARC4" 5 "ARC5" 6 "ARC6" 7 "ARC7" 8 "ARC8" 15 "SNA" ;
+VAL_ 826 PTS_GraphicRL 0 "SLOW_FLS_RQ" 1 "FAST_FLS_RQ" 2 "CONT_FLS_RQ" 3 "None" ;
+VAL_ 826 PTS_AlrRR 0 "PTS_ALR_NOD" 1 "ARC1" 2 "ARC2" 3 "ARC3" 4 "ARC4" 5 "ARC5" 6 "ARC6" 7 "ARC7" 8 "ARC8" 15 "SNA" ;
+VAL_ 826 PTS_GraphicRR 0 "SLOW_FLS_RQ" 1 "FAST_FLS_RQ" 2 "CONT_FLS_RQ" 3 "None" ;
+VAL_ 826 PTS_AlrRC 0 "PTS_ALR_NOD" 1 "ARC1" 2 "ARC2" 3 "ARC3" 4 "ARC4" 5 "ARC5" 6 "ARC6" 7 "ARC7" 8 "ARC8" 15 "SNA" ;
+VAL_ 826 PTS_GraphicRC 0 "SLOW_FLS_RQ" 1 "FAST_FLS_RQ" 2 "CONT_FLS_RQ" 3 "None" ;
+VAL_ 826 PTS_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 826 PTS_AlrFC 0 "PTS_ALR_NOD" 1 "ARC1" 2 "ARC2" 3 "ARC3" 4 "ARC4" 5 "ARC5" 6 "ARC6" 7 "ARC7" 8 "ARC8" 15 "SNA" ;
+VAL_ 826 PTS_AlrFL 0 "PTS_ALR_NOD" 1 "ARC1" 2 "ARC2" 3 "ARC3" 4 "ARC4" 5 "ARC5" 6 "ARC6" 7 "ARC7" 8 "ARC8" 15 "SNA" ;
+VAL_ 826 PTS_AlrFR 0 "PTS_ALR_NOD" 1 "ARC1" 2 "ARC2" 3 "ARC3" 4 "ARC4" 5 "ARC5" 6 "ARC6" 7 "ARC7" 8 "ARC8" 15 "SNA" ;
+VAL_ 826 PTS_GraphicFC 0 "SLOW_FLS_RQ" 1 "FAST_FLS_RQ" 2 "CONT_FLS_RQ" 3 "None" ;
+VAL_ 826 PTS_GraphicFL 0 "SLOW_FLS_RQ" 1 "FAST_FLS_RQ" 2 "CONT_FLS_RQ" 3 "None" ;
+VAL_ 826 PTS_GraphicFR 0 "SLOW_FLS_RQ" 1 "FAST_FLS_RQ" 2 "CONT_FLS_RQ" 3 "None" ;
+VAL_ 832 VehSpdDisp 65535 "SNA" ;
+VAL_ 832 xtended_AvgFuelLvl 4095 "SNA" ;
+VAL_ 838 AS_CHIME_TYPE 0 "NONE" 1 "TYP_1" 2 "TYP_2" 3 "TYP_3" 4 "TYP_4" 5 "TYP_5" 6 "TYP_6" 7 "TYP_7" 8 "TYP_8" 9 "TYP_9" 10 "TYP_10" 11 "TYP_11" 12 "TYP_12" 13 "TYP_13" 14 "TYP_14" 15 "SNA" ;
+VAL_ 840 FailSafeError 65535 "SNA" ;
+VAL_ 848 DateTmSec 255 "SNA" ;
+VAL_ 848 DateTmMinute 255 "SNA" ;
+VAL_ 848 DateTmHour 255 "SNA" ;
+VAL_ 848 DateTmYear 65535 "SNA" ;
+VAL_ 848 DateTmMonth 255 "SNA" ;
+VAL_ 848 DateTmDay 255 "SNA" ;
+VAL_ 848 DateTmFormat 0 "NDEF0" 1 "FORMAT_12H" 2 "FORMAT_24H" 3 "FORMAT_0" 4 "FORMAT_1" 5 "FORMAT_2" 6 "FORMAT_3" 7 "SNA" ;
+VAL_ 853 RrAxleLckr_Rq 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 853 TCASE_NEUT_RQ 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 853 TcaseSwTyp 0 "ROT" 1 "PB" 3 "SNA" ;
+VAL_ 853 TcaseAWD_Rq 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 853 Tcase4Low_Rq 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 853 Tcase4Lock_Rq 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 853 Tcase2WD_Rq 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 853 PARK_ASST_RQ 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 853 FT_PARK_ASST_RQ 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 856 CMP_DIR 0 "CMP_N" 1 "CMP_N_E" 2 "CMP_E" 3 "CMP_S_E" 4 "CMP_S" 5 "CMP_S_W" 6 "CMP_W" 7 "CMP_N_W" 8 "NONE" 15 "SNA" ;
+VAL_ 856 VAR_VAL 15 "SNA_Default" ;
+VAL_ 856 CMP_DIR_RAW 511 "SNA_Default" ;
+VAL_ 860 DIST_TO_TURN 65535 "SNA" ;
+VAL_ 860 UNITS 0 "NO_UNITS" 1 "MILE" 2 "FEET" 3 "KM" 4 "METER" 5 "YARD" 7 "SNA" ;
+VAL_ 860 NAV_ARROW 0 "NAV_NOT_ACT" ;
+VAL_ 863 RevOilLifeRst 65535 "SNA" ;
+VAL_ 882 LANG_C 0 "GERMAN" 1 "US_ENGLISH" 2 "FRENCH" 3 "ITALIAN" 4 "SPANISH" 5 "JAPANESE" 6 "PORTUGESE" 7 "DUTCH" 8 "UK_ENGLISH" 9 "MANDARIN_S" 10 "RUSSIAN" 11 "KOREAN" 12 "ARABIC" 13 "BRAZILIAN" 14 "MANDARIN_T" 15 "HINDI" 16 "TURKISH" 17 "POLISH" 31 "LANG_NO_CHG" ;
+VAL_ 882 PowerUnit 0 "KW" 1 "HP_UK" 2 "HP_US" ;
+VAL_ 882 PressureUnit 0 "KPA" 1 "BAR" 2 "PSI" ;
+VAL_ 882 CapacityUnit 0 "L" 1 "G_UK" 2 "G_US" ;
+VAL_ 882 ConsumptionUnit 0 "KMPL" 1 "LP100KM" 2 "MPG_UK" 3 "MPG_US" 7 "SNA" ;
+VAL_ 882 UNIT_SET_CSO 0 "UnitSet_1" 1 "UnitSet_2" 2 "UnitSet_3" 3 "UnitSet_4" ;
+VAL_ 897 VC_VehCfg7_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 897 VC_TransType 0 "NP" 1 "SI_EVT_Hybrid_Trans" 2 "MTA" 3 "c40TES" 4 "Aisin_LD" 5 "W5A580" 6 "c62TE" 7 "c65RFE" 8 "c66RFE" 9 "c68RFE" 10 "AISIN_HD" 11 "DDCT_C635" 12 "HPT_6F24" 13 "ZF_8Spd" 14 "ZF_9Spd" 63 "SNA" ;
+VAL_ 897 VC_AS_ERS 0 "NONE" 1 "ERS" 2 "AS" 3 "SNA" ;
+VAL_ 897 VC_ACC_Type 0 "NONE" 1 "ACC" 2 "STOP" 3 "GO" ;
+VAL_ 897 VC_AxleLockerPrsnt 0 "NONE" 1 "REAR" 2 "FTRR" ;
+VAL_ 897 VC_PBTyp 0 "MECH" 1 "EPB_MOC" 2 "EPB_CP" 3 "IMOC" 4 "ICP" 7 "SNA" ;
+VAL_ 897 VC_TPMS_Configuration 0 "NHTSA" 1 "NAFTA" 2 "ECE" 3 "OTHER" 4 "CHINA" 7 "SNA" ;
+VAL_ 897 VC_HybridType 0 "NONE" 1 "BEV" 2 "HEV" 3 "PHEV" 4 "BSG48" ;
+VAL_ 897 VC_Temp_Display_Resolution 0 "One_Degree_C" 1 "Half_Degree_C" ;
+VAL_ 897 VC_Suspension_Type 0 "None" 1 "1" 2 "2" 3 "3" 4 "4" 5 "5" 6 "6" 7 "7" 8 "8" 9 "9" 10 "10" 11 "11" 12 "12" 13 "13" 14 "14" 15 "15" ;
+VAL_ 897 VC_MOC_Type 0 "NO_MOC" 1 "MOC_BREMBO" 2 "MOC_CONTI" ;
+VAL_ 897 VC_Brake_Type 0 "None" 1 "1" 2 "2" 3 "3" 4 "4" 5 "5" 6 "6" 7 "7" 8 "8" 9 "9" 10 "10" 11 "11" 12 "12" 13 "13" 14 "14" 15 "15" ;
+VAL_ 897 VC_AGSprsnt 0 "Not_Present" 1 "Present" ;
+VAL_ 897 VC_GlareFree_Prsnt 0 "Not_Present" 1 "Present" ;
+VAL_ 897 VC_Vehicle_Package 0 "None" 1 "Type_1" 2 "Type_2" 3 "Type_3" 4 "Type_4" 5 "Type_5" 6 "Type_6" 7 "Type_7" ;
+VAL_ 897 VC_TrafficSignInfo 0 "Not_Present" 1 "Present" ;
+VAL_ 897 VC_PAD_Lamp_Ctrl 0 "CLUSTER" 1 "ORC" ;
+VAL_ 897 VC_LDW_Audio 0 "Not_Present" 1 "Present" ;
+VAL_ 897 VC_LaneCentering 0 "Not_Present" 1 "Present" ;
+VAL_ 898 VC_BU_VehCfg7_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 898 VC_BU_TransType 0 "NP" 1 "SI_EVT_Hybrid_Trans" 2 "MTA" 3 "c40TES" 4 "Aisin_LD" 5 "W5A580" 6 "c62TE" 7 "c65RFE" 8 "c66RFE" 9 "c68RFE" 10 "AISIN_HD" 11 "DDCT_C635" 12 "HPT_6F24" 13 "ZF_8Spd" 14 "ZF_9Spd" 63 "SNA" ;
+VAL_ 898 VC_BU_AS_ERS 0 "NONE" 1 "ERS" 2 "AS" 3 "SNA" ;
+VAL_ 898 VC_BU_ACC_Type 0 "NONE" 1 "ACC" 2 "STOP" 3 "GO" ;
+VAL_ 898 VC_BU_AxleLockerPrsnt 0 "NONE" 1 "REAR" 2 "FTRR" ;
+VAL_ 898 VC_BU_PBTyp 0 "MECH" 1 "EPB_MOC" 2 "EPB_CP" 3 "IMOC" 4 "ICP" 7 "SNA" ;
+VAL_ 898 VC_BU_TPMS_Configuration 0 "NHTSA" 1 "NAFTA" 2 "ECE" 3 "OTHER" 4 "CHINA" 7 "SNA" ;
+VAL_ 898 VC_BU_HybridType 0 "NONE" 1 "BEV" 2 "HEV" 3 "PHEV" 4 "BSG48" ;
+VAL_ 898 VC_BU_Temp_Display_Resolution 0 "One_Degree_C" 1 "Half_Degree_C" ;
+VAL_ 898 VC_BU_Suspension_Type 0 "None" 1 "1" 2 "2" 3 "3" 4 "4" 5 "5" 6 "6" 7 "7" 8 "8" 9 "9" 10 "10" 11 "11" 12 "12" 13 "13" 14 "14" 15 "15" ;
+VAL_ 898 VC_BU_MOC_Type 0 "NO_MOC" 1 "MOC_BREMBO" 2 "MOC_CONTI" ;
+VAL_ 898 VC_BU_Brake_Type 0 "None" 1 "1" 2 "2" 3 "3" 4 "4" 5 "5" 6 "6" 7 "7" 8 "8" 9 "9" 10 "10" 11 "11" 12 "12" 13 "13" 14 "14" 15 "15" ;
+VAL_ 898 VC_BU_AGSprsnt 0 "Not_Present" 1 "Present" ;
+VAL_ 898 VC_BU_Vehicle_Package 0 "NA" 1 "Type_1" 2 "Type_2" 3 "Type_3" 4 "Type_4" 5 "Type_5" 6 "Type_6" 7 "Type_7" ;
+VAL_ 898 VC_BU_TrafficSignInfo 0 "Not_Present" 1 "Present" ;
+VAL_ 898 VC_BU_PAD_Lamp_Ctrl 0 "CLUSTER" 1 "ORC" ;
+VAL_ 898 VC_BU_GlareFree_Prsnt 0 "Not_Present" 1 "Present" ;
+VAL_ 898 VC_BU_LDW_Audio 0 "Not_Present" 1 "Present" ;
+VAL_ 898 VC_BU_LaneCentering 0 "Not_Present" 1 "Present" ;
+VAL_ 937 ILL_APRCH_TIME 255 "SNA" ;
+VAL_ 937 HL_DLY_TIME 255 "SNA" ;
+VAL_ 937 ACC_DLY_TIME 65535 "SNA" ;
+VAL_ 937 SOUND_LK_1ST_2ND 0 "OFF" 1 "FIRST" 2 "SECOND" 3 "SNA" ;
+VAL_ 947 VC_VehCfgCSO1_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 947 VC_PRK_AST_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 947 VC_FCW_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 947 VC_HRN_RMT_LK_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 947 VC_DCS_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 947 VC_AUX_SWS_CSO 0 "Absent" 1 "SWITCH_1_4" 2 "SWITCH_2_5" 3 "SWITCH_3_6" ;
+VAL_ 947 VC_CMRA_GRDLNS_CSO 0 "Absent" 1 "STATIC" 2 "DYNAMIC" 3 "STATIC_DYNAMIC" ;
+VAL_ 948 VC_VehCfgCSO2_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 948 VC_SPEED_WARNING_CSO 0 "ABSENT" 1 "ONE" 2 "FIVE" ;
+VAL_ 949 VC_BU_VehCfgCSO1_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 949 VC_BU_PRK_AST_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 949 VC_BU_FCW_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 949 VC_BU_HRN_RMT_LK_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 949 VC_BU_DCS_CSO 0 "Absent" 1 "Option_1_2" 2 "Option_2_3" ;
+VAL_ 949 VC_BU_AUX_SWS_CSO 0 "Absent" 1 "SWITCH_1_4" 2 "SWITCH_2_5" 3 "SWITCH_3_6" ;
+VAL_ 949 VC_BU_CMRA_GRDLNS_CSO 0 "Absent" 1 "STATIC" 2 "DYNAMIC" 3 "STATIC_DYNAMIC" ;
+VAL_ 950 VC_BU_VehCfgCSO2_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 950 VC_BU_SPEED_WARNING_CSO 0 "ABSENT" 1 "ONE" 2 "FIVE" ;
+VAL_ 956 NAV_GrpTyp 0 "NO_TEXT" 63 "SNA" ;
+VAL_ 969 AMB_TEMP_AVG_F 255 "SNA" ;
+VAL_ 969 AMB_TEMP_AVG_C 255 "SNA" ;
+VAL_ 974 FT_HVAC_BLW_FN_SP 127 "SNA" ;
+VAL_ 974 DRV_TEMP_DR_POS 127 "SNA" ;
+VAL_ 977 TransTyp 0 "NS" 1 "TRNS1" 2 "TRNS2" 255 "SNA" ;
+VAL_ 979 EC_ECUCfg14_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 980 EC_ECUCfg13_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 981 EC_ECUCfg12_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 982 EC_ECUCfg11_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 983 EC_ECUCfg10_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 984 EC_ECUCfg9_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 985 EC_BU_ECUCfg14_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 986 EC_BU_ECUCfg13_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 987 EC_BU_ECUCfg12_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 988 EC_BU_ECUCfg11_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 989 EC_BU_ECUCfg10_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 991 EC_BU_ECUCfg9_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 993 DISPLACEMENT 255 "SNA" ;
+VAL_ 993 NUM_CYL 15 "SNA" ;
+VAL_ 993 ENG_ASP 0 "INTAKE_NORM" 1 "TURBO1" 2 "TURBO2" 3 "SUPER" 7 "SNA" ;
+VAL_ 993 FUEL_TYPE 0 "UNLEADED" 1 "DIESEL" 2 "FLEX" 3 "CNG" 7 "SNA" ;
+VAL_ 993 ECM_Vehi_Type 0 "STANDARD" 1 "EVEHICLE" 3 "SNA" ;
+VAL_ 993 Manufacture 0 "ENG_DCA" 1 "ENG_DCS" 2 "ENG_MMC" 3 "ENG_HY" 7 "ENG_NP" ;
+VAL_ 993 NUM_VALVE 7 "SNA" ;
+VAL_ 993 EngStyle 0 "CHOICE1" 1 "CHOICE2" 2 "CHOICE3" 3 "CHOICE4" 4 "CHOICE5" 5 "CHOICE6" 7 "SNA" ;
+VAL_ 995 NET_CFG_STAT_INT 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 995 NetCfg_ANC_I 0 "Not_Present" 1 "Present" ;
+VAL_ 995 NetCfg_TTM 0 "Not_Present" 1 "Present" ;
+VAL_ 996 NET_CFG_STAT_PT 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 996 NetCfg_BSMO 0 "Not_Present" 1 "Present" ;
+VAL_ 996 NetCfg_SGW 0 "Not_Present" 1 "Present" ;
+VAL_ 996 NetCfg_DPDM 0 "Not_Present" 1 "Present" ;
+VAL_ 996 NetCfg_ASBS 0 "Not_Present" 1 "Present" ;
+VAL_ 996 NetCfg_SWSM 0 "Not_Present" 1 "Present" ;
+VAL_ 996 NetCfg_MSBD 0 "Not_Present" 1 "Present" ;
+VAL_ 998 BU_NET_CFG_STAT_INT 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 998 BU_NetCfg_ANC_I 0 "Not_Present" 1 "Present" ;
+VAL_ 999 BU_NET_CFG_STAT_PT 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 999 BU_NetCfg_BSMO 0 "Not_Present" 1 "Present" ;
+VAL_ 999 BU_NetCfg_SGW 0 "Not_Present" 1 "Present" ;
+VAL_ 999 BU_NetCfg_DPDM 0 "Not_Present" 1 "Present" ;
+VAL_ 999 BU_NetCfg_ASBS 0 "Not_Present" 1 "Present" ;
+VAL_ 999 BU_NetCfg_SWSM 0 "Not_Present" 1 "Present" ;
+VAL_ 999 BU_NetCfg_MSBD 0 "Not_Present" 1 "Present" ;
+VAL_ 1000 VC_VehCfg1_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1000 VC_MODEL_YEAR 63 "SNA" ;
+VAL_ 1000 VC_VEH_LINE 0 "VEH_NONE" 1 "VEH_WK" 2 "VEH_LX" 22 "VEH_JC" 29 "VEH_DS" 31 "VEH_D2" 32 "VEH_DD" 33 "VEH_DP" 34 "VEH_DJ" 35 "VEH_WD" 39 "VEH_DX" 41 "VEH_LD" 42 "VEH_M156" 43 "VEH_ZD" 44 "VEH_LA" 45 "VEH_RU" 46 "VEH_M161" 47 "VEH_WS" 48 "VEH_DF" 49 "VEH_JL" 50 "VEH_M157" 51 "VEH_RA" 52 "VEH_WL" 53 "VEH_DT" 54 "VEH_DU" 55 "VEH_JT" 80 "VEH_PF" 81 "VEH_KL" 82 "VEH_UF" 83 "VEH_UT" 84 "VEH_M145" 85 "VEH_M145BD" 86 "VEH_K8" 87 "VEH_FF" 255 "SNA" ;
+VAL_ 1000 VC_COUNTRY 0 "ROW" 2 "USA" 3 "EU" 4 "CND" 5 "GB" 6 "JPN" 7 "GER" 8 "SWISS" 9 "MLY" 10 "AUS" 11 "IND" 12 "GULF" 13 "VEN" 14 "MEX" 15 "BRZ" 16 "CHINA" 17 "EGYPT" 20 "S_KOR" 21 "ECE" 31 "COUNTRY_SNA" ;
+VAL_ 1000 VC_LHD_RHD 0 "NA" 1 "LHD" 2 "RHD" 3 "SNA" ;
+VAL_ 1000 VC_XWD 0 "2FT" 1 "2RR" 2 "ALLWD" 3 "4WD" ;
+VAL_ 1000 VC_BODY_STYLE 0 "BODY_NONE" 1 "BODY_4DS" 2 "BODY_2DS" 3 "BODY_CONV" 4 "BODY_WAGON" 5 "BODY_4DH" 6 "BODY_2DP" 7 "BODY_4DP" 8 "BODY_4DMP" 15 "BODY_SNA" ;
+VAL_ 1000 VC_MAX_VEH_SPD 255 "SNA" ;
+VAL_ 1000 VC_ShftrTyp 0 "TYPE_NA" 1 "TYPE_ERS4" 2 "TYPE_AS4" 3 "TYPE_ERS5" 4 "TYPE_AS5" 5 "TYPE_RS5M" 6 "TYPE_RS5S" 7 "TYPE_RS5L" 8 "TYPE_ERS4ESW" 9 "TYPE_MS7D" 10 "TYPE_MS7M156" 11 "TYPE_RS4" 12 "TYPE_MS7S" 13 "TYPE_MS7" 14 "TYPE_PS5" 15 "SNA" ;
+VAL_ 1000 VC_PTS_DispTyp 0 "HEAD_DISP" 1 "CCN_DISP" 2 "AUDIO_DISP" 7 "SNA" ;
+VAL_ 1000 VC_SpecialPKG 0 "NONE" 255 "SNA" ;
+VAL_ 1000 VC_PTS_Config 0 "REAR" 1 "FRT_REAR" 3 "SEMI" ;
+VAL_ 1001 VC_VehCfg2_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1001 VC_PwrIvtrTyp 0 "NoPwrIvtr" 1 "MtrySw" 2 "LchSw" ;
+VAL_ 1001 VC_MaseratiMd 0 "NORMAL" 1 "GTS" 2 "RACE" 3 "SNA" ;
+VAL_ 1001 VC_SpecialPKG_IC 0 "NONE" 1 "PKG_70JP" 2 "PKG_300S" 3 "PKG_BEATS" 4 "PKG_SUPERBEE" 5 "MOPAR" 6 "Hellcat" 7 "Shaker" 8 "Scat" 9 "ADR" 10 "Scat_Drag" 11 "High_Output" 16 "LARAMIE" 17 "BIGHORN" 18 "LONGHORN" 19 "LONESTAR" 20 "LIMITED" 21 "MOSSY_OAK" 22 "ORT" 23 "POWERWAGON" 24 "HD_DX" 25 "SPORT" 26 "PWGN_Laramie" 27 "RAM_1500" 28 "PWGN_GOODYEAR" 29 "LONGHORN_BLACK" 30 "LONGHORN_BROWN" 31 "RAM_2500" 32 "RAM_3500" 33 "RAM_4500" 34 "RAM_5500" 100 "WRANGLER_SPORT" 101 "WRANGLER_SAHARA" 102 "WRANGLER_RUBICON" 150 "TRAILHAWK_SUPERCHARGED" 246 "DODGE_100" 247 "VARVATOS" 255 "SNA" ;
+VAL_ 1001 VC_ShftInd_Prsnt 0 "NONE" 1 "GSI" 2 "PSI" 3 "PGSI" ;
+VAL_ 1001 VC_MaxLdPressRrTr 255 "SNA" ;
+VAL_ 1001 VC_MaxLdPressFtTr 255 "SNA" ;
+VAL_ 1001 VC_LgtLdPressRrTr 255 "SNA" ;
+VAL_ 1001 VC_LgtLdPressFtTr 255 "SNA" ;
+VAL_ 1002 VC_VehCfg3_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1002 VC_TcaseTyp 0 "NOT_PRSNT" 1 "TCASE_143_144" 2 "BW4445_46_48_WS" 3 "Tcase_253_1522" 4 "Tcase_BW4444" 5 "Tcase_BW4446" 6 "Tcase_MPT3025C" 7 "Tcase_241_MPT1222C" 8 "BW4447_WOS" 9 "Tcase_243" 10 "BW4447_49_WS" 11 "Tcase_273" 12 "Tcase_MAS_ATC" 13 "Tcase_BW4440" 14 "Tcase_156" 15 "Tcase_256_3022" ;
+VAL_ 1002 VC_WHL_BASE 0 "SHORT" 1 "LONG" 2 "XLONG" 3 "SNA" ;
+VAL_ 1002 VC_FUEL_CAP 255 "SNA" ;
+VAL_ 1002 VC_WIN_EXPR_FEAT 0 "WIN_EXPR_DRV" 1 "WIN_EXPR_FT" 2 "WIN_EXPR_ALL" 3 "WIN_EXPR_NN" ;
+VAL_ 1002 VC_ChassisType 127 "SNA" ;
+VAL_ 1002 VC_HVAC_Config 0 "1_ZN_MTC" 1 "1_ZN_MTC_p_RR" 2 "1_ZN_ATC" 3 "2_ZN_MTC" 4 "2_ZN_ATC" 5 "2_ZN_ATC_p_RR" 6 "2_ZN_MTC_p_RR" 15 "SNA" ;
+VAL_ 1002 VC_VEH_BRAND 1 "CHRYSLER" 2 "DODGE" 3 "JEEP" 4 "MERCEDES_BENZ" 5 "MITSUBISHI" 6 "VOLKSWAGEN" 7 "FREIGHTLINER" 8 "ALPHA" 9 "FIAT" 10 "LANCIA" 11 "MASERATI" 12 "RAM" 15 "SNA" ;
+VAL_ 1002 VC_Liftgate_Trunk 0 "TRUNK" 1 "PLG" 2 "MANUAL_LG" 3 "SNA" ;
+VAL_ 1003 VC_TCASE_HI_RATIO 16383 "SNA" ;
+VAL_ 1003 VC_VehCfg4_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1003 VC_AXLE_RATIO 65535 "SNA" ;
+VAL_ 1003 VC_TCASE_LO_RATIO 65535 "SNA" ;
+VAL_ 1003 VC_TIRE_CIRCUMF 65535 "SNA" ;
+VAL_ 1004 VC_BU_VehCfg1_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1004 VC_BU_MODEL_YEAR 63 "SNA" ;
+VAL_ 1004 VC_BU_VEH_LINE 0 "VEH_NONE" 1 "VEH_WK" 2 "VEH_LX" 22 "VEH_JC" 29 "VEH_DS" 31 "VEH_D2" 32 "VEH_DD" 33 "VEH_DP" 34 "VEH_DJ" 35 "VEH_WD" 39 "VEH_DX" 41 "VEH_LD" 42 "VEH_M156" 43 "VEH_ZD" 44 "VEH_LA" 45 "VEH_RU" 46 "VEH_M161" 47 "VEH_WS" 48 "VEH_DF" 49 "VEH_JL" 50 "VEH_M157" 51 "VEH_RA" 52 "VEH_WL" 53 "VEH_DT" 54 "VEH_DU" 55 "VEH_JT" 80 "VEH_PF" 81 "VEH_KL" 82 "VEH_UF" 83 "VEH_UT" 84 "VEH_M145" 85 "VEH_M145BD" 86 "VEH_K8" 87 "VEH_FF" 255 "SNA" ;
+VAL_ 1004 VC_BU_COUNTRY 0 "ROW" 2 "USA" 3 "EU" 4 "CND" 5 "GB" 6 "JPN" 7 "GER" 8 "SWISS" 9 "MLY" 10 "AUS" 11 "IND" 12 "GULF" 13 "VEN" 14 "MEX" 15 "BRZ" 16 "CHINA" 17 "EGYPT" 20 "S_KOR" 21 "ECE" 31 "COUNTRY_SNA" ;
+VAL_ 1004 VC_BU_LHD_RHD 0 "NA" 1 "LHD" 2 "RHD" 3 "SNA" ;
+VAL_ 1004 VC_BU_RemStPrsnt 0 "SNA" ;
+VAL_ 1004 VC_BU_XWD 0 "2FT" 1 "2RR" 2 "ALLWD" 3 "4WD" ;
+VAL_ 1004 VC_BU_BODY_STYLE 0 "BODY_NONE" 1 "BODY_4DS" 2 "BODY_2DS" 3 "BODY_CONV" 4 "BODY_WAGON" 5 "BODY_4DH" 6 "BODY_2DP" 7 "BODY_4DP" 8 "BODY_4DMP" 15 "BODY_SNA" ;
+VAL_ 1004 VC_BU_MAX_VEH_SPD 255 "SNA" ;
+VAL_ 1004 VC_BU_ShftrTyp 0 "TYPE_NA" 1 "TYPE_ERS4" 2 "TYPE_AS4" 3 "TYPE_ERS5" 4 "TYPE_AS5" 5 "TYPE_RS5M" 6 "TYPE_RS5S" 7 "TYPE_RS5L" 8 "TYPE_ERS4ESW" 9 "TYPE_MS7D" 10 "TYPE_MS7M156" 11 "TYPE_RS4" 12 "TYPE_MS7S" 13 "TYPE_MS7" 14 "TYPE_PS5" 15 "SNA" ;
+VAL_ 1004 VC_BU_PTS_DispTyp 0 "HEAD_DISP" 1 "CCN_DISP" 2 "AUDIO_DISP" 7 "SNA" ;
+VAL_ 1004 VC_BU_SpecialPKG 0 "NONE" 255 "SNA" ;
+VAL_ 1004 VC_BU_PTS_Config 0 "REAR" 1 "FRT_REAR" 3 "SEMI" ;
+VAL_ 1005 VC_BU_VehCfg2_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1005 VC_BU_PwrIvtrTyp 0 "NoPwrIvtr" 1 "MtrySw" 2 "LchSw" ;
+VAL_ 1005 VC_BU_MaseratiMd 0 "NORMAL" 1 "GTS" 2 "RACE" 3 "SNA" ;
+VAL_ 1005 VC_BU_SpecialPKG_IC 0 "NONE" 1 "PKG_70JP" 2 "PKG_300S" 3 "PKG_BEATS" 4 "PKG_SUPERBEE" 5 "MOPAR" 6 "Hellcat" 7 "Shaker" 8 "Scat" 9 "ADR" 10 "Scat_Drag" 11 "High_Output" 16 "LARAMIE" 17 "BIGHORN" 18 "LONGHORN" 19 "LONESTAR" 20 "LIMITED" 21 "MOSSY_OAK" 22 "ORT" 23 "POWERWAGON" 24 "HD_DX" 25 "SPORT" 26 "PWGN_Laramie" 27 "RAM_1500" 28 "PWGN_GOODYEAR" 29 "LONGHORN_BLACK" 30 "LONGHORN_BROWN" 31 "RAM_2500" 32 "RAM_3500" 33 "RAM_4500" 34 "RAM_5500" 100 "WRANGLER_SPORT" 101 "WRANGLER_SAHARA" 102 "WRANGLER_RUBICON" 150 "TRAILHAWK_SUPERCHARGED" 246 "DODGE_100" 247 "VARVATOS" 255 "SNA" ;
+VAL_ 1005 VC_BU_ShftInd_Prsnt 0 "NONE" 1 "GSI" 2 "PSI" 3 "PGSI" ;
+VAL_ 1005 VC_BU_MaxLdPressRrTr 255 "SNA" ;
+VAL_ 1005 VC_BU_MaxLdPressFtTr 255 "SNA" ;
+VAL_ 1005 VC_BU_LgtLdPressRrTr 255 "SNA" ;
+VAL_ 1005 VC_BU_LgtLdPressFtTr 255 "SNA" ;
+VAL_ 1006 VC_BU_VehCfg3_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1006 VC_BU_TcaseTyp 0 "NOT_PRSNT" 1 "TCASE_143_144" 2 "BW4445_46_48_WS" 3 "Tcase_253_1522" 4 "Tcase_BW4444" 5 "Tcase_BW4446" 6 "Tcase_MPT3025C" 7 "Tcase_241_MPT1222C" 8 "BW4447_WOS" 9 "Tcase_243" 10 "BW4447_49_WS" 11 "Tcase_273" 12 "Tcase_MAS_ATC" 13 "Tcase_BW4440" 14 "Tcase_156" 15 "Tcase_256_3022" ;
+VAL_ 1006 VC_BU_WHL_BASE 0 "SHORT" 1 "LONG" 2 "XLONG" 3 "SNA" ;
+VAL_ 1006 VC_BU_ELV_PRSNT 0 "SNA" ;
+VAL_ 1006 VC_BU_FUEL_CAP 255 "SNA" ;
+VAL_ 1006 VC_BU_WIN_EXPR_FEAT 0 "WIN_EXPR_DRV" 1 "WIN_EXPR_FT" 2 "WIN_EXPR_ALL" 3 "WIN_EXPR_NN" ;
+VAL_ 1006 VC_BU_ChassisType 127 "SNA" ;
+VAL_ 1006 VC_BU_HVAC_Config 0 "1_ZN_MTC" 1 "1_ZN_MTC_p_RR" 2 "1_ZN_ATC" 3 "2_ZN_MTC" 4 "2_ZN_ATC" 5 "2_ZN_ATC_p_RR" 6 "2_ZN_MTC_p_RR" 15 "SNA" ;
+VAL_ 1006 VC_BU_VEH_BRAND 1 "CHRYSLER" 2 "DODGE" 3 "JEEP" 4 "MERCEDES_BENZ" 5 "MITSUBISHI" 6 "VOLKSWAGEN" 7 "FREIGHTLINER" 8 "ALPHA" 9 "FIAT" 10 "LANCIA" 11 "MASERATI" 12 "RAM" 15 "SNA" ;
+VAL_ 1006 VC_BU_Liftgate_Trunk 0 "TRUNK" 1 "PLG" 2 "MANUAL_LG" 3 "SNA" ;
+VAL_ 1007 VC_BU_TCASE_HI_RATIO 16383 "SNA" ;
+VAL_ 1007 VC_BU_VehCfg4_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1007 VC_BU_AXLE_RATIO 65535 "SNA" ;
+VAL_ 1007 VC_BU_TCASE_LO_RATIO 65535 "SNA" ;
+VAL_ 1007 VC_BU_TIRE_CIRCUMF 65535 "SNA" ;
+VAL_ 1008 EC_ECUCfg1_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1009 EC_ECUCfg2_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1010 EC_ECUCfg3_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1011 EC_ECUCfg4_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1012 EC_ECUCfg5_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1013 EC_ECUCfg6_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1014 EC_ECUCfg7_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1015 EC_ECUCfg8_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1016 EC_BU_ECUCfg1_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1017 EC_BU_ECUCfg2_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1018 EC_BU_ECUCfg3_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1019 EC_BU_ECUCfg4_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1020 EC_BU_ECUCfg5_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1021 EC_BU_ECUCfg6_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1022 EC_BU_ECUCfg7_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1023 EC_BU_ECUCfg8_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1024 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1024 NM_Successor 255 "SNA" ;
+VAL_ 1024 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1024 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 1025 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1025 NM_Successor 255 "SNA" ;
+VAL_ 1025 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1025 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 1026 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1026 NM_Successor 255 "SNA" ;
+VAL_ 1026 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1026 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 1031 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1031 NM_Successor 255 "SNA" ;
+VAL_ 1031 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1031 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 1033 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1033 NM_Successor 255 "SNA" ;
+VAL_ 1033 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1033 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 1059 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1059 NM_Successor 255 "SNA" ;
+VAL_ 1059 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1059 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 1098 VC_VehCfg5_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1098 VC_AmbTempLct 0 "CBC" 1 "DCM" 3 "SNA" ;
+VAL_ 1098 VC_Strng_Rt_0 255 "SNA" ;
+VAL_ 1098 VC_Strng_Rt_pls1 255 "SNA" ;
+VAL_ 1098 VC_Strng_Rt_pls2 255 "SNA" ;
+VAL_ 1098 VC_Strng_Rt_pls3 255 "SNA" ;
+VAL_ 1098 VC_Strng_Rt_pls4 255 "SNA" ;
+VAL_ 1098 VC_Strng_Rt_pls5 255 "SNA" ;
+VAL_ 1099 VC_BU_VehCfg5_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1099 VC_BU_AmbTempLct 0 "CBC" 1 "DCM" 3 "SNA" ;
+VAL_ 1099 VC_BU_Strng_Rt_0 255 "SNA" ;
+VAL_ 1099 VC_BU_Strng_Rt_pls1 255 "SNA" ;
+VAL_ 1099 VC_BU_Strng_Rt_pls2 255 "SNA" ;
+VAL_ 1099 VC_BU_Strng_Rt_pls3 255 "SNA" ;
+VAL_ 1099 VC_BU_Strng_Rt_pls4 255 "SNA" ;
+VAL_ 1099 VC_BU_Strng_Rt_pls5 255 "SNA" ;
+VAL_ 1100 VC_VehCfg6_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 1100 VC_AnlgDrSnsr 0 "NONE" 1 "DRV" 2 "FT" 3 "ALL" ;
+VAL_ 1100 VC_BrkTyp 0 "SMALL" 1 "PB" 2 "CB" 3 "MB" 7 "SNA" ;
+VAL_ 1100 VC_Strng_Rt_Mns1 255 "SNA" ;
+VAL_ 1100 VC_Strng_Rt_Mns2 255 "SNA" ;
+VAL_ 1100 VC_Strng_Rt_Mns3 255 "SNA" ;
+VAL_ 1100 VC_Strng_Rt_Mns4 255 "SNA" ;
+VAL_ 1100 VC_Strng_Rt_Mns5 255 "SNA" ;
+VAL_ 1100 VC_TireCircumfFT 65535 "SNA" ;
+VAL_ 1101 VC_BU_VehCfg6_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 1101 VC_BU_AnlgDrSnsr 0 "NONE" 1 "DRV" 2 "FT" 3 "ALL" ;
+VAL_ 1101 VC_BU_BrkTyp 0 "SMALL" 1 "PB" 2 "CB" 3 "MB" 7 "SNA" ;
+VAL_ 1101 VC_BU_Strng_Rt_Mns1 255 "SNA" ;
+VAL_ 1101 VC_BU_Strng_Rt_Mns2 255 "SNA" ;
+VAL_ 1101 VC_BU_Strng_Rt_Mns3 255 "SNA" ;
+VAL_ 1101 VC_BU_Strng_Rt_Mns4 255 "SNA" ;
+VAL_ 1101 VC_BU_Strng_Rt_Mns5 255 "SNA" ;
+VAL_ 1101 VC_BU_TireCircumfFT 65535 "SNA" ;
+VAL_ 362 DrvLnTrqRq 511 "SNA" ;
+VAL_ 640 Mem_D_Pos_Rq 0 "IDLE" 1 "MEMPOS1" 2 "MEMPOS2" ;
+VAL_ 752 MEM_RC_STAT 0 "MEM_ENBL" 1 "SB_BUCKLED" 2 "VEH_NOT_PARK" 3 "VEH_IN_MOT" 7 "SNA" ;
+VAL_ 752 MSMD_PDL_LKOUT 0 "LKOUT_NONE" 1 "LKOUT_CRUISE" 2 "LKOUT_TX_REV" 3 "AP_DSBL" 7 "SNA" ;
+VAL_ 752 EASY_EXIT 0 "OFF" 1 "ON" 2 "NDEF2" 3 "SNA" ;
+VAL_ 847 RF_FobNum 0 "FOB_DEFAULT" 1 "FOB_1" 2 "FOB_2" 3 "FOB_3" 4 "FOB_4" 5 "FOB_5" 6 "FOB_6" 7 "FOB_7" 8 "FOB_8" 15 "SNA" ;
+VAL_ 806 AFLS_Stat 0 "DISABLED" 1 "ENABLED" 2 "F_HL" 3 "F_HS" ;
+VAL_ 530 Adblue_FL_LVL 255 "SNA" ;
+VAL_ 530 Adblue_Stat 0 "OK" 1 "DEFLW1" 2 "DEFLW2" 3 "DEFLW3" 4 "DEFLW4" 5 "DEFLW5" 6 "DEFLW6" 7 "DEFLW7" 8 "DEFLW8" 9 "DEFLW9" 10 "DEFLW10" 11 "DEFLW11" 12 "DEFLW12" 13 "DEFLW13" 14 "DEFLW14" 15 "DEFLW15" 16 "DEFQW1" 17 "DEFQW2" 18 "DEFQW3" 19 "DEFQW4" 20 "DEFQW5" 21 "DEFQW6" 22 "DEFQW7" 23 "DEFQW8" 24 "DEFQW9" 25 "DEFQW10" 33 "DEFLW1_RL" 34 "DEFLW2_RL" 35 "DEFLW3_RL" 36 "DEFLW4_RL" 37 "DEFLW5_RL" 38 "DEFLW6_RL" 39 "DEFLW7_RL" 40 "DEFLW8_RL" 41 "DEFLW9_RL" 42 "DEFLW10_RL" 43 "DEFLW11_RL" 44 "DEFLW12_RL" 45 "DEFLW13_RL" 46 "DEFLW14_RL" 47 "DEFLW15_RL" 48 "DEFQW1_RL" 49 "DEFQW2_RL" 50 "DEFQW3_RL" 51 "DEFQW4_RL" 52 "DEFQW5_RL" 53 "DEFQW6_RL" 54 "DEFQW7_RL" 55 "DEFQW8_RL" 56 "DEFQW9_RL" 57 "DEFQW10_RL" 63 "SNA" ;
+VAL_ 530 AdblueRemainDist 65535 "SNA" ;
+VAL_ 530 DEF_LOW 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 530 ECM_HMI_Timer_RQ 0 "TMR120" 1 "TMR60" 2 "TMR30" 7 "SNA" ;
+VAL_ 530 PFW_Stat 0 "PFW_MN" 1 "RegRqPFW_Stat" 2 "SerRqPFW_Stat" 3 "SER_REQ" 4 "REG_CMPL" 5 "RegActPFW_Stat" 6 "PWR_RED" 9 "RegRqPFW_StatRL" 10 "SerRqPFW_StatRL" 11 "SER_REQ_RL" 12 "REG_CMPL_RL" 13 "RegActPFW_StatRL" 14 "PWR_RED_RL" 15 "SNA" ;
+VAL_ 530 PrcntCplt 15 "SNA" ;
+VAL_ 530 PreHtIndLmp_On_Rq 0 "SNA" ;
+VAL_ 530 WtrFuelIndLmp_On_Rq 0 "SNA" ;
+VAL_ 625 DsrSpeed_KPH 255 "SNA" ;
+VAL_ 625 FCWSetting 0 "OFF" 1 "NEAR" 2 "MEDIUM" 3 "FAR" ;
+VAL_ 684 INV_CARGO_OnState 0 "None" 1 "Disable" 2 "Enable" 3 "SNA" ;
+VAL_ 684 GateOnOffSts 0 "DOOR_ON" 1 "DOOR_OFF" 2 "FLT" 3 "SNA" ;
+VAL_ 705 VEH_INT_TEMP 65535 "SNA" ;
+VAL_ 705 SwayBarBtnRq 0 "NOT_PRESSED" 1 "PRESSED" 2 "STUCK" 3 "SNA" ;
+VAL_ 709 EC_ECUCfg16_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 710 EC_ECUCfg17_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 714 EC_BU_ECUCfg16_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 715 EC_BU_ECUCfg17_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 773 Tire_FL 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 773 Tire_FR 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 773 Tire_RL 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 773 Tire_RR 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 773 Tire_Spr 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 773 TirePrssFL 255 "SNA" ;
+VAL_ 773 TirePrssFR 255 "SNA" ;
+VAL_ 773 TirePrssRL 255 "SNA" ;
+VAL_ 773 TirePrssRR 255 "SNA" ;
+VAL_ 773 TirePrssSpr 255 "SNA" ;
+VAL_ 773 TPM_IndLmpOnRq 0 "IND_LMP_OFF" 1 "IND_LMP_ON" 2 "IND_LMP_FLASH" 3 "SNA" ;
+VAL_ 773 TPM_SysStat 0 "NON_LOCALIZED" 1 "PERF_LOCALIZATION" 2 "LOCALIZATION_CMPLT" 3 "TPM_NA" 4 "LOCALIZATION_NOT_CMPLT" 7 "SNA" ;
+VAL_ 773 TPMHornChirp 0 "HORN_CHIRP_OFF" 1 "SINGLE_HORN_CHIRP" 2 "MULTIPLE_HORN_CHIRP" 3 "SNA" ;
+VAL_ 773 TPMHazardFlash 0 "FALSE" 1 "TRUE" ;
+VAL_ 778 TrboBstPress 255 "SNA" ;
+VAL_ 778 EngBrkStat 0 "EB_OFF" 1 "EB_ENBL" 2 "EB_RQ" 3 "SNA" ;
+VAL_ 778 WTS_CntDnTmr 255 "SNA" ;
+VAL_ 778 Man_PFW_Stat 0 "Man_Default" 1 "Man_FilterNotFull" 2 "Man_InsufficientFuel" 3 "Man_InsufficientTime" 4 "Man_EngNotOn" 5 "Man_NoPark" 6 "Man_PedalPrsd" 7 "Man_SerRqd" 8 "Man_Res1" 9 "Man_Res2" 10 "Man_Res3" 11 "Man_Res4" 12 "Man_Others" 13 "Man_LowOil" 14 "Man_PTOAct" 15 "SNA" ;
+VAL_ 778 EB_Stat3 0 "EB_OFF" 1 "EB_ON" 2 "EB_LT" 3 "EB_MED" 4 "EB_HVY" 5 "EB_SMART" 7 "SNA" ;
+VAL_ 778 EB_Pwr 255 "SNA" ;
+VAL_ 778 DPF_Man_Stat 0 "Man_Regen_Disabld" 1 "Man_Regen_Enbld" 2 "Man_Regen_InProcess" 3 "Man_Regen_Res1" 4 "Man_Regen_Completed" 5 "Man_Regen_Res2" 6 "Man_Regen_Cancelled" 7 "SNA" ;
+VAL_ 778 DrtdTrqMd 0 "NM" 1 "MESS1" 2 "MESS2" 3 "MESS3" ;
+VAL_ 831 RL_Lvl 254 "NOT_INIT" 255 "SNA" ;
+VAL_ 831 RR_Lvl 254 "NOT_INIT" 255 "SNA" ;
+VAL_ 844 ASCM_Exit_Rq 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 844 ASCM_HMI_Stat 0 "NONE" 1 "ASCM_RedSpd" 2 "ASCM_LvlnPrmt" 3 "ASCM_Cooldn" 4 "ASCM_Dr" 5 "ASCM_Srv" 6 "ASCM_SysFail" 7 "ASCM_VLSt" 8 "ASCM_TJM_Disp" 9 "ASCM_LowClr" 10 "ASCM_Highlr" 11 "TM_Enbl" 12 "ALM_Enbl" 13 "ASCM_WarnONly" 14 "ASCM_AeroDslb" 15 "SNA" ;
+VAL_ 844 ASCM_Stat 0 "NO_MESS" 1 "DUMP" 2 "PARK" 3 "AERO" 4 "NVL" 5 "OR1" 6 "ORL2" 7 "EEHNA" 8 "RAISE" 9 "LOWER" 10 "RL_INT" 11 "SRVS" 12 "AERO2" 15 "SNA" ;
+VAL_ 844 ASCM_StatDisp 0 "NO_MESS" 1 "DUMP" 2 "PARK" 3 "AERO" 4 "NVL" 5 "OR1" 6 "ORL2" 7 "EEHNA" 8 "LMR" 9 "LML" 10 "RL_INT" 11 "LNA_OL" 12 "ASCM_LNP_SPEED" 13 "ASCM_LNP_PAYLOAD" 14 "ASCM_LNP_MINLoad" 15 "SNA" ;
+VAL_ 844 Loading_Lv 0 "LND" 1 "LIGHT" 2 "MEDIUM" 3 "FULL" 4 "OVERLOAD_1" 5 "OVERLOAD_2" 6 "MIP" 7 "SNA" ;
+VAL_ 844 LvlAdjStat 0 "STATIC" 1 "RAISE" 2 "LOWER" 3 "RL_INT" ;
+VAL_ 844 Tgt_Level 0 "TR_Dump" 1 "Park" 2 "AERO" 3 "STD" 4 "OR1" 5 "ORL2" 6 "AERO2" 7 "SNA" ;
+VAL_ 1062 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1062 NM_Successor 255 "SNA" ;
+VAL_ 1062 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1062 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 294 LatAcceleration 4095 "SNA" ;
+VAL_ 294 AXSStat 0 "SISL" 1 "TSE" 2 "PSE" 3 "SEII" ;
+VAL_ 294 AYSStat 0 "SISL" 1 "TSE" 2 "PSE" 3 "SEII" ;
+VAL_ 294 LongAcceleration 4095 "SNA" ;
+VAL_ 294 YRSStat 0 "SISL" 1 "TSE" 2 "PSE" 3 "SEII" ;
+VAL_ 294 YawRate 4095 "SNA" ;
+VAL_ 516 ControlEncodingRsp 16 "ControlEncoding_TEN" 153 "ControlEncoding_UC" 170 "ControlEncoding_PRA" 171 "ControlEncoding_PVA" ;
+VAL_ 517 ControlEncodingRq 5 "ControlEncoding_ENQ" 6 "ControlEncoding_ACK" 21 "ControlEncoding_NACK" 129 "ControlEncoding_NACKp" 132 "ControlEncoding_EOTp" 133 "ControlEncoding_ENQp" 134 "ControlEncoding_ACK1p" 135 "ControlEncoding_ACK2p" ;
+VAL_ 526 CodeCheckSts 0 "No_Code" 1 "CodeCheck_OK" 2 "CodeCheck_Fault" ;
+VAL_ 526 TxpID 0 "Transponder_Not_Authenticated" 1 "Transponder_1_Authenticated" 2 "Transponder_2_Authenticated" 3 "Transponder_3_Authenticated" 4 "Transponder_4_Authenticated" 5 "Transponder_5_Authenticated" 6 "Transponder_6_Authenticated" 7 "Transponder_7_Authenticated" 8 "Transponder_8_Authenticated" 9 "Transponder_9_Authenticated" 10 "Transponder_10_Authenticated" 11 "Transponder_11_Authenticated" 12 "Transponder_12_Authenticated" 13 "Transponder_13_Authenticated" 14 "Transponder_14_Authenticated" 15 "Transponder_15_Authenticated" ;
+VAL_ 527 FrameNumber 0 "Frame_1" 1 "Frame_2" 2 "Frame_3" 3 "Frame_4" 4 "Frame_5" 5 "Frame_6" 6 "Frame_7" 7 "Frame_8" 8 "Frame_9" 9 "Frame_10" 10 "Frame_11" 11 "Frame_12" 12 "Frame_13" 13 "Frame_14" 14 "Frame_15" 15 "Frame_16" ;
+VAL_ 527 TotalFrameNumber 0 "One_Frame" 1 "Two_Frames" 2 "Three_Frames" 3 "Four_Frames" 4 "Five_Frames" 5 "Six_Frames" 6 "Seven_Frames" 7 "Eight_Frame" 8 "Nine_Frames" 9 "Ten_Frames" 10 "Eleven_Frames" 11 "Twelve_Frames" 12 "Thirteen_Frames" 13 "Fourteen_Frames" 14 "Fifteen_Frames" 15 "Sixteen_Frames" ;
+VAL_ 542 PTRInfo 0 "SN" 1 "CPN" 3 "SUPPLIER" ;
+VAL_ 782 Gas_Range 1023 "SNA" ;
+VAL_ 782 CFG_Manual_DPF 0 "CFG_DEF" 1 "CFG_START" 2 "CFG_RESERVED" 3 "SNA" ;
+VAL_ 938 A_MPG 1023 "SNA" ;
+VAL_ 939 A_KMpL 1023 "SNA" ;
+VAL_ 940 A_Total_Dist_Miles 16777215 "SNA" ;
+VAL_ 940 A_Total_Dist_Kilometers 16777215 "SNA" ;
+VAL_ 941 B_MPG 1023 "SNA" ;
+VAL_ 942 B_KMpL 1023 "SNA" ;
+VAL_ 943 B_Total_Dist_Miles 16777215 "SNA" ;
+VAL_ 943 B_Total_Dist_Kilometers 16777215 "SNA" ;
+VAL_ 55 EngTrqRq_2 8191 "SNA" ;
+VAL_ 55 MaxTrqDes_2 8191 "SNA" ;
+VAL_ 55 TrnsTrqReqSlow_2 8191 "SNA" ;
+VAL_ 55 TrqCtrlModeRq_2 0 "NONE" 1 "TRQ_INC_Fast" 2 "TRQ_DEC_Fast" 7 "SNA" ;
+VAL_ 1073 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1073 NM_Successor 255 "SNA" ;
+VAL_ 1073 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1073 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 973 WATER_IN_FUEL_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 TIRE_PRESSURE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 STOP_START_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 SERVICE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 SERVICE_ACC_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 OVER_TEMP_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 OIL_TEMP_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 OIL_PRESSURE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 LANE_SENSE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 FOUR_WD_SERVICE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 FCW_SYSTEM_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 ETC_CONTROL_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 EPS_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 EPB_WARN_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 ENGINE_TEMP_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 ENGINE_MIL_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 ELEC_STAB_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 DEF_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 DAMPING_SYSTEM_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 BRK_IND_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 BRAKE_PAD_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 BATTERY_CHARGE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 AWD_SERVICE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 ABS_IND_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 WINDSHIELD_FLUID_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 OIL_LEVEL_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 FUEL_CAP_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 COOLENT_LEVEL_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 TORQUE_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 ELECTRIC_WRENCH_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 973 CATALYST_TEMP_STAT 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 754 Inst_Fuel_Econ 1023 "SNA" ;
+VAL_ 754 Avg_Fuel_Econ 1023 "SNA" ;
+VAL_ 910 IBS3_TempFailStatus 0 "Fail_not_present" 1 "Fail_present" ;
+VAL_ 910 IBS3_T_BATT 255 "SNA" ;
+VAL_ 910 IBS3_SOH_Q_Accuracy 0 "Inaccurate" 1 "Accurate" ;
+VAL_ 910 IBS3_SOH_Q 127 "SNA" ;
+VAL_ 910 IBS3_SOF_VC 127 "SNA" ;
+VAL_ 910 IBS3_SOF_V_Accuracy 0 "Inaccurate" 1 "Accurate" ;
+VAL_ 910 IBS3_SOF_Q_Accuracy 0 "Inaccurate" 1 "Accurate" ;
+VAL_ 910 IBS3_SOF_Q 255 "SNA" ;
+VAL_ 910 IBS3_SOC_Accuracy 0 "Inaccurate" 1 "Accurate" ;
+VAL_ 910 IBS3_SOC 127 "SNA" ;
+VAL_ 910 IBS3_FLAG_DISCONNECT 0 "No_Disconnect" 1 "Disconnect" ;
+VAL_ 910 Ft_RrAxleLckr_Rq 0 "NPSD" 1 "PSD" 2 "NDEF2" 3 "SNA" ;
+VAL_ 579 AxleLckrOFF_SW 0 "NOT_PSD" 1 "PSD" 3 "SNA" ;
+VAL_ 579 TGW_AUD_MD2_CAB_DR 0 "NONE" 1 "Android_Auto" 2 "Apple_CarPlay" 3 "Music_Muted" 4 "Baidu_CarLife" ;
+VAL_ 683 VoltBattFailStatus 0 "Fail_not_present" 1 "Fail_present" ;
+VAL_ 683 RsErrIBS3 0 "NO_ERROR" 1 "ERROR" ;
+VAL_ 683 IBS3_Vbatt 511 "SNA" ;
+VAL_ 683 IBS3_Ibatt 65535 "SNA" ;
+VAL_ 683 IBS3_Error_Internal 0 "NO_ERROR" 1 "ERROR" ;
+VAL_ 683 CurrBattFailStatus 0 "Fail_not_present" 1 "Fail_present" ;
+VAL_ 685 Cfg_Aux_PTO 0 "NONE" 3 "FOUR_CUTOFF" 4 "FOUR" 5 "FIVE" 6 "SIX" 7 "SNA" ;
+VAL_ 881 SwayBarEVICDisplay 0 "TM0" 1 "TM1" 2 "TM2" 3 "TM3" 4 "TM4" 5 "TM5" 6 "TM6" 7 "TM7" 8 "TM8" 9 "TM9" 10 "TM10" 11 "TM11" 12 "TM12" 13 "TM13" 14 "TM14" 15 "SNA" ;
+VAL_ 881 SwayBar_Sts 0 "UNLOCKED" 1 "LOCKED" 2 "S_I_P" 3 "SNA" ;
+VAL_ 881 SwayBar_LEDRq 0 "OFF" 1 "CONT" 2 "BLINK" 3 "SNA" ;
+VAL_ 739 CNG_GaLvl 255 "SNA" ;
+VAL_ 739 EngRunFuelTyp 0 "IND_GCLMPS_OFF" 1 "IND_GLMP_OFF" 2 "IND_GLMP_ON" 3 "IND_GLMP_FLASH" 4 "IND_CLMP_OFF" 5 "IND_CLMP_ON" 6 "IND_CLMP_FLASH" 7 "SNA" ;
+VAL_ 676 MAP_4_Bar 511 "SNA" ;
+VAL_ 676 ECM_WARN_EXT 0 "NONE" 1 "WARN_EXT_1" 2 "WARN_EXT_2" 3 "WARN_EXT_3" 4 "WARN_EXT_4" 5 "WARN_EXT_5" 6 "WARN_EXT_6" 7 "WARN_EXT_7" 8 "WARN_EXT_8" 9 "WARN_EXT_9" 10 "WARN_EXT_10" 12 "WARN_EXT_12" 13 "WARN_EXT_13" 14 "WARN_EXT_14" 15 "WARN_EXT_15" 16 "WARN_EXT_16" 17 "WARN_EXT_17" 18 "WARN_EXT_18" 19 "WARN_EXT_19" 20 "WARN_EXT_20" 21 "WARN_EXT_21" 22 "WARN_EXT_22" 23 "WARN_EXT_23" 24 "WARN_EXT_24" 25 "WARN_EXT_25" ;
+VAL_ 676 TransWarmup_Min_RPM 255 "SNA" ;
+VAL_ 963 VC_BU_VehCfgCSO3_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 963 VC_BU_TRUNK_UNLOCK_ENABLE_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_SPEED_THRESHOLD_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_PEB_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_EXTERNAL_LIGHT_SENSOR_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_BUZZER_VOLUME_LEVEL_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_AUTO_STOP_START_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_AL_OR_PLUS_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_AL_FFC_OR_PLUS_CSO 0 "Absent" 1 "Present" ;
+VAL_ 963 VC_BU_CHMSL_DYN_CNTR_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_VehCfgCSO3_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 962 VC_TRUNK_UNLOCK_ENABLE_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_SPEED_THRESHOLD_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_PEB_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_EXTERNAL_LIGHT_SENSOR_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_BUZZER_VOLUME_LEVEL_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_AUTO_STOP_START_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_AL_OR_PLUS_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_AL_FFC_OR_PLUS_CSO 0 "Absent" 1 "Present" ;
+VAL_ 962 VC_CHMSL_DYN_CNTR_CSO 0 "Absent" 1 "Present" ;
+VAL_ 907 VC_BU_VehCfg8_Stat 0 "NA" 1 "PROGAMMED" 2 "NA1" 3 "SNA" ;
+VAL_ 907 VC_BU_Steering_Cfactor 0 "TYPE_1" 1 "TYPE_2" 2 "TYPE_3" 3 "TYPE_4" ;
+VAL_ 907 VC_BU_Speedometer_Tolerance 0 "Tolerance_0" 1 "Tolerance_1" 2 "Tolerance_2" 3 "Tolerance_3" 4 "Tolerance_4" 5 "Tolerance_5" 6 "Tolerance_6" 7 "Tolerance_7" 8 "Tolerance_8" 9 "Tolerance_9" 10 "Tolerance_10" 11 "Tolerance_Neg1" 12 "Tolerance_Neg2" 13 "Tolerance_Neg3" 14 "Tolerance_Neg4" 15 "Tolerance_Neg5" ;
+VAL_ 907 VC_BU_Increasing_Speed_Constant 0 "Increasing_0" 1 "Increasing_1" 2 "Increasing_2" 3 "Increasing_3" 4 "Increasing_4" 5 "Increasing_5" 6 "Increasing_6" 7 "Increasing_7" ;
+VAL_ 907 VC_BU_WHL_BASE_LENGTH 0 "Not_Used" 1 "Length_1" 2 "Length_2" 3 "Length_3" 4 "Length_4" 5 "Length_5" 6 "Length_6" 7 "Length_7" 8 "Length_8" 9 "Length_9" 10 "Length_10" 11 "Length_11" 12 "Length_12" 13 "Length_13" 14 "Length_14" 15 "Length_15" ;
+VAL_ 907 VC_BU_OHC_TYPE 0 "Not_Present" 1 "Base_OHC" 2 "Premium_OHC" 3 "SNA" ;
+VAL_ 907 VC_BU_SBL_FBL_CORNERING_PRSNT 0 "Not_Present" 1 "SBL_FBL_Present" 2 "Cornering_Present" ;
+VAL_ 907 VC_BU_PPPAHardBtn 0 "Not_Present" 1 "Present" ;
+VAL_ 907 VC_BU_PEB_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 907 VC_BU_DBL_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 907 VC_BU_BEAM_SHAPING_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 907 VC_BU_AVAC_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 907 VC_BU_TACHO_TYPE 0 "DISABLED" 1 "TYP_1" 2 "TYP_2" 3 "TYP_3" ;
+VAL_ 907 VC_BU_MARKET_HEADLAMP 0 "CONF_SNA" 1 "ECE" 2 "SAE" 3 "APAC" ;
+VAL_ 906 VC_VehCfg8_Stat 0 "NA" 1 "PROGAMMED" 2 "REQUEST_DATA" 3 "SNA" ;
+VAL_ 906 VC_Steering_Cfactor 0 "TYPE_1" 1 "TYPE_2" 2 "TYPE_3" 3 "TYPE_4" ;
+VAL_ 906 VC_Speedometer_Tolerance 0 "Tolerance_0" 1 "Tolerance_1" 2 "Tolerance_2" 3 "Tolerance_3" 4 "Tolerance_4" 5 "Tolerance_5" 6 "Tolerance_6" 7 "Tolerance_7" 8 "Tolerance_8" 9 "Tolerance_9" 10 "Tolerance_10" 11 "Tolerance_Neg1" 12 "Tolerance_Neg2" 13 "Tolerance_Neg3" 14 "Tolerance_Neg4" 15 "Tolerance_Neg5" ;
+VAL_ 906 VC_Increasing_Speed_Constant 0 "Increasing_0" 1 "Increasing_1" 2 "Increasing_2" 3 "Increasing_3" 4 "Increasing_4" 5 "Increasing_5" 6 "Increasing_6" 7 "Increasing_7" ;
+VAL_ 906 VC_WHL_BASE_LENGTH 0 "Not_Used" 1 "Length_1" 2 "Length_2" 3 "Length_3" 4 "Length_4" 5 "Length_5" 6 "Length_6" 7 "Length_7" 8 "Length_8" 9 "Length_9" 10 "Length_10" 11 "Length_11" 12 "Length_12" 13 "Length_13" 14 "Length_14" 15 "Length_15" ;
+VAL_ 906 VC_OHC_TYPE 0 "Not_Present" 1 "Base_OHC" 2 "Premium_OHC" 3 "SNA" ;
+VAL_ 906 VC_SBL_FBL_CORNERING_PRSNT 0 "Not_Present" 1 "SBL_FBL_Present" 2 "Cornering_Present" ;
+VAL_ 906 VC_PPPAHardBtn 0 "Not_Present" 1 "Present" ;
+VAL_ 906 VC_PEB_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 906 VC_DBL_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 906 VC_BEAM_SHAPING_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 906 VC_AVAC_PRSNT 0 "Not_Present" 1 "Present" ;
+VAL_ 906 VC_TACHO_TYPE 0 "DISABLED" 1 "TYP_1" 2 "TYP_2" 3 "TYP_3" ;
+VAL_ 906 VC_MARKET_HEADLAMP 0 "CONF_SNA" 1 "ECE" 2 "SAE" 3 "APAC" ;
+VAL_ 687 TrlrTripDist 16777215 "SNA" ;
+VAL_ 687 TrlrStyle_4 0 "NONE" 1 "TRAILER" 2 "BOAT" 3 "CAR" 4 "CARGO" 5 "DUMP" 6 "EQUIPMENT" 7 "FLAT" 8 "GOOSE" 9 "LIVESTOCK" 10 "HORSE" 11 "MOTORCYCLE" 12 "SNOWMOBILE" 13 "TRAVEL" 14 "UTILITY" 15 "FIFTH" 31 "SNA" ;
+VAL_ 687 TrlrStyle_3 0 "NONE" 1 "TRAILER" 2 "BOAT" 3 "CAR" 4 "CARGO" 5 "DUMP" 6 "EQUIPMENT" 7 "FLAT" 8 "GOOSE" 9 "LIVESTOCK" 10 "HORSE" 11 "MOTORCYCLE" 12 "SNOWMOBILE" 13 "TRAVEL" 14 "UTILITY" 15 "FIFTH" 31 "SNA" ;
+VAL_ 687 TrlrStyle_2 0 "NONE" 1 "TRAILER" 2 "BOAT" 3 "CAR" 4 "CARGO" 5 "DUMP" 6 "EQUIPMENT" 7 "FLAT" 8 "GOOSE" 9 "LIVESTOCK" 10 "HORSE" 11 "MOTORCYCLE" 12 "SNOWMOBILE" 13 "TRAVEL" 14 "UTILITY" 15 "FIFTH" 31 "SNA" ;
+VAL_ 687 TrlrStyle_1 0 "NONE" 1 "TRAILER" 2 "BOAT" 3 "CAR" 4 "CARGO" 5 "DUMP" 6 "EQUIPMENT" 7 "FLAT" 8 "GOOSE" 9 "LIVESTOCK" 10 "HORSE" 11 "MOTORCYCLE" 12 "SNOWMOBILE" 13 "TRAVEL" 14 "UTILITY" 15 "FIFTH" 31 "SNA" ;
+VAL_ 687 SelTrlrStyle 0 "NONE" 1 "TRAILER" 2 "BOAT" 3 "CAR" 4 "CARGO" 5 "DUMP" 6 "EQUIPMENT" 7 "FLAT" 8 "GOOSE" 9 "LIVESTOCK" 10 "HORSE" 11 "MOTORCYCLE" 12 "SNOWMOBILE" 13 "TRAVEL" 14 "UTILITY" 15 "FIFTH" 31 "SNA" ;
+VAL_ 687 SelTrlrNum 0 "NONE" 1 "T1" 2 "T2" 3 "T3" 4 "T4" 7 "SNA" ;
+VAL_ 629 IRCM_AHB_On 0 "OFF" 1 "ON" ;
+VAL_ 875 ATMM_PopUpRqst 0 "TM0" 1 "TM1" 2 "TM2" 3 "SNA" ;
+VAL_ 924 MsgFobBattLow 0 "MSG_DEFAULT" 1 "MSG_ACTIVE" 3 "SNA" ;
+VAL_ 924 MsgFobNotFnd 0 "MSG_DEFAULT" 1 "MSG_ACTIVE" 3 "SNA" ;
+VAL_ 924 MsgNotInPark 0 "MSG_DEFAULT" 1 "MSG_ACTIVE" 3 "SNA" ;
+VAL_ 924 MsgKG1 0 "MSG_DEFAULT" 1 "MSG_ACTIVE" 3 "SNA" ;
+VAL_ 924 FOB_SrchRslt 0 "NO_ACT" 1 "SIP" 2 "COMPLETE" 3 "TIMEOUT" ;
+VAL_ 924 MsgKG2 0 "MSG_DEFAULT" 1 "MSG_ACTIVE" 3 "SNA" ;
+VAL_ 818 A2D_DRV_TEMP_DR_POS 1023 "SNA" ;
+VAL_ 818 Blower_Speed 511 "SNA" ;
+VAL_ 818 Blower_Diagnostics 1023 "SNA" ;
+VAL_ 181 TrqRq_SlowFast 2047 "SNA" ;
+VAL_ 181 EngRPM_Tach 65535 "SNA" ;
+VAL_ 179 TransLosses 1023 "SNA" ;
+VAL_ 774 Tire_RR2 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 774 Tire_RL2 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 774 TirePrssRR2 255 "SNA" ;
+VAL_ 774 TirePrssRL2 255 "SNA" ;
+VAL_ 960 TrqC_Temp 255 "SNA" ;
+VAL_ 302 STFARrAlertPress 255 "SNA" ;
+VAL_ 302 STFAFtAlertPress 255 "SNA" ;
+VAL_ 302 SelectedTPMTrailer_Number 0 "TRAILER_NOT_SELECTED" 1 "TRAILER_1" 2 "TRAILER_2" 3 "TRAILER_3" 4 "TRAILER_4" 7 "SNA" ;
+VAL_ 302 Program_Single_TPM 0 "TIRE_NOT_SELECTED" 1 "TIRE1" 2 "TIRE2" 3 "TIRE3" 4 "TIRE4" 5 "TIRE5" 6 "TIRE6" 7 "TIRE7" 8 "TIRE8" 9 "TIRE9" 10 "TIRE10" 11 "TIRE11" 12 "TIRE12" 15 "SNA" ;
+VAL_ 302 Number_of_Trl_Tires 0 "TRL_TIRE_NOT_SELECTED" 1 "TWO_TIRES" 2 "FOUR_TIRES" 3 "SIX_TIRES" 4 "EIGHT_TIRES" 5 "TWELVE_TIRES" 7 "SNA" ;
+VAL_ 302 Number_of_Trl_Axles 0 "TRL_AXLE_NOT_SELECTED" 1 "ONE_AXLE" 2 "TWO_AXLES" 3 "THREE_AXLES" 7 "SNA" ;
+VAL_ 302 Clear_Trailer_TPM_Settings 0 "TRAILER_NOT_SELECTED" 1 "TRAILER_1" 2 "TRAILER_2" 3 "TRAILER_3" 4 "TRAILER_4" 7 "SNA" ;
+VAL_ 903 ITBM_TrlrStat 0 "NO_TRLR" 1 "TRLR_PRSNT" 2 "TRLR_DCONN" 3 "SNA" ;
+VAL_ 903 ITBM_OP_PWR 255 "SNA" ;
+VAL_ 903 ITBM_GAIN_STAT 31 "SNA" ;
+VAL_ 903 ITBM_DSP_RQ 0 "NO_DISP_RQ" 1 "FLT_TRLR_WIRE" 2 "FLT_ITBM" 3 "FLT_TRLR_DCONN" 4 "GAIN_ADJ" 5 "FLT_CONN" 6 "TLR_NOT_CONN" 7 "MANUAL" 8 "SAFE" 15 "SNA" ;
+VAL_ 903 ITBM_BrkStyle 0 "LT_ELECT" 1 "HV_ELECT" 2 "LT_EOH" 3 "HV_EOH" ;
+VAL_ 903 ITBM_BRK_SW 0 "BRAKE_OFF" 1 "BRAKE_ON" 3 "SNA" ;
+VAL_ 341 SEIU_Sts 0 "SEIU_On" 1 "SEIU_Off" 2 "SPEED_LT2" 3 "PARK" 4 "REL_CLUTCH" 5 "REL_BRAKE" 6 "ECT_HIGH" 7 "EOT_HIGH" 8 "FAULT" 9 "RPM_HIGH" 10 "RPM_MIN" 11 "REL_ACC" 12 "COLD" 13 "MESS1" 15 "SNA" ;
+VAL_ 341 SEIU_RPM 255 "SNA" ;
+VAL_ 341 PTO_Target_Gear 0 "Gear_4" 1 "Gear_5" 2 "Gear_6" 7 "SNA" ;
+VAL_ 341 PTO_Remote_RPM_Method 0 "Set_Speed" 1 "Throttle" 2 "J1939_Command" 3 "SNA" ;
+VAL_ 341 PTO_Ramp_Rate 0 "FIFTY" 1 "SEVENTY_FIVE" 2 "HUNDRED" 3 "ONE_HUNDRED_TWENTY_FIVE" 4 "ONE_HUNDRED_FIFTY" 5 "ONE_HUNDRED_SEVENTY_FIVE" 6 "TWO_HUNDRED" 7 "TWO_HUNDRED_TWENTY_FIVE" 8 "TWO_HUNDRED_FIFTY" 9 "TWO_HUNDRED_SEVENTY_FIVE" 10 "THREE_HUNDRED" 11 "THREE_HUNDRED_TWENTY_FIVE" 12 "THREE_HUNDRED_FIFTY" 13 "THREE_HUNDRED_SEVENTY_FIVE" 14 "FOUR_HUNDRED" 15 "FOUR_HUNDRED_TWENTY_FIVE" 16 "FOUR_HUNDRED_FIFTY" 17 "FOUR_HUNDRED_SEVENTY_FIVE" 18 "FIVE_HUNDRED" 31 "SNA" ;
+VAL_ 341 PTO_High_Idle_RPM 255 "SNA" ;
+VAL_ 341 PTO_Active 0 "OFF" 1 "Blinking" 2 "Solid_ON" 3 "SNA" ;
+VAL_ 564 AM_ECM_Trace 0 "DEFAULT" 2 "AM_ECM_TRACE" 3 "SNA" ;
+VAL_ 664 ASCM_HMI_Stat2 0 "NONE" 1 "BDL_Enbl" 2 "BDL_Complete" 3 "BDL_Unsucc" 15 "SNA" ;
+VAL_ 811 AxlLckrSts 0 "UNLOCKED" 1 "RR_LKD" 2 "FR_RR_LKD" 3 "SNA" ;
+VAL_ 811 AxleLockerEVICDisplay 0 "NONE" 1 "SCREEN_1" 2 "SCREEN_2" 3 "SCREEN_3" 4 "SCREEN_4" 5 "SCREEN_5" 6 "SCREEN_6" 7 "SCREEN_7" 8 "SCREEN_8" 9 "SCREEN_9" 15 "SNA" ;
+VAL_ 811 RrAxleLockerIndRq 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 811 Ft_RrAxleLockerIndRq 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 811 AxleUnlockIndRq 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 811 AXLE_LCKR_SRV_RQ 0 "OFF" 1 "ON" 2 "BLINK" 3 "SNA" ;
+VAL_ 560 EVAP_TEMP 255 "SNA" ;
+VAL_ 560 EvapTempTar 255 "SNA" ;
+VAL_ 560 PTC_Enbl 1 "SNA" ;
+VAL_ 821 TrlTPMSetPress_TTPM 255 "SNA" ;
+VAL_ 821 Trailer_Sensor_Mismatch 0 "TRAILER_NOT_SELECTED" 1 "TRAILER_1" 2 "TRAILER_2" 3 "TRAILER_3" 4 "TRAILER_4" ;
+VAL_ 821 TPMTrailer_Number 0 "TRAILER_NOT_SELECTED" 1 "TRAILER_1" 2 "TRAILER_2" 3 "TRAILER_3" 4 "TRAILER_4" ;
+VAL_ 821 TPMSensor_Programmed 0 "TIRE_NOT_SELECTED" 1 "TIRE1" 2 "TIRE2" 3 "TIRE3" 4 "TIRE4" 5 "TIRE5" 6 "TIRE6" 7 "TIRE7" 8 "TIRE8" 9 "TIRE9" 10 "TIRE10" 11 "TIRE11" 12 "TIRE12" ;
+VAL_ 821 TPMLearnHornChirp 0 "HORN_CHIRP_OFF" 1 "SINGLE_HORN_CHIRP" 2 "MULTIPLE_HORN_CHIRP" ;
+VAL_ 821 Number_of_Trl_Tires_TTPM 0 "TRL_TIRE_NOT_SELECTED" 1 "TWO_TIRES" 2 "FOUR_TIRES" 3 "SIX_TIRES" 4 "EIGHT_TIRES" 5 "TWELVE_TIRES" ;
+VAL_ 821 Number_of_Trl_Axles_TTPM 0 "TRL_AXLE_NOT_SELECTED" 1 "ONE_AXLE" 2 "TWO_AXLES" 3 "THREE_AXLES" ;
+VAL_ 813 TrlTire9_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 813 TrlTire8_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 813 TrlTire7_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 813 TrlTire12_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 813 TrlTire11_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 813 TrlTire10_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 813 TrailerTirePress9 255 "SNA" ;
+VAL_ 813 TrailerTirePress8 255 "SNA" ;
+VAL_ 813 TrailerTirePress7 255 "SNA" ;
+VAL_ 813 TrailerTirePress12 255 "SNA" ;
+VAL_ 813 TrailerTirePress11 255 "SNA" ;
+VAL_ 813 TrailerTirePress10 255 "SNA" ;
+VAL_ 812 TrlTire6_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 812 TrlTire5_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 812 TrlTire4_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 812 TrlTire3_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 812 TrlTire2_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 812 TrlTire1_Stat 0 "NORMAL" 1 "LOW" 2 "HIGH" 3 "SNA" ;
+VAL_ 812 TrailerTirePress6 255 "SNA" ;
+VAL_ 812 TrailerTirePress5 255 "SNA" ;
+VAL_ 812 TrailerTirePress4 255 "SNA" ;
+VAL_ 812 TrailerTirePress3 255 "SNA" ;
+VAL_ 812 TrailerTirePress2 255 "SNA" ;
+VAL_ 812 TrailerTirePress1 255 "SNA" ;
+VAL_ 388 CustKeyInIgn 0 "CUST_KEY_DEFAULT" 1 "CUST_KEY_NOT_IN_IGNITION" 2 "CUST_KEY_IN_IGNITION" 3 "SNA" ;
+VAL_ 388 IgnPos 0 "IGN_LK" 3 "IGN_OFF_ACC" 4 "IGN_RUN" 5 "IGN_START" 7 "SNA" ;
+VAL_ 388 ValImmKey 0 "CUST_IMMOB_KEY_DEFAULT" 1 "CUST_IMMOB_KEY_VALID" 3 "SNA" ;
+VAL_ 1048 NM_Mode 252 "LHOM" 253 "RING" 254 "ALIVE" 255 "SNA" ;
+VAL_ 1048 NM_Successor 255 "SNA" ;
+VAL_ 1048 NM_Ud_Launch 4 "BROADCAST" 63 "SNA" ;
+VAL_ 1048 Nw_Id 0 "POWERTRAIN" 1 "BODY" 2 "AUDIO_TELE" 255 "SNA" ;
+VAL_ 274 CmdIgnStat 0 "IGN_LK" 3 "IGN_OFF_ACC" 4 "IGN_RUN" 5 "IGN_START" 7 "SNA" ;
+VAL_ 274 StTyp 0 "ST_NOT_ACT" 1 "NOR_ST" 2 "TIP_ST" 3 "REM_ST" 7 "SNA" ;
+VAL_ 274 KeyInIgn 0 "KEY_DEF" 1 "KEY_NOT_IN_IGN" 2 "KEY_IN_IGN" 3 "SNA" ;


### PR DESCRIPTION
DBC for 2019 Ram 3500 - output from Cabana

Should contain definitions for all High Speed messages on the 2019+ Diesel RAMs 68RFE and Aisin variants.