### PR TITLE
Update Jinja2 to fix markupsafe error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Cython==0.29.14
 flake8==3.7.9
-Jinja2==2.11.3
+Jinja2==3.0.3
 numpy==1.21.0
 pycapnp==1.0.0
 pylint==2.4.3


### PR DESCRIPTION
I've been scratching my head about building Plotjuggler recently and found there was a package which was deprecated that opendbc builds with. The latest version of Plotjugger fails to build due to the requirements.txt in opendbc. 

**Steps to reproduce the issue:**
1. Download a clean installation of Plotjuggler. Consider modifying the command which runs docker in build.sh to use "--no-cache".
2. Initialize and update submodules.
3. run build.sh
**Error:**
![image](https://user-images.githubusercontent.com/64510542/155278052-603e82e1-d4fa-4b55-802f-7467d6587e8d.png)

markupsafe can't find softunicode

**Reason for this problem:**
Markupsafe has deprecated soft unicode
https://markupsafe.palletsprojects.com/en/2.1.x/changes/#version-2-1-0

In requirements.txt of opendbc:
Jinja2==2.11.3

Jinja2 is looking for soft_unicode, so obviously it crashes.

**Fix:**
Update Jinja2 to a version which supports soft_str as mentioned in the markupsafe changelog.
Not sure if you a more preferred way of handling this but I found it builds fine on my machine and C3.

![image](https://user-images.githubusercontent.com/64510542/155278847-e98cccf0-372b-4526-9bf1-360eac1def70.png)
