### PR TITLE
CANParser: display name for missing messages

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -64,6 +64,8 @@ cdef class CANParser:
       s = signals[i]
       if not isinstance(s[1], numbers.Number):
         name = s[1].encode('utf8')
+        if name not in list(self.msg_name_to_address):
+          raise RuntimeError(f"CANParser: could not find message {name.decode()} in DBC {self.dbc_name.decode()}")
         s = (s[0], self.msg_name_to_address[name])
         signals[i] = s
 
@@ -71,6 +73,8 @@ cdef class CANParser:
       c = checks[i]
       if not isinstance(c[0], numbers.Number):
         name = c[0].encode('utf8')
+        if name not in list(self.msg_name_to_address):
+          raise RuntimeError(f"CANParser: could not find message {name.decode()} in DBC {self.dbc_name.decode()}")
         c = (self.msg_name_to_address[name], c[1])
         checks[i] = c
 


### PR DESCRIPTION
...instead of address 0x0, helps with car ports.

parser.cc handles the missing messages if address is provided instead of name. Ideally parser.cc handles all of this, but passing in message name required a little bigger of a change in pyx than I'd like, and we should refactor it all at once if we do that.