### PR TITLE
VW MQB: Detect sport-manumatic shift program

### DIFF
--- a/vw_mqb_2010.dbc
+++ b/vw_mqb_2010.dbc
@@ -1411,7 +1411,7 @@ CM_ SG_ 780 SetSpeed "ACC set speed";
 CM_ SG_ 391 GearPosition "Traditional PRND plus B-mode aggressive regen, B-mode mapped to Drive";
 CM_ SG_ 960 ZAS_Kl_15 "Indicates ignition on";
 VAL_ 159 EPS_HCA_Status 0 "disabled" 1 "initializing" 2 "fault" 3 "ready" 4 "rejected" 5 "active";
-VAL_ 173 GE_Fahrstufe 5 "P" 6 "R" 7 "N" 8 "D" 9 "S" 10 "E" 14 "T";
+VAL_ 173 GE_Fahrstufe 5 "P" 6 "R" 7 "N" 8 "D" 9 "S" 10 "E" 13 "T" 14 "T";
 VAL_ 288 TSK_Status 0 "init" 1 "disabled" 2 "enabled" 3 "regulating" 4 "accel_pedal_override" 5 "brake_only" 6 "temp_fault" 7 "perm_fault";
 VAL_ 302 ACC_Freewheel_Type 0 "freewheel_released" 1 "freewheel_not_permitted" 2 "freewheel_not_released" 3 "freewheel_requested" ;
 VAL_ 302 ACC_Hold_Type 0 "no_request" 1 "hold" 2 "park" 3 "hold_standby" 4 "startup" 5 "loosen_over_ramp" ;


### PR DESCRIPTION
Add a duplicate enum value for Tiptronic in sport/race mode, which the transmission handles a little differently from the manumatic program used in normal and eco modes. Fixes "gear not D" when trying to engage while in sport/race Tip mode.

Verified the different enum value in `3cfdec54aa035f3f|2022-04-08--20-06-57`, and also against the official DBC enum, which we don't use in openpilot to maintain code commonality with other car ports.

`VAL_ 173 GE_Fahrstufe 0 "Zwischenstellung" 1 "Init" 5 "Position_P" 6 "Position_R" 7 "Position_N" 8 "Position_D" 9 "Position_S" 10 "Effizienz" 13 "Tipp_in_S" 14 "Tipp_in_D" 15 "Fehler" ;`

No changes required to openpilot, other than an opendbc bump.