### PR TITLE
Chrysler: use universal gas and brake signals

### DIFF
--- a/chrysler_pacifica_2017_hybrid.dbc
+++ b/chrysler_pacifica_2017_hybrid.dbc
@@ -74,7 +74,6 @@ BO_ 284 BRAKE_1: 8 XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 320 ESP_1: 8 XXX
- SG_ SPEED_RELATED_2 : 47|8@0+ (1,0) [0|63] "" XXX
  SG_ Brake_Pedal_State : 2|2@1+ (1,0) [0|0] "" XXX
  SG_ Vehicle_Speed : 33|10@0+ (0.5,0) [0|511] "km/h" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX

--- a/chrysler_pacifica_2017_hybrid.dbc
+++ b/chrysler_pacifica_2017_hybrid.dbc
@@ -40,8 +40,8 @@ BO_ 258 STEERING: 8 XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
  SG_ UNKNOWN_STEERING : 50|3@0+ (1,0) [0|15] "" XXX
- SG_ STEERING_RATE : 20|13@0+ (0.3187251,-1305.498) [0|8191] "deg/s" XXX
- SG_ STEER_ANGLE : 4|13@0+ (0.3187251,-1307.888) [-360|360] "deg" XXX
+ SG_ STEERING_RATE : 21|14@0+ (0.5,-2048) [-2048|2047] "deg/s" XXX
+ SG_ STEER_ANGLE : 5|14@0+ (0.5,-2048) [-2048|2047] "Degrees" XXX
 
 BO_ 514 SPEED_1: 8 XXX
  SG_ SPEED_LEFT : 7|12@0+ (0.071028,0) [0|65535] "m/s" XXX
@@ -67,7 +67,7 @@ BO_ 746 GEAR: 5 XXX
  SG_ COUNTER : 31|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 284 BRAKE_1: 8 XXX
- SG_ SPEED_RELATED_1 : 37|14@0+ (1,0) [0|255] "" XXX
+ SG_ VEHICLE_SPEED : 39|16@0+ (0.0078125,0) [0|511.984375] "km/h" XXX
  SG_ BRAKE_RELATED_1_2 : 18|11@0+ (1,0) [0|255] "" XXX
  SG_ BRAKE_RELATED_1_1 : 3|12@0+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
@@ -77,7 +77,7 @@ BO_ 320 BRAKE_2: 8 XXX
  SG_ SPEED_RELATED_2 : 47|8@0+ (1,0) [0|63] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ BRAKE_PRESSED_2 : 2|3@0+ (1,0) [0|7] "" XXX
+ SG_ BRAKE_PRESSED_2 : 2|2@1+ (1,0) [0|0] "" XXX
  SG_ BRAKE_PRESSED_ACC : 6|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 736 TRIP: 8 XXX
@@ -85,10 +85,10 @@ BO_ 736 TRIP: 8 XXX
  SG_ COUNTER_2 : 23|16@0+ (1,0) [0|65535] "Meters" XXX
 
 BO_ 344 WHEEL_SPEEDS: 8 XXX
- SG_ WHEEL_SPEED_FL : 3|12@0+ (0.0189408,0) [0|65535] "m/s" XXX
- SG_ WHEEL_SPEED_RR : 51|12@0+ (0.0189408,0) [0|255] "m/s" XXX
- SG_ WHEEL_SPEED_RL : 35|12@0+ (0.0189408,0) [0|3] "m/s" XXX
- SG_ WHEEL_SPEED_FR : 19|12@0+ (0.0189408,0) [0|255] "m/s" XXX
+ SG_ WHEEL_SPEED_FL : 5|14@0+ (0.5,0) [0|8191] "rpm" XXX
+ SG_ WHEEL_SPEED_RR : 53|14@0+ (0.5,0) [0|8191] "rpm" XXX
+ SG_ WHEEL_SPEED_RL : 37|14@0+ (0.5,0) [0|8191] "rpm" XXX
+ SG_ WHEEL_SPEED_FR : 21|14@0+ (0.5,0) [0|8191] "rpm" XXX
 
 BO_ 792 STEERING_LEVERS: 8 XXX
  SG_ HIGH_BEAM_PUSHED_IN : 2|1@0+ (1,0) [0|3] "" XXX
@@ -109,6 +109,14 @@ BO_ 544 EPS_STATUS: 8 XXX
  SG_ TORQUE_MOTOR_RAW : 19|12@0+ (1,-2048) [-2048|2047] "" XXX
  SG_ TORQUE_MOTOR : 34|11@0+ (1,-1024) [-1024|1023] "" XXX
  SG_ AUTO_PARK_HAS_CONTROL_2 : 51|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+
+BO_ 545 EPS_STATUS_1: 8 XXX
+ SG_ DASM_FAULT : 34|1@0+ (1,0) [0|1] "" XXX
+ SG_ ACTIVATION_STATUS : 48|3@1+ (1,0) [0|1] "" XXX
+ SG_ DRIVER_OVERRIDE : 35|1@0+ (1,0) [0|1] "" XXX
+ SG_ HANDS_ON_WHEEL : 51|1@0+ (1,0) [0|1] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
@@ -268,7 +276,7 @@ BO_ 532 ENERGY_RELATED_214: 8 XXX
  SG_ ENERGY_RELATED : 0|9@0+ (1,0) [0|255] "" XXX
 
 BO_ 559 ACCEL_GAS_22F: 8 XXX
- SG_ ACCEL_22F : 3|4@0+ (1,0) [0|255] "" XXX
+ SG_ ACCELERATOR_POSITION : 0|8@1+ (0.4,0) [0|100] "%" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
@@ -286,6 +294,7 @@ BO_ 764 ACCEL_RELATED_2FC: 8 XXX
 BO_ 816 TRACTION_BUTTON: 8 XXX
  SG_ TRACTION_OFF : 19|1@0+ (1,0) [0|3] "" XXX
  SG_ TOGGLE_PARKSENSE : 52|1@0+ (1,0) [0|3] "" XXX
+ SG_ LKAS_BUTTON : 53|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 878 ACCEL_RELATED_36E: 8 XXX
  SG_ ACCEL_OR_RPM_2 : 15|8@0+ (1,0) [0|255] "" XXX
@@ -332,9 +341,13 @@ BO_ 941 NEW_MSG_3ad: 8 XXX
  SG_ INCREASING_2 : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 500 ACC_2: 8 XXX
+ SG_ ENGINE_TORQUE_REQUEST : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" XXX
+ SG_ ACC_STANDSTILL : 5|1@1+ (1,0) [0|0] ""  XXX
+ SG_ ENGINE_TORQUE_REQUEST_MAX : 7|1@1+ (1,0) [0|0] "" XXX
  SG_ ACC_STATUS_1 : 7|3@0+ (1,0) [0|255] "" XXX
  SG_ BRAKE_MAYBE : 18|11@0+ (1,0) [0|255] "" XXX
- SG_ ACC_STATUS_2 : 21|3@0+ (1,0) [0|255] "" XXX
+ SG_ ACC_ENABLED : 20|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_ENGAGED : 21|1@1+ (1,0) [0|0] "" XXX
  SG_ BRAKE_BOOL_1 : 36|1@0+ (1,0) [0|3] "" XXX
  SG_ ACC_FAULTED : 47|1@0+ (1,0) [0|1] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
@@ -366,6 +379,12 @@ BO_ 512 NEW_MSG_200: 8 XXX
  SG_ COUNTER : 51|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
+BO_ 368 TRANSMISSION_STATUS: 8 XXX
+ SG_ GEAR_STATE : 2|3@1+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+
+
 CM_ SG_ 258 UNKNOWN_STEERING "never goes above 4. see if human-applied torque";
 CM_ SG_ 258 STEER_ANGLE "positive is left (counter-clockwise)";
 CM_ SG_ 514 SPEED_LEFT "TODO find upper limit";
@@ -374,9 +393,9 @@ CM_ SG_ 820 TURN_LIGHT_LEFT "oscillates with the light blinking";
 CM_ SG_ 820 TURN_LIGHT_RIGHT "hazard blinks both right and left lights";
 CM_ SG_ 746 PRNDL "5=L, 4=D, 3=N, 2=R, 1=P";
 CM_ SG_ 746 GEAR_CHECKSUM "different than the LKAS checksum. unknown non-simple algorithm. just build a lookup table for it.";
-CM_ SG_ 284 SPEED_RELATED_1 "Another Speed Signal, Maybe RPMs?";
+CM_ SG_ 284 VEHICLE_SPEED "The Actual Speed the EPS references";
 CM_ SG_ 284 BRAKE_RELATED_1_1 "Correlates with braking";
-CM_ SG_ 320 BRAKE_PRESSED_2 "Value is 5 when brake is pressed by human, 1 when ACC brake";
+CM_ SG_ 320 BRAKE_PRESSED_2 3 "Sna" 2 "unknown" 1 "Pressed" 0 "Not Pressed" ;
 CM_ SG_ 320 BRAKE_PRESSED_ACC "set when ACC brakes";
 CM_ SG_ 792 TURN_SIGNALS "1=Left, 2=Right";
 CM_ SG_ 792 HIGH_BEAM_FLASH "use this for genericToggle";
@@ -422,7 +441,6 @@ CM_ SG_ 848 INCREASING_MSB "upper part of time counter";
 CM_ SG_ 908 INCREASING_MSB "time based";
 CM_ SG_ 500 ACC_STATUS_1 "2 briefly (9 packets) when ACC goes to green, 1 help when ACC coming to a stop and at a stop";
 CM_ SG_ 500 BRAKE_MAYBE "2046 in non-ACC and non-decel. Signal on deceleration. 818 for already stopped break.";
-CM_ SG_ 500 ACC_STATUS_2 "set to 1 when ACC not available, 3 when ACC available (white icon), and 7 when ACC active (green icon)";
 CM_ SG_ 500 BRAKE_BOOL_1 "set to 1 when ACC decel. 0 on non-ACC and accel.";
 CM_ SG_ 501 CRUISE_STATE "may just be an icon, but seems to indicate different cruise modes: ACC and Non-ACC and engaged state for both.";
 CM_ SG_ 625 SPEED "zero on non-acc drives";
@@ -433,3 +451,4 @@ CM_ SG_ 384 NEW_SIGNAL_1 "set in ACC gas driving. not set in electric human. not
 VAL_ 501 CRUISE_STATE 0 "Off" 1 "CC On" 2 "CC Engaged" 3 "ACC On" 4 "ACC Engaged";
 VAL_ 746 PRNDL 5 "L" 4 "D" 3 "N" 2 "R" 1 "P";
 VAL_ 792 TURN_SIGNALS 2 "Right" 1 "Left";
+VAL_ 368 GEAR_STATE 4 "D" 2 "N" 1 "R" 0 "P" ;

--- a/chrysler_pacifica_2017_hybrid.dbc
+++ b/chrysler_pacifica_2017_hybrid.dbc
@@ -40,8 +40,8 @@ BO_ 258 STEERING: 8 XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
  SG_ UNKNOWN_STEERING : 50|3@0+ (1,0) [0|15] "" XXX
- SG_ STEERING_RATE : 21|14@0+ (0.5,-2048) [-2048|2047] "deg/s" XXX
- SG_ STEER_ANGLE : 5|14@0+ (0.5,-2048) [-2048|2047] "Degrees" XXX
+ SG_ STEERING_RATE : 20|13@0+ (0.3187251,-1305.498) [0|8191] "deg/s" XXX
+ SG_ STEER_ANGLE : 4|13@0+ (0.3187251,-1307.888) [-360|360] "deg" XXX
 
 BO_ 514 SPEED_1: 8 XXX
  SG_ SPEED_LEFT : 7|12@0+ (0.071028,0) [0|65535] "m/s" XXX
@@ -67,17 +67,18 @@ BO_ 746 GEAR: 5 XXX
  SG_ COUNTER : 31|4@0+ (1,0) [0|15] "" XXX
 
 BO_ 284 BRAKE_1: 8 XXX
- SG_ VEHICLE_SPEED : 39|16@0+ (0.0078125,0) [0|511.984375] "km/h" XXX
+ SG_ SPEED_RELATED_1 : 37|14@0+ (1,0) [0|255] "" XXX
  SG_ BRAKE_RELATED_1_2 : 18|11@0+ (1,0) [0|255] "" XXX
  SG_ BRAKE_RELATED_1_1 : 3|12@0+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 320 BRAKE_2: 8 XXX
+BO_ 320 ESP_1: 8 XXX
  SG_ SPEED_RELATED_2 : 47|8@0+ (1,0) [0|63] "" XXX
+ SG_ Brake_Pedal_State : 2|2@1+ (1,0) [0|0] "" XXX
+ SG_ Vehicle_Speed : 33|10@0+ (0.5,0) [0|511] "km/h" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ BRAKE_PRESSED_2 : 2|2@1+ (1,0) [0|0] "" XXX
  SG_ BRAKE_PRESSED_ACC : 6|1@0+ (1,0) [0|3] "" XXX
 
 BO_ 736 TRIP: 8 XXX
@@ -85,10 +86,10 @@ BO_ 736 TRIP: 8 XXX
  SG_ COUNTER_2 : 23|16@0+ (1,0) [0|65535] "Meters" XXX
 
 BO_ 344 WHEEL_SPEEDS: 8 XXX
- SG_ WHEEL_SPEED_FL : 5|14@0+ (0.5,0) [0|8191] "rpm" XXX
- SG_ WHEEL_SPEED_RR : 53|14@0+ (0.5,0) [0|8191] "rpm" XXX
- SG_ WHEEL_SPEED_RL : 37|14@0+ (0.5,0) [0|8191] "rpm" XXX
- SG_ WHEEL_SPEED_FR : 21|14@0+ (0.5,0) [0|8191] "rpm" XXX
+ SG_ WHEEL_SPEED_FL : 3|12@0+ (0.0189408,0) [0|65535] "m/s" XXX
+ SG_ WHEEL_SPEED_RR : 51|12@0+ (0.0189408,0) [0|255] "m/s" XXX
+ SG_ WHEEL_SPEED_RL : 35|12@0+ (0.0189408,0) [0|3] "m/s" XXX
+ SG_ WHEEL_SPEED_FR : 19|12@0+ (0.0189408,0) [0|255] "m/s" XXX
 
 BO_ 792 STEERING_LEVERS: 8 XXX
  SG_ HIGH_BEAM_PUSHED_IN : 2|1@0+ (1,0) [0|3] "" XXX
@@ -112,11 +113,8 @@ BO_ 544 EPS_STATUS: 8 XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 545 EPS_STATUS_1: 8 XXX
- SG_ DASM_FAULT : 34|1@0+ (1,0) [0|1] "" XXX
- SG_ ACTIVATION_STATUS : 48|3@1+ (1,0) [0|1] "" XXX
- SG_ DRIVER_OVERRIDE : 35|1@0+ (1,0) [0|1] "" XXX
- SG_ HANDS_ON_WHEEL : 51|1@0+ (1,0) [0|1] "" XXX
+BO_ 559 ECM_5: 8 XXX
+ SG_ Accelerator_Position : 0|8@1+ (0.4,0) [0|100] "%" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
@@ -275,11 +273,6 @@ BO_ 532 ENERGY_RELATED_214: 8 XXX
  SG_ NOISY_SLOWLY_DECREASING : 16|9@0+ (1,0) [0|255] "" XXX
  SG_ ENERGY_RELATED : 0|9@0+ (1,0) [0|255] "" XXX
 
-BO_ 559 ACCEL_GAS_22F: 8 XXX
- SG_ ACCELERATOR_POSITION : 0|8@1+ (0.4,0) [0|100] "%" XXX
- SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
-
 BO_ 655 CHARGING_MAYBE_28F: 8 XXX
  SG_ CHARGING : 1|2@0+ (1,0) [0|3] "" XXX
 
@@ -294,7 +287,6 @@ BO_ 764 ACCEL_RELATED_2FC: 8 XXX
 BO_ 816 TRACTION_BUTTON: 8 XXX
  SG_ TRACTION_OFF : 19|1@0+ (1,0) [0|3] "" XXX
  SG_ TOGGLE_PARKSENSE : 52|1@0+ (1,0) [0|3] "" XXX
- SG_ LKAS_BUTTON : 53|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 878 ACCEL_RELATED_36E: 8 XXX
  SG_ ACCEL_OR_RPM_2 : 15|8@0+ (1,0) [0|255] "" XXX
@@ -341,13 +333,9 @@ BO_ 941 NEW_MSG_3ad: 8 XXX
  SG_ INCREASING_2 : 63|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 500 ACC_2: 8 XXX
- SG_ ENGINE_TORQUE_REQUEST : 4|13@0+ (0.25,-500) [-500|1547.5] "Nm" XXX
- SG_ ACC_STANDSTILL : 5|1@1+ (1,0) [0|0] ""  XXX
- SG_ ENGINE_TORQUE_REQUEST_MAX : 7|1@1+ (1,0) [0|0] "" XXX
  SG_ ACC_STATUS_1 : 7|3@0+ (1,0) [0|255] "" XXX
  SG_ BRAKE_MAYBE : 18|11@0+ (1,0) [0|255] "" XXX
- SG_ ACC_ENABLED : 20|1@1+ (1,0) [0|0] "" XXX
- SG_ ACC_ENGAGED : 21|1@1+ (1,0) [0|0] "" XXX
+ SG_ ACC_STATUS_2 : 21|3@0+ (1,0) [0|255] "" XXX
  SG_ BRAKE_BOOL_1 : 36|1@0+ (1,0) [0|3] "" XXX
  SG_ ACC_FAULTED : 47|1@0+ (1,0) [0|1] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
@@ -379,12 +367,6 @@ BO_ 512 NEW_MSG_200: 8 XXX
  SG_ COUNTER : 51|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 368 TRANSMISSION_STATUS: 8 XXX
- SG_ GEAR_STATE : 2|3@1+ (1,0) [0|15] "" XXX
- SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
-
-
 CM_ SG_ 258 UNKNOWN_STEERING "never goes above 4. see if human-applied torque";
 CM_ SG_ 258 STEER_ANGLE "positive is left (counter-clockwise)";
 CM_ SG_ 514 SPEED_LEFT "TODO find upper limit";
@@ -393,9 +375,9 @@ CM_ SG_ 820 TURN_LIGHT_LEFT "oscillates with the light blinking";
 CM_ SG_ 820 TURN_LIGHT_RIGHT "hazard blinks both right and left lights";
 CM_ SG_ 746 PRNDL "5=L, 4=D, 3=N, 2=R, 1=P";
 CM_ SG_ 746 GEAR_CHECKSUM "different than the LKAS checksum. unknown non-simple algorithm. just build a lookup table for it.";
-CM_ SG_ 284 VEHICLE_SPEED "The Actual Speed the EPS references";
+CM_ SG_ 284 SPEED_RELATED_1 "Another Speed Signal, Maybe RPMs?";
 CM_ SG_ 284 BRAKE_RELATED_1_1 "Correlates with braking";
-CM_ SG_ 320 BRAKE_PRESSED_2 3 "Sna" 2 "unknown" 1 "Pressed" 0 "Not Pressed" ;
+CM_ SG_ 320 BRAKE_PRESSED_2 "Value is 5 when brake is pressed by human, 1 when ACC brake";
 CM_ SG_ 320 BRAKE_PRESSED_ACC "set when ACC brakes";
 CM_ SG_ 792 TURN_SIGNALS "1=Left, 2=Right";
 CM_ SG_ 792 HIGH_BEAM_FLASH "use this for genericToggle";
@@ -441,6 +423,7 @@ CM_ SG_ 848 INCREASING_MSB "upper part of time counter";
 CM_ SG_ 908 INCREASING_MSB "time based";
 CM_ SG_ 500 ACC_STATUS_1 "2 briefly (9 packets) when ACC goes to green, 1 help when ACC coming to a stop and at a stop";
 CM_ SG_ 500 BRAKE_MAYBE "2046 in non-ACC and non-decel. Signal on deceleration. 818 for already stopped break.";
+CM_ SG_ 500 ACC_STATUS_2 "set to 1 when ACC not available, 3 when ACC available (white icon), and 7 when ACC active (green icon)";
 CM_ SG_ 500 BRAKE_BOOL_1 "set to 1 when ACC decel. 0 on non-ACC and accel.";
 CM_ SG_ 501 CRUISE_STATE "may just be an icon, but seems to indicate different cruise modes: ACC and Non-ACC and engaged state for both.";
 CM_ SG_ 625 SPEED "zero on non-acc drives";
@@ -451,4 +434,3 @@ CM_ SG_ 384 NEW_SIGNAL_1 "set in ACC gas driving. not set in electric human. not
 VAL_ 501 CRUISE_STATE 0 "Off" 1 "CC On" 2 "CC Engaged" 3 "ACC On" 4 "ACC Engaged";
 VAL_ 746 PRNDL 5 "L" 4 "D" 3 "N" 2 "R" 1 "P";
 VAL_ 792 TURN_SIGNALS 2 "Right" 1 "Left";
-VAL_ 368 GEAR_STATE 4 "D" 2 "N" 1 "R" 0 "P" ;


### PR DESCRIPTION
Some easy to verify signals moved from https://github.com/commaai/opendbc/pull/628. Posted verification data there. Purpose of this PR is for support of the upcoming RAMs, these signal definitions are identical with the only difference being the address, simplifies panda safety and openpilot