### PR TITLE
support Ford checksums

### DIFF
--- a/can/common.cc
+++ b/can/common.cc
@@ -244,3 +244,9 @@ unsigned int hkg_can_fd_checksum(uint32_t address, const Signal &sig, const std:
 
   return crc;
 }
+
+unsigned int ford_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d) {
+  uint8_t sum = 0;
+
+  return sum;
+}

--- a/can/common.cc
+++ b/can/common.cc
@@ -246,7 +246,19 @@ unsigned int hkg_can_fd_checksum(uint32_t address, const Signal &sig, const std:
 }
 
 unsigned int ford_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d) {
-  uint8_t sum = 0;
-
-  return sum;
+  switch (address) {
+    // Gear_Shift_by_Wire_FD1 (checksum byte 4)
+    case 0x5a: {
+      uint8_t checksum = 0xFF;
+      for (int i = 0; i < d.size(); i++) {
+        if (i == 4) continue;
+        checksum -= d[i];
+      }
+      return checksum;
+    }
+    default: {
+      printf("Attempt to checksum undefined Ford message 0x%02X\n", address);
+      return -1;
+    }
+  }
 }

--- a/can/common.h
+++ b/can/common.h
@@ -30,6 +30,7 @@ unsigned int chrysler_checksum(uint32_t address, const Signal &sig, const std::v
 unsigned int volkswagen_mqb_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
 unsigned int xor_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
 unsigned int hkg_can_fd_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
+unsigned int ford_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
 unsigned int pedal_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
 
 class MessageState {

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -23,6 +23,7 @@ cdef extern from "common_dbc.h":
     SUBARU_CHECKSUM,
     CHRYSLER_CHECKSUM
     HKG_CAN_FD_CHECKSUM,
+    FORD_CHECKSUM,
 
   cdef struct Signal:
     string name

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -40,6 +40,7 @@ enum SignalType {
   SUBARU_CHECKSUM,
   CHRYSLER_CHECKSUM,
   HKG_CAN_FD_CHECKSUM,
+  FORD_CHECKSUM,
 };
 
 struct Signal {

--- a/can/dbc.cc
+++ b/can/dbc.cc
@@ -75,6 +75,8 @@ ChecksumState* get_checksum(const std::string& dbc_name) {
     s = new ChecksumState({8, -1, 7, -1, false, CHRYSLER_CHECKSUM, &chrysler_checksum});
   } else if (startswith(dbc_name, "comma_body")) {
     s = new ChecksumState({8, 4, 7, 3, false, PEDAL_CHECKSUM, &pedal_checksum});
+  } else if (startswith(dbc_name, "ford_")) {
+    s = new ChecksumState({8, 4, 0, 0, false, FORD_CHECKSUM, &ford_checksum});
   }
   return s;
 }
@@ -82,14 +84,14 @@ ChecksumState* get_checksum(const std::string& dbc_name) {
 void set_signal_type(Signal& s, ChecksumState* chk, const std::string& dbc_name, int line_num) {
   s.calc_checksum = nullptr;
   if (chk) {
-    if (s.name == "CHECKSUM") {
+    if (s.name == "CHECKSUM" || endswith(s.name, "_Cs")) {
       DBC_ASSERT(chk->checksum_size == -1 || s.size == chk->checksum_size, "CHECKSUM is not " << chk->checksum_size << " bits long");
       DBC_ASSERT(chk->checksum_start_bit == -1 || (s.start_bit % 8) == chk->checksum_start_bit, " CHECKSUM starts at wrong bit");
       DBC_ASSERT(s.is_little_endian == chk->little_endian, "CHECKSUM has wrong endianness");
       DBC_ASSERT(chk->calc_checksum != nullptr, "CHECKSUM calculate function not supplied");
       s.type = chk->checksum_type;
       s.calc_checksum = chk->calc_checksum;
-    } else if (s.name == "COUNTER") {
+    } else if (s.name == "COUNTER" || endswith(s.name, "_Cnt")) {
       DBC_ASSERT(chk->counter_size == -1 || s.size == chk->counter_size, "COUNTER is not " << chk->counter_size << " bits long");
       DBC_ASSERT(chk->counter_start_bit == -1 || (s.start_bit % 8) == chk->counter_start_bit, "COUNTER starts at wrong bit");
       DBC_ASSERT(chk->little_endian == s.is_little_endian, "COUNTER has wrong endianness");


### PR DESCRIPTION
WIP

- Ford checksums are named "SignalName_Cs" and counters are named "SignalName_Cnt"
- The checksum algorithm and byte position changes for each message
- Ford also sometimes has multiple checksums in one message...

example (although I can't see this message on the bus anyway):
```
BO_ 931 Body_Info_9_FD1: 8 GWM
 SG_ PtWakeReas_D_Stat : 38|4@0+ (1,0) [0|15] "SED"  PCM_HEV
 SG_ VehOnSrc_D_Stat : 19|4@0+ (1,0) [0|15] "SED"  ABS_ESC,PCM_HEV,ECM_Diesel,PCM
 SG_ StrtrMtrCtlDStat_No_Cs : 31|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,ECM_Diesel,PCM
 SG_ EngStrtActv_B_Stat : 39|1@0+ (1,0) [0|1] "SED"  PCM_HEV,ECM_Diesel,PCM
 SG_ EngStrt_B_Rq : 0|1@0+ (1,0) [0|1] "SED"  PCM_HEV,ECM_Diesel,PCM
 SG_ DrvInCtl_B_Stat : 1|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
 SG_ AdvStrt_D_Stat : 23|4@0+ (1,0) [0|15] "SED"  PCM_HEV,ECM_Diesel,PCM
 SG_ CrnkInhbt_No_Cs : 15|8@0+ (1,0) [0|255] "Unitless"  ECM_Diesel,PCM,PCM_HEV
 SG_ CrnkInhbt_No_Cnt : 6|4@0+ (1,0) [0|15] "Unitless"  ECM_Diesel,PCM,PCM_HEV
 SG_ CrnkInhbt_B_Stat : 7|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
 SG_ IgnPreOffActv_B_Stat : 2|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
```