### PR TITLE
HKG CAN-FD: rename brake signal

### DIFF
--- a/hyundai_canfd.dbc
+++ b/hyundai_canfd.dbc
@@ -158,8 +158,8 @@ BO_ 373 TCS: 24 XXX
  SG_ PROBABLY_EQUIP : 136|2@1+ (1,0) [0|3] "" XXX
  SG_ AEB_EQUIP_MAYBE : 96|1@0+ (1,0) [0|1] "" XXX
  SG_ EQUIP_MAYBE : 64|1@0+ (1,0) [0|1] "" XXX
- SG_ DriverBrakingLowSens : 84|1@1+ (1,0) [0|31] "" XXX
  SG_ DriverBraking : 81|1@0+ (1,0) [0|1] "" XXX
+ SG_ DriverBrakingLowSens : 84|1@1+ (1,0) [0|31] "" XXX
  SG_ ACC_REQ : 68|1@0+ (1,0) [0|1] "" XXX
  SG_ ACCEL_REF_ACC : 48|11@1- (1,0) [0|1023] "" XXX
 

--- a/hyundai_canfd.dbc
+++ b/hyundai_canfd.dbc
@@ -158,8 +158,8 @@ BO_ 373 TCS: 24 XXX
  SG_ PROBABLY_EQUIP : 136|2@1+ (1,0) [0|3] "" XXX
  SG_ AEB_EQUIP_MAYBE : 96|1@0+ (1,0) [0|1] "" XXX
  SG_ EQUIP_MAYBE : 64|1@0+ (1,0) [0|1] "" XXX
- SG_ DriverBraking : 84|1@1+ (1,0) [0|31] "" XXX
- SG_ BRAKE_RELATED : 81|1@0+ (1,0) [0|1] "" XXX
+ SG_ DriverBrakingLowSens : 84|1@1+ (1,0) [0|31] "" XXX
+ SG_ DriverBraking : 81|1@0+ (1,0) [0|1] "" XXX
  SG_ ACC_REQ : 68|1@0+ (1,0) [0|1] "" XXX
  SG_ ACCEL_REF_ACC : 48|11@1- (1,0) [0|1023] "" XXX
 

--- a/hyundai_canfd.dbc
+++ b/hyundai_canfd.dbc
@@ -523,8 +523,10 @@ BO_ 485 BLINDSPOTS_FRONT_CORNER_1: 16 XXX
 
 CM_ SG_ 96 BRAKE_PRESSURE "User applied brake pedal pressure. Ramps from computer applied pressure on falling edge of cruise. Cruise cancels if !=0";
 CM_ SG_ 101 BRAKE_POSITION "User applied brake pedal position, max is ~700. Signed on some vehicles";
-CM_ SG_ 373 PROBABLY_EQUIP "aeb equip?";
 CM_ SG_ 352 SET_ME_9 "has something to do with AEB settings";
+CM_ SG_ 373 DriverBraking "Likely derived from BRAKE->BRAKE_POSITION";
+CM_ SG_ 373 DriverBrakingLowSens "Higher threshold version of DriverBraking";
+CM_ SG_ 373 PROBABLY_EQUIP "aeb equip?";
 CM_ SG_ 961 COUNTER_ALT "only increments on change";
 CM_ SG_ 1041 COUNTER_ALT "only increments on change";
 CM_ SG_ 1043 COUNTER_ALT "only increments on change";

--- a/hyundai_canfd.dbc
+++ b/hyundai_canfd.dbc
@@ -159,7 +159,7 @@ BO_ 373 TCS: 24 XXX
  SG_ AEB_EQUIP_MAYBE : 96|1@0+ (1,0) [0|1] "" XXX
  SG_ EQUIP_MAYBE : 64|1@0+ (1,0) [0|1] "" XXX
  SG_ DriverBraking : 81|1@0+ (1,0) [0|1] "" XXX
- SG_ DriverBrakingLowSens : 84|1@1+ (1,0) [0|31] "" XXX
+ SG_ DriverBrakingLowSens : 84|1@1+ (1,0) [0|1] "" XXX
  SG_ ACC_REQ : 68|1@0+ (1,0) [0|1] "" XXX
  SG_ ACCEL_REF_ACC : 48|11@1- (1,0) [0|1023] "" XXX
 


### PR DESCRIPTION
DriverBrakingLowSens is also based on `BRAKE->BRAKE_POSITION`, but is much less sensitive