### PR TITLE
remove checksum and counter alignment checks

### DIFF
--- a/can/dbc.cc
+++ b/can/dbc.cc
@@ -80,12 +80,10 @@ void set_signal_type(Signal& s, ChecksumState* chk, const std::string& dbc_name,
   if (chk) {
     if (s.name == "CHECKSUM") {
       DBC_ASSERT(s.size == chk->checksum_size, "CHECKSUM is not " << chk->checksum_size << " bits long");
-      DBC_ASSERT((s.start_bit % 8) == chk->checksum_start_bit, " CHECKSUM starts at wrong bit");
       DBC_ASSERT(s.is_little_endian == chk->little_endian, "CHECKSUM has wrong endianness");
       s.type = chk->checksum_type;
     } else if (s.name == "COUNTER") {
       DBC_ASSERT(chk->counter_size == -1 || s.size == chk->counter_size, "COUNTER is not " << chk->counter_size << " bits long");
-      DBC_ASSERT(chk->counter_start_bit == -1 || (s.start_bit % 8) == chk->counter_start_bit, "COUNTER starts at wrong bit");
       DBC_ASSERT(chk->little_endian == s.is_little_endian, "COUNTER has wrong endianness");
       s.type = chk->counter_type;
     }


### PR DESCRIPTION
Cherrypicked from #633 for independent consideration.

There's no reason we have to do these checks, other than we've always done them. They are now interfering with VW PQ, which has a few four-bit aligned counters, and a genuinely unaligned counter in Getriebe_1. Checksums and counters start at the bit the vehicle manufacturer chooses, we can't change them if we don't like them.