### PR TITLE
GM bugfix: ECMEngineStatus.EngineRPM value incorrect over 4096 due to truncation

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -69,7 +69,7 @@ BO_ 190 ECMAcceleratorPos: 6 K20_ECM
 
 BO_ 201 ECMEngineStatus: 8 K20_ECM
  SG_ EngineTPS : 39|8@0+ (0.392156863,0) [0|100.000000065] "%" NEO
- SG_ EngineRPM : 13|14@0+ (0.25,0) [0|0] "RPM" NEO
+ SG_ EngineRPM : 15|16@0+ (0.25,0) [0|0] "RPM" NEO
  SG_ CruiseMainOn : 29|1@0+ (1,0) [0|1] "" NEO
  SG_ Brake_Pressed : 40|1@0+ (1,0) [0|1] "" NEO
  SG_ Standstill : 2|1@0+ (1,0) [0|1] "" NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -89,7 +89,7 @@ BO_ 190 ECMAcceleratorPos: 6 K20_ECM
 
 BO_ 201 ECMEngineStatus: 8 K20_ECM
  SG_ EngineTPS : 39|8@0+ (0.392156863,0) [0|100.000000065] "%" NEO
- SG_ EngineRPM : 13|14@0+ (0.25,0) [0|0] "RPM" NEO
+ SG_ EngineRPM : 15|16@0+ (0.25,0) [0|0] "RPM" NEO
  SG_ CruiseMainOn : 29|1@0+ (1,0) [0|1] "" NEO
  SG_ Brake_Pressed : 40|1@0+ (1,0) [0|1] "" NEO
  SG_ Standstill : 2|1@0+ (1,0) [0|1] "" NEO


### PR DESCRIPTION
The signal specification for EngineRPM was 2 bits too short, and the value was being truncated at 4096 RPM. When this happened, the RPM appeared to wrap around to zero.
![brokenRPM](https://user-images.githubusercontent.com/29778397/152063805-488293e4-f7ea-40be-887e-d704b9cb9b38.png)

Updating the dbc to increase the field to the full 16-bits resolves the issue, and the correct RPM value is available.
Note that this signal is not presently used anywhere in OP - the bug was discovered by @twilsonco (thanks!).

![image](https://user-images.githubusercontent.com/29778397/152063998-d17d47d4-cf6f-47e4-b22b-4ed525346de6.png)
