### PR TITLE
Bump pylint version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ flake8==3.7.9
 Jinja2==3.0.3
 numpy==1.21.0
 pycapnp==1.0.0
-pylint==2.4.3
+pylint==2.5.2
 pyyaml==5.4
 scons


### PR DESCRIPTION
A bug (https://github.com/PyCQA/pylint/issues/3098) was fixed in 2.5.0 relating to detecting abstract subclasses, bump to 2.5.2 like panda.

@adeebshihadeh somehow the panda docker is installing 2.4.3 in CI, causing a PR to fail static analysis which shouldn't, can that be affected by opendbc's pylint version? That's why I'm bumping it