### PR TITLE
Allow UTF-8 characters in DBC files

### DIFF
--- a/can/dbc.py
+++ b/can/dbc.py
@@ -20,7 +20,7 @@ DBCSignal = namedtuple("DBCSignal", ["name", "start_bit", "msb", "lsb", "size", 
 class dbc():
   def __init__(self, fn):
     self.name, _ = os.path.splitext(os.path.basename(fn))
-    with open(fn, encoding="ascii") as f:
+    with open(fn, encoding="utf-8") as f:
       self.txt = f.readlines()
     self._warned_addresses = set()
 


### PR DESCRIPTION
Required to parse certain German Engineered™ signal comments.

Examples to come:

```
CM_ SG_ 385 VZE_Anzeigemodus "Steuert die verschiedenen Möglichkeiten der Anzeige, vor allem die Aktivierung sowie die erweiterten Anzeigen im Kombi";
CM_ SG_ 385 VZE_Hinweistext "Über Index wird ein Hinweistext beschrieben, der durch das Kombi dargestellte werden soll.

Wertebereich lt. Hashtabelle";
CM_ SG_ 385 VZE_Statuszaehler_1 "Steuerungssignal zur Steuerung des Distanzzählers von Verkehrszeichen 1";
CM_ SG_ 385 VZE_Statuszaehler_2 "Steuerungssignal zur Steuerung des Distanzzählers von Verkehrszeichen 2";
CM_ SG_ 385 VZE_Statuszaehler_3 "Steuerungssignal zur Steuerung des Distanzzählers von Verkehrszeichen 3";
```