### PR TITLE
CANParser: remove ts field

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -34,7 +34,6 @@ public:
   std::vector<double> vals;
   std::vector<std::vector<double>> updated_vals;
 
-  uint16_t ts;
   uint64_t seen;
   uint64_t check_threshold;
 
@@ -44,7 +43,7 @@ public:
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
-  bool parse(uint64_t sec, uint16_t ts_, uint8_t * dat);
+  bool parse(uint64_t sec, uint8_t * dat);
   bool update_counter_generic(int64_t v, int cnt_size);
 };
 

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -60,7 +60,6 @@ cdef extern from "common_dbc.h":
 
   cdef struct SignalValue:
     uint32_t address
-    uint16_t ts
     const char* name
     double value
     vector[double] updated_values

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -24,7 +24,6 @@ struct MessageParseOptions {
 
 struct SignalValue {
   uint32_t address;
-  uint16_t ts;
   const char* name;
   double value;  // latest value
   std::vector<double> updated_values;  // values updated this cycle

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -13,7 +13,7 @@
 // #define DEBUG printf
 #define INFO printf
 
-bool MessageState::parse(uint64_t sec, uint16_t ts_, uint8_t * dat) {
+bool MessageState::parse(uint64_t sec, uint8_t * dat) {
   uint64_t dat_le = read_u64_le(dat);
   uint64_t dat_be = read_u64_be(dat);
 
@@ -85,7 +85,6 @@ bool MessageState::parse(uint64_t sec, uint16_t ts_, uint8_t * dat) {
     vals[i] = tmp * sig.factor + sig.offset;
     updated_vals[i].push_back(vals[i]);
   }
-  ts = ts_;
   seen = sec;
 
   return true;
@@ -241,7 +240,7 @@ void CANParser::UpdateCans(uint64_t sec, const capnp::List<cereal::CanData>::Rea
     uint8_t dat[8] = {0};
     memcpy(dat, cmsg.getDat().begin(), cmsg.getDat().size());
 
-    state_it->second.parse(sec, cmsg.getBusTime(), dat);
+    state_it->second.parse(sec, dat);
   }
 }
 #endif
@@ -265,7 +264,7 @@ void CANParser::UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cms
   if (dat.size() > 8) return; //shouldn't ever happen
   uint8_t data[8] = {0};
   memcpy(data, dat.begin(), dat.size());
-  state_it->second.parse(sec, cmsg.get("busTime").as<uint16_t>(), data);
+  state_it->second.parse(sec, data);
 }
 
 void CANParser::UpdateValid(uint64_t sec) {
@@ -293,7 +292,6 @@ std::vector<SignalValue> CANParser::update_vl() {
       const Signal &sig = state.parse_sigs[i];
       ret.push_back((SignalValue){
         .address = state.address,
-        .ts = state.ts,
         .name = sig.name,
         .value = state.vals[i],
         .updated_values = state.updated_vals[i],

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -29,7 +29,6 @@ cdef class CANParser:
   cdef readonly:
     string dbc_name
     dict vl
-    dict ts
     dict updated
     bool can_valid
     int can_invalid_cnt
@@ -43,7 +42,6 @@ cdef class CANParser:
     if not self.dbc:
       raise RuntimeError(f"Can't find DBC: {dbc_name}")
     self.vl = {}
-    self.ts = {}
     self.updated = {}
 
     self.can_invalid_cnt = CAN_INVALID_CNT
@@ -58,8 +56,6 @@ cdef class CANParser:
       self.address_to_msg_name[msg.address] = name
       self.vl[msg.address] = {}
       self.vl[name] = {}
-      self.ts[msg.address] = {}
-      self.ts[name] = {}
       self.updated[msg.address] = {}
       self.updated[name] = {}
 
@@ -126,9 +122,6 @@ cdef class CANParser:
 
       self.vl[cv.address][cv_name] = cv.value
       self.vl[name][cv_name] = cv.value
-
-      self.ts[cv.address][cv_name] = cv.ts
-      self.ts[name][cv_name] = cv.ts
 
       self.updated[cv.address][cv_name] = cv.updated_values
       self.updated[name][cv_name] = cv.updated_values


### PR DESCRIPTION
Was set with 0 before, and setting with logMonoTime doesn't give us any more information as it's guaranteed that we receive messages in the same order here: https://gist.github.com/sshane/93d1adab1570dbbf1c2c1fadcfd227b4