### PR TITLE
Bump pylint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ flake8==3.7.9
 Jinja2==3.0.3
 numpy==1.21.0
 pycapnp==1.0.0
-pylint==2.5.2
+pylint==2.15.4
 pyyaml==5.4
 scons


### PR DESCRIPTION
pylint 2.12.0 has a fix for relative imports introduced in 2.5.1, bump to the openpilot version instead.

Likely introduced here: https://github.com/PyCQA/pylint/commit/a6d7ffc4679b0ad2258cf6c31c6dfbeeb2b331ef

Related issues:
- https://github.com/PyCQA/pylint/issues/5131
- https://github.com/PyCQA/pylint/issues/2967