### PR TITLE
GM dbc: Add ECMPRDNL2.PRNDL2 Message / signal with more detailed "gear" status

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -149,6 +149,9 @@ BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate : 35|12@0- (0.625,0) [0|1] "" NEO
  SG_ YawRate2 : 51|12@0- (0.0625,0) [-2047|2047] "grad/s" NEO
 
+BO_ 501 ECMPRDNL2: 8 K20_ECM
+ SG_ PRNDL2 : 31|8@0+ (1,0) [0|255] "" NEO
+
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
 
@@ -278,3 +281,4 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
+VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Unknown";

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -169,6 +169,9 @@ BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate : 35|12@0- (0.625,0) [0|1] "" NEO
  SG_ YawRate2 : 51|12@0- (0.0625,0) [-2047|2047] "grad/s" NEO
 
+BO_ 501 ECMPRDNL2: 8 K20_ECM
+ SG_ PRNDL2 : 31|8@0+ (1,0) [0|255] "" NEO
+
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
 
@@ -298,3 +301,4 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
+VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Unknown";


### PR DESCRIPTION
The existing signal used to determine the gear shifter position does not differentiate between "D" and "L", nor is Neutral included.

This new signal has a distinct value for each shifter position. Differentiating between "D" and "L" is important especially for EVs and Hybrids where "L" mode is also known as single pedal mode. In this mode the gas pedal will perform regenerative braking.

The message - 501 - is present in all the current fingerprints.
![new with L mode](https://user-images.githubusercontent.com/29778397/151932636-9bf7823c-d018-4b3a-a0f6-832789e25577.png)

Further analysis will be required to determine if this message is more appropriate than the one currently being used for all vehicles or only Hybrid/EV.