### PR TITLE
Subaru signals update

### DIFF
--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -115,6 +115,11 @@ BO_ 313 Brake_Pedal: 8 XXX
  SG_ Brake_Pedal : 36|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal4 : 48|16@1+ (1,0) [0|65535] "" XXX
 
+BO_ 372 Engine_Stop_Start: 8 XXX
+  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+  SG_ STOP_START_STATE : 39|2@0+ (1,0) [0|3] "" XXX
+
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
@@ -157,6 +162,7 @@ BO_ 912 Dashlights: 8 XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|1] "" XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
+ SG_ STOP_START : 54|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 940 BodyInfo: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/generator/subaru/_subaru_preglobal_2015.dbc
+++ b/generator/subaru/_subaru_preglobal_2015.dbc
@@ -130,10 +130,10 @@ BO_ 352 ES_Brake: 8 XXX
  SG_ Counter : 48|3@1+ (1,0) [0|7] "" XXX
  SG_ Checksum : 56|8@1+ (1,0) [0|255] "" XXX
 
-BO_ 353 ES_CruiseThrottle: 8 XXX
- SG_ Throttle_Cruise : 0|12@1+ (1,0) [0|4095] "" XXX
+BO_ 353 ES_Distance: 8 XXX
+ SG_ Cruise_Throttle : 0|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_Activated : 16|1@1+ (1,0) [0|1] "" XXX
+ SG_ Car_Follow : 16|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 17|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake_On : 20|1@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX

--- a/generator/subaru/subaru_forester_2017.dbc
+++ b/generator/subaru/subaru_forester_2017.dbc
@@ -3,9 +3,12 @@ CM_ "IMPORT _subaru_preglobal_2015.dbc";
 BO_ 355 ES_DashStatus: 8 XXX
  SG_ Not_Ready_Startup : 4|2@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_On : 16|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Activated : 17|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 40|3@1+ (1,0) [0|7] "" XXX
- SG_ Cruise_Activated : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ Brake : 43|1@1+ (1,0) [0|1] "" XXX
+ SG_ Car_Follow : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ Far_Distance : 56|4@1+ (1,0) [0|1] "" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/subaru_forester_2017_generated.dbc
+++ b/subaru_forester_2017_generated.dbc
@@ -134,10 +134,10 @@ BO_ 352 ES_Brake: 8 XXX
  SG_ Counter : 48|3@1+ (1,0) [0|7] "" XXX
  SG_ Checksum : 56|8@1+ (1,0) [0|255] "" XXX
 
-BO_ 353 ES_CruiseThrottle: 8 XXX
- SG_ Throttle_Cruise : 0|12@1+ (1,0) [0|4095] "" XXX
+BO_ 353 ES_Distance: 8 XXX
+ SG_ Cruise_Throttle : 0|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_Activated : 16|1@1+ (1,0) [0|1] "" XXX
+ SG_ Car_Follow : 16|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 17|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake_On : 20|1@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX
@@ -253,9 +253,12 @@ CM_ "subaru_forester_2017.dbc starts here";
 BO_ 355 ES_DashStatus: 8 XXX
  SG_ Not_Ready_Startup : 4|2@1+ (1,0) [0|3] "" XXX
  SG_ Cruise_On : 16|1@1+ (1,0) [0|1] "" XXX
+ SG_ Cruise_Activated : 17|1@0+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set_Speed : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 40|3@1+ (1,0) [0|7] "" XXX
- SG_ Cruise_Activated : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ Brake : 43|1@1+ (1,0) [0|1] "" XXX
+ SG_ Car_Follow : 54|1@1+ (1,0) [0|1] "" XXX
+ SG_ Far_Distance : 56|4@1+ (1,0) [0|1] "" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -119,6 +119,11 @@ BO_ 313 Brake_Pedal: 8 XXX
  SG_ Brake_Pedal : 36|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal4 : 48|16@1+ (1,0) [0|65535] "" XXX
 
+BO_ 372 Engine_Stop_Start: 8 XXX
+  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+  SG_ STOP_START_STATE : 39|2@0+ (1,0) [0|3] "" XXX
+
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
@@ -161,6 +166,7 @@ BO_ 912 Dashlights: 8 XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|1] "" XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
+ SG_ STOP_START : 54|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 940 BodyInfo: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -119,6 +119,11 @@ BO_ 313 Brake_Pedal: 8 XXX
  SG_ Brake_Pedal : 36|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal4 : 48|16@1+ (1,0) [0|65535] "" XXX
 
+BO_ 372 Engine_Stop_Start: 8 XXX
+  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
+  SG_ STOP_START_STATE : 39|2@0+ (1,0) [0|3] "" XXX
+
 BO_ 290 ES_LKAS: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ Counter : 8|4@1+ (1,0) [0|15] "" XXX
@@ -161,6 +166,7 @@ BO_ 912 Dashlights: 8 XXX
  SG_ SEATBELT_FL : 48|1@1+ (1,0) [0|1] "" XXX
  SG_ LEFT_BLINKER : 50|1@1+ (1,0) [0|1] "" XXX
  SG_ RIGHT_BLINKER : 51|1@1+ (1,0) [0|1] "" XXX
+ SG_ STOP_START : 54|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 940 BodyInfo: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_outback_2015_generated.dbc
+++ b/subaru_outback_2015_generated.dbc
@@ -134,10 +134,10 @@ BO_ 352 ES_Brake: 8 XXX
  SG_ Counter : 48|3@1+ (1,0) [0|7] "" XXX
  SG_ Checksum : 56|8@1+ (1,0) [0|255] "" XXX
 
-BO_ 353 ES_CruiseThrottle: 8 XXX
- SG_ Throttle_Cruise : 0|12@1+ (1,0) [0|4095] "" XXX
+BO_ 353 ES_Distance: 8 XXX
+ SG_ Cruise_Throttle : 0|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_Activated : 16|1@1+ (1,0) [0|1] "" XXX
+ SG_ Car_Follow : 16|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 17|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake_On : 20|1@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX

--- a/subaru_outback_2019_generated.dbc
+++ b/subaru_outback_2019_generated.dbc
@@ -134,10 +134,10 @@ BO_ 352 ES_Brake: 8 XXX
  SG_ Counter : 48|3@1+ (1,0) [0|7] "" XXX
  SG_ Checksum : 56|8@1+ (1,0) [0|255] "" XXX
 
-BO_ 353 ES_CruiseThrottle: 8 XXX
- SG_ Throttle_Cruise : 0|12@1+ (1,0) [0|4095] "" XXX
+BO_ 353 ES_Distance: 8 XXX
+ SG_ Cruise_Throttle : 0|12@1+ (1,0) [0|4095] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
- SG_ Cruise_Activated : 16|1@1+ (1,0) [0|1] "" XXX
+ SG_ Car_Follow : 16|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal2 : 17|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake_On : 20|1@1+ (1,0) [0|1] "" XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX


### PR DESCRIPTION
This PR:
- Adds Engine Stop-Start signals for global
- Renames preglobal ES_ThrottleCruise message to ES_Distance to match global message and signals
- Fixes/updates preglobal Car_Follow signal in ES_Distance (used for SNG)
- Adds Brake, Cruise_Activated, Car_Follow and Far_Distance signals to ES_DashStatus message for Forester

I will submit openpilot PR for ES_Distance change and separate PR for adding SNG support