### PR TITLE
Make def_vals use set in dbc.py

### DIFF
--- a/can/dbc.py
+++ b/can/dbc.py
@@ -41,7 +41,7 @@ class dbc():
     self.msgs = {}
 
     # A dictionary which maps message ids to a list of tuples (signal name, definition value pairs)
-    self.def_vals = defaultdict(list)
+    self.def_vals = defaultdict(set)
 
     # lookup to bit reverse each byte
     self.bits_index = [(i & ~0b111) + ((-i - 1) & 0b111) for i in range(64)]
@@ -108,7 +108,7 @@ class dbc():
         defvals[1::2] = [d.strip().upper().replace(" ", "_") for d in defvals[1::2]]
         defvals = '"' + "".join(str(i) for i in defvals) + '"'
 
-        self.def_vals[ids].append((sgname, defvals))
+        self.def_vals[ids].add((sgname, defvals))
 
     for msg in self.msgs.values():
       msg[1].sort(key=lambda x: x.start_bit)

--- a/can/dbc.py
+++ b/can/dbc.py
@@ -6,6 +6,7 @@ import sys
 import numbers
 from collections import namedtuple, defaultdict
 
+
 def int_or_float(s):
   # return number, trying to maintain int format
   if s.isdigit():

--- a/can/process_dbc.py
+++ b/can/process_dbc.py
@@ -8,6 +8,7 @@ import jinja2
 from collections import Counter
 from opendbc.can.dbc import dbc
 
+
 def process(in_fn, out_fn):
   dbc_name = os.path.split(out_fn)[-1].replace('.cc', '')
   # print("processing %s: %s -> %s" % (dbc_name, in_fn, out_fn))
@@ -23,8 +24,7 @@ def process(in_fn, out_fn):
   msgs = [(address, msg_name, msg_size, sorted(msg_sigs, key=lambda s: s.name not in ("COUNTER", "CHECKSUM")))
           for address, ((msg_name, msg_size), msg_sigs) in sorted(can_dbc.msgs.items()) if msg_sigs]
 
-  def_vals = {a: sorted(set(b)) for a, b in can_dbc.def_vals.items()}  # remove duplicates
-  def_vals = sorted(def_vals.items())
+  def_vals = sorted((a, sorted(b)) for a, b in can_dbc.def_vals.items())
 
   if can_dbc.name.startswith(("honda_", "acura_")):
     checksum_type = "honda"
@@ -112,6 +112,7 @@ def process(in_fn, out_fn):
       out_f.seek(0)
       out_f.truncate()
       out_f.write(parser_code)
+
 
 def main():
   if len(sys.argv) != 3:


### PR DESCRIPTION
Just saves a line (minus formatting) and ensures the defs don't have any duplicates inside dbc. Measured identical build times. I can provide tests if wanted