### PR TITLE
Toyota: comments for LTA steering signals

### DIFF
--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -38,7 +38,7 @@ CM_ SG_ 401 SETME_X64 "ramps to 0 smoothly then back on falling edge of STEER_RE
 CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
 CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
-CM_ SG_ 401 BIT "has coorelation to STEER_REQUEST";
+CM_ SG_ 401 BIT "has correlation to STEER_REQUEST";
 CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";

--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -33,6 +33,13 @@ BO_ 1014 BSM: 8 XXX
  SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
  SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
 
+CM_ SG_ 401 PERCENTAGE "driver override percentage (0-100), very close to steeringPressed in OP";
+CM_ SG_ 401 SETME_X64 "ramps to 0 smoothly then back on falling edge of STEER_REQUEST if BIT isn't 1";
+CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
+CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
+CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
+CM_ SG_ 401 BIT "has coorelation to STEER_REQUEST";
+CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -550,6 +550,13 @@ BO_ 1014 BSM: 8 XXX
  SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
  SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
 
+CM_ SG_ 401 PERCENTAGE "driver override percentage (0-100), very close to steeringPressed in OP";
+CM_ SG_ 401 SETME_X64 "ramps to 0 smoothly then back on falling edge of STEER_REQUEST if BIT isn't 1";
+CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
+CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
+CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
+CM_ SG_ 401 BIT "has coorelation to STEER_REQUEST";
+CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";


### PR DESCRIPTION
Dashcam LTA route:
4aa5d874f367adbc|2022-02-20--22-59-18

“Stock” LTA OP
4aa5d874f367adbc|2022-02-21--18-22-18

"Broken" OP LTA route (would not steer):
4aa5d874f367adbc|2022-02-21--18-37-54

Dashcam with disablements (LTA OEM steer overrides)
4aa5d874f367adbc|2022-02-22--14-47-21

Dadcam mode TSS2.5 stock
f15e3c37c118e841|2022-02-18--13-58-56