### PR TITLE
GM steering rate scale & limits fix

### DIFF
--- a/cadillac_ct6_powertrain.dbc
+++ b/cadillac_ct6_powertrain.dbc
@@ -137,8 +137,8 @@ BO_ 481 ASCMSteeringButton: 7 K124_ASCM
  SG_ ACCButtons : 46|3@0+ (1,0) [0|0] ""  NEO
 
 BO_ 485 PSCMSteeringAngle: 8 K43_PSCM
- SG_ SteeringWheelAngle : 15|16@0- (0.0625,0) [-540|540] "deg"  NEO
- SG_ SteeringWheelRate : 27|12@0- (0.5,0) [-100|100] "deg/s"  NEO
+ SG_ SteeringWheelAngle : 15|16@0- (0.0625,0) [-2047|2047] "deg"  NEO
+ SG_ SteeringWheelRate : 27|12@0- (1,0) [-2047|2047] "deg/s"  NEO
 
 BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate : 51|12@0- (0.0625,0) [-2047|2047] "grad/s"  NEO

--- a/gm_global_a_powertrain.dbc
+++ b/gm_global_a_powertrain.dbc
@@ -133,8 +133,8 @@ BO_ 481 ASCMSteeringButton: 7 K124_ASCM
  SG_ DriveModeButton : 39|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 485 PSCMSteeringAngle: 8 K43_PSCM
- SG_ SteeringWheelAngle : 15|16@0- (0.0625,0) [-540|540] "deg"  NEO
- SG_ SteeringWheelRate : 27|12@0- (0.5,0) [-100|100] "deg/s"  NEO
+ SG_ SteeringWheelAngle : 15|16@0- (0.0625,0) [-2047|2047] "deg"  NEO
+ SG_ SteeringWheelRate : 27|12@0- (1,0) [-2047|2047] "deg/s"  NEO
 
 BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ BrakePedalPressed : 6|1@0+ (1,0) [0|0] "" NEO


### PR DESCRIPTION
Very useful for INDI, and related to https://github.com/commaai/openpilot/issues/20232 

Tasks complete:

- ~~spin wheel to stops at 90deg/sec~~ Good: rate matches intended & measured angle over time.
- ~~try to decode last byte, probably checksum~~ Not able now.
- ~~merge / generate GM and Cadillac~~ Not now.

![90deg-steps](https://user-images.githubusercontent.com/42746943/110829534-1452de80-824d-11eb-84de-053f3997a1ad.png)
![rapid-steer](https://user-images.githubusercontent.com/42746943/110829549-17e66580-824d-11eb-8c31-fdf98e56929b.png)
