### PR TITLE
GM: use steer command units for driver, eps torque

### DIFF
--- a/gm_global_a_powertrain.dbc
+++ b/gm_global_a_powertrain.dbc
@@ -117,9 +117,9 @@ BO_ 388 PSCMStatus: 8 K43_PSCM
  SG_ HandsOffSWDetectionMode : 20|2@0+ (1,0) [0|3] "" NEO
  SG_ HandsOffSWlDetectionStatus : 21|1@0+ (1,0) [0|1] "" NEO
  SG_ LKATorqueDeliveredStatus : 5|3@0+ (1,0) [0|7] "" NEO
- SG_ LKADriverAppldTrq : 50|11@0- (0.01,0) [-10.24|10.23] "Nm" NEO
- SG_ LKATorqueDelivered : 18|11@0- (0.01,0) [0|1] "" NEO
- SG_ LKATotalTorqueDelivered : 2|11@0- (0.01,0) [-10.24|10.23] "Nm" NEO
+ SG_ LKADriverAppldTrq : 50|11@0- (1,0) [0|0] "" NEO
+ SG_ LKATorqueDelivered : 18|11@0- (1,0) [0|0] "" NEO
+ SG_ LKATotalTorqueDelivered : 2|11@0- (1,0) [0|0] "" NEO
 
 BO_ 417 AcceleratorPedal: 7 XXX
  SG_ AcceleratorPedal : 55|8@0+ (1,0) [0|0] ""  NEO


### PR DESCRIPTION
These aren't Newton-meters, and it makes life easier to stick to the same unit for now: steer command units, 0-300.

openpilot PR: https://github.com/commaai/openpilot/pull/22776