### PR TITLE
Toyota: fix description of DISTANCE signal

### DIFF
--- a/generator/toyota/_toyota_2017.dbc
+++ b/generator/toyota/_toyota_2017.dbc
@@ -145,19 +145,19 @@ BO_ 742 LEAD_INFO: 8 DSU
 
 BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACCEL_CMD : 7|16@0- (0.001,0) [-20|20] "m/s^2" HCU
- SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
- SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
- SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
- SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
+ SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
+ SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ PERMIT_BRAKING : 30|1@0+ (1,0) [0|1] "" HCU
  SG_ RELEASE_STANDSTILL : 31|1@0+ (1,0) [0|1] "" HCU
- SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACCEL_CMD_ALT : 47|8@0- (0.05,0) [0|0] "m/s^2" XXX
- SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 836 PRE_COLLISION_2: 8 DSU
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
@@ -378,7 +378,7 @@ CM_ SG_ 835 ACC_TYPE "if 2, car is likely to have a permanent low speed lockout.
 CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
-CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 DISTANCE "Cycle through ACC following distance from long, mid, short when set to 1";
 CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";

--- a/toyota_new_mc_pt_generated.dbc
+++ b/toyota_new_mc_pt_generated.dbc
@@ -190,19 +190,19 @@ BO_ 742 LEAD_INFO: 8 DSU
 
 BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACCEL_CMD : 7|16@0- (0.001,0) [-20|20] "m/s^2" HCU
- SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
- SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
- SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
- SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
+ SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
+ SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ PERMIT_BRAKING : 30|1@0+ (1,0) [0|1] "" HCU
  SG_ RELEASE_STANDSTILL : 31|1@0+ (1,0) [0|1] "" HCU
- SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACCEL_CMD_ALT : 47|8@0- (0.05,0) [0|0] "m/s^2" XXX
- SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 836 PRE_COLLISION_2: 8 DSU
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
@@ -423,7 +423,7 @@ CM_ SG_ 835 ACC_TYPE "if 2, car is likely to have a permanent low speed lockout.
 CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
-CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 DISTANCE "Cycle through ACC following distance from long, mid, short when set to 1";
 CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -190,19 +190,19 @@ BO_ 742 LEAD_INFO: 8 DSU
 
 BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACCEL_CMD : 7|16@0- (0.001,0) [-20|20] "m/s^2" HCU
- SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
- SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
- SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
- SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
+ SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
+ SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ PERMIT_BRAKING : 30|1@0+ (1,0) [0|1] "" HCU
  SG_ RELEASE_STANDSTILL : 31|1@0+ (1,0) [0|1] "" HCU
- SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACCEL_CMD_ALT : 47|8@0- (0.05,0) [0|0] "m/s^2" XXX
- SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 836 PRE_COLLISION_2: 8 DSU
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
@@ -423,7 +423,7 @@ CM_ SG_ 835 ACC_TYPE "if 2, car is likely to have a permanent low speed lockout.
 CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
-CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 DISTANCE "Cycle through ACC following distance from long, mid, short when set to 1";
 CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";

--- a/toyota_tnga_k_pt_generated.dbc
+++ b/toyota_tnga_k_pt_generated.dbc
@@ -190,19 +190,19 @@ BO_ 742 LEAD_INFO: 8 DSU
 
 BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ACCEL_CMD : 7|16@0- (0.001,0) [-20|20] "m/s^2" HCU
- SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
- SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ ALLOW_LONG_PRESS : 17|2@0+ (1,0) [0|2] "" XXX
- SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
- SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ ACC_MALFUNCTION : 18|1@0+ (1,0) [0|0] "" XXX
+ SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
  SG_ DISTANCE : 20|1@0+ (1,0) [0|1] "" XXX
  SG_ MINI_CAR : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACC_TYPE : 23|2@0+ (1,0) [0|3] "" HCU
+ SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
+ SG_ ACC_CUT_IN : 25|1@0+ (1,0) [0|1] "" XXX
  SG_ PERMIT_BRAKING : 30|1@0+ (1,0) [0|1] "" HCU
  SG_ RELEASE_STANDSTILL : 31|1@0+ (1,0) [0|1] "" HCU
- SG_ CANCEL_REQ : 24|1@0+ (1,0) [0|1] "" HCU
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACCEL_CMD_ALT : 47|8@0- (0.05,0) [0|0] "m/s^2" XXX
- SG_ RADAR_DIRTY : 19|1@0+ (1,0) [0|1] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 836 PRE_COLLISION_2: 8 DSU
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
@@ -423,7 +423,7 @@ CM_ SG_ 835 ACC_TYPE "if 2, car is likely to have a permanent low speed lockout.
 CM_ SG_ 835 RADAR_DIRTY "Display Clean Radar Sensor message on HUD";
 CM_ SG_ 835 ACC_MALFUNCTION "display ACC fault on dash if set to 1";
 CM_ SG_ 835 ACC_CUT_IN "Display blinking yellow lead if set to 1";
-CM_ SG_ 835 DISTANCE "Display Distance Bars on HUD Permanently";
+CM_ SG_ 835 DISTANCE "Cycle through ACC following distance from long, mid, short when set to 1";
 CM_ SG_ 835 ITS_CONNECT_LEAD "Displayed when lead car is capable of ITS Connect";
 CM_ SG_ 835 ALLOW_LONG_PRESS "Enable Toyota's factory set speed increment behaviour, available on both metrics cars and imperial unit cars";
 CM_ SG_ 835 PERMIT_BRAKING "Original ACC has this going high when a car in front is detected. In openpilot and before the PERMIT_BRAKING name, this was 'SET_ME_1' and is hardcoded to be high. Unsure if only informational or has an effect though existing usage in openpilot is to always set it to 1. Originally 'PMTBRKG' in the leaked toyota_2017_ref_pt.dbc file and name expansion speculated to be PerMiT BRaKinG.";


### PR DESCRIPTION
The `DISTANCE` signal is used to cycle through different following distances, the following distance goes from long to medium to short on every instances where the signal is set to `1`, I misinterpreted the signal before and put the wrong description in the dbc file, fixing it now.

PR is also rearranging `ACC_CONTROL` in numerical order.