### PR TITLE
hyundai: update LFAHDA_MFC for HDA

### DIFF
--- a/hyundai_kia_generic.dbc
+++ b/hyundai_kia_generic.dbc
@@ -1479,10 +1479,11 @@ BO_ 905 SCC14: 8 SCC
 
 BO_ 1157 LFAHDA_MFC: 4 XXX
  SG_ HDA_USM : 0|2@1+ (1,0) [0|3] "" XXX
- SG_ ACTIVE2 : 4|2@0+ (1,0) [0|3] "" XXX
+ SG_ HDA_C_State : 2|3@1+ (1,0) [0|1] "" XXX
+ SG_ HDA_VSetReq : 8|8@1+ (1,0) [0|255] "km/h" XXX
  SG_ LFA_SysWarning : 16|2@1+ (1,0) [0|3] "" XXX
- SG_ ACTIVE : 25|1@1+ (1,0) [0|3] "" XXX
- SG_ LFA_USM : 28|2@1+ (1,0) [0|3] "" XXX
+ SG_ LFA_Icon_State : 24|2@1+ (1,0) [0|3] "" XXX
+ SG_ LFA_USM : 27|2@1+ (1,0) [0|3] "" XXX
 
 BO_ 913 BCM_PO_11: 8 Vector__XXX
  SG_ BCM_Door_Dri_Status : 5|1@0+ (1,0) [0|1] "" PT_ESC_ABS

--- a/hyundai_kia_generic.dbc
+++ b/hyundai_kia_generic.dbc
@@ -1634,3 +1634,6 @@ BO_ 1042 ICM_412h: 8 ICM
  SG_ PopupMessageOutput_8Level : 55|1@0+ (1,0) [0|1] "" Vector__XXX
 
 VAL_ 909 CF_VSM_Warn 2 "FCW" 3 "AEB";
+VAL_ 1157 LFA_Icon_State 0 "no_wheel" 1 "white_wheel" 2 "green_wheel"
+VAL_ 1157 LFA_SysWarning 0 "no_message" 1 "switching_to_hda" 2 "switching_to_scc" 3 "lfa_error"
+VAL_ 1157 HDA_C_State 0 "hda_not_available" 4 "hda_available" 5 "hda_active"

--- a/hyundai_kia_generic.dbc
+++ b/hyundai_kia_generic.dbc
@@ -1634,6 +1634,6 @@ BO_ 1042 ICM_412h: 8 ICM
  SG_ PopupMessageOutput_8Level : 55|1@0+ (1,0) [0|1] "" Vector__XXX
 
 VAL_ 909 CF_VSM_Warn 2 "FCW" 3 "AEB";
-VAL_ 1157 LFA_Icon_State 0 "no_wheel" 1 "white_wheel" 2 "green_wheel"
-VAL_ 1157 LFA_SysWarning 0 "no_message" 1 "switching_to_hda" 2 "switching_to_scc" 3 "lfa_error"
-VAL_ 1157 HDA_C_State 0 "hda_not_available" 4 "hda_available" 5 "hda_active"
+VAL_ 1157 LFA_Icon_State 0 "no_wheel" 1 "white_wheel" 2 "green_wheel";
+VAL_ 1157 LFA_SysWarning 0 "no_message" 1 "switching_to_hda" 2 "switching_to_scc" 3 "lfa_error";
+VAL_ 1157 HDA_C_State 0 "hda_not_available" 4 "hda_available" 5 "hda_active";


### PR DESCRIPTION
first step for controlling ACC speed using `HDA_VSetReq` signal

some of the modified signals are currently used by openpilot