### PR TITLE
Subaru ACC speed units signals update

### DIFF
--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -152,6 +152,7 @@ BO_ 552 BSD_RCTA: 8 XXX
 BO_ 912 Dashlights: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ UNITS : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ ICY_ROAD : 32|2@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|1] "" XXX
@@ -237,7 +238,6 @@ CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
-CM_ SG_ 1677 Units "AU/EU: 1 = imperial, 3 = metric US: 3 = imperial, 4 = metric";

--- a/generator/subaru/_subaru_preglobal_2015.dbc
+++ b/generator/subaru/_subaru_preglobal_2015.dbc
@@ -214,7 +214,7 @@ BO_ 864 Engine_Temp: 8 XXX
 BO_ 866 Fuel: 8 XXX
 
 BO_ 977 Dash_State2: 8 XXX
-  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ UNITS : 15|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 1745 Dash_State: 8 XXX
  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
@@ -239,6 +239,6 @@ CM_ SG_ 604 L_RCTA "Rear cross traffic alert, only when in R gear";
 CM_ SG_ 642 Counter "Affected by signals";
 CM_ SG_ 642 SEATBELT_FL "Driver seatbelt";
 CM_ SG_ 880 Steering_Voltage_Flat "receives later than 371";
+CM_ SG_ 977 UNITS "0 = Metric, 1 = Imperial";
 
 VAL_ 328 Gear 0 "N" 1 "D" 2 "D" 3 "D" 4 "D" 5 "D" 6 "D" 14 "R" 15 "P";
-VAL_ 1745 Units 0 "Metric" 1 "Imperial";

--- a/subaru_forester_2017_generated.dbc
+++ b/subaru_forester_2017_generated.dbc
@@ -218,7 +218,7 @@ BO_ 864 Engine_Temp: 8 XXX
 BO_ 866 Fuel: 8 XXX
 
 BO_ 977 Dash_State2: 8 XXX
-  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ UNITS : 15|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 1745 Dash_State: 8 XXX
  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
@@ -243,9 +243,9 @@ CM_ SG_ 604 L_RCTA "Rear cross traffic alert, only when in R gear";
 CM_ SG_ 642 Counter "Affected by signals";
 CM_ SG_ 642 SEATBELT_FL "Driver seatbelt";
 CM_ SG_ 880 Steering_Voltage_Flat "receives later than 371";
+CM_ SG_ 977 UNITS "0 = Metric, 1 = Imperial";
 
 VAL_ 328 Gear 0 "N" 1 "D" 2 "D" 3 "D" 4 "D" 5 "D" 6 "D" 14 "R" 15 "P";
-VAL_ 1745 Units 0 "Metric" 1 "Imperial";
 
 CM_ "subaru_forester_2017.dbc starts here";
 

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -156,6 +156,7 @@ BO_ 552 BSD_RCTA: 8 XXX
 BO_ 912 Dashlights: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ UNITS : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ ICY_ROAD : 32|2@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|1] "" XXX
@@ -241,10 +242,9 @@ CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
-CM_ SG_ 1677 Units "AU/EU: 1 = imperial, 3 = metric US: 3 = imperial, 4 = metric";
 
 CM_ "subaru_global_2017.dbc starts here";
 

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -156,6 +156,7 @@ BO_ 552 BSD_RCTA: 8 XXX
 BO_ 912 Dashlights: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ UNITS : 24|1@1+ (1,0) [0|1] "" XXX
  SG_ ICY_ROAD : 32|2@1+ (1,0) [0|3] "" XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|1] "" XXX
@@ -241,10 +242,9 @@ CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
 CM_ SG_ 801 Far_Distance "1=0-5m, 2=5-10m, 3=10-15m, 4=15-20m, 5=20-25m, 6=25-30m, 7=30-35m, 8=35-40m, 9=40-45m, 10=45-50m, 11=50-55m, 12=55-60m, 13=60-65m, 14=65-70m, 15=75m+";
 CM_ SG_ 801 Cruise_Soft_Disable "Eyesight soft disable (eg direct sunlight)";
 CM_ SG_ 802 LKAS_Alert "1 = FCW_Cont_Beep, 2 = FCW_Repeated_Beep, 3 = Throttle_Management_Activated_Warning, 4 = Throttle_Management_Activated_Alert, 8 = Traffic_Light_Ahead, 9 = Apply_Brake_to_Hold Position, 11 = LDW_Right, 12 = LDW_Left, 13 = Stay_Alert, 14 = Lead_Vehicle_Start_Alert";
+CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-CM_ SG_ 940 Highbeam "01 = low beam, 11 = high beam";
 CM_ SG_ 940 FOG_LIGHTS2 "yellow fog light in the dash";
-CM_ SG_ 1677 Units "AU/EU: 1 = imperial, 3 = metric US: 3 = imperial, 4 = metric";
 
 CM_ "subaru_global_2020_hybrid.dbc starts here";
 

--- a/subaru_outback_2015_generated.dbc
+++ b/subaru_outback_2015_generated.dbc
@@ -218,7 +218,7 @@ BO_ 864 Engine_Temp: 8 XXX
 BO_ 866 Fuel: 8 XXX
 
 BO_ 977 Dash_State2: 8 XXX
-  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ UNITS : 15|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 1745 Dash_State: 8 XXX
  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
@@ -243,9 +243,9 @@ CM_ SG_ 604 L_RCTA "Rear cross traffic alert, only when in R gear";
 CM_ SG_ 642 Counter "Affected by signals";
 CM_ SG_ 642 SEATBELT_FL "Driver seatbelt";
 CM_ SG_ 880 Steering_Voltage_Flat "receives later than 371";
+CM_ SG_ 977 UNITS "0 = Metric, 1 = Imperial";
 
 VAL_ 328 Gear 0 "N" 1 "D" 2 "D" 3 "D" 4 "D" 5 "D" 6 "D" 14 "R" 15 "P";
-VAL_ 1745 Units 0 "Metric" 1 "Imperial";
 
 CM_ "subaru_outback_2015.dbc starts here";
 

--- a/subaru_outback_2019_generated.dbc
+++ b/subaru_outback_2019_generated.dbc
@@ -218,7 +218,7 @@ BO_ 864 Engine_Temp: 8 XXX
 BO_ 866 Fuel: 8 XXX
 
 BO_ 977 Dash_State2: 8 XXX
-  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ UNITS : 15|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 1745 Dash_State: 8 XXX
  SG_ Units : 15|1@1+ (1,0) [0|1] "" XXX
@@ -243,9 +243,9 @@ CM_ SG_ 604 L_RCTA "Rear cross traffic alert, only when in R gear";
 CM_ SG_ 642 Counter "Affected by signals";
 CM_ SG_ 642 SEATBELT_FL "Driver seatbelt";
 CM_ SG_ 880 Steering_Voltage_Flat "receives later than 371";
+CM_ SG_ 977 UNITS "0 = Metric, 1 = Imperial";
 
 VAL_ 328 Gear 0 "N" 1 "D" 2 "D" 3 "D" 4 "D" 5 "D" 6 "D" 14 "R" 15 "P";
-VAL_ 1745 Units 0 "Metric" 1 "Imperial";
 
 CM_ "subaru_outback_2019.dbc starts here";
 


### PR DESCRIPTION
This PR adds new Dashlights UNITS signal for Subaru Global models and changes Preglobal Dash_State2 UNITS signal. Both have been in use in subaru-community branch since beginning of July and they have been working reliably for all supported models.