### PR TITLE
GM: Add signals, correct AEB signal sizes and standardize names

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -73,6 +73,7 @@ BO_ 201 ECMEngineStatus: 8 K20_ECM
  SG_ CruiseMainOn : 29|1@0+ (1,0) [0|1] "" NEO
  SG_ Brake_Pressed : 40|1@0+ (1,0) [0|1] "" NEO
  SG_ Standstill : 2|1@0+ (1,0) [0|1] "" NEO
+ SG_ CruiseActive : 31|2@0+ (1,0) [0|3] "" NEO
 
 BO_ 209 EBCMBrakePedalSensors: 7 K17_EBCM
  SG_ Counter1 : 7|2@0+ (1,0) [0|3] "" XXX

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -221,6 +221,7 @@ BO_ 880 ASCMActiveCruiseControlStatus: 6 K124_ASCM
 
 BO_ 1001 ECMVehicleSpeed: 8 K20_ECM
  SG_ VehicleSpeed : 7|16@0+ (0.01,0) [0|0] "mph"  NEO
+ SG_ VehicleSpeedLeft : 39|16@0+ (0.01,0) [0|0] "mph" NEO
 
 BO_ 1033 ASCMKeepAlive: 7 NEO
  SG_ ASCMKeepAliveAllZero : 7|56@0+ (1,0) [0|0] ""  NEO
@@ -265,6 +266,7 @@ CM_ SG_ 352 Ignition "Non-zero when ignition is on";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
 CM_ SG_ 497 Ignition "Describes ignition + preconditioning mode, noisy";
 CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
+CM_ SG_ 1001 VehicleSpeed "Spinouts show here on 2wd. Speed derived from right front wheel (drive tire)";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;
 BA_DEF_  "ProtocolType" STRING ;
 BA_DEF_  "BusType" STRING ;

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -191,9 +191,10 @@ BO_ 789 EBCMFrictionBrakeCmd: 5 K124_ASCM
 
 BO_ 800 AEBCmd: 6 K124_ASCM
  SG_ RollingCounter : 5|2@0+ (1,0) [0|3] "" NEO
- SG_ Checksum : 27|20@0+ (1,0) [0|2047] "" NEO
- SG_ BrakeCmdActive : 3|1@1+ (1,0) [0|1] "" NEO
- SG_ BrakingForce : 2|7@0+ (1,0) [0|7] "" NEO
+ SG_ AEBChecksum : 27|20@0+ (1,0) [0|0] "" NEO
+ SG_ AEBCmdActive : 3|1@1+ (1,0) [0|1] "" NEO
+ SG_ AEBCmd : 2|11@0+ (1,0) [0|0] "" NEO
+ SG_ AEBCmd2 : 23|8@0+ (1,0) [0|0] "" NEO
 
 BO_ 810 TCICOnStarGPSPosition: 8 K73_TCIC
  SG_ GPSLongitude : 39|32@0+ (1,-2147483648) [0|0] "milliarcsecond"  NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -211,9 +211,10 @@ BO_ 789 EBCMFrictionBrakeCmd: 5 K124_ASCM
 
 BO_ 800 AEBCmd: 6 K124_ASCM
  SG_ RollingCounter : 5|2@0+ (1,0) [0|3] "" NEO
- SG_ Checksum : 27|20@0+ (1,0) [0|2047] "" NEO
- SG_ BrakeCmdActive : 3|1@1+ (1,0) [0|1] "" NEO
- SG_ BrakingForce : 2|7@0+ (1,0) [0|7] "" NEO
+ SG_ AEBChecksum : 27|20@0+ (1,0) [0|0] "" NEO
+ SG_ AEBCmdActive : 3|1@1+ (1,0) [0|1] "" NEO
+ SG_ AEBCmd : 2|11@0+ (1,0) [0|0] "" NEO
+ SG_ AEBCmd2 : 23|8@0+ (1,0) [0|0] "" NEO
 
 BO_ 810 TCICOnStarGPSPosition: 8 K73_TCIC
  SG_ GPSLongitude : 39|32@0+ (1,-2147483648) [0|0] "milliarcsecond"  NEO
@@ -241,6 +242,7 @@ BO_ 880 ASCMActiveCruiseControlStatus: 6 K124_ASCM
 
 BO_ 1001 ECMVehicleSpeed: 8 K20_ECM
  SG_ VehicleSpeed : 7|16@0+ (0.01,0) [0|0] "mph"  NEO
+ SG_ VehicleSpeedLeft : 39|16@0+ (0.01,0) [0|0] "mph" NEO
 
 BO_ 1033 ASCMKeepAlive: 7 NEO
  SG_ ASCMKeepAliveAllZero : 7|56@0+ (1,0) [0|0] ""  NEO
@@ -285,6 +287,7 @@ CM_ SG_ 352 Ignition "Non-zero when ignition is on";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
 CM_ SG_ 497 Ignition "Describes ignition + preconditioning mode, noisy";
 CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
+CM_ SG_ 1001 VehicleSpeed "Spinouts show here on 2wd. Speed derived from right front wheel (drive tire)";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;
 BA_DEF_  "ProtocolType" STRING ;
 BA_DEF_  "BusType" STRING ;

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -93,6 +93,7 @@ BO_ 201 ECMEngineStatus: 8 K20_ECM
  SG_ CruiseMainOn : 29|1@0+ (1,0) [0|1] "" NEO
  SG_ Brake_Pressed : 40|1@0+ (1,0) [0|1] "" NEO
  SG_ Standstill : 2|1@0+ (1,0) [0|1] "" NEO
+ SG_ CruiseActive : 31|2@0+ (1,0) [0|3] "" NEO
 
 BO_ 209 EBCMBrakePedalSensors: 7 K17_EBCM
  SG_ Counter1 : 7|2@0+ (1,0) [0|3] "" XXX


### PR DESCRIPTION
Add and cleanup some signals in GM Powertrain DBC

* ECMVehicleSpeed contains signals based on the left and right tire - add VehicleSpeedLeft and comment regarding spin of right tire.
* ECMEngineStatus contains a signal for the active state of standard Cruise Control: added CruiseActive
* Cleaned up AEBCmd signal names to better align with other messages (Message is not yet in use)
* Added AEBCmd2
* Corrected size of AEBCmd

The operation of the AEB message is still being reverse engineered: having the updated definition will aid in analysis in plotjugger and Cabana