### PR TITLE
Subaru: Use SI units for ACC distance signals

### DIFF
--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -205,7 +205,7 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
+ SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX

--- a/generator/subaru/_subaru_preglobal_2015.dbc
+++ b/generator/subaru/_subaru_preglobal_2015.dbc
@@ -139,7 +139,7 @@ BO_ 353 ES_Distance: 8 XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX
  SG_ Standstill : 22|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 24|8@1+ (0.0196,0) [0|255] "m" XXX
+ SG_ Close_Distance : 24|8@1+ (0.019607,0) [0|5] "m" XXX
  SG_ Signal4 : 32|9@1+ (1,0) [0|255] "" XXX
  SG_ Standstill_2 : 41|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Fault : 42|1@1+ (1,0) [0|1] "" XXX

--- a/generator/subaru/subaru_forester_2017.dbc
+++ b/generator/subaru/subaru_forester_2017.dbc
@@ -8,7 +8,7 @@ BO_ 355 ES_DashStatus: 8 XXX
  SG_ Counter : 40|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake : 43|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 54|1@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 56|4@1+ (1,0) [0|1] "" XXX
+ SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/generator/subaru/subaru_global_2017.dbc
+++ b/generator/subaru/subaru_global_2017.dbc
@@ -24,7 +24,7 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ Distance_Swap : 37|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
+ SG_ Close_Distance : 40|8@1+ (0.019607,0) [0|5] "m" XXX
  SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX

--- a/generator/subaru/subaru_outback_2015.dbc
+++ b/generator/subaru/subaru_outback_2015.dbc
@@ -16,7 +16,7 @@ BO_ 358 ES_DashStatus: 8 XXX
  SG_ Counter : 37|3@1+ (1,0) [0|7] "" XXX
  SG_ Steep_Hill_Disengage : 44|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 46|1@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 48|4@1+ (5,0) [0|15] "m" XXX
+ SG_ Far_Distance : 48|4@1+ (5,0) [0|75] "m" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/generator/subaru/subaru_outback_2019.dbc
+++ b/generator/subaru/subaru_outback_2019.dbc
@@ -16,7 +16,7 @@ BO_ 358 ES_DashStatus: 8 XXX
  SG_ Counter : 37|3@1+ (1,0) [0|7] "" XXX
  SG_ Steep_Hill_Disengage : 44|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 46|1@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 48|4@1+ (5,0) [0|15] "m" XXX
+ SG_ Far_Distance : 48|4@1+ (5,0) [0|75] "m" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/subaru_forester_2017_generated.dbc
+++ b/subaru_forester_2017_generated.dbc
@@ -143,7 +143,7 @@ BO_ 353 ES_Distance: 8 XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX
  SG_ Standstill : 22|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 24|8@1+ (0.0196,0) [0|255] "m" XXX
+ SG_ Close_Distance : 24|8@1+ (0.019607,0) [0|5] "m" XXX
  SG_ Signal4 : 32|9@1+ (1,0) [0|255] "" XXX
  SG_ Standstill_2 : 41|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Fault : 42|1@1+ (1,0) [0|1] "" XXX
@@ -257,7 +257,7 @@ BO_ 355 ES_DashStatus: 8 XXX
  SG_ Counter : 40|3@1+ (1,0) [0|7] "" XXX
  SG_ Brake : 43|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 54|1@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 56|4@1+ (1,0) [0|1] "" XXX
+ SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -209,7 +209,7 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
+ SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX
@@ -287,7 +287,7 @@ BO_ 545 ES_Distance: 8 XXX
  SG_ Distance_Swap : 37|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_EPB : 38|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal4 : 39|1@0+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 40|8@1+ (1,0) [0|1] "" XXX
+ SG_ Close_Distance : 40|8@1+ (0.019607,0) [0|5] "m" XXX
  SG_ Signal5 : 48|8@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Cancel : 56|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Set : 57|1@1+ (1,0) [0|1] "" XXX

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -209,7 +209,7 @@ BO_ 801 ES_DashStatus: 8 XXX
  SG_ Brake_Lights : 51|1@1+ (1,0) [0|1] "" XXX
  SG_ Car_Follow : 52|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal7 : 53|3@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 56|4@1+ (1,0) [0|15] "" XXX
+ SG_ Far_Distance : 56|4@1+ (5,0) [0|75] "m" XXX
  SG_ Cruise_State : 60|4@1+ (1,0) [0|15] "" XXX
 
 BO_ 802 ES_LKAS_State: 8 XXX

--- a/subaru_outback_2015_generated.dbc
+++ b/subaru_outback_2015_generated.dbc
@@ -143,7 +143,7 @@ BO_ 353 ES_Distance: 8 XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX
  SG_ Standstill : 22|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 24|8@1+ (0.0196,0) [0|255] "m" XXX
+ SG_ Close_Distance : 24|8@1+ (0.019607,0) [0|5] "m" XXX
  SG_ Signal4 : 32|9@1+ (1,0) [0|255] "" XXX
  SG_ Standstill_2 : 41|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Fault : 42|1@1+ (1,0) [0|1] "" XXX
@@ -265,7 +265,7 @@ BO_ 358 ES_DashStatus: 8 XXX
  SG_ Counter : 37|3@1+ (1,0) [0|7] "" XXX
  SG_ Steep_Hill_Disengage : 44|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 46|1@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 48|4@1+ (5,0) [0|15] "m" XXX
+ SG_ Far_Distance : 48|4@1+ (5,0) [0|75] "m" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX

--- a/subaru_outback_2019_generated.dbc
+++ b/subaru_outback_2019_generated.dbc
@@ -143,7 +143,7 @@ BO_ 353 ES_Distance: 8 XXX
  SG_ Distance_Swap : 21|1@1+ (1,0) [0|1] "" XXX
  SG_ Standstill : 22|1@1+ (1,0) [0|1] "" XXX
  SG_ Signal3 : 23|1@1+ (1,0) [0|1] "" XXX
- SG_ Close_Distance : 24|8@1+ (0.0196,0) [0|255] "m" XXX
+ SG_ Close_Distance : 24|8@1+ (0.019607,0) [0|5] "m" XXX
  SG_ Signal4 : 32|9@1+ (1,0) [0|255] "" XXX
  SG_ Standstill_2 : 41|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Fault : 42|1@1+ (1,0) [0|1] "" XXX
@@ -265,7 +265,7 @@ BO_ 358 ES_DashStatus: 8 XXX
  SG_ Counter : 37|3@1+ (1,0) [0|7] "" XXX
  SG_ Steep_Hill_Disengage : 44|1@1+ (1,0) [0|3] "" XXX
  SG_ Car_Follow : 46|1@1+ (1,0) [0|1] "" XXX
- SG_ Far_Distance : 48|4@1+ (5,0) [0|15] "m" XXX
+ SG_ Far_Distance : 48|4@1+ (5,0) [0|75] "m" XXX
 
 BO_ 881 Steering_Torque: 8 XXX
  SG_ Steering_Motor_Flat : 0|10@1+ (32,0) [0|1000] "" XXX


### PR DESCRIPTION
This PR adds scaling factors to ACC Close_Distance (<5m) and Far_Distance (5-75m, 5m steps) signals for converting the raw values to meters. Close_Distance signal is used as input for SnG (https://github.com/commaai/openpilot/pull/23025)