### PR TITLE
CANParser: remove timestamp dict

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -33,7 +33,6 @@ public:
   std::vector<Signal> parse_sigs;
   std::vector<double> vals;
 
-  uint16_t ts;
   uint64_t seen;
   uint64_t check_threshold;
 
@@ -43,7 +42,7 @@ public:
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
-  bool parse(uint64_t sec, uint16_t ts_, uint8_t * dat);
+  bool parse(uint64_t sec, uint8_t * dat);
   bool update_counter_generic(int64_t v, int cnt_size);
 };
 

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -60,7 +60,6 @@ cdef extern from "common_dbc.h":
 
   cdef struct SignalValue:
     uint32_t address
-    uint16_t ts
     const char* name
     double value
 

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -24,7 +24,6 @@ struct MessageParseOptions {
 
 struct SignalValue {
   uint32_t address;
-  uint16_t ts;
   const char* name;
   double value;
 };

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -29,7 +29,6 @@ cdef class CANParser:
   cdef readonly:
     string dbc_name
     dict vl
-    dict ts
     bool can_valid
     int can_invalid_cnt
 
@@ -42,7 +41,6 @@ cdef class CANParser:
     if not self.dbc:
       raise RuntimeError(f"Can't find DBC: {dbc_name}")
     self.vl = {}
-    self.ts = {}
 
     self.can_invalid_cnt = CAN_INVALID_CNT
 
@@ -56,8 +54,6 @@ cdef class CANParser:
       self.address_to_msg_name[msg.address] = name
       self.vl[msg.address] = {}
       self.vl[name] = {}
-      self.ts[msg.address] = {}
-      self.ts[name] = {}
 
     # Convert message names into addresses
     for i in range(len(signals)):
@@ -121,10 +117,7 @@ cdef class CANParser:
       cv_name = <unicode>cv.name
 
       self.vl[cv.address][cv_name] = cv.value
-      self.ts[cv.address][cv_name] = cv.ts
-
       self.vl[name][cv_name] = cv.value
-      self.ts[name][cv_name] = cv.ts
 
       updated_val.insert(cv.address)
 


### PR DESCRIPTION
busTime was removed from the CAN data, so we need to use the logMonoTime for timestamp