### PR TITLE
[docker] rm cereal .git folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,5 @@ COPY ./site_scons /project/site_scons
 COPY . /project/opendbc
 
 RUN rm -rf /project/opendbc/.git
+RUN rm -rf /project/cereal/.git
 RUN scons -c && scons -j$(nproc)

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,6 @@ COPY SConstruct .
 COPY ./site_scons /project/site_scons
 COPY . /project/opendbc
 
-RUN rm -rf /project/opendbc/.git
-RUN rm -rf /project/cereal/.git
+RUN rm -rf /project/opendbc/.git && \
+    rm -rf /project/cereal/.git
 RUN scons -c && scons -j$(nproc)


### PR DESCRIPTION
treat cereal the same as opendbc, remove .git for both