### PR TITLE
Add test for Subaru Brake_Status Signal1 large value

### DIFF
--- a/can/parser.cc
+++ b/can/parser.cc
@@ -21,7 +21,7 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
     int msb = (int)(sig.msb / 8) == i ? sig.msb : (i+1)*8 - 1;
     int size = msb - lsb + 1;
 
-    uint8_t d = (msg[i] >> (lsb - (i*8))) & ((1ULL << size) - 1);
+    uint64_t d = (msg[i] >> (lsb - (i*8))) & ((1ULL << size) - 1);
     ret |= d << (bits - size);
 
     bits -= size;

--- a/can/tests/test.dbc
+++ b/can/tests/test.dbc
@@ -9,6 +9,15 @@ BO_ 228 STEERING_CONTROL: 5 EON
  SG_ COUNTER : 37|2@0+ (1,0) [0|3] "" EPS
  SG_ CHECKSUM : 35|4@0+ (1,0) [0|15] "" EPS
 
+BO_ 316 Brake_Status: 8 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Signal1 : 12|46@1+ (1,0) [0|1] "" XXX
+ SG_ ES_Brake : 58|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal2 : 59|3@1+ (1,0) [0|1] "" XXX
+ SG_ Brake : 62|1@1+ (1,0) [0|1] "" XXX
+ SG_ Signal3 : 63|1@1+ (1,0) [0|1] "" XXX
+
 BO_ 245 CAN_FD_MESSAGE: 32 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|1] "" XXX
  SG_ SIGNED : 22|16@0- (1,0) [0|1] "" XXX

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -112,39 +112,41 @@ class TestCanParserPacker(unittest.TestCase):
       ("STEER_TORQUE", "STEERING_CONTROL"),
       ("STEER_TORQUE_REQUEST", "STEERING_CONTROL"),
 
+      ("Signal1", "Brake_Status"),
+
       ("COUNTER", "CAN_FD_MESSAGE"),
       ("64_BIT_LE", "CAN_FD_MESSAGE"),
       ("64_BIT_BE", "CAN_FD_MESSAGE"),
       ("SIGNED", "CAN_FD_MESSAGE"),
     ]
-    checks = [("STEERING_CONTROL", 0), ("CAN_FD_MESSAGE", 0)]
 
     packer = CANPacker(TEST_DBC)
-    parser = CANParser(TEST_DBC, signals, checks, 0)
+    parser = CANParser(TEST_DBC, signals, [], 0, enforce_checks=False)
 
     for steer in range(-256, 255):
       for active in (1, 0):
-        v1 = {
-          "STEER_TORQUE": steer,
-          "STEER_TORQUE_REQUEST": active,
+        values = {
+          "STEERING_CONTROL": {
+            "STEER_TORQUE": steer,
+            "STEER_TORQUE_REQUEST": active,
+          },
+          "Brake_Status": {
+            "Signal1": 61042322657536.0,
+          },
+          "CAN_FD_MESSAGE": {
+            "SIGNED": steer,
+            "64_BIT_LE": random.randint(0, 100),
+            "64_BIT_BE": random.randint(0, 100),
+          },
         }
-        m1 = packer.make_can_msg("STEERING_CONTROL", 0, v1)
 
-        v2 = {
-          "SIGNED": steer,
-          "64_BIT_LE": random.randint(0, 100),
-          "64_BIT_BE": random.randint(0, 100),
-        }
-        m2 = packer.make_can_msg("CAN_FD_MESSAGE", 0, v2)
-
-        bts = can_list_to_can_capnp([m1, m2])
+        msgs = [packer.make_can_msg(k, 0, v) for k, v in values.items()]
+        bts = can_list_to_can_capnp(msgs)
         parser.update_string(bts)
 
-        for key, val in v1.items():
-          self.assertAlmostEqual(parser.vl["STEERING_CONTROL"][key], val)
-
-        for key, val in v2.items():
-          self.assertAlmostEqual(parser.vl["CAN_FD_MESSAGE"][key], val)
+        for k, v in values.items():
+          for key, val in v.items():
+            self.assertAlmostEqual(parser.vl[k][key], val)
 
         # also check address
         for sig in ("STEER_TORQUE", "STEER_TORQUE_REQUEST", "COUNTER", "CHECKSUM"):
@@ -206,42 +208,6 @@ class TestCanParserPacker(unittest.TestCase):
         self.assertAlmostEqual(parser.vl["ES_LKAS"]["SET_1"], 1)
         self.assertAlmostEqual(parser.vl["ES_LKAS"]["COUNTER"], idx % 16)
         idx += 1
-
-  def test_subaru_large_value(self):
-    # Subaru is little endian
-
-    dbc_file = "subaru_global_2017_generated"
-
-    signals = [
-      ("COUNTER", "Brake_Status"),
-      ("Signal1", "Brake_Status"),
-      ("Brake", "Brake_Status"),
-      ("Signal2", "Brake_Status"),
-      ("ES_Brake", "Brake_Status"),
-      ("Signal3", "Brake_Status"),
-    ]
-    checks = [("Brake_Status", 50)]
-
-    parser = CANParser(dbc_file, signals, checks, 0)
-    packer = CANPacker(dbc_file)
-
-    values = {
-      "Signal1": 57174604644354.0,
-      "Brake": 0,
-      "Signal2": 4.0,
-      "ES_Brake": 0,
-      "Signal3": 0.0
-    }
-
-    msgs = packer.make_can_msg("Brake_Status", 0, values)
-    bts = can_list_to_can_capnp([msgs])
-    parser.update_string(bts)
-
-    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal1"], 57174604644354)
-    self.assertAlmostEqual(parser.vl["Brake_Status"]["Brake"], 0)
-    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal2"], 4)
-    self.assertAlmostEqual(parser.vl["Brake_Status"]["ES_Brake"], 0)
-    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal3"], 0)
 
   def test_bus_timeout(self):
     """Test CAN bus timeout detection"""

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -173,7 +173,7 @@ class TestCanParserPacker(unittest.TestCase):
       self.assertAlmostEqual(parser.vl["VSA_STATUS"]["USER_BRAKE"], brake)
 
   def test_subaru(self):
-    # Subuaru is little endian
+    # Subaru is little endian
 
     dbc_file = "subaru_global_2017_generated"
 
@@ -206,6 +206,42 @@ class TestCanParserPacker(unittest.TestCase):
         self.assertAlmostEqual(parser.vl["ES_LKAS"]["SET_1"], 1)
         self.assertAlmostEqual(parser.vl["ES_LKAS"]["COUNTER"], idx % 16)
         idx += 1
+
+  def test_subaru_large_value(self):
+    # Subaru is little endian
+
+    dbc_file = "subaru_global_2017_generated"
+
+    signals = [
+      ("COUNTER", "Brake_Status"),
+      ("Signal1", "Brake_Status"),
+      ("Brake", "Brake_Status"),
+      ("Signal2", "Brake_Status"),
+      ("ES_Brake", "Brake_Status"),
+      ("Signal3", "Brake_Status"),
+    ]
+    checks = [("Brake_Status", 50)]
+
+    parser = CANParser(dbc_file, signals, checks, 0)
+    packer = CANPacker(dbc_file)
+
+    values = {
+      "Signal1": 57174604644354.0,
+      "Brake": 0,
+      "Signal2": 4.0,
+      "ES_Brake": 0,
+      "Signal3": 0.0
+    }
+
+    msgs = packer.make_can_msg("Brake_Status", 0, values)
+    bts = can_list_to_can_capnp([msgs])
+    parser.update_string(bts)
+
+    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal1"], 57174604644354)
+    self.assertAlmostEqual(parser.vl["Brake_Status"]["Brake"], 0)
+    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal2"], 4)
+    self.assertAlmostEqual(parser.vl["Brake_Status"]["ES_Brake"], 0)
+    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal3"], 0)
 
   def test_bus_timeout(self):
     """Test CAN bus timeout detection"""


### PR DESCRIPTION
This PR adds test for one edge case found while debugging why Eyesight started faulting after https://github.com/commaai/opendbc/commit/859fea7ded706516f4b963218a3c9cf543f39c2a on subaru longitudinal branch (https://github.com/commaai/openpilot/pull/25345). Fault did not occur when I disabled Brake_Status and CruiseControl filtering in panda fwd hook and allowed stock messages to pass through. 

Brake_Status signal values debug output from subarucan showed that Signal1 output value changed after the https://github.com/commaai/opendbc/commit/859fea7ded706516f4b963218a3c9cf543f39c2a:

```
working
--
send brake_status
{'Brake': 0.0,
 'CHECKSUM': 193.0,
 'Counter': 1.0,
 'ES_Brake': 0,
 'Signal1': 57174604644354.0,
 'Signal2': 4.0,
 'Signal3': 0.0}
--
fault
--
send brake_status
{'Brake': 0.0,
 'CHECKSUM': 162.0,
 'COUNTER': 2.0,
 'ES_Brake': 0,
 'Signal1': 13312.0,
 'Signal2': 4.0,
 'Signal3': 0.0}
--
```

Brake_Status Signal1 is 46bit filler signal that may contain large values like 57174604644354.0 
Brake_Status message is copied using copy.copy in carstate in order to set ES_Brake feedback signal to 0 in subarucan.

```
BO_ 316 Brake_Status: 8 XXX
 SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
 SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
 SG_ Signal1 : 12|46@1+ (1,0) [0|1] "" XXX
 SG_ ES_Brake : 58|1@1+ (1,0) [0|1] "" XXX
 SG_ Signal2 : 59|3@1+ (1,0) [0|1] "" XXX
 SG_ Brake : 62|1@1+ (1,0) [0|1] "" XXX
 SG_ Signal3 : 63|1@1+ (1,0) [0|1] "" XXX
```

Before https://github.com/commaai/opendbc/commit/859fea7ded706516f4b963218a3c9cf543f39c2a the test passes:
```
cd opendbc
git checkout 0ccc718b1a35316cf6f553bf220f25b156e67c63
cd ..
./opendbc/can/tests/test_packer_parser.py
.....
----------------------------------------------------------------------
Ran 5 tests in 0.097s

OK
```
After https://github.com/commaai/opendbc/commit/859fea7ded706516f4b963218a3c9cf543f39c2a the test fails:
```
cd opendbc
git checkout 859fea7ded706516f4b963218a3c9cf543f39c2a
cd ..
./opendbc/can/tests/test_packer_parser.py           
....F.
======================================================================
FAIL: test_subaru_large_value (__main__.TestCanParserPacker)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./opendbc/can/tests/test_packer_parser.py", line 182, in test_subaru_large_value
    self.assertAlmostEqual(parser.vl["Brake_Status"]["Signal1"], 57174604644354)
AssertionError: 13314.0 != 57174604644354 within 7 places (57174604631040.0 difference)

----------------------------------------------------------------------
Ran 6 tests in 0.120s

FAILED (failures=1)
```
