### PR TITLE
CANParser: only return updated values

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -70,7 +70,7 @@ public:
   #endif
   void UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cans);
   void UpdateValid(uint64_t sec);
-  std::vector<SignalValue> update_vl();
+  std::vector<SignalValue> query_latest();
 };
 
 class CANPacker {

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -77,7 +77,7 @@ cdef extern from "common.h":
     bool can_valid
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
     void update_string(string, bool)
-    vector[SignalValue] update_vl()
+    vector[SignalValue] query_latest()
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -283,11 +283,12 @@ void CANParser::UpdateValid(uint64_t sec) {
   }
 }
 
-std::vector<SignalValue> CANParser::update_vl() {
+std::vector<SignalValue> CANParser::query_latest() {
   std::vector<SignalValue> ret;
 
   for (auto& kv : message_states) {
     auto& state = kv.second;
+    if (last_sec != 0 && state.updated_vals[0].size() == 0) continue;
 
     for (int i=0; i<state.parse_sigs.size(); i++) {
       const Signal &sig = state.parse_sigs[i];

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -139,11 +139,15 @@ class TestCanParserPacker(unittest.TestCase):
       values = {"USER_BRAKE": user_brake}
       msgs.append(packer.make_can_msg("VSA_STATUS", 0, values))
 
-    parser.update_strings([can_list_to_can_capnp(msgs)])
+    parser.update_string(can_list_to_can_capnp(msgs))
     updated = parser.updated["VSA_STATUS"]["USER_BRAKE"]
 
     self.assertEqual(updated, user_brake_vals)
     self.assertEqual(updated[-1], parser.vl["VSA_STATUS"]["USER_BRAKE"])
+
+    parser.update_string(can_list_to_can_capnp([]))
+    updated = parser.updated["VSA_STATUS"]["USER_BRAKE"]
+    self.assertEqual(len(updated), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
To process a certain route, the total time taken before #548 on the `update_strings` function was `0.164151` seconds. After that PR it took `0.863472` seconds. With this PR it takes `0.381665` seconds

Still trying to optimize it