### PR TITLE
GM: Add ParkBrake signal for manual parking brakes

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -154,6 +154,7 @@ BO_ 352 VehicleIgnition: 5 XXX
 
 BO_ 497 VehicleIgnitionAlt: 8 XXX
  SG_ Ignition : 5|1@0+ (1,0) [0|1] "" XXX
+ SG_ ParkBrake : 36|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 501 ECMPRDNL2: 8 K20_ECM
  SG_ TransmissionState : 48|4@1+ (1,0) [0|7] "" NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -174,6 +174,7 @@ BO_ 352 VehicleIgnition: 5 XXX
 
 BO_ 497 VehicleIgnitionAlt: 8 XXX
  SG_ Ignition : 5|1@0+ (1,0) [0|1] "" XXX
+ SG_ ParkBrake : 36|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 501 ECMPRDNL2: 8 K20_ECM
  SG_ TransmissionState : 48|4@1+ (1,0) [0|7] "" NEO


### PR DESCRIPTION
GM port / dbc only had a signal for Electronic parking brakes - in vehicle with manual parking brakes (Suburban, Tahoe, trucks)  the entire message used for EPBs is missing and there is only a manual brake.

This update to the GM powertrain dbc adds a new flag to the VehicleIgnitionAlt message that returns true for both electronic and manual parking brakes.

**I coordinated a button press with depressing the parking brake - this first image shows this visual alignment from the Suburban:**

![Suburban_button_correlated](https://user-images.githubusercontent.com/29778397/166608655-3d9d77c5-3fb1-48df-88fd-97c0f67c2394.png)

**I then confirmed with verylukyguy's Acadia (that has an EPB) that the flag goes high for both Electronic and Manual parking brakes:**

![New_Park_Brake_Signal](https://user-images.githubusercontent.com/29778397/166608450-36e087c0-137f-4072-a354-5ab64d3aad36.png)

