### PR TITLE
GM: add new ECMPRDNL2 message with more detailed transmission / gear status

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -150,7 +150,9 @@ BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate2 : 51|12@0- (0.0625,0) [-2047|2047] "grad/s" NEO
 
 BO_ 501 ECMPRDNL2: 8 K20_ECM
- SG_ PRNDL2 : 31|8@0+ (1,0) [0|255] "" NEO
+ SG_ TransmissionState : 48|4@1+ (1,0) [0|7] "" NEO
+ SG_ PRNDL2 : 27|4@0+ (1,0) [0|255] "" NEO
+ SG_ ManualMode : 41|1@0+ (1,0) [0|1] "" NEO
 
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
@@ -251,6 +253,7 @@ CM_ BU_ K124_ASCM "Active Safety Control Module";
 CM_ SG_ 381 MSG17D_AccPower "Need to investigate";
 CM_ SG_ 190 GasPedalAndAcc "ACC baseline is 62";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
+CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;
 BA_DEF_  "ProtocolType" STRING ;
 BA_DEF_  "BusType" STRING ;
@@ -281,4 +284,6 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
-VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Unknown";
+VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Shifting";
+VAL_ 501 TransmissionState 11 "Shifting" 10 "Reverse" 9 "Forward" 8 "Disengaged";
+VAL_ 501 ManualMode 1 "Active" 0 "Inactive"

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -149,6 +149,9 @@ BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate : 35|12@0- (0.625,0) [0|1] "" NEO
  SG_ YawRate2 : 51|12@0- (0.0625,0) [-2047|2047] "grad/s" NEO
 
+BO_ 501 ECMPRDNL2: 8 K20_ECM
+ SG_ PRNDL2 : 31|8@0+ (1,0) [0|255] "" NEO
+
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
 
@@ -278,3 +281,4 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
+VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Unknown";

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -169,6 +169,9 @@ BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate : 35|12@0- (0.625,0) [0|1] "" NEO
  SG_ YawRate2 : 51|12@0- (0.0625,0) [-2047|2047] "grad/s" NEO
 
+BO_ 501 ECMPRDNL2: 8 K20_ECM
+ SG_ PRNDL2 : 31|8@0+ (1,0) [0|255] "" NEO
+
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
 
@@ -298,3 +301,4 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
+VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Unknown";

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -170,7 +170,9 @@ BO_ 489 EBCMVehicleDynamic: 8 K17_EBCM
  SG_ YawRate2 : 51|12@0- (0.0625,0) [-2047|2047] "grad/s" NEO
 
 BO_ 501 ECMPRDNL2: 8 K20_ECM
- SG_ PRNDL2 : 31|8@0+ (1,0) [0|255] "" NEO
+ SG_ TransmissionState : 48|4@1+ (1,0) [0|7] "" NEO
+ SG_ PRNDL2 : 27|4@0+ (1,0) [0|255] "" NEO
+ SG_ ManualMode : 41|1@0+ (1,0) [0|1] "" NEO
 
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
@@ -271,6 +273,7 @@ CM_ BU_ K124_ASCM "Active Safety Control Module";
 CM_ SG_ 381 MSG17D_AccPower "Need to investigate";
 CM_ SG_ 190 GasPedalAndAcc "ACC baseline is 62";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
+CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;
 BA_DEF_  "ProtocolType" STRING ;
 BA_DEF_  "BusType" STRING ;
@@ -301,4 +304,6 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
-VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Unknown";
+VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Shifting";
+VAL_ 501 TransmissionState 11 "Shifting" 10 "Reverse" 9 "Forward" 8 "Disengaged";
+VAL_ 501 ManualMode 1 "Active" 0 "Inactive"


### PR DESCRIPTION
The existing signal used to determine the gear shifter position does not differentiate between "D" and "L" and does not include the Manual Mode available on some larger vehicles, nor is Neutral included.

This new signal has a distinct value for each shifter position. Differentiating between "D" and "L" is important especially for EVs and Hybrids where "L" mode is also known as single pedal mode. In this mode the gas pedal will perform regenerative braking.

The message - 501 - is present in all the current fingerprints.

The main value - PRNDL2 Actually supplies all of Park, Reverse, Neutral, Drive and "L" as opposed to the first identified. In EV/Hybrids, "L" refers to single-pedal mode. This signal's meaning changes slightly depending on the value of the ManualMode flag. The details are noted in the dbc comments.

So far the signal has been tested on a Volt, Bolt and Suburban and may end up being superior to the existing signal. Further testing will of course be required.

**Example on the Chevy Bolt:**
![new with L mode](https://user-images.githubusercontent.com/29778397/152066886-f98c5278-f838-4c74-9545-2e1bcec00c37.png)


**Example from Suburban:**
![new tranny](https://user-images.githubusercontent.com/29778397/152066945-8fdb5fa4-7c83-45d4-8cde-d28a1be34dc2.png)


Note that there is overlap when the Suburban is in L-mode (D and L10 have the same value) - this is differentiated using the ManualMode flag.
The immediate need for this signal involves detecting single-pedal mode on the Volt / Bolt / other hybrids or EVs for use in new functionality.
