### PR TITLE
CANParser: fix missing updated values

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -135,8 +135,8 @@ cdef class CANParser:
 
     updated_addrs = set()
     for s in strings:
-      updated_addrs = self.update_string(s, sendcan)
-      updated_addrs.update(updated_addrs)
+      self.can.update_string(s, sendcan)
+      updated_addrs.update(self.update_vl())
     return updated_addrs
 
 

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -142,7 +142,7 @@ class TestCanParserPacker(unittest.TestCase):
       user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
       can_msgs = [[], []]
       for frame, brake_vals in enumerate((user_brake_vals[:5], user_brake_vals[-5:])):
-        for user_brake in user_brake_vals:
+        for user_brake in brake_vals:
           values = {"USER_BRAKE": user_brake}
           can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values, idx))
           idx += 1

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -139,9 +139,10 @@ class TestCanParserPacker(unittest.TestCase):
     idx = 0
     for _ in range(10):
       # Ensure CANParser holds the values of any duplicate messages over multiple frames
-      user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
+      user_brake_vals = [random.randrange(100) for _ in range(random.randrange(5, 10))]
+      half_idx = len(user_brake_vals) // 2
       can_msgs = [[], []]
-      for frame, brake_vals in enumerate((user_brake_vals[:5], user_brake_vals[-5:])):
+      for frame, brake_vals in enumerate((user_brake_vals[:half_idx], user_brake_vals[half_idx:])):
         for user_brake in brake_vals:
           values = {"USER_BRAKE": user_brake}
           can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values, idx))

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -138,15 +138,17 @@ class TestCanParserPacker(unittest.TestCase):
 
     idx = 0
     for _ in range(10):
-      # Ensure CANParser holds the values of any duplicate messages
+      # Ensure CANParser holds the values of any duplicate messages over multiple frames
       user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
-      msgs = []
-      for user_brake in user_brake_vals:
-        values = {"USER_BRAKE": user_brake}
-        msgs.append(packer.make_can_msg("VSA_STATUS", 0, values, idx))
-        idx += 1
+      can_msgs = [[], []]
+      for frame, brake_vals in enumerate((user_brake_vals[:5], user_brake_vals[-5:])):
+        for user_brake in user_brake_vals:
+          values = {"USER_BRAKE": user_brake}
+          can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values, idx))
+          idx += 1
 
-      parser.update_strings((can_list_to_can_capnp(msgs), ))
+      can_strings = [can_list_to_can_capnp(msgs) for msgs in can_msgs]
+      parser.update_strings(can_strings)
       vl_all = parser.vl_all["VSA_STATUS"]["USER_BRAKE"]
 
       self.assertEqual(vl_all, user_brake_vals)


### PR DESCRIPTION
Don't clear `vl_all` inside `update_string` so we don't throw away any updated values before returning to the CANParser user

Average before: `(.3018515+.30946+.295825+.289596+.288537+.2926395+.28401279+.28353)/8=0.293181474` seconds
Average now: `(.27749109+.303485+.2765805+.295201+.26981163+.270950555)/6=0.282253296` seconds