### PR TITLE
add missing iterator include

### DIFF
--- a/can/dbc.cc
+++ b/can/dbc.cc
@@ -8,6 +8,7 @@
 #include <vector>
 #include <mutex>
 #include <cstring>
+#include <iterator>
 
 #include "common.h"
 #include "common_dbc.h"


### PR DESCRIPTION
Fixes compilation with `clang version 14.0.6`.

```
opendbc/can/dbc.cc:184:50: error: no template named 'ostream_iterator' in namespace 'std'; did you mean 'ostreambuf_iterator'?
      std::copy(words.begin(), words.end(), std::ostream_iterator<std::string>(s, " "));
                                            ~~~~~^~~~~~~~~~~~~~~~
                                                 ostreambuf_iterator
```