### PR TITLE
CANParser: add field for all values from a cycle

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -70,7 +70,7 @@ public:
   #endif
   void UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cans);
   void UpdateValid(uint64_t sec);
-  std::vector<SignalValue> update_vl();
+  std::vector<SignalValue> query_latest();
 };
 
 class CANPacker {

--- a/can/common.h
+++ b/can/common.h
@@ -32,7 +32,7 @@ public:
 
   std::vector<Signal> parse_sigs;
   std::vector<double> vals;
-  std::vector<std::vector<double>> updated_vals;
+  std::vector<std::vector<double>> all_vals;
 
   uint64_t seen;
   uint64_t check_threshold;
@@ -58,7 +58,6 @@ private:
 public:
   bool can_valid = false;
   uint64_t last_sec = 0;
-  std::map<uint32_t, std::map<std::string, std::vector<double>>> updated_values;
 
   CANParser(int abus, const std::string& dbc_name,
             const std::vector<MessageParseOptions> &options,

--- a/can/common.h
+++ b/can/common.h
@@ -58,6 +58,7 @@ private:
 public:
   bool can_valid = false;
   uint64_t last_sec = 0;
+  std::map<uint32_t, std::map<std::string, std::vector<double>>> updated_values;
 
   CANParser(int abus, const std::string& dbc_name,
             const std::vector<MessageParseOptions> &options,

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -62,6 +62,7 @@ cdef extern from "common_dbc.h":
     uint32_t address
     const char* name
     double value
+    vector[double] all_values
 
   cdef struct SignalPackValue:
     string name
@@ -73,7 +74,6 @@ cdef extern from "common.h":
 
   cdef cppclass CANParser:
     bool can_valid
-    map[uint32_t, map[string, vector[double]]] updated_values
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
     void update_string(string, bool)
     vector[SignalValue] query_latest()

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -76,7 +76,7 @@ cdef extern from "common.h":
     map[uint32_t, map[string, vector[double]]] updated_values
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
     void update_string(string, bool)
-    vector[SignalValue] update_vl()
+    vector[SignalValue] query_latest()
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -62,7 +62,6 @@ cdef extern from "common_dbc.h":
     uint32_t address
     const char* name
     double value
-    vector[double] updated_values
 
   cdef struct SignalPackValue:
     string name
@@ -74,6 +73,7 @@ cdef extern from "common.h":
 
   cdef cppclass CANParser:
     bool can_valid
+    map[uint32_t, map[string, vector[double]]] updated_values
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
     void update_string(string, bool)
     vector[SignalValue] update_vl()

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -25,7 +25,8 @@ struct MessageParseOptions {
 struct SignalValue {
   uint32_t address;
   const char* name;
-  double value;
+  double value;  // latest value
+  std::vector<double> all_values;  // all values from this cycle
 };
 
 enum SignalType {

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -25,8 +25,7 @@ struct MessageParseOptions {
 struct SignalValue {
   uint32_t address;
   const char* name;
-  double value;  // latest value
-  std::vector<double> updated_values;  // values updated this cycle
+  double value;
 };
 
 enum SignalType {

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -288,16 +288,17 @@ std::vector<SignalValue> CANParser::update_vl() {
   for (auto& kv : message_states) {
     auto& state = kv.second;
     const bool msg_updated = last_sec == 0 || state.seen == last_sec;
-    for (int i=0; i<state.parse_sigs.size(); i++) {
+    for (int i = 0; i < state.parse_sigs.size(); i++) {
+      const Signal &sig = state.parse_sigs[i];
       if (msg_updated) {
-        const Signal &sig = state.parse_sigs[i];
         ret.push_back((SignalValue){
           .address = state.address,
           .name = sig.name,
           .value = state.vals[i],
-          .updated_values = state.updated_vals[i],
+//          .updated_values = state.updated_vals[i],
         });
       }
+      updated_values[state.address][sig.name] = state.updated_vals[i];
       state.updated_vals[i].clear();  // reset updated values for next cycle
     }
   }

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -83,6 +83,7 @@ bool MessageState::parse(uint64_t sec, uint8_t * dat) {
     }
 
     vals[i] = tmp * sig.factor + sig.offset;
+    all_vals[i].push_back(vals[i]);
   }
   seen = sec;
 
@@ -147,6 +148,7 @@ CANParser::CANParser(int abus, const std::string& dbc_name,
       if (sig->type != SignalType::DEFAULT) {
         state.parse_sigs.push_back(*sig);
         state.vals.push_back(0);
+        state.all_vals.push_back({});
       }
     }
 
@@ -160,6 +162,7 @@ CANParser::CANParser(int abus, const std::string& dbc_name,
             && sig->type == SignalType::DEFAULT) {
           state.parse_sigs.push_back(*sig);
           state.vals.push_back(0);
+          state.all_vals.push_back({});
           break;
         }
       }
@@ -188,6 +191,7 @@ CANParser::CANParser(int abus, const std::string& dbc_name, bool ignore_checksum
       const Signal *sig = &msg->sigs[j];
       state.parse_sigs.push_back(*sig);
       state.vals.push_back(0);
+      state.all_vals.push_back({});
     }
 
     message_states[state.address] = state;
@@ -209,7 +213,7 @@ void CANParser::update_string(const std::string &data, bool sendcan) {
 
   last_sec = event.getLogMonoTime();
 
-  auto cans = sendcan? event.getSendcan() : event.getCan();
+  auto cans = sendcan ? event.getSendcan() : event.getCan();
   UpdateCans(last_sec, cans);
 
   UpdateValid(last_sec);
@@ -284,18 +288,17 @@ std::vector<SignalValue> CANParser::query_latest() {
 
   for (auto& kv : message_states) {
     auto& state = kv.second;
-    const bool msg_updated = last_sec == 0 || state.seen == last_sec;
+    if (last_sec != 0 && state.seen != last_sec) continue;
+
     for (int i = 0; i < state.parse_sigs.size(); i++) {
       const Signal &sig = state.parse_sigs[i];
-      if (msg_updated) {
-        ret.push_back((SignalValue){
-          .address = state.address,
-          .name = sig.name,
-          .value = state.vals[i],
-        });
-      }
-      updated_values[state.address][sig.name] = state.updated_vals[i];
-      state.updated_vals[i].clear();  // reset updated values for next cycle
+      ret.push_back((SignalValue){
+        .address = state.address,
+        .name = sig.name,
+        .value = state.vals[i],
+        .all_values = state.all_vals[i],
+      });
+      state.all_vals[i].clear();
     }
   }
 

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -282,7 +282,7 @@ void CANParser::UpdateValid(uint64_t sec) {
   }
 }
 
-std::vector<SignalValue> CANParser::update_vl() {
+std::vector<SignalValue> CANParser::query_latest() {
   std::vector<SignalValue> ret;
 
   for (auto& kv : message_states) {
@@ -295,7 +295,6 @@ std::vector<SignalValue> CANParser::update_vl() {
           .address = state.address,
           .name = sig.name,
           .value = state.vals[i],
-//          .updated_values = state.updated_vals[i],
         });
       }
       updated_values[state.address][sig.name] = state.updated_vals[i];

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -287,15 +287,17 @@ std::vector<SignalValue> CANParser::update_vl() {
 
   for (auto& kv : message_states) {
     auto& state = kv.second;
-
+    const bool msg_updated = last_sec == 0 || state.seen == last_sec;
     for (int i=0; i<state.parse_sigs.size(); i++) {
-      const Signal &sig = state.parse_sigs[i];
-      ret.push_back((SignalValue){
-        .address = state.address,
-        .name = sig.name,
-        .value = state.vals[i],
-        .updated_values = state.updated_vals[i],
-      });
+      if (msg_updated) {
+        const Signal &sig = state.parse_sigs[i];
+        ret.push_back((SignalValue){
+          .address = state.address,
+          .name = sig.name,
+          .value = state.vals[i],
+          .updated_values = state.updated_vals[i],
+        });
+      }
       state.updated_vals[i].clear();  // reset updated values for next cycle
     }
   }

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -42,7 +42,6 @@ cdef class CANParser:
   cdef:
     cpp_CANParser *can
     const DBC *dbc
-    # map[string, uint32_t] msg_name_to_address
     dict msg_name_to_address
     map[uint32_t, string] address_to_msg_name
     vector[SignalValue] can_values
@@ -51,7 +50,6 @@ cdef class CANParser:
   cdef readonly:
     string dbc_name
     CANParserField vl
-    # dict updated
     bool can_valid
     int can_invalid_cnt
 
@@ -65,7 +63,6 @@ cdef class CANParser:
       raise RuntimeError(f"Can't find DBC: {dbc_name}")
     self.vl = CANParserField()
     self.msg_name_to_address = {}
-    # self.updated = {}
 
     self.can_invalid_cnt = CAN_INVALID_CNT
 
@@ -78,9 +75,6 @@ cdef class CANParser:
       self.msg_name_to_address[name] = msg.address
       self.address_to_msg_name[msg.address] = name
       self.vl.dat[msg.address] = {}
-      # self.vl.dat[name] = {}
-      # self.updated[msg.address] = {}
-      # self.updated[name] = {}
 
     self.vl.msg_name_to_address = self.msg_name_to_address
 
@@ -135,7 +129,7 @@ cdef class CANParser:
     cdef string sig_name
     cdef unordered_set[uint32_t] updated_val
 
-    can_values = self.can.update_vl()
+    can_values = self.can.query_latest()
     valid = self.can.can_valid
 
     # Update invalid flag
@@ -145,17 +139,8 @@ cdef class CANParser:
     self.can_valid = self.can_invalid_cnt < CAN_INVALID_CNT
 
     for cv in can_values:
-      # Cast char * directly to unicode
-      #name = <unicode>self.address_to_msg_name[cv.address].c_str()
       cv_name = <unicode>cv.name
-
       self.vl.dat[cv.address][cv_name] = cv.value
-      #self.vl[name][cv_name] = cv.value
-
-      #self.updated[cv.address][cv_name] = cv.updated_values
-      #self.updated[name][cv_name] = cv.updated_values
-
-      #if cv.updated_values.size():
       updated_val.insert(cv.address)
 
     return updated_val

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -139,8 +139,7 @@ cdef class CANParser:
     self.can_valid = self.can_invalid_cnt < CAN_INVALID_CNT
 
     for cv in can_values:
-      cv_name = <unicode>cv.name
-      self.vl.dat[cv.address][cv_name] = cv.value
+      self.vl.dat[cv.address][<unicode>cv.name] = cv.value
       updated_val.insert(cv.address)
 
     return updated_val

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -123,8 +123,8 @@ cdef class CANParser:
       self.vl[cv.address][cv_name] = cv.value
       self.vl[name][cv_name] = cv.value
 
-      self.updated[cv.address][cv_name] = cv.updated_values
-      self.updated[name][cv_name] = cv.updated_values
+      #self.updated[cv.address][cv_name] = cv.updated_values
+      #self.updated[name][cv_name] = cv.updated_values
 
       if cv.updated_values.size():
         updated_val.insert(cv.address)

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -139,11 +139,15 @@ class TestCanParserPacker(unittest.TestCase):
       values = {"USER_BRAKE": user_brake}
       msgs.append(packer.make_can_msg("VSA_STATUS", 0, values))
 
-    parser.update_strings([can_list_to_can_capnp(msgs)])
+    parser.update_string(can_list_to_can_capnp(msgs))
     updated = parser.updated["VSA_STATUS"]["USER_BRAKE"]
 
     self.assertEqual(updated, user_brake_vals)
     self.assertEqual(updated[-1], parser.vl["VSA_STATUS"]["USER_BRAKE"])
+
+    parser.update_string(can_list_to_can_capnp([]))
+    updated = parser.updated["VSA_STATUS"]["USER_BRAKE"]
+    self.assertEqual(len(updated), 0)
 
 
 if __name__ == "__main__":

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import unittest
+import random
 
 import cereal.messaging as messaging
 from opendbc.can.parser import CANParser
@@ -138,7 +139,7 @@ class TestCanParserPacker(unittest.TestCase):
     idx = 0
     for _ in range(10):
       # Ensure CANParser holds the values of any duplicate messages
-      user_brake_vals = [4, 5, 6, 7]
+      user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
       msgs = []
       for user_brake in user_brake_vals:
         values = {"USER_BRAKE": user_brake}
@@ -149,7 +150,8 @@ class TestCanParserPacker(unittest.TestCase):
       vl_all = parser.vl_all["VSA_STATUS"]["USER_BRAKE"]
 
       self.assertEqual(vl_all, user_brake_vals)
-      self.assertEqual(vl_all[-1], parser.vl["VSA_STATUS"]["USER_BRAKE"])
+      if len(user_brake_vals):
+        self.assertEqual(vl_all[-1], parser.vl["VSA_STATUS"]["USER_BRAKE"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Only returns updated values from cpp's update_vl/query_latest, as before
- Only keeps one copy of the data under the address
  - Converts message name into address only when accessing data
- The updated values data is kept track of in C++ CANParser for practically free
  - Then when the Cython `updated` field is accessed, only then do we pull from that C++ map and access the message/signal we need

Test includes updating strings/parsing, updating the Cython CANParser's fields, and then a Toyota radar interface to simulate grabbing messages by string.

- Before #548: on average `0.25845228492` s
- After #548: on average `0.896` s
- This PR: on average `0.198003333` s

Just the `__pyx_convert_vector_to_py_double` operation for converting the updated_vals vector from C++ to Python raises the minimum time to ~0.26 seconds on average, so now we don't copy or convert it until accessed.