### PR TITLE
GM: add bits for moving backwards

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -210,13 +210,17 @@ BO_ 810 TCICOnStarGPSPosition: 8 K73_TCIC
  SG_ GPSLongitude : 39|32@0+ (1,-2147483648) [0|0] "milliarcsecond"  NEO
  SG_ GPSLatitude : 7|32@0+ (1,0) [0|0] "milliarcsecond"  NEO
 
-BO_ 840 EBCMWheelSpdFront: 4 K17_EBCM
+BO_ 840 EBCMWheelSpdFront: 5 K17_EBCM
  SG_ FLWheelSpd : 7|16@0+ (0.0311,0) [0|255] "km/h"  NEO
  SG_ FRWheelSpd : 23|16@0+ (0.0311,0) [0|255] "km/h"  NEO
 
 BO_ 842 EBCMWheelSpdRear: 5 K17_EBCM
  SG_ RLWheelSpd : 7|16@0+ (0.0311,0) [0|255] "km/h"  NEO
  SG_ RRWheelSpd : 23|16@0+ (0.0311,0) [0|255] "km/h"  NEO
+ SG_ MovingForward : 32|1@0+ (1,0) [0|1] "" XXX
+ SG_ MovingBackward : 33|1@0+ (1,0) [0|1] "" XXX
+ SG_ MovingForward2 : 35|1@1+ (1,0) [0|1] "" XXX
+ SG_ MovingBackward2 : 36|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 869 ASCM_365: 4 K124_ASCM
 

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -230,13 +230,17 @@ BO_ 810 TCICOnStarGPSPosition: 8 K73_TCIC
  SG_ GPSLongitude : 39|32@0+ (1,-2147483648) [0|0] "milliarcsecond"  NEO
  SG_ GPSLatitude : 7|32@0+ (1,0) [0|0] "milliarcsecond"  NEO
 
-BO_ 840 EBCMWheelSpdFront: 4 K17_EBCM
+BO_ 840 EBCMWheelSpdFront: 5 K17_EBCM
  SG_ FLWheelSpd : 7|16@0+ (0.0311,0) [0|255] "km/h"  NEO
  SG_ FRWheelSpd : 23|16@0+ (0.0311,0) [0|255] "km/h"  NEO
 
 BO_ 842 EBCMWheelSpdRear: 5 K17_EBCM
  SG_ RLWheelSpd : 7|16@0+ (0.0311,0) [0|255] "km/h"  NEO
  SG_ RRWheelSpd : 23|16@0+ (0.0311,0) [0|255] "km/h"  NEO
+ SG_ MovingForward : 32|1@0+ (1,0) [0|1] "" XXX
+ SG_ MovingBackward : 33|1@0+ (1,0) [0|1] "" XXX
+ SG_ MovingForward2 : 35|1@1+ (1,0) [0|1] "" XXX
+ SG_ MovingBackward2 : 36|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 869 ASCM_365: 4 K124_ASCM
 


### PR DESCRIPTION
To fix a fault where you can engage while backing up after going into D (before you stop)