### PR TITLE
GM: add new undefined brake-related signals

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -168,7 +168,7 @@ BO_ 501 ECMPRDNL2: 8 K20_ECM
  SG_ ManualMode : 41|1@0+ (1,0) [0|1] "" NEO
 
 BO_ 532 BRAKE_RELATED: 6 XXX
- SG_ UserBrakePressure : 15|8@0+ (1,0) [0|255] "" XXX
+ SG_ UserBrakePressure : 0|9@0+ (1,0) [0|511] "" XXX
 
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -282,6 +282,8 @@ CM_ SG_ 352 Ignition "Non-zero when ignition is on";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
 CM_ SG_ 497 Ignition "Describes ignition + preconditioning mode, noisy";
 CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
+CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brake are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
+CM_ SG_ 761 UserBrakePressure2 "Similar to BRAKE_RELATED->UserBrakePressure";
 CM_ SG_ 1001 VehicleSpeed "Spinouts show here on 2wd. Speed derived from right front wheel (drive tire)";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;
 BA_DEF_  "ProtocolType" STRING ;

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -84,6 +84,7 @@ BO_ 209 EBCMBrakePedalSensors: 7 K17_EBCM
  SG_ BrakeNormalized2 : 47|8@0- (-1,0) [0|255] "" XXX
 
 BO_ 241 EBCMBrakePedalPosition: 6 K17_EBCM
+ SG_ BrakePressed : 1|1@0+ (1,0) [0|1] "" XXX
  SG_ BrakePedalPosition : 15|8@0+ (1,0) [0|255] ""  NEO
 
 BO_ 298 BCMDoorBeltStatus: 8 K9_BCM
@@ -166,6 +167,9 @@ BO_ 501 ECMPRDNL2: 8 K20_ECM
  SG_ PRNDL2 : 27|4@0+ (1,0) [0|255] "" NEO
  SG_ ManualMode : 41|1@0+ (1,0) [0|1] "" NEO
 
+BO_ 532 BRAKE_RELATED: 6 XXX
+ SG_ UserBrakePressure : 15|8@0+ (1,0) [0|255] "" XXX
+
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
 
@@ -185,6 +189,9 @@ BO_ 715 ASCMGasRegenCmd: 8 K124_ASCM
  SG_ GasRegenCmd : 22|12@0+ (1,0) [0|0] ""  NEO
 
 BO_ 717 ASCM_2CD: 5 K124_ASCM
+
+BO_ 761 BRAKE_RELATED_2: 7 XXX
+ SG_ UserBrakePressure2 : 47|9@0+ (1,0) [0|511] "" XXX
 
 BO_ 789 EBCMFrictionBrakeCmd: 5 K124_ASCM
  SG_ RollingCounter : 33|2@0+ (1,0) [0|0] ""  NEO

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -71,7 +71,7 @@ BO_ 201 ECMEngineStatus: 8 K20_ECM
  SG_ EngineTPS : 39|8@0+ (0.392156863,0) [0|100.000000065] "%" NEO
  SG_ EngineRPM : 15|16@0+ (0.25,0) [0|0] "RPM" NEO
  SG_ CruiseMainOn : 29|1@0+ (1,0) [0|1] "" NEO
- SG_ Brake_Pressed : 40|1@0+ (1,0) [0|1] "" NEO
+ SG_ BrakePressed : 40|1@0+ (1,0) [0|1] "" NEO
  SG_ Standstill : 2|1@0+ (1,0) [0|1] "" NEO
  SG_ CruiseActive : 31|2@0+ (1,0) [0|3] "" NEO
 

--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -282,7 +282,7 @@ CM_ SG_ 352 Ignition "Non-zero when ignition is on";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
 CM_ SG_ 497 Ignition "Describes ignition + preconditioning mode, noisy";
 CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
-CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brake are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
+CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brakes are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
 CM_ SG_ 761 UserBrakePressure2 "Similar to BRAKE_RELATED->UserBrakePressure";
 CM_ SG_ 1001 VehicleSpeed "Spinouts show here on 2wd. Speed derived from right front wheel (drive tire)";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -104,6 +104,7 @@ BO_ 209 EBCMBrakePedalSensors: 7 K17_EBCM
  SG_ BrakeNormalized2 : 47|8@0- (-1,0) [0|255] "" XXX
 
 BO_ 241 EBCMBrakePedalPosition: 6 K17_EBCM
+ SG_ BrakePressed : 1|1@0+ (1,0) [0|1] "" XXX
  SG_ BrakePedalPosition : 15|8@0+ (1,0) [0|255] ""  NEO
 
 BO_ 298 BCMDoorBeltStatus: 8 K9_BCM
@@ -186,6 +187,9 @@ BO_ 501 ECMPRDNL2: 8 K20_ECM
  SG_ PRNDL2 : 27|4@0+ (1,0) [0|255] "" NEO
  SG_ ManualMode : 41|1@0+ (1,0) [0|1] "" NEO
 
+BO_ 532 BRAKE_RELATED: 6 XXX
+ SG_ UserBrakePressure : 15|8@0+ (1,0) [0|255] "" XXX
+
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO
 
@@ -205,6 +209,9 @@ BO_ 715 ASCMGasRegenCmd: 8 K124_ASCM
  SG_ GasRegenCmd : 22|12@0+ (1,0) [0|0] ""  NEO
 
 BO_ 717 ASCM_2CD: 5 K124_ASCM
+
+BO_ 761 BRAKE_RELATED_2: 7 XXX
+ SG_ UserBrakePressure2 : 47|9@0+ (1,0) [0|511] "" XXX
 
 BO_ 789 EBCMFrictionBrakeCmd: 5 K124_ASCM
  SG_ RollingCounter : 33|2@0+ (1,0) [0|0] ""  NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -188,7 +188,7 @@ BO_ 501 ECMPRDNL2: 8 K20_ECM
  SG_ ManualMode : 41|1@0+ (1,0) [0|1] "" NEO
 
 BO_ 532 BRAKE_RELATED: 6 XXX
- SG_ UserBrakePressure : 15|8@0+ (1,0) [0|255] "" XXX
+ SG_ UserBrakePressure : 0|9@0+ (1,0) [0|511] "" XXX
 
 BO_ 560 EPBStatus: 8 EPB
  SG_ EPBClosed : 12|1@0+ (1,0) [0|1] ""  NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -302,6 +302,8 @@ CM_ SG_ 352 Ignition "Non-zero when ignition is on";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
 CM_ SG_ 497 Ignition "Describes ignition + preconditioning mode, noisy";
 CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
+CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brake are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
+CM_ SG_ 761 UserBrakePressure2 "Similar to BRAKE_RELATED->UserBrakePressure";
 CM_ SG_ 1001 VehicleSpeed "Spinouts show here on 2wd. Speed derived from right front wheel (drive tire)";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;
 BA_DEF_  "ProtocolType" STRING ;

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -91,7 +91,7 @@ BO_ 201 ECMEngineStatus: 8 K20_ECM
  SG_ EngineTPS : 39|8@0+ (0.392156863,0) [0|100.000000065] "%" NEO
  SG_ EngineRPM : 15|16@0+ (0.25,0) [0|0] "RPM" NEO
  SG_ CruiseMainOn : 29|1@0+ (1,0) [0|1] "" NEO
- SG_ Brake_Pressed : 40|1@0+ (1,0) [0|1] "" NEO
+ SG_ BrakePressed : 40|1@0+ (1,0) [0|1] "" NEO
  SG_ Standstill : 2|1@0+ (1,0) [0|1] "" NEO
  SG_ CruiseActive : 31|2@0+ (1,0) [0|3] "" NEO
 

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -302,7 +302,7 @@ CM_ SG_ 352 Ignition "Non-zero when ignition is on";
 CM_ SG_ 451 GasPedalAndAcc2 "ACC baseline is 62";
 CM_ SG_ 497 Ignition "Describes ignition + preconditioning mode, noisy";
 CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
-CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brake are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
+CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brakes are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
 CM_ SG_ 761 UserBrakePressure2 "Similar to BRAKE_RELATED->UserBrakePressure";
 CM_ SG_ 1001 VehicleSpeed "Spinouts show here on 2wd. Speed derived from right front wheel (drive tire)";
 BA_DEF_  "UseGMParameterIDs" INT 0 0;


### PR DESCRIPTION
used a script to find all bits similar to CS.brakePressed, ended up finding bits and continuous signals. may be helpful in resolving some more faults