### PR TITLE
Add definition to value entries in CANDefine

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -186,7 +186,7 @@ cdef class CANDefine():
 
 
       # two ways to lookup: address or msg name
-      dv[address][sgname] = dict(zip(values, defs))
+      dv[address][sgname] = dict(zip(values + defs, defs + values))
       dv[msgname][sgname] = dv[address][sgname]
 
       self.dv = dict(dv)

--- a/can/tests/test_define.py
+++ b/can/tests/test_define.py
@@ -6,19 +6,17 @@ from opendbc.can.can_define import CANDefine
 
 class TestCADNDefine(unittest.TestCase):
   def test_civic(self):
-
     dbc_file = "honda_civic_touring_2016_can_generated"
     defs = CANDefine(dbc_file)
 
     self.assertDictEqual(defs.dv[399], defs.dv['STEER_STATUS'])
-    self.assertDictEqual(defs.dv[399],
-                         {'STEER_STATUS':
-                          {6: 'TMP_FAULT',
-                           5: 'FAULT_1',
-                           4: 'NO_TORQUE_ALERT_2',
-                           3: 'LOW_SPEED_LOCKOUT',
-                           2: 'NO_TORQUE_ALERT_1',
-                           0: 'NORMAL'}
+    self.assertDictEqual(defs.dv[399]['STEER_STATUS'],
+                         {6: 'TMP_FAULT', 'TMP_FAULT': 6,
+                          5: 'FAULT_1', 'FAULT_1': 5,
+                          4: 'NO_TORQUE_ALERT_2', 'NO_TORQUE_ALERT_2': 4,
+                          3: 'LOW_SPEED_LOCKOUT', 'LOW_SPEED_LOCKOUT': 3,
+                          2: 'NO_TORQUE_ALERT_1', 'NO_TORQUE_ALERT_1': 2,
+                          0: 'NORMAL', 'NORMAL': 0,
                           }
                          )
 


### PR DESCRIPTION
Would let us move these into the DBC: https://github.com/commaai/openpilot/blob/master/selfdrive/car/volkswagen/values.py#L48 to use in carcontroller, as @jyoung8607 suggested.