### PR TITLE
CANParser: vl_all doesn't contain latest value

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -135,8 +135,8 @@ cdef class CANParser:
 
     updated_addrs = set()
     for s in strings:
-      updated_addrs = self.update_string(s, sendcan)
-      updated_addrs.update(updated_addrs)
+      self.can.update_string(s, sendcan)
+      updated_addrs.update(self.update_vl())
     return updated_addrs
 
 

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -142,7 +142,7 @@ class TestCanParserPacker(unittest.TestCase):
       user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
       can_msgs = [[], []]
       for frame, brake_vals in enumerate((user_brake_vals[:5], user_brake_vals[-5:])):
-        for user_brake in user_brake_vals:
+        for user_brake in brake_vals:
           values = {"USER_BRAKE": user_brake}
           can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values, idx))
           idx += 1

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -139,9 +139,10 @@ class TestCanParserPacker(unittest.TestCase):
     idx = 0
     for _ in range(10):
       # Ensure CANParser holds the values of any duplicate messages over multiple frames
-      user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
+      user_brake_vals = [random.randrange(100) for _ in range(random.randrange(5, 10))]
+      half_idx = len(user_brake_vals) // 2
       can_msgs = [[], []]
-      for frame, brake_vals in enumerate((user_brake_vals[:5], user_brake_vals[-5:])):
+      for frame, brake_vals in enumerate((user_brake_vals[:half_idx], user_brake_vals[half_idx:])):
         for user_brake in brake_vals:
           values = {"USER_BRAKE": user_brake}
           can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values, idx))

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -138,15 +138,17 @@ class TestCanParserPacker(unittest.TestCase):
 
     idx = 0
     for _ in range(10):
-      # Ensure CANParser holds the values of any duplicate messages
+      # Ensure CANParser holds the values of any duplicate messages over multiple frames
       user_brake_vals = [random.randrange(100) for _ in range(random.randrange(10))]
-      msgs = []
-      for user_brake in user_brake_vals:
-        values = {"USER_BRAKE": user_brake}
-        msgs.append(packer.make_can_msg("VSA_STATUS", 0, values, idx))
-        idx += 1
+      can_msgs = [[], []]
+      for frame, brake_vals in enumerate((user_brake_vals[:5], user_brake_vals[-5:])):
+        for user_brake in user_brake_vals:
+          values = {"USER_BRAKE": user_brake}
+          can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values, idx))
+          idx += 1
 
-      parser.update_strings((can_list_to_can_capnp(msgs), ))
+      can_strings = [can_list_to_can_capnp(msgs) for msgs in can_msgs]
+      parser.update_strings(can_strings)
       vl_all = parser.vl_all["VSA_STATUS"]["USER_BRAKE"]
 
       self.assertEqual(vl_all, user_brake_vals)


### PR DESCRIPTION
As multiple messages received per cycle aren't the majority, we now only update the `vl_all` when there's two updates, where vl contains value at `t0` and `vl_all` contains values starting from `t-1` back.