### PR TITLE
add missing import for std::numeric_limits<...>::max()

### DIFF
--- a/can/parser.cc
+++ b/can/parser.cc
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <limits>
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -61,7 +62,7 @@ bool MessageState::parse(uint64_t sec, const std::vector<uint8_t> &dat) {
 
     bool counter_failed = false;
     if (!ignore_counter) {
-      if (sig.type == SignalType::HONDA_COUNTER || sig.type == SignalType::VOLKSWAGEN_COUNTER || sig.type == SignalType::PEDAL_COUNTER) { 
+      if (sig.type == SignalType::HONDA_COUNTER || sig.type == SignalType::VOLKSWAGEN_COUNTER || sig.type == SignalType::PEDAL_COUNTER) {
         counter_failed = !update_counter_generic(tmp, sig.size);
       }
     }


### PR DESCRIPTION
I was getting a build error for this missing import...
```
opendbc/can/parser.cc:111:32: error: no member named 'numeric_limits' in namespace 'std'
  bus_timeout_threshold = std::numeric_limits<uint64_t>::max();
                          ~~~~~^
opendbc/can/parser.cc:111:47: error: unexpected type name 'uint64_t': expected expression
  bus_timeout_threshold = std::numeric_limits<uint64_t>::max();
                                              ^
opendbc/can/parser.cc:111:58: error: no member named 'max' in the global namespace
  bus_timeout_threshold = std::numeric_limits<uint64_t>::max();
                                                       ~~^
3 errors generated.
scons: *** [opendbc/can/parser.os] Error 1
scons: building terminated because of errors.
```

I'm using Ubuntu 22.04 (sorry) with clang 14.0.0-1ubuntu1, if that matters