### PR TITLE
C++ CANParser: only return updated values

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -37,7 +37,6 @@ public:
   uint16_t ts;
   uint64_t seen;
   uint64_t check_threshold;
-  bool cleared_last;
 
   uint8_t counter;
   uint8_t counter_fail;
@@ -59,6 +58,7 @@ private:
 
 public:
   bool can_valid = false;
+  std::map<uint32_t, bool> msg_updated;
   uint64_t last_sec = 0;
 
   CANParser(int abus, const std::string& dbc_name,

--- a/can/common.h
+++ b/can/common.h
@@ -37,6 +37,7 @@ public:
   uint16_t ts;
   uint64_t seen;
   uint64_t check_threshold;
+  bool cleared_last;
 
   uint8_t counter;
   uint8_t counter_fail;

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -75,6 +75,7 @@ cdef extern from "common.h":
 
   cdef cppclass CANParser:
     bool can_valid
+    map[uint32_t, bool] msg_updated
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
     void update_string(string, bool)
     vector[SignalValue] update_vl()

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -288,16 +288,17 @@ std::vector<SignalValue> CANParser::update_vl() {
 
   for (auto& kv : message_states) {
     auto& state = kv.second;
-
-    for (int i=0; i<state.parse_sigs.size(); i++) {
-      const Signal &sig = state.parse_sigs[i];
-      ret.push_back((SignalValue){
-        .address = state.address,
-        .ts = state.ts,
-        .name = sig.name,
-        .value = state.vals[i],
-        .updated_values = state.updated_vals[i],
-      });
+    for (int i = 0; i < state.parse_sigs.size(); i++) {
+      if (last_sec == 0 || state.seen == last_sec) {
+        const Signal &sig = state.parse_sigs[i];
+        ret.push_back((SignalValue){
+          .address = state.address,
+          .ts = state.ts,
+          .name = sig.name,
+          .value = state.vals[i],
+          .updated_values = state.updated_vals[i],
+        });
+      }
       state.updated_vals[i].clear();  // reset updated values for next cycle
     }
   }

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -288,8 +288,9 @@ std::vector<SignalValue> CANParser::update_vl() {
 
   for (auto& kv : message_states) {
     auto& state = kv.second;
+    bool cleared = false;
     for (int i = 0; i < state.parse_sigs.size(); i++) {
-      if (last_sec == 0 || state.seen == last_sec) {
+      if (last_sec == 0 || state.seen == last_sec || state.cleared_last) {
         const Signal &sig = state.parse_sigs[i];
         ret.push_back((SignalValue){
           .address = state.address,
@@ -299,8 +300,10 @@ std::vector<SignalValue> CANParser::update_vl() {
           .updated_values = state.updated_vals[i],
         });
       }
+      if (state.updated_vals[i].size() > 0) cleared = true;
       state.updated_vals[i].clear();  // reset updated values for next cycle
     }
+    state.cleared_last = cleared;
   }
 
   return ret;

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -288,9 +288,9 @@ std::vector<SignalValue> CANParser::update_vl() {
 
   for (auto& kv : message_states) {
     auto& state = kv.second;
-    bool cleared = false;
+    msg_updated[state.address] = last_sec == 0 || state.seen == last_sec;
     for (int i = 0; i < state.parse_sigs.size(); i++) {
-      if (last_sec == 0 || state.seen == last_sec || state.cleared_last) {
+      if (msg_updated[state.address]) {
         const Signal &sig = state.parse_sigs[i];
         ret.push_back((SignalValue){
           .address = state.address,
@@ -300,10 +300,8 @@ std::vector<SignalValue> CANParser::update_vl() {
           .updated_values = state.updated_vals[i],
         });
       }
-      if (state.updated_vals[i].size() > 0) cleared = true;
       state.updated_vals[i].clear();  // reset updated values for next cycle
     }
-    state.cleared_last = cleared;
   }
 
   return ret;

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -76,9 +76,6 @@ cdef class CANParser:
       self.vl.dat[msg.address] = {}
       self.ts.dat[msg.address] = {}
       self.updated.dat[msg.address] = {}
-      for x in range(msg.num_sigs):
-        self.vl.dat[msg.address][<unicode>msg.sigs[x].name] = 0
-        self.ts.dat[msg.address][<unicode>msg.sigs[x].name] = 0
 
     self.vl.msg_name_to_address = self.msg_name_to_address
     self.ts.msg_name_to_address = self.msg_name_to_address
@@ -123,9 +120,9 @@ cdef class CANParser:
       message_options_v.push_back(mpo)
 
     self.can = new cpp_CANParser(bus, dbc_name, message_options_v, signal_options_v)
-    self.update_vl()
+    self.update_vl(init=True)
 
-  cdef unordered_set[uint32_t] update_vl(self):
+  cdef unordered_set[uint32_t] update_vl(self, init=False):
     cdef string sig_name
     cdef unordered_set[uint32_t] updated_val
 
@@ -142,10 +139,11 @@ cdef class CANParser:
       cv_name = <unicode>cv.name
 
       self.updated.dat[cv.address][cv_name] = cv.updated_values
-      if len(cv.updated_values) > 0:
+      if init or len(cv.updated_values) > 0:
         self.vl.dat[cv.address][cv_name] = cv.value
         self.ts.dat[cv.address][cv_name] = cv.ts
-        updated_val.insert(cv.address)
+        if not init:
+          updated_val.insert(cv.address)
 
     return updated_val
 

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -120,9 +120,9 @@ cdef class CANParser:
       message_options_v.push_back(mpo)
 
     self.can = new cpp_CANParser(bus, dbc_name, message_options_v, signal_options_v)
-    self.update_vl(init=True)
+    self.update_vl()
 
-  cdef unordered_set[uint32_t] update_vl(self, init=False):
+  cdef unordered_set[uint32_t] update_vl(self):
     cdef string sig_name
     cdef unordered_set[uint32_t] updated_val
 
@@ -135,15 +135,17 @@ cdef class CANParser:
       self.can_invalid_cnt = 0
     self.can_valid = self.can_invalid_cnt < CAN_INVALID_CNT
 
+    for msg in self.updated.dat:
+      if not self.can.msg_updated[msg]:
+        self.updated.dat[msg] = {sig: [] for sig in self.updated.dat[msg]}
+
     for cv in can_values:
       cv_name = <unicode>cv.name
 
       self.updated.dat[cv.address][cv_name] = cv.updated_values
-      if init or len(cv.updated_values) > 0:
-        self.vl.dat[cv.address][cv_name] = cv.value
-        self.ts.dat[cv.address][cv_name] = cv.ts
-        if not init:
-          updated_val.insert(cv.address)
+      self.vl.dat[cv.address][cv_name] = cv.value
+      self.ts.dat[cv.address][cv_name] = cv.ts
+      updated_val.insert(cv.address)
 
     return updated_val
 

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -17,24 +17,16 @@ from collections import defaultdict
 
 cdef int CAN_INVALID_CNT = 5
 
-cdef class SigValDict:  # TODO: better name
-  cdef public:
-    # dict dat
-    map[uint32_t, map[string, double]] dat
-    dict msg_name_to_address
-
-  def __init__(self, msg_name_to_address):
+class SigValDict():
+  def __init__(self, dat, msg_name_to_address):
+    self.dat = dat
     self.msg_name_to_address = msg_name_to_address
 
   def __getitem__(self, key):
     # Converts unicode message name into address
     if not isinstance(key, numbers.Number):
       key = self.msg_name_to_address[bytes(key, encoding='utf8')]
-    print(self.dat[key])
     return self.dat[key]
-
-  def __setitem__(self, key, value):
-    self.dat[key] = value
 
 cdef class CANParser:
   cdef:
@@ -43,11 +35,9 @@ cdef class CANParser:
     map[string, uint32_t] msg_name_to_address
     map[uint32_t, string] address_to_msg_name
     vector[SignalValue] can_values
-    #map[uint32_t, map[string, double]] _vl
-    SigValDict _vl
+    map[uint32_t, map[string, double]] _vl
     map[uint32_t, map[string, uint16_t]] _ts
     map[uint32_t, map[string, vector[double]]] _updated
-    bool test_mode_enabled
 
   cdef readonly:
     string dbc_name
@@ -72,8 +62,6 @@ cdef class CANParser:
 
       self.msg_name_to_address[name] = msg.address
       self.address_to_msg_name[msg.address] = name
-
-    self._vl = SigValDict(self.msg_name_to_address)
 
     # Convert message names into addresses
     for i in range(len(signals)):
@@ -120,16 +108,15 @@ cdef class CANParser:
 
   @property
   def vl(self):
-    return self._vl
-    # return SigValDict(self._vl, self.msg_name_to_address)
+    return SigValDict(self._vl, self.msg_name_to_address)
 
-  #@property
-  #def ts(self):
-  #  return SigValDict(self._ts, self.msg_name_to_address)
+  @property
+  def ts(self):
+    return SigValDict(self._ts, self.msg_name_to_address)
 
-  #@property
-  #def updated(self):
-  #  return SigValDict(self._updated, self.msg_name_to_address)
+  @property
+  def updated(self):
+    return SigValDict(self._updated, self.msg_name_to_address)
 
   cdef unordered_set[uint32_t] update_vl(self, init=False):
     cdef unordered_set[uint32_t] updated_val
@@ -151,12 +138,9 @@ cdef class CANParser:
     for cv in can_values:
       cv_name = <unicode>cv.name
 
-      print(cv.address, cv_name, cv.value)
-      self._vl.dat[cv.address][cv_name] = cv.value
+      self._vl[cv.address][cv_name] = cv.value
       self._ts[cv.address][cv_name] = cv.ts
       self._updated[cv.address][cv_name] = cv.updated_values
-      print(self._vl.dat)
-      print()
 
       updated_val.insert(cv.address)
 

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -35,10 +35,9 @@ cdef class CANParser:
     map[string, uint32_t] msg_name_to_address
     map[uint32_t, string] address_to_msg_name
     vector[SignalValue] can_values
-    bool test_mode_enabled
-    dict _vl  # TODO: use maps
-    dict _ts
-    dict _updated
+    map[uint32_t, map[string, double]] _vl
+    map[uint32_t, map[string, uint16_t]] _ts
+    map[uint32_t, map[string, vector[double]]] _updated
 
   cdef readonly:
     string dbc_name
@@ -53,10 +52,6 @@ cdef class CANParser:
     self.dbc = dbc_lookup(dbc_name)
     if not self.dbc:
       raise RuntimeError(f"Can't find DBC: {dbc_name}")
-    self._vl = {}
-    self._ts = {}
-    self._updated = {}
-
     self.can_invalid_cnt = CAN_INVALID_CNT
 
     cdef int i
@@ -67,10 +62,6 @@ cdef class CANParser:
 
       self.msg_name_to_address[name] = msg.address
       self.address_to_msg_name[msg.address] = name
-
-      self._vl[msg.address] = {}
-      self._ts[msg.address] = {}
-      self._updated[msg.address] = {}
 
     # Convert message names into addresses
     for i in range(len(signals)):
@@ -128,7 +119,6 @@ cdef class CANParser:
     return SigValDict(self._updated, self.msg_name_to_address)
 
   cdef unordered_set[uint32_t] update_vl(self, init=False):
-    cdef string sig_name
     cdef unordered_set[uint32_t] updated_val
 
     can_values = self.can.update_vl()
@@ -140,9 +130,10 @@ cdef class CANParser:
       self.can_invalid_cnt = 0
     self.can_valid = self.can_invalid_cnt < CAN_INVALID_CNT
 
+    # TODO: build class fields independent of cpp_CANParser
     if not init:
       for msg in self._updated:
-        self._updated[msg] = {sig: [] for sig in self._updated[msg]}
+        (sig.second.clear() for sig in msg.second)
 
     for cv in can_values:
       cv_name = <unicode>cv.name

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -76,6 +76,9 @@ cdef class CANParser:
       self.vl.dat[msg.address] = {}
       self.ts.dat[msg.address] = {}
       self.updated.dat[msg.address] = {}
+      for x in range(msg.num_sigs):
+        self.vl.dat[msg.address][<unicode>msg.sigs[x].name] = 0
+        self.ts.dat[msg.address][<unicode>msg.sigs[x].name] = 0
 
     self.vl.msg_name_to_address = self.msg_name_to_address
     self.ts.msg_name_to_address = self.msg_name_to_address
@@ -139,10 +142,9 @@ cdef class CANParser:
       cv_name = <unicode>cv.name
 
       self.updated.dat[cv.address][cv_name] = cv.updated_values
-      self.vl.dat[cv.address][cv_name] = cv.value
-      self.ts.dat[cv.address][cv_name] = cv.ts
-
       if len(cv.updated_values) > 0:
+        self.vl.dat[cv.address][cv_name] = cv.value
+        self.ts.dat[cv.address][cv_name] = cv.ts
         updated_val.insert(cv.address)
 
     return updated_val


### PR DESCRIPTION
- Only returns updated values from cpp's update_vl/query_latest
  - Was to avoid logic for the updated values field in two places, but this is faster until a bigger refactor.
- Only keeps one copy of the data under the address
  - Converts message name into address only when accessing data

Test includes updating strings/parsing, updating the Cython CANParser's fields, and then a Toyota radar interface to simulate grabbing messages by name.

- Before #548: on average `0.25845228492` s
- After #548: on average `0.896` s
- This PR: on average `0.30398622744` s

Just the `__pyx_convert_vector_to_py_double` operation for the updated values field from C++ makes our new absolute minimum time ~0.26 seconds on average. Somehow, copying the updated_vals vector is slower than conversion.