### PR TITLE
add cmake to docker to fix build on arm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-openssl \
     xz-utils \
     zlib1g-dev \
+    cmake \
   && rm -rf /var/lib/apt/lists/*
 
 RUN curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Cython==0.29.14
 flake8==3.7.9
 Jinja2==3.0.3
 numpy==1.21.0
-pycapnp==1.0.0
+pycapnp==1.1.0
 pylint==2.4.3
 pyyaml==5.4
 scons==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Cython==0.29.14
 flake8==3.7.9
 Jinja2==3.0.3
 numpy==1.21.0
-pycapnp==1.1.0
 pylint==2.4.3
 pyyaml==5.4
 scons==3.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Cython==0.29.14
 flake8==3.7.9
 Jinja2==3.0.3
 numpy==1.21.0
+pycapnp==1.0.0
 pylint==2.4.3
 pyyaml==5.4
 scons==3.1.1


### PR DESCRIPTION
Fix for https://github.com/commaai/opendbc/issues/663

The dockerfile doesn't work on ARM arch because some of the python dependencies build from source for ARM.

Pycapnp has a bug that prevents building from source in version 1.0.0. The bug is fixed in version 1.1.0. of pycapnp. Info on pycapnp bug: https://github.com/capnproto/pycapnp/issues/240

Furthermore, pycapnp needs to build its own dependency libpcap. This requires cmake, which isn't installed in the container. So we need to add that.

This PR makes two changes to fix the build on arm:
1) In requirements.txt, bump the pinned version of pycapnp from 1.0.0 to 1.1.0.
2) In the dockerfile: add cmake to apt-get at beginning of Dockerfile. This is necessary so pycapnp can build its dependency libcapnp.

If the project maintainers are concerned about bumping pycapnp to 1.1.0, I can work on a different fix to try to get pycapnp 1.0.0 to be happy with its build environment on arm.