### PR TITLE
Chrysler: add Ram HD

### DIFF
--- a/chrysler_ram_hd_generated.dbc
+++ b/chrysler_ram_hd_generated.dbc
@@ -111,41 +111,9 @@ CM_ SG_ 678 LKAS_ICON_COLOR "3 is yellow, 2 is green, 1 is white, 0 is null";
 CM_ SG_ 678 LKAS_LANE_LINES "0x01 transparent lines, 0x02 left white, 0x03 right white, 0x04 left yellow with car on top, 0x05 left yellow with car on top, 0x06 both white, 0x07 left yellow, 0x08 left yellow right white, 0x09 right yellow, 0x0a right yellow left white, 0x0b left yellow with car on top right white, 0x0c right yellow with car on top left white, (0x00, 0x0d, 0x0e, 0x0f) null";
 CM_ SG_ 678 LKAS_ALERTS "(0x01, 0x02) lane sense off, (0x03, 0x04, 0x06) place hands on steering wheel, 0x07 lane departure detected + place hands on steering wheel, (0x08, 0x09) lane sense unavailable + clean front windshield, 0x0b lane sense and auto high beam unavailable + clean front windshield, 0x0c lane sense unavailable + service required, (0x00, 0x05, 0x0a, 0x0d, 0x0e, 0x0f) null";
 
-CM_ "chrysler_ram_dt.dbc starts here";
+CM_ "chrysler_ram_hd.dbc starts here";
 
-BO_ 37 PCM_1: 8 XXX
- SG_ ENGINE_RPM : 7|16@0+ (1,0) [0|1] "" XXX
- SG_ ENGINE_TRQ_REQ : 23|12@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
-
-BO_ 53 PCM_2: 8 XXX
- SG_ ENG_TORQUE_REQ : 3|12@0+ (1,0) [0|7] "" XXX
- SG_ ENG_TORQUE_OUT : 19|12@0+ (1,0) [0|1] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
-
-BO_ 133 TCM_1: 8 XXX
- SG_ DESIRED_GEAR : 15|4@0+ (1,0) [0|1] "" XXX
- SG_ SHIFT_PENDING : 2|1@0+ (1,0) [0|1] "" XXX
- SG_ SPEED_TURBINE : 27|12@0+ (0.04,0) [0|1] "km/h" XXX
- SG_ ACTUAL_GEAR : 11|4@0+ (1,0) [0|15] "" XXX
-
-BO_ 135 ABS_2: 8 XXX
- SG_ COUNTER : 55|4@0+ (1,0) [0|1] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|1] "" XXX
- SG_ DRIVER_BRAKE : 15|8@0+ (1,0) [0|1] "" XXX
-
-BO_ 137 ESP_4: 8 XXX
- SG_ Yaw_Rate : 7|16@0+ (0.01,-327.68) [-327.68|327.66] "deg/s" XXX
- SG_ Acceleration : 32|8@1+ (0.08,-10.24) [-10.24|10.08] "m/s2" XXX
-
-BO_ 147 Transmission_Status: 8 XXX
- SG_ Gear_State : 2|3@1+ (1,0) [0|15] "" XXX
- SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
-
-BO_ 164 EPS_3: 8 XXX
+BO_ 545 EPS_3: 8 XXX
  SG_ DASM_FAULT : 34|1@0+ (1,0) [0|1] "" XXX
  SG_ Activation_Status : 48|3@1+ (1,0) [0|1] "" XXX
  SG_ Driver_Override : 35|1@0+ (1,0) [0|1] "" XXX
@@ -153,26 +121,10 @@ BO_ 164 EPS_3: 8 XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 166 LKAS_COMMAND: 8 XXX
+BO_ 630 LKAS_COMMAND: 8 XXX
  SG_ STEERING_TORQUE : 10|11@0+ (1,-1024) [0|1] "" XXX
  SG_ LKAS_CONTROL_BIT : 24|3@1+ (1,0) [0|1] "" XXX
  SG_ DASM_FAULT : 51|1@0+ (1,0) [0|1] "" XXX
  SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 221 Center_Stack_1: 8 XXX
- SG_ LKAS_Button : 53|1@1+ (1,0) [0|0] "" XXX
- SG_ Traction_Button : 54|1@0+ (1,0) [0|1] "" XXX
-
-BO_ 650 Center_Stack_2: 8 XXX
- SG_ LKAS_Button : 57|1@1+ (1,0) [0|0] "" XXX
-
-
-CM_ SG_ 133 ACTUAL_GEAR "0xd = P, 0x1-8 = D (actual gear), 0xb = R or N?? TODO find R vs N";
-CM_ SG_ 153 ACC_Engaged "SENT BY FORWARD CAMERA 1 = ACTIVE, 3 = ENGAGED, 0 = DISENGAGED/OFF";
-CM_ SG_ 166 LKAS_CONTROL_BIT "0=IDLE, 1=HAS 2=LKAS 3=ABSD, 4=TJA, 7=SNA";
-CM_ SG_ 250 Auto_High_Beam "1 = HIGH BEAMS OK 0 = HIGH BEAMS OFF ";
-CM_ SG_ 250 LKAS_LANE_LINES "9 = LEFT CAUTION, 11 = VERY LEFT CAUTION 10 = RIGHT CAUTION, 14 = VERY RIGHT, 4 = NO LINES DETECTED, 3 = LINES DETECTED, SYSTEM ACTIVE";
-CM_ SG_ 464 Driver_Seatbelt_Status "1 unbuckled 0 buckled";
-CM_ SG_ 792 High_Beam_Lever_Status "1 is high beam, 0 reg";
-VAL_ 147 Gear_State 4 "D" 2 "N" 1 "R" 0 "P" ;

--- a/generator/chrysler/.gitignore
+++ b/generator/chrysler/.gitignore
@@ -1,1 +1,1 @@
-_stellantis_common_ram.dbc
+_*generated.dbc

--- a/generator/chrysler/_stellantis_common_ram.py
+++ b/generator/chrysler/_stellantis_common_ram.py
@@ -1,42 +1,47 @@
 #!/usr/bin/env python3
 import os
-from pathlib import Path
 
-CHRYSLER_TO_RAM_ADDR = {
-  258: 35,
-  284: 121,
-  320: 131,
-  344: 139,
-  464: 464,
-  500: 153,
-  501: 232,
-  544: 49,
-  571: 177,
-  559: 157,
-  678: 250,
-  720: 720,
-  792: 792,
-  820: 657,
+chrysler_to_ram = {
+  "_stellantis_common_ram_dt_generated.dbc": {
+    258: 35,
+    284: 121,
+    320: 131,
+    344: 139,
+    464: 464,
+    500: 153,
+    501: 232,
+    544: 49,
+    571: 177,
+    559: 157,
+    678: 250,
+    720: 720,
+    792: 792,
+    820: 657,
+  },
+  "_stellantis_common_ram_hd_generated.dbc": {
+    571: 570,
+    678: 629,
+  },
 }
 
 if __name__ == "__main__":
   src = '_stellantis_common.dbc'
-  out = Path(__file__).stem + '.dbc'
   chrysler_path = os.path.dirname(os.path.realpath(__file__))
 
-  with open(os.path.join(chrysler_path, src)) as in_f, open(os.path.join(chrysler_path, out), 'w') as out_f:
-    out_f.write(f'CM_ "Generated from {src}"\n\n')
+  for out, addr_lookup in chrysler_to_ram.items():
+    with open(os.path.join(chrysler_path, src)) as in_f, open(os.path.join(chrysler_path, out), 'w') as out_f:
+      out_f.write(f'CM_ "Generated from {src}"\n\n')
 
-    wrote_addrs = set()
-    for line in in_f.readlines():
-      if line.startswith('BO_'):
-        sl = line.split(' ')
-        addr = int(sl[1])
-        wrote_addrs.add(addr)
+      wrote_addrs = set()
+      for line in in_f.readlines():
+        if line.startswith('BO_'):
+          sl = line.split(' ')
+          addr = int(sl[1])
+          wrote_addrs.add(addr)
 
-        sl[1] = str(CHRYSLER_TO_RAM_ADDR.get(addr, addr))
-        line = ' '.join(sl)
-      out_f.write(line)
+          sl[1] = str(addr_lookup.get(addr, addr))
+          line = ' '.join(sl)
+        out_f.write(line)
 
-    missing_addrs = set(CHRYSLER_TO_RAM_ADDR.keys()) - wrote_addrs
-    assert len(missing_addrs) == 0, f"Missing addrs from {src}: {missing_addrs}"
+      missing_addrs = set(addr_lookup.keys()) - wrote_addrs
+      assert len(missing_addrs) == 0, f"Missing addrs from {src}: {missing_addrs}"

--- a/generator/chrysler/chrysler_ram_dt.dbc
+++ b/generator/chrysler/chrysler_ram_dt.dbc
@@ -1,4 +1,4 @@
-CM_ "IMPORT _stellantis_common_ram.dbc";
+CM_ "IMPORT _stellantis_common_ram_dt_generated.dbc";
 
 BO_ 37 PCM_1: 8 XXX
  SG_ ENGINE_RPM : 7|16@0+ (1,0) [0|1] "" XXX

--- a/generator/chrysler/chrysler_ram_hd.dbc
+++ b/generator/chrysler/chrysler_ram_hd.dbc
@@ -1,0 +1,17 @@
+CM_ "IMPORT _stellantis_common_ram_dt_generated.dbc";
+
+BO_ 545 EPS_3: 8 XXX
+ SG_ DASM_FAULT : 34|1@0+ (1,0) [0|1] "" XXX
+ SG_ Activation_Status : 48|3@1+ (1,0) [0|1] "" XXX
+ SG_ Driver_Override : 35|1@0+ (1,0) [0|1] "" XXX
+ SG_ Hands_on_Wheel : 51|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+
+BO_ 630 LKAS_COMMAND: 8 XXX
+ SG_ STEERING_TORQUE : 10|11@0+ (1,-1024) [0|1] "" XXX
+ SG_ LKAS_CONTROL_BIT : 24|3@1+ (1,0) [0|1] "" XXX
+ SG_ DASM_FAULT : 51|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 55|4@0+ (1,0) [0|15] "" XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+


### PR DESCRIPTION
This adds the needed messages to incorporate the Ram HD trucks. 

I have changed the names of 678 and 658 to more accurate names. 

Updated signals to uppercase to be uniform. 