### PR TITLE
Toyota: clean up nodsu DBCs

### DIFF
--- a/generator/toyota/_toyota_nodsu_common.dbc
+++ b/generator/toyota/_toyota_nodsu_common.dbc
@@ -11,6 +11,24 @@ BO_ 401 STEERING_LTA: 8 XXX
  SG_ STEER_REQUEST_2 : 0|1@0+ (1,0) [0|1] "" XXX
  SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 550 BRAKE_MODULE: 8 XXX
+ SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
+ SG_ BRAKE_POSITION : 16|9@0+ (1,0) [0|511] "" XXX
+ SG_ BRAKE_PRESSED : 37|1@0+ (1,0) [0|1] "" XXX
+
+BO_ 608 STEER_TORQUE_SENSOR: 8 XXX
+ SG_ STEER_TORQUE_EPS : 47|16@0- (0.73,0) [-20000|20000] "" XXX
+ SG_ STEER_TORQUE_DRIVER : 15|16@0- (1,0) [-32768|32767] "" XXX
+ SG_ STEER_OVERRIDE : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ STEER_ANGLE : 31|16@0- (0.0573,0) [-500|500] "" XXX
+
+BO_ 610 EPS_STATUS: 8 EPS
+ SG_ IPAS_STATE : 3|4@0+ (1,0) [0|15] "" XXX
+ SG_ LKA_STATE : 31|7@0+ (1,0) [0|127] "" XXX
+ SG_ TYPE : 24|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+
 BO_ 1014 BSM: 8 XXX
  SG_ L_ADJACENT : 0|1@0+ (1,0) [0|1] "" XXX
  SG_ L_APPROACHING : 8|1@0+ (1,0) [0|1] "" XXX
@@ -19,9 +37,14 @@ BO_ 1014 BSM: 8 XXX
  SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
  SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
 
+CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
+CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
+CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
 CM_ SG_ 1014 L_ADJACENT "vehicle adjacent left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
 CM_ SG_ 1014 L_APPROACHING "vehicle approaching from left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
 CM_ SG_ 1014 R_ADJACENT "vehicle adjacent right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
 CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
 CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
+VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
+VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";

--- a/generator/toyota/_toyota_nodsu_common.dbc
+++ b/generator/toyota/_toyota_nodsu_common.dbc
@@ -37,8 +37,8 @@ BO_ 1014 BSM: 8 XXX
  SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
  SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
 
-CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
-CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
+CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
+CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
 CM_ SG_ 1014 L_ADJACENT "vehicle adjacent left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
 CM_ SG_ 1014 L_APPROACHING "vehicle approaching from left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";

--- a/generator/toyota/toyota_nodsu_hybrid_pt.dbc
+++ b/generator/toyota/toyota_nodsu_hybrid_pt.dbc
@@ -8,31 +8,8 @@ BO_ 295 GEAR_PACKET: 8 XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
  SG_ GEAR : 47|4@0+ (1,0) [0|15] "" XXX
 
-BO_ 550 BRAKE_MODULE: 8 XXX
- SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
- SG_ BRAKE_POSITION : 16|9@0+ (1,0) [0|511] "" XXX
- SG_ BRAKE_PRESSED : 37|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 581 GAS_PEDAL: 8 XXX
  SG_ GAS_PEDAL : 23|8@0+ (0.005,0) [0|1] "" XXX
 
-BO_ 608 STEER_TORQUE_SENSOR: 8 XXX
- SG_ STEER_TORQUE_EPS : 47|16@0- (0.73,0) [-20000|20000] "" XXX
- SG_ STEER_TORQUE_DRIVER : 15|16@0- (1,0) [-32768|32767] "" XXX
- SG_ STEER_OVERRIDE : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ STEER_ANGLE : 31|16@0- (0.0573,0) [-500|500] "" XXX
-
-BO_ 610 EPS_STATUS: 8 EPS
- SG_ IPAS_STATE : 3|4@0+ (1,0) [0|15] "" XXX
- SG_ LKA_STATE : 31|7@0+ (1,0) [0|127] "" XXX
- SG_ TYPE : 24|1@0+ (1,0) [0|1] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
-
-CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
-CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
-CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
 CM_ SG_ 581 GAS_PEDAL "it seems slightly filtered";
 VAL_ 295 GEAR 0 "P" 1 "R" 2 "N" 3 "D" 4 "B";
-VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
-VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";

--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -2,38 +2,15 @@ CM_ "IMPORT _toyota_2017.dbc";
 CM_ "IMPORT _comma.dbc";
 CM_ "IMPORT _toyota_nodsu_common.dbc";
 
-BO_ 550 BRAKE_MODULE: 8 XXX
- SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
- SG_ BRAKE_POSITION : 16|9@0+ (1,0) [0|511] "" XXX
- SG_ BRAKE_PRESSED : 37|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 705 GAS_PEDAL: 8 XXX
  SG_ GAS_RELEASED : 3|1@0+ (1,0) [0|1] "" XXX
  SG_ GAS_PEDAL : 55|8@0+ (0.005,0) [0|1] "" XXX
-
-BO_ 608 STEER_TORQUE_SENSOR: 8 XXX
- SG_ STEER_TORQUE_EPS : 47|16@0- (0.73,0) [-20000|20000] "" XXX
- SG_ STEER_TORQUE_DRIVER : 15|16@0- (1,0) [-32768|32767] "" XXX
- SG_ STEER_OVERRIDE : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ STEER_ANGLE : 31|16@0- (0.0573,0) [-500|500] "" XXX
-
-BO_ 610 EPS_STATUS: 8 EPS
- SG_ IPAS_STATE : 3|4@0+ (1,0) [0|15] "" XXX
- SG_ LKA_STATE : 31|7@0+ (1,0) [0|127] "" XXX
- SG_ TYPE : 24|1@0+ (1,0) [0|1] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 956 GEAR_PACKET: 8 XXX
  SG_ SPORT_ON : 2|1@0+ (1,0) [0|1] "" XXX
  SG_ GEAR : 13|6@0+ (1,0) [0|63] "" XXX
  SG_ ECON_ON : 40|1@0+ (1,0) [0|1] "" XXX
 
-CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
-CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
-CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
-VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
-VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";
 VAL_ 956 GEAR 0 "D" 1 "S" 8 "N" 16 "R" 32 "P";
 VAL_ 956 SPORT_ON 0 "off" 1 "on";
 VAL_ 956 ECON_ON 0 "off" 1 "on";

--- a/toyota_nodsu_hybrid_pt_generated.dbc
+++ b/toyota_nodsu_hybrid_pt_generated.dbc
@@ -430,39 +430,10 @@ BO_ 401 STEERING_LTA: 8 XXX
  SG_ STEER_REQUEST_2 : 0|1@0+ (1,0) [0|1] "" XXX
  SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
 
-BO_ 1014 BSM: 8 XXX
- SG_ L_ADJACENT : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ L_APPROACHING : 8|1@0+ (1,0) [0|1] "" XXX
- SG_ R_ADJACENT : 1|1@0+ (1,0) [0|1] "" XXX
- SG_ R_APPROACHING : 10|1@0+ (1,0) [0|1] "" XXX
- SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
- SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
-
-CM_ SG_ 1014 L_ADJACENT "vehicle adjacent left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 L_APPROACHING "vehicle approaching from left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 R_ADJACENT "vehicle adjacent right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
-CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
-
-CM_ "toyota_nodsu_hybrid_pt.dbc starts here";
-
-
-
-
-BO_ 295 GEAR_PACKET: 8 XXX
- SG_ CAR_MOVEMENT : 39|8@0- (1,0) [0|255] "" XXX
- SG_ COUNTER : 55|8@0+ (1,0) [0|255] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ GEAR : 47|4@0+ (1,0) [0|15] "" XXX
-
 BO_ 550 BRAKE_MODULE: 8 XXX
  SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
  SG_ BRAKE_POSITION : 16|9@0+ (1,0) [0|511] "" XXX
  SG_ BRAKE_PRESSED : 37|1@0+ (1,0) [0|1] "" XXX
-
-BO_ 581 GAS_PEDAL: 8 XXX
- SG_ GAS_PEDAL : 23|8@0+ (0.005,0) [0|1] "" XXX
 
 BO_ 608 STEER_TORQUE_SENSOR: 8 XXX
  SG_ STEER_TORQUE_EPS : 47|16@0- (0.73,0) [-20000|20000] "" XXX
@@ -477,10 +448,39 @@ BO_ 610 EPS_STATUS: 8 EPS
  SG_ TYPE : 24|1@0+ (1,0) [0|1] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
-CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
+BO_ 1014 BSM: 8 XXX
+ SG_ L_ADJACENT : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ L_APPROACHING : 8|1@0+ (1,0) [0|1] "" XXX
+ SG_ R_ADJACENT : 1|1@0+ (1,0) [0|1] "" XXX
+ SG_ R_APPROACHING : 10|1@0+ (1,0) [0|1] "" XXX
+ SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
+ SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
+CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
-CM_ SG_ 581 GAS_PEDAL "it seems slightly filtered";
-VAL_ 295 GEAR 0 "P" 1 "R" 2 "N" 3 "D" 4 "B";
+CM_ SG_ 1014 L_ADJACENT "vehicle adjacent left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 L_APPROACHING "vehicle approaching from left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 R_ADJACENT "vehicle adjacent right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
+CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
 VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";
+
+CM_ "toyota_nodsu_hybrid_pt.dbc starts here";
+
+
+
+
+BO_ 295 GEAR_PACKET: 8 XXX
+ SG_ CAR_MOVEMENT : 39|8@0- (1,0) [0|255] "" XXX
+ SG_ COUNTER : 55|8@0+ (1,0) [0|255] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ GEAR : 47|4@0+ (1,0) [0|15] "" XXX
+
+BO_ 581 GAS_PEDAL: 8 XXX
+ SG_ GAS_PEDAL : 23|8@0+ (0.005,0) [0|1] "" XXX
+
+CM_ SG_ 581 GAS_PEDAL "it seems slightly filtered";
+VAL_ 295 GEAR 0 "P" 1 "R" 2 "N" 3 "D" 4 "B";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -430,34 +430,10 @@ BO_ 401 STEERING_LTA: 8 XXX
  SG_ STEER_REQUEST_2 : 0|1@0+ (1,0) [0|1] "" XXX
  SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
 
-BO_ 1014 BSM: 8 XXX
- SG_ L_ADJACENT : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ L_APPROACHING : 8|1@0+ (1,0) [0|1] "" XXX
- SG_ R_ADJACENT : 1|1@0+ (1,0) [0|1] "" XXX
- SG_ R_APPROACHING : 10|1@0+ (1,0) [0|1] "" XXX
- SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
- SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
-
-CM_ SG_ 1014 L_ADJACENT "vehicle adjacent left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 L_APPROACHING "vehicle approaching from left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 R_ADJACENT "vehicle adjacent right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
-CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
-CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
-
-CM_ "toyota_nodsu_pt.dbc starts here";
-
-
-
-
 BO_ 550 BRAKE_MODULE: 8 XXX
  SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
  SG_ BRAKE_POSITION : 16|9@0+ (1,0) [0|511] "" XXX
  SG_ BRAKE_PRESSED : 37|1@0+ (1,0) [0|1] "" XXX
-
-BO_ 705 GAS_PEDAL: 8 XXX
- SG_ GAS_RELEASED : 3|1@0+ (1,0) [0|1] "" XXX
- SG_ GAS_PEDAL : 55|8@0+ (0.005,0) [0|1] "" XXX
 
 BO_ 608 STEER_TORQUE_SENSOR: 8 XXX
  SG_ STEER_TORQUE_EPS : 47|16@0- (0.73,0) [-20000|20000] "" XXX
@@ -472,16 +448,40 @@ BO_ 610 EPS_STATUS: 8 EPS
  SG_ TYPE : 24|1@0+ (1,0) [0|1] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
+BO_ 1014 BSM: 8 XXX
+ SG_ L_ADJACENT : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ L_APPROACHING : 8|1@0+ (1,0) [0|1] "" XXX
+ SG_ R_ADJACENT : 1|1@0+ (1,0) [0|1] "" XXX
+ SG_ R_APPROACHING : 10|1@0+ (1,0) [0|1] "" XXX
+ SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
+ SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
+
+CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
+CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
+CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
+CM_ SG_ 1014 L_ADJACENT "vehicle adjacent left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 L_APPROACHING "vehicle approaching from left side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 R_ADJACENT "vehicle adjacent right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled above 10mph, regardless of ADJACENT_ENABLED or APPROACHING_ENABLED";
+CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
+CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
+VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
+VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";
+
+CM_ "toyota_nodsu_pt.dbc starts here";
+
+
+
+
+BO_ 705 GAS_PEDAL: 8 XXX
+ SG_ GAS_RELEASED : 3|1@0+ (1,0) [0|1] "" XXX
+ SG_ GAS_PEDAL : 55|8@0+ (0.005,0) [0|1] "" XXX
+
 BO_ 956 GEAR_PACKET: 8 XXX
  SG_ SPORT_ON : 2|1@0+ (1,0) [0|1] "" XXX
  SG_ GEAR : 13|6@0+ (1,0) [0|63] "" XXX
  SG_ ECON_ON : 40|1@0+ (1,0) [0|1] "" XXX
 
-CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
-CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
-CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
-VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
-VAL_ 610 LKA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 1 "standby";
 VAL_ 956 GEAR 0 "D" 1 "S" 8 "N" 16 "R" 32 "P";
 VAL_ 956 SPORT_ON 0 "off" 1 "on";
 VAL_ 956 ECON_ON 0 "off" 1 "on";


### PR DESCRIPTION
I moved the common signals to `_toyota_nodsu_common.dbc`, and fixed the comments for the `BRAKE_MODULE` having the wrong address.