### PR TITLE
Toyota: add ITS Connect Lead Signal

### DIFF
--- a/generator/toyota/_toyota_2017.dbc
+++ b/generator/toyota/_toyota_2017.dbc
@@ -127,6 +127,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -316,6 +317,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/generator/toyota/_toyota_2017.dbc
+++ b/generator/toyota/_toyota_2017.dbc
@@ -317,7 +317,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_ct200h_2018_pt_generated.dbc
+++ b/lexus_ct200h_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_ct200h_2018_pt_generated.dbc
+++ b/lexus_ct200h_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_gs300h_2017_pt_generated.dbc
+++ b/lexus_gs300h_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_gs300h_2017_pt_generated.dbc
+++ b/lexus_gs300h_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_is_2018_pt_generated.dbc
+++ b/lexus_is_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_is_2018_pt_generated.dbc
+++ b/lexus_is_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_nx300_2018_pt_generated.dbc
+++ b/lexus_nx300_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_nx300_2018_pt_generated.dbc
+++ b/lexus_nx300_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_nx300h_2018_pt_generated.dbc
+++ b/lexus_nx300h_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_nx300h_2018_pt_generated.dbc
+++ b/lexus_nx300h_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_rx_350_2016_pt_generated.dbc
+++ b/lexus_rx_350_2016_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_rx_350_2016_pt_generated.dbc
+++ b/lexus_rx_350_2016_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_rx_hybrid_2017_pt_generated.dbc
+++ b/lexus_rx_hybrid_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/lexus_rx_hybrid_2017_pt_generated.dbc
+++ b/lexus_rx_hybrid_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_avalon_2017_pt_generated.dbc
+++ b/toyota_avalon_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_avalon_2017_pt_generated.dbc
+++ b/toyota_avalon_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_camry_hybrid_2018_pt_generated.dbc
+++ b/toyota_camry_hybrid_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_camry_hybrid_2018_pt_generated.dbc
+++ b/toyota_camry_hybrid_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_corolla_2017_pt_generated.dbc
+++ b/toyota_corolla_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_corolla_2017_pt_generated.dbc
+++ b/toyota_corolla_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_highlander_2017_pt_generated.dbc
+++ b/toyota_highlander_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_highlander_2017_pt_generated.dbc
+++ b/toyota_highlander_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_highlander_hybrid_2018_pt_generated.dbc
+++ b/toyota_highlander_hybrid_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_highlander_hybrid_2018_pt_generated.dbc
+++ b/toyota_highlander_hybrid_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_nodsu_hybrid_pt_generated.dbc
+++ b/toyota_nodsu_hybrid_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_nodsu_hybrid_pt_generated.dbc
+++ b/toyota_nodsu_hybrid_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_prius_2017_pt_generated.dbc
+++ b/toyota_prius_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_prius_2017_pt_generated.dbc
+++ b/toyota_prius_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_rav4_2017_pt_generated.dbc
+++ b/toyota_rav4_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_rav4_2017_pt_generated.dbc
+++ b/toyota_rav4_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_rav4_hybrid_2017_pt_generated.dbc
+++ b/toyota_rav4_hybrid_2017_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_rav4_hybrid_2017_pt_generated.dbc
+++ b/toyota_rav4_hybrid_2017_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_sienna_xle_2018_pt_generated.dbc
+++ b/toyota_sienna_xle_2018_pt_generated.dbc
@@ -321,7 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
-CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";

--- a/toyota_sienna_xle_2018_pt_generated.dbc
+++ b/toyota_sienna_xle_2018_pt_generated.dbc
@@ -131,6 +131,7 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
  SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
@@ -320,6 +321,7 @@ CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
 CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 ITS_CONNECT_LEAD "Display Lead Car as ITS Connect Capable";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";
 CM_ SG_ 835 ACCEL_CMD_ALT "Copy of main ACCEL_CMD, but across 8 bits instead of 16 bits like ACCEL_CMD. Unsure if only informational or has an effect. Likely informational as existing openpilot sets this to 0 and no loss of functionality observed. Originally 'AT_RAW' in leaked toyota_2017_ref_pt.dbc file.";


### PR DESCRIPTION
This PR is not mission critical, just adding more signal definitions.

In Japan, Toyota has this service called ITS Connect, if RADAR Cruise detects an ITS Connect capable car ahead, it will display the lead car with a green ring and two wireless indicators around it.

It's called Communication Enabled Radar Cruise Control (https://global.toyota/jp/download/10064634/)
![crwa1510_35](https://user-images.githubusercontent.com/12470297/146175859-057d0d94-3b2c-4168-a618-ba55d1942c71.jpg)

