### PR TITLE
Move common ACC_HUD message to _honda_common

### DIFF
--- a/acura_ilx_2016_can_generated.dbc
+++ b/acura_ilx_2016_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "acura_ilx_2016_can.dbc starts here";
 

--- a/acura_rdx_2018_can_generated.dbc
+++ b/acura_rdx_2018_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "acura_rdx_2018_can.dbc starts here";
 

--- a/acura_rdx_2020_can_generated.dbc
+++ b/acura_rdx_2020_can_generated.dbc
@@ -86,6 +86,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -150,9 +177,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -328,30 +358,6 @@ BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ CRUISE_SETTING : 3|2@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
-
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ ZEROS_BOH : 7|24@0+ (0.002759506,0) [0|100] "m/s" BDY
- SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_TO_1 : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ BOH_6 : 51|4@0+ (1,0) [0|15] "" XXX
- SG_ SET_TO_X1 : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 806 SCM_FEEDBACK: 8 SCM
  SG_ DRIVERS_DOOR_OPEN : 17|1@0+ (1,0) [0|1] "" XXX

--- a/generator/honda/_bosch_2018.dbc
+++ b/generator/honda/_bosch_2018.dbc
@@ -168,30 +168,6 @@ BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ ZEROS_BOH : 7|24@0+ (0.002759506,0) [0|100] "m/s" BDY
- SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_TO_1 : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ BOH_6 : 51|4@0+ (1,0) [0|15] "" XXX
- SG_ SET_TO_X1 : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
-
 BO_ 806 SCM_FEEDBACK: 8 SCM
  SG_ DRIVERS_DOOR_OPEN : 17|1@0+ (1,0) [0|1] "" XXX
  SG_ MAIN_ON : 28|1@0+ (1,0) [0|1] "" EON

--- a/generator/honda/_dual_can_nidec_2018.dbc
+++ b/generator/honda/_dual_can_nidec_2018.dbc
@@ -39,43 +39,13 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";

--- a/generator/honda/_honda_common.dbc
+++ b/generator/honda/_honda_common.dbc
@@ -82,6 +82,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -146,9 +173,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";

--- a/generator/honda/_nidec_2017.dbc
+++ b/generator/honda/_nidec_2017.dbc
@@ -56,43 +56,13 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";

--- a/honda_accord_2018_can_generated.dbc
+++ b/honda_accord_2018_can_generated.dbc
@@ -86,6 +86,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -150,9 +177,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -328,30 +358,6 @@ BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ CRUISE_SETTING : 3|2@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
-
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ ZEROS_BOH : 7|24@0+ (0.002759506,0) [0|100] "m/s" BDY
- SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_TO_1 : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ BOH_6 : 51|4@0+ (1,0) [0|15] "" XXX
- SG_ SET_TO_X1 : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 806 SCM_FEEDBACK: 8 SCM
  SG_ DRIVERS_DOOR_OPEN : 17|1@0+ (1,0) [0|1] "" XXX

--- a/honda_civic_hatchback_ex_2017_can_generated.dbc
+++ b/honda_civic_hatchback_ex_2017_can_generated.dbc
@@ -86,6 +86,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -150,9 +177,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -328,30 +358,6 @@ BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ CRUISE_SETTING : 3|2@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
-
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ ZEROS_BOH : 7|24@0+ (0.002759506,0) [0|100] "m/s" BDY
- SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_TO_1 : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ BOH_6 : 51|4@0+ (1,0) [0|15] "" XXX
- SG_ SET_TO_X1 : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 806 SCM_FEEDBACK: 8 SCM
  SG_ DRIVERS_DOOR_OPEN : 17|1@0+ (1,0) [0|1] "" XXX

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_civic_touring_2016_can.dbc starts here";
 

--- a/honda_clarity_hybrid_2018_can_generated.dbc
+++ b/honda_clarity_hybrid_2018_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -218,46 +248,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_clarity_hybrid_2018_can.dbc starts here";
 

--- a/honda_crv_ex_2017_can_generated.dbc
+++ b/honda_crv_ex_2017_can_generated.dbc
@@ -86,6 +86,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -150,9 +177,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -328,30 +358,6 @@ BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ CRUISE_SETTING : 3|2@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
-
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ ZEROS_BOH : 7|24@0+ (0.002759506,0) [0|100] "m/s" BDY
- SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_TO_1 : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ BOH_6 : 51|4@0+ (1,0) [0|15] "" XXX
- SG_ SET_TO_X1 : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 806 SCM_FEEDBACK: 8 SCM
  SG_ DRIVERS_DOOR_OPEN : 17|1@0+ (1,0) [0|1] "" XXX

--- a/honda_crv_executive_2016_can_generated.dbc
+++ b/honda_crv_executive_2016_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_crv_executive_2016_can.dbc starts here";
 

--- a/honda_crv_touring_2016_can_generated.dbc
+++ b/honda_crv_touring_2016_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_crv_touring_2016_can.dbc starts here";
 

--- a/honda_fit_ex_2018_can_generated.dbc
+++ b/honda_fit_ex_2018_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_fit_ex_2018_can.dbc starts here";
 

--- a/honda_fit_hybrid_2018_can_generated.dbc
+++ b/honda_fit_hybrid_2018_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -218,46 +248,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_fit_hybrid_2018_can.dbc starts here";
 

--- a/honda_insight_ex_2019_can_generated.dbc
+++ b/honda_insight_ex_2019_can_generated.dbc
@@ -86,6 +86,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -150,9 +177,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -328,30 +358,6 @@ BO_ 662 SCM_BUTTONS: 4 SCM
  SG_ CRUISE_SETTING : 3|2@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 29|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|15] "" EON
-
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ ZEROS_BOH : 7|24@0+ (0.002759506,0) [0|100] "m/s" BDY
- SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_TO_1 : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" XXX
- SG_ BOH_6 : 51|4@0+ (1,0) [0|15] "" XXX
- SG_ SET_TO_X1 : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 806 SCM_FEEDBACK: 8 SCM
  SG_ DRIVERS_DOOR_OPEN : 17|1@0+ (1,0) [0|1] "" XXX

--- a/honda_odyssey_exl_2018_generated.dbc
+++ b/honda_odyssey_exl_2018_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_odyssey_exl_2018.dbc starts here";
 

--- a/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
+++ b/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
@@ -104,6 +104,33 @@ BO_ 777 CAR_SPEED: 8 PCM
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ IMPERIAL_UNIT : 63|1@0+ (1,0) [0|1] "" XXX
 
+BO_ 780 ACC_HUD: 8 ADAS
+ SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
+ SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
+ SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
+ SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
+ SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
+ SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
+ SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
+ SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
+ SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
+ SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
+ SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
+ SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
+ SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
+ SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
+ SG_ ACC_ON : 52|1@0+ (1,0) [0|1] "" BDY
+ SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
+ SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
+ SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
+
 BO_ 804 CRUISE: 8 PCM
  SG_ HUD_SPEED_KPH : 7|8@0+ (1,0) [0|255] "kph" EON
  SG_ HUD_SPEED_MPH : 15|8@0+ (1,0) [0|255] "mph" EON
@@ -168,9 +195,12 @@ CM_ SG_ 420 BRAKE_HOLD_RELATED "On when Brake Hold engaged";
 CM_ SG_ 490 LONG_ACCEL "wheel speed derivative, noisy and zero snapping";
 CM_ SG_ 773 PASS_AIRBAG_ON "Might just be indicator light";
 CM_ SG_ 773 PASS_AIRBAG_OFF "Might just be indicator light";
+CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 CM_ SG_ 804 CRUISE_SPEED_PCM "255 = no speed";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
+VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 VAL_ 884 DASHBOARD_ALERT 0 "none" 51 "acc_problem" 55 "cmbs_problem" 75 "key_not_detected" 79 "fasten_seatbelt" 111 "lkas_problem" 131 "brake_system_problem" 132 "brake_hold_problem" 139 "tbd" 161 "door_open";
 VAL_ 891 WIPERS 4 "High" 2 "Low" 0 "Off";
@@ -235,46 +265,16 @@ BO_ 597 ROUGH_WHEEL_SPEED: 8 VSA
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
 
-BO_ 780 ACC_HUD: 8 ADAS
- SG_ PCM_SPEED : 7|16@0+ (0.01,0) [0|250] "kph" BDY
- SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
- SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
- SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF : 36|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_OFF_2 : 35|1@0+ (1,0) [0|1] "" BDY
- SG_ FCM_PROBLEM : 34|1@0+ (1,0) [0|1] "" BDY
- SG_ RADAR_OBSTRUCTED : 33|1@0+ (1,0) [0|1] "" BDY
- SG_ ENABLE_MINI_CAR : 32|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE : 47|2@0+ (1,0) [0|3] "" BDY
- SG_ HUD_LEAD : 45|2@0+ (1,0) [0|3] "" BDY
- SG_ BOH_3 : 43|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_4 : 42|1@0+ (1,0) [0|3] "" BDY
- SG_ BOH_5 : 41|1@0+ (1,0) [0|3] "" BDY
- SG_ CRUISE_CONTROL_LABEL : 40|1@0+ (1,0) [0|3] "" BDY
- SG_ SET_ME_X01_2 : 55|1@0+ (1,0) [0|1] "" BDY
- SG_ IMPERIAL_UNIT : 54|1@0+ (1,0) [0|1] "" BDY
- SG_ HUD_DISTANCE_3 : 52|1@0+ (1,0) [0|1] "" BDY
- SG_ CHIME : 51|3@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X01 : 48|1@0+ (1,0) [0|1] "" BDY
- SG_ ICONS : 63|2@0+ (1,0) [0|1] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" BDY
-
 BO_ 892 CRUISE_PARAMS: 8 PCM
  SG_ CRUISE_SPEED_OFFSET : 31|8@0- (0.1,0) [-128|127] "kph" EON
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
-CM_ SG_ 780 CRUISE_SPEED "255 = no speed";
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 780 CRUISE_SPEED 255 "no_speed" 252 "stopped";
-VAL_ 780 HUD_LEAD 3 "acc_off" 2 "solid_car" 1 "dashed_car" 0 "no_car";
 
 CM_ "honda_odyssey_extreme_edition_2018_china_can.dbc starts here";
 


### PR DESCRIPTION
For Nidec:
- Renames unused `HUD_DISTANCE_3` to `ACC_ON` used by Bosch
- Add "kph" unit to `CRUISE_SPEED`

For Bosch:
- Adds `PCM_SPEED`, `PCM_GAS`, `CHIME`, `ICONS` signals
- Renames `SET_TO_1` to `FCM_OFF`, `FCM_OFF` to `FCM_OFF_2`