### PR TITLE
Subaru Global Dash state and LKAS messages

### DIFF
--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -166,32 +166,36 @@ BO_ 940 BodyInfo: 8 XXX
  SG_ DOOR_OPEN_RL : 34|1@1+ (1,0) [0|1] "" XXX
  SG_ DOOR_OPEN_RR : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ DOOR_OPEN_TRUNK : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ DASH_BTN_LIGHTS : 56|1@0+ (1,0) [0|1] "" XXX
- SG_ Lowbeam : 57|1@1+ (1,0) [0|1] "" XXX
- SG_ Highbeam : 58|1@1+ (1,0) [0|1] "" XXX
- SG_ FOG_LIGHTS2 : 60|1@1+ (1,0) [0|1] "" XXX
- SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
  SG_ BRAKE : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ DASH_BTN_LIGHTS : 56|1@0+ (1,0) [0|1] "" XXX
+ SG_ LOWBEAM : 57|1@1+ (1,0) [0|1] "" XXX
+ SG_ HIGHBEAM : 58|1@1+ (1,0) [0|1] "" XXX
+ SG_ FOG_LIGHTS : 60|1@1+ (1,0) [0|1] "" XXX
+ SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 801 ES_DashStatus: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ PCB_Off : 12|1@1+ (1,0) [0|1] "" XXX
  SG_ LDW_Off : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|10@1+ (1,0) [0|1023] "" XXX
+ SG_ Signal1 : 14|2@1+ (1,0) [0|3] "" XXX
+ SG_ Cruise_State_Msg : 16|4@1+ (1,0) [0|15] "" XXX
+ SG_ LKAS_State_Msg : 20|3@1+ (1,0) [0|7] "" XXX
+ SG_ Signal2 : 23|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Soft_Disable : 24|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 25|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Status_Msg : 25|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal3 : 27|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Distance : 28|3@1+ (1,0) [0|7] "" XXX
- SG_ Signal3 : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 33|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal5 : 33|2@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ Signal6 : 37|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_On : 49|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal6 : 50|1@1+ (1,0) [0|1] "" XXX
+ SG_ Display_Own_Car : 50|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
@@ -205,18 +209,17 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ Empty_Box : 13|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 14|3@1+ (1,0) [0|7] "" XXX
  SG_ LKAS_ACTIVE : 17|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 18|5@1+ (1,0) [0|31] "" XXX
+ SG_ LKAS_Dash_State : 18|2@1+ (1,0) [0|2] "" XXX
+ SG_ Signal2 : 20|3@1+ (1,0) [0|7] "" XXX
  SG_ Backward_Speed_Limit_Menu : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_ENABLE_3 : 24|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Enable : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Left_Line_Light_Blink : 25|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_ENABLE_2 : 26|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Right_Line_Enable : 26|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Right_Line_Light_Blink : 27|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Left_Line_Visible : 28|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Left_Line_Green : 29|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Right_Line_Visible : 30|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Right_Line_Green : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Alert : 32|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal3 : 36|28@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Visible : 28|2@1+ (1,0) [0|3] "" XXX
+ SG_ LKAS_Right_Line_Visible : 30|2@1+ (1,0) [0|3] "" XXX
+ SG_ LKAS_Alert : 32|5@1+ (1,0) [0|31] "" XXX
+ SG_ Signal3 : 37|27@1+ (1,0) [0|1] "" XXX
 
 BO_ 722 AC_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -236,8 +239,14 @@ CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
+CM_ SG_ 801 LKAS_State_Msg "1 = LKAS_Off_Sharp_Curve, 2 = Keep_Hands_On_Steering_wheel_disabled, 3 = LKAS_Off, 4 = LKAS_Off_Too_Slow, 5 = LKAS_Off_Too_Fast";
+CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3 = Cruise_lvl2_comfort, 4 = Cruise_off_empty_reason, 5 = Cruise_off, 6 = Cruise_Unable_to_set, 7 = Cruise_Unable_to_set_brakes_applied, 8 = Eyesight_not_ready, 9 = Cruise_lvl3_standard, 10 = Cruise_lvl4_dynamic, 11 = Cruise_Unable_to_set_steep_slope";
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
-CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
+CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
+CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
+CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
+CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
+CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";

--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -205,9 +205,8 @@ BO_ 801 ES_DashStatus: 8 XXX
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Keep_Hands_On_Wheel : 12|1@1+ (1,0) [0|1] "" XXX
- SG_ Empty_Box : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|3@1+ (1,0) [0|7] "" XXX
+ SG_ LKAS_Alert_Msg : 12|3@1+ (1,0) [0|7] "" XXX
+ SG_ Signal1 : 15|2@1+ (1,0) [0|3] "" XXX
  SG_ LKAS_ACTIVE : 17|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Dash_State : 18|2@1+ (1,0) [0|2] "" XXX
  SG_ Signal2 : 20|3@1+ (1,0) [0|7] "" XXX
@@ -244,6 +243,7 @@ CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
 CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
+CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Off";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
 CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -170,32 +170,36 @@ BO_ 940 BodyInfo: 8 XXX
  SG_ DOOR_OPEN_RL : 34|1@1+ (1,0) [0|1] "" XXX
  SG_ DOOR_OPEN_RR : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ DOOR_OPEN_TRUNK : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ DASH_BTN_LIGHTS : 56|1@0+ (1,0) [0|1] "" XXX
- SG_ Lowbeam : 57|1@1+ (1,0) [0|1] "" XXX
- SG_ Highbeam : 58|1@1+ (1,0) [0|1] "" XXX
- SG_ FOG_LIGHTS2 : 60|1@1+ (1,0) [0|1] "" XXX
- SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
  SG_ BRAKE : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ DASH_BTN_LIGHTS : 56|1@0+ (1,0) [0|1] "" XXX
+ SG_ LOWBEAM : 57|1@1+ (1,0) [0|1] "" XXX
+ SG_ HIGHBEAM : 58|1@1+ (1,0) [0|1] "" XXX
+ SG_ FOG_LIGHTS : 60|1@1+ (1,0) [0|1] "" XXX
+ SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 801 ES_DashStatus: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ PCB_Off : 12|1@1+ (1,0) [0|1] "" XXX
  SG_ LDW_Off : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|10@1+ (1,0) [0|1023] "" XXX
+ SG_ Signal1 : 14|2@1+ (1,0) [0|3] "" XXX
+ SG_ Cruise_State_Msg : 16|4@1+ (1,0) [0|15] "" XXX
+ SG_ LKAS_State_Msg : 20|3@1+ (1,0) [0|7] "" XXX
+ SG_ Signal2 : 23|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Soft_Disable : 24|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 25|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Status_Msg : 25|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal3 : 27|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Distance : 28|3@1+ (1,0) [0|7] "" XXX
- SG_ Signal3 : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 33|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal5 : 33|2@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ Signal6 : 37|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_On : 49|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal6 : 50|1@1+ (1,0) [0|1] "" XXX
+ SG_ Display_Own_Car : 50|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
@@ -209,18 +213,17 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ Empty_Box : 13|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 14|3@1+ (1,0) [0|7] "" XXX
  SG_ LKAS_ACTIVE : 17|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 18|5@1+ (1,0) [0|31] "" XXX
+ SG_ LKAS_Dash_State : 18|2@1+ (1,0) [0|2] "" XXX
+ SG_ Signal2 : 20|3@1+ (1,0) [0|7] "" XXX
  SG_ Backward_Speed_Limit_Menu : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_ENABLE_3 : 24|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Enable : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Left_Line_Light_Blink : 25|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_ENABLE_2 : 26|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Right_Line_Enable : 26|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Right_Line_Light_Blink : 27|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Left_Line_Visible : 28|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Left_Line_Green : 29|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Right_Line_Visible : 30|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Right_Line_Green : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Alert : 32|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal3 : 36|28@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Visible : 28|2@1+ (1,0) [0|3] "" XXX
+ SG_ LKAS_Right_Line_Visible : 30|2@1+ (1,0) [0|3] "" XXX
+ SG_ LKAS_Alert : 32|5@1+ (1,0) [0|31] "" XXX
+ SG_ Signal3 : 37|27@1+ (1,0) [0|1] "" XXX
 
 BO_ 722 AC_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -240,11 +243,17 @@ CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
+CM_ SG_ 801 LKAS_State_Msg "1 = LKAS_Off_Sharp_Curve, 2 = Keep_Hands_On_Steering_wheel_disabled, 3 = LKAS_Off, 4 = LKAS_Off_Too_Slow, 5 = LKAS_Off_Too_Fast";
+CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3 = Cruise_lvl2_comfort, 4 = Cruise_off_empty_reason, 5 = Cruise_off, 6 = Cruise_Unable_to_set, 7 = Cruise_Unable_to_set_brakes_applied, 8 = Eyesight_not_ready, 9 = Cruise_lvl3_standard, 10 = Cruise_lvl4_dynamic, 11 = Cruise_Unable_to_set_steep_slope";
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
-CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
+CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
+CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
+CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
+CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
+CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 
 CM_ "subaru_global_2017.dbc starts here";
 

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -247,7 +247,7 @@ CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
 CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
-CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Now";
+CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Off";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
 CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -209,9 +209,8 @@ BO_ 801 ES_DashStatus: 8 XXX
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Keep_Hands_On_Wheel : 12|1@1+ (1,0) [0|1] "" XXX
- SG_ Empty_Box : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|3@1+ (1,0) [0|7] "" XXX
+ SG_ LKAS_Alert_Msg : 12|3@1+ (1,0) [0|7] "" XXX
+ SG_ Signal1 : 15|2@1+ (1,0) [0|3] "" XXX
  SG_ LKAS_ACTIVE : 17|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Dash_State : 18|2@1+ (1,0) [0|2] "" XXX
  SG_ Signal2 : 20|3@1+ (1,0) [0|7] "" XXX
@@ -248,6 +247,7 @@ CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
 CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
+CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Now";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
 CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -247,7 +247,7 @@ CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
 CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
-CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Now";
+CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Off";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
 CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -209,9 +209,8 @@ BO_ 801 ES_DashStatus: 8 XXX
 BO_ 802 ES_LKAS_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Keep_Hands_On_Wheel : 12|1@1+ (1,0) [0|1] "" XXX
- SG_ Empty_Box : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|3@1+ (1,0) [0|7] "" XXX
+ SG_ LKAS_Alert_Msg : 12|3@1+ (1,0) [0|7] "" XXX
+ SG_ Signal1 : 15|2@1+ (1,0) [0|3] "" XXX
  SG_ LKAS_ACTIVE : 17|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Dash_State : 18|2@1+ (1,0) [0|2] "" XXX
  SG_ Signal2 : 20|3@1+ (1,0) [0|7] "" XXX
@@ -248,6 +247,7 @@ CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
 CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
+CM_ SG_ 802 LKAS_Alert_Msg "1 = Keep_Hands_On_Wheel, 6 = Pre_Collision_Braking, 7 = Keep_Hands_On_Wheel_Now";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
 CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -170,32 +170,36 @@ BO_ 940 BodyInfo: 8 XXX
  SG_ DOOR_OPEN_RL : 34|1@1+ (1,0) [0|1] "" XXX
  SG_ DOOR_OPEN_RR : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ DOOR_OPEN_TRUNK : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ DASH_BTN_LIGHTS : 56|1@0+ (1,0) [0|1] "" XXX
- SG_ Lowbeam : 57|1@1+ (1,0) [0|1] "" XXX
- SG_ Highbeam : 58|1@1+ (1,0) [0|1] "" XXX
- SG_ FOG_LIGHTS2 : 60|1@1+ (1,0) [0|1] "" XXX
- SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
  SG_ BRAKE : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ DASH_BTN_LIGHTS : 56|1@0+ (1,0) [0|1] "" XXX
+ SG_ LOWBEAM : 57|1@1+ (1,0) [0|1] "" XXX
+ SG_ HIGHBEAM : 58|1@1+ (1,0) [0|1] "" XXX
+ SG_ FOG_LIGHTS : 60|1@1+ (1,0) [0|1] "" XXX
+ SG_ WIPERS : 62|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 801 ES_DashStatus: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ PCB_Off : 12|1@1+ (1,0) [0|1] "" XXX
  SG_ LDW_Off : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal1 : 14|10@1+ (1,0) [0|1023] "" XXX
+ SG_ Signal1 : 14|2@1+ (1,0) [0|3] "" XXX
+ SG_ Cruise_State_Msg : 16|4@1+ (1,0) [0|15] "" XXX
+ SG_ LKAS_State_Msg : 20|3@1+ (1,0) [0|7] "" XXX
+ SG_ Signal2 : 23|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Soft_Disable : 24|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 25|3@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Status_Msg : 25|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal3 : 27|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Distance : 28|3@1+ (1,0) [0|7] "" XXX
- SG_ Signal3 : 31|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal4 : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Conventional_Cruise : 32|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal4 : 33|2@1+ (1,0) [0|3] "" XXX
+ SG_ Signal5 : 33|2@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_Disengaged : 35|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Activated : 36|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal5 : 37|3@1+ (1,0) [0|1] "" XXX
+ SG_ Signal6 : 37|3@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 40|8@1+ (1,0) [0|255] "" XXX
  SG_ Cruise_Fault : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_On : 49|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal6 : 50|1@1+ (1,0) [0|1] "" XXX
+ SG_ Display_Own_Car : 50|1@1+ (1,0) [0|1] "" XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
@@ -209,18 +213,17 @@ BO_ 802 ES_LKAS_State: 8 XXX
  SG_ Empty_Box : 13|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal1 : 14|3@1+ (1,0) [0|7] "" XXX
  SG_ LKAS_ACTIVE : 17|1@1+ (1,0) [0|1] "" XXX
- SG_ Signal2 : 18|5@1+ (1,0) [0|31] "" XXX
+ SG_ LKAS_Dash_State : 18|2@1+ (1,0) [0|2] "" XXX
+ SG_ Signal2 : 20|3@1+ (1,0) [0|7] "" XXX
  SG_ Backward_Speed_Limit_Menu : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_ENABLE_3 : 24|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Enable : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Left_Line_Light_Blink : 25|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_ENABLE_2 : 26|1@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Right_Line_Enable : 26|1@1+ (1,0) [0|1] "" XXX
  SG_ LKAS_Right_Line_Light_Blink : 27|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Left_Line_Visible : 28|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Left_Line_Green : 29|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Right_Line_Visible : 30|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Right_Line_Green : 31|1@1+ (1,0) [0|1] "" XXX
- SG_ LKAS_Alert : 32|4@1+ (1,0) [0|15] "" XXX
- SG_ Signal3 : 36|28@1+ (1,0) [0|1] "" XXX
+ SG_ LKAS_Left_Line_Visible : 28|2@1+ (1,0) [0|3] "" XXX
+ SG_ LKAS_Right_Line_Visible : 30|2@1+ (1,0) [0|3] "" XXX
+ SG_ LKAS_Alert : 32|5@1+ (1,0) [0|31] "" XXX
+ SG_ Signal3 : 37|27@1+ (1,0) [0|1] "" XXX
 
 BO_ 722 AC_State: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -240,11 +243,17 @@ CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
+CM_ SG_ 801 LKAS_State_Msg "1 = LKAS_Off_Sharp_Curve, 2 = Keep_Hands_On_Steering_wheel_disabled, 3 = LKAS_Off, 4 = LKAS_Off_Too_Slow, 5 = LKAS_Off_Too_Fast";
+CM_ SG_ 801 Cruise_State_Msg "1 = Cruise_Off_Steep_Slope, 2 = Cruise_lvl1_eco, 3 = Cruise_lvl2_comfort, 4 = Cruise_off_empty_reason, 5 = Cruise_off, 6 = Cruise_Unable_to_set, 7 = Cruise_Unable_to_set_brakes_applied, 8 = Eyesight_not_ready, 9 = Cruise_lvl3_standard, 10 = Cruise_lvl4_dynamic, 11 = Cruise_Unable_to_set_steep_slope";
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
-CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 801 Cruise_Status_Msg "1 = Disabled_Bad_Visibility, 2 = Disabled_Check_Manual";
+CM_ SG_ 802 LKAS_ACTIVE "Turns on the full LKAS dash display";
+CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 5 = Pre_Collision_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert, 18 = Keep_Hands_On_Steering_Alert, 24 = Audio_Beep, 25 = Audio_Lead_Car_Change, 26 = Audio_ACC_Disengaged, 27 = Audio_LKAS_disabled, 28 = Audio_Ding_Ding, 30 = Audio_Repeated_Beep";
+CM_ SG_ 802 LKAS_Left_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
+CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
+CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
 
 CM_ "subaru_global_2020_hybrid.dbc starts here";
 


### PR DESCRIPTION
This PR adds and fixes signals in Subaru Global ES_DashStatus and ES_LKAS_State messages, mainly so we can filter out some confusing stock ACC and LKAS dash notification messages while openpilot is active. I will open related openpilot and panda PR-s soon