### PR TITLE
Fix duplicate signal names inside one message

### DIFF
--- a/generator/toyota/_comma.dbc
+++ b/generator/toyota/_comma.dbc
@@ -5,7 +5,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_ct200h_2018_pt_generated.dbc
+++ b/lexus_ct200h_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_gs300h_2017_pt_generated.dbc
+++ b/lexus_gs300h_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_is_2018_pt_generated.dbc
+++ b/lexus_is_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_nx300_2018_pt_generated.dbc
+++ b/lexus_nx300_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_nx300h_2018_pt_generated.dbc
+++ b/lexus_nx300h_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_rx_350_2016_pt_generated.dbc
+++ b/lexus_rx_350_2016_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/lexus_rx_hybrid_2017_pt_generated.dbc
+++ b/lexus_rx_hybrid_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_avalon_2017_pt_generated.dbc
+++ b/toyota_avalon_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_camry_hybrid_2018_pt_generated.dbc
+++ b/toyota_camry_hybrid_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_corolla_2017_pt_generated.dbc
+++ b/toyota_corolla_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_highlander_2017_pt_generated.dbc
+++ b/toyota_highlander_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_highlander_hybrid_2018_pt_generated.dbc
+++ b/toyota_highlander_hybrid_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_nodsu_hybrid_pt_generated.dbc
+++ b/toyota_nodsu_hybrid_pt_generated.dbc
@@ -26,7 +26,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -26,7 +26,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_prius_2010_pt.dbc
+++ b/toyota_prius_2010_pt.dbc
@@ -98,7 +98,7 @@ BO_ 614 STEERING_IPAS: 8 IPAS
  SG_ STATE : 7|4@0+ (1,0) [0|15] "" XXX
  SG_ ANGLE : 3|12@0- (1,0) [0|16777215] "" XXX
  SG_ SET_ME_X10 : 23|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 

--- a/toyota_prius_2017_pt_generated.dbc
+++ b/toyota_prius_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_rav4_2017_pt_generated.dbc
+++ b/toyota_rav4_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_rav4_hybrid_2017_pt_generated.dbc
+++ b/toyota_rav4_hybrid_2017_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";

--- a/toyota_sienna_xle_2018_pt_generated.dbc
+++ b/toyota_sienna_xle_2018_pt_generated.dbc
@@ -9,7 +9,7 @@ BO_ 359 STEERING_IPAS_COMMA: 8 IPAS
  SG_ SET_ME_X00 : 31|8@0+ (1,0) [0|255] "" XXX
  SG_ DIRECTION_CMD : 38|2@0+ (1,0) [0|3] "" XXX
  SG_ SET_ME_X40 : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ STEERING_IPAS_COMMA: Copy of msg 614 so we can do angle control while the Park Assist ECU is connected (Panda spoofs 614 with 359 on connector J70). Note that addresses 0x266 and 0x167 are checksum-invariant";


### PR DESCRIPTION
Fix duplicate signal names inside one message (_comma.dbc and generated files)