### PR TITLE
hyundai_2015_ccan.dbc: fix signal scale

### DIFF
--- a/hyundai_2015_ccan.dbc
+++ b/hyundai_2015_ccan.dbc
@@ -295,7 +295,7 @@ BO_ 399 EMS_H12: 8 EMS
  SG_ CF_Ems_FCopen : 59|1@1+ (1.0,0.0) [0.0|1.0] ""  CLU,IBOX
  SG_ CF_Ems_ActEcoAct : 60|1@1+ (1.0,0.0) [0.0|1.0] ""  CLU,IBOX,TCU
  SG_ CF_Ems_EngRunNorm : 61|1@1+ (1.0,0.0) [0.0|1.0] ""  ABS,ESC,IBOX,TCU
- SG_ CF_Ems_IsgStat2 : 62|2@1+ (2.0,0.0) [0.0|3.0] ""  CLU,IBOX,TCU
+ SG_ CF_Ems_IsgStat2 : 62|2@1+ (1.0,0.0) [0.0|3.0] ""  CLU,IBOX,TCU
 
 BO_ 1419 LCA11: 8 LCA
  SG_ CF_Lca_Stat : 0|4@1+ (1.0,0.0) [0.0|15.0] ""  BCM,CLU


### PR DESCRIPTION
The scale of signal `CF_Ems_IsgStat2` should be 1.0 instead of 2.0 because two bits are assigned for the signal. Otherwise, the range of the signal must be [0.0|6.0] rather than [0.0|3.0].