### PR TITLE
GM: Add Standard Cruse Message, SetSpeed signal

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -221,6 +221,10 @@ BO_ 880 ASCMActiveCruiseControlStatus: 6 K124_ASCM
  SG_ ACCCmdActive : 23|1@0+ (1,0) [0|0] ""  NEO
  SG_ FCWAlert : 41|2@0+ (1,0) [0|3] "" XXX
 
+BO_ 977 ECMCruiseControl: 8 K20_ECM
+ SG_ CruiseActive : 39|1@0+ (1,0) [0|3] "" NEO
+ SG_ CruiseSetSpeed : 19|12@0+ (0.0625,0) [0|0] "km/h" NEO
+
 BO_ 1001 ECMVehicleSpeed: 8 K20_ECM
  SG_ VehicleSpeed : 7|16@0+ (0.01,0) [0|0] "mph"  NEO
  SG_ VehicleSpeedLeft : 39|16@0+ (0.01,0) [0|0] "mph" NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -241,6 +241,10 @@ BO_ 880 ASCMActiveCruiseControlStatus: 6 K124_ASCM
  SG_ ACCCmdActive : 23|1@0+ (1,0) [0|0] ""  NEO
  SG_ FCWAlert : 41|2@0+ (1,0) [0|3] "" XXX
 
+BO_ 977 ECMCruiseControl: 8 K20_ECM
+ SG_ CruiseActive : 39|1@0+ (1,0) [0|3] "" NEO
+ SG_ CruiseSetSpeed : 19|12@0+ (0.0625,0) [0|0] "km/h" NEO
+
 BO_ 1001 ECMVehicleSpeed: 8 K20_ECM
  SG_ VehicleSpeed : 7|16@0+ (0.01,0) [0|0] "mph"  NEO
  SG_ VehicleSpeedLeft : 39|16@0+ (0.01,0) [0|0] "mph" NEO


### PR DESCRIPTION
As part of the process to fill out the standard CC messages, a Message containing the CC SetSpeed in Km/h was discovered, and it scales / operates much the same as the ACC equivalents - the value must be divided by 16 to get km/h.

Note: While there are other pieces to the message, no other meanings could be decoded.

The attached CC was initially set to 69. Each step up and down is the result of a single press of the SET or RESUME buttons. Turning off the CC system resets the speed value back to zero.

![image](https://user-images.githubusercontent.com/29778397/185731163-c8bd8d96-1735-4085-976d-cf782306d9dd.png)

This allows OP to get the set-speed from either type of Cruise Control, in essentially the same way