### PR TITLE
update_string: use cached buffer

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -43,6 +43,7 @@ public:
 class CANParser {
 private:
   const int bus;
+  kj::Array<capnp::word> aligned_buf;
 
   const DBC *dbc = NULL;
   std::unordered_map<uint32_t, MessageState> message_states;


### PR DESCRIPTION
CanParser doesn't seem to be used in multiple threads.added a cached buffer to avoid memory allocation