### PR TITLE
Add PQ Braking and ACC led control CAN messages

### DIFF
--- a/vw_golf_mk4.dbc
+++ b/vw_golf_mk4.dbc
@@ -1139,7 +1139,7 @@ BO_ 210 HCA_1: 5 XXX
  SG_ Vib_Freq : 32|4@1+ (4,0) [0|60] "Hz" XXX
  SG_ Vib_Amp : 36|4@1+ (0.5,0) [0|7.5] "Nm" XXX
  
-BO_ 644 mMotor_Bremse: 6 Motor_Diesel
+BO_ 644 Motor_Bremse: 6 XXX
  SG_ MOB_Standby : 12|1@1+ (1,0) [0|1] "" Bremse_MK25AESP
  SG_ MOB_Freigabe : 14|1@1+ (1,0) [0|1] "" BCM_Gateway,Bremse_MK25AESP,Gateway_separat
  SG_ MOB_Anhaltewunsch : 13|1@1+ (1,0) [0|1] "" Bremse_MK25AESP,Getriebe_DQ

--- a/vw_golf_mk4.dbc
+++ b/vw_golf_mk4.dbc
@@ -1138,6 +1138,39 @@ BO_ 210 HCA_1: 5 XXX
  SG_ LM_OffSign : 31|1@1+ (1,0) [0|1] "" XXX
  SG_ Vib_Freq : 32|4@1+ (4,0) [0|60] "Hz" XXX
  SG_ Vib_Amp : 36|4@1+ (0.5,0) [0|7.5] "Nm" XXX
+ 
+BO_ 644 mMotor_Bremse: 6 Motor_Diesel
+ SG_ MOB_Standby : 12|1@1+ (1,0) [0|1] "" Bremse_MK25AESP
+ SG_ MOB_Freigabe : 14|1@1+ (1,0) [0|1] "" BCM_Gateway,Bremse_MK25AESP,Gateway_separat
+ SG_ MOB_Anhaltewunsch : 13|1@1+ (1,0) [0|1] "" Bremse_MK25AESP,Getriebe_DQ
+ SG_ MOB_CHECKSUM : 0|8@1+ (1,0) [0|255] "" Bremse_MK25AESP
+ SG_ MOB_COUNTER : 8|4@1+ (1,0) [0|15] "" Bremse_MK25AESP
+ SG_ TSK_v_Begrenzung_aktiv : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ TSK_ax_Getriebe_01 : 40|8@1+ (0.048,0) [0|255] "m/s2" XXX
+ SG_ MOB_Bremsstgr : 16|11@1+ (0.76,0) [0|100] "Unit_PerCent" Vector__XXX
+ SG_ MOB_Bremsmom : 27|13@1+ (1,0) [0|8190] "Unit_NewtoMeter" Bremse_MK25AESP
+
+BO_ 870 mAWV: 5 ACC
+ SG_ AWV_2_Gurtstraffer : 39|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_Infoton : 38|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster
+ SG_ AWV_2_Warnsymbol : 37|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster
+ SG_ AWV_2_Warnton : 36|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster
+ SG_ AWV_2_Ruckprofil : 33|3@1+ (1,0) [0|7] ""  Bremsbooster
+ SG_ AWV_2_Freigabe : 32|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_2_Umfeldwarn : 31|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_2_SU_Lampe : 30|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_2_SU_Gong : 29|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_2_SU_Bremsruck : 28|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_2_SU_Warnzeit : 26|2@1+ (1,0) [0|3] ""  Bremsbooster
+ SG_ AWV_2_Fehler : 25|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster
+ SG_ AWV_2_Status : 24|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster
+ SG_ AWV_res_20 : 20|4@1+ (1,0) [0|0] ""  Bremsbooster
+ SG_ AWV_1_Parameter : 18|2@1+ (1,0) [0|3] ""  Bremsbooster
+ SG_ AWV_1_Prefill : 17|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_1_Freigabe : 16|1@1+ (1,0) [0|1] ""  Bremsbooster
+ SG_ AWV_Text : 12|4@1+ (1,0) [0|15] ""  Gateway_Kbi_VW_A,Bremsbooster
+ SG_ AWV_Zaehler : 8|4@1+ (1,0) [0|15] ""  Bremsbooster
+ SG_ AWV_Checksumme : 0|8@1+ (1,0) [0|255] ""  Bremsbooster
 
 BO_ 1470 LDW_1: 8 XXX
  SG_ Right_Lane_Status : 0|2@1+ (1,0) [0|3] "" XXX

--- a/vw_golf_mk4.dbc
+++ b/vw_golf_mk4.dbc
@@ -1140,7 +1140,7 @@ BO_ 210 HCA_1: 5 XXX
  SG_ Vib_Amp : 36|4@1+ (0.5,0) [0|7.5] "Nm" XXX
  
 BO_ 644 Motor_Bremse: 6 XXX
- SG_ MOB_Standby : 12|1@1+ (1,0) [0|1] "" Bremse_MK25AESP
+ SG_ MOB_Standby : 12|1@1+ (1,0) [0|1] ""  XXX
  SG_ MOB_Freigabe : 14|1@1+ (1,0) [0|1] "" BCM_Gateway,Bremse_MK25AESP,Gateway_separat
  SG_ MOB_Anhaltewunsch : 13|1@1+ (1,0) [0|1] "" Bremse_MK25AESP,Getriebe_DQ
  SG_ MOB_CHECKSUM : 0|8@1+ (1,0) [0|255] "" Bremse_MK25AESP

--- a/vw_golf_mk4.dbc
+++ b/vw_golf_mk4.dbc
@@ -1150,7 +1150,7 @@ BO_ 644 Motor_Bremse: 6 XXX
  SG_ MOB_Bremsstgr : 16|11@1+ (0.76,0) [0|100] "Unit_PerCent" Vector__XXX
  SG_ MOB_Bremsmom : 27|13@1+ (1,0) [0|8190] "Unit_NewtoMeter" Bremse_MK25AESP
 
-BO_ 870 mAWV: 5 ACC
+BO_ 870 AWV: 5 XXX
  SG_ AWV_2_Gurtstraffer : 39|1@1+ (1,0) [0|1] ""  Bremsbooster
  SG_ AWV_Infoton : 38|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster
  SG_ AWV_2_Warnsymbol : 37|1@1+ (1,0) [0|1] ""  Gateway_Kbi_VW_A,Bremsbooster


### PR DESCRIPTION
mMotor_Bremse used to control braking on cars that don't support ACC.
mAWV used to control ACC led in dashboard.