### PR TITLE
Bugfix in dbc CAN encoder

### DIFF
--- a/can/dbc.py
+++ b/can/dbc.py
@@ -148,7 +148,7 @@ class dbc():
       ival = dd.get(s.name)
       if ival is not None:
 
-        ival = (ival / s.factor) - s.offset
+        ival = (ival - s.offset) / s.factor
         ival = int(round(ival))
 
         if s.is_signed and ival < 0:


### PR DESCRIPTION
While encoding, we need to subtract the offset first before we apply the factor.