### PR TITLE
CANParser: add timestamp field

### DIFF
--- a/can/common.pxd
+++ b/can/common.pxd
@@ -61,6 +61,7 @@ cdef extern from "common_dbc.h":
 
   cdef struct SignalValue:
     uint32_t address
+    uint64_t ts
     string name
     double value
     vector[double] all_values

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -61,7 +61,7 @@ cdef extern from "common_dbc.h":
 
   cdef struct SignalValue:
     uint32_t address
-    uint64_t ts
+    uint64_t ts_nanos
     string name
     double value
     vector[double] all_values

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -24,6 +24,7 @@ struct MessageParseOptions {
 
 struct SignalValue {
   uint32_t address;
+  uint64_t ts;
   std::string name;
   double value;  // latest value
   std::vector<double> all_values;  // all values from this cycle

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -24,7 +24,7 @@ struct MessageParseOptions {
 
 struct SignalValue {
   uint32_t address;
-  uint64_t ts;
+  uint64_t ts_nanos;
   std::string name;
   double value;  // latest value
   std::vector<double> all_values;  // all values from this cycle

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -310,7 +310,7 @@ std::vector<SignalValue> CANParser::query_latest() {
       const Signal &sig = state.parse_sigs[i];
       ret.push_back((SignalValue){
         .address = state.address,
-        .ts = state.last_seen_nanos,
+        .ts_nanos = state.last_seen_nanos,
         .name = sig.name,
         .value = state.vals[i],
         .all_values = state.all_vals[i],

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -310,6 +310,7 @@ std::vector<SignalValue> CANParser::query_latest() {
       const Signal &sig = state.parse_sigs[i];
       ret.push_back((SignalValue){
         .address = state.address,
+        .ts = state.last_seen_nanos,
         .name = sig.name,
         .value = state.vals[i],
         .all_values = state.all_vals[i],

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -26,6 +26,7 @@ cdef class CANParser:
   cdef readonly:
     dict vl
     dict vl_all
+    dict ts
     string dbc_name
 
   def __init__(self, dbc_name, signals, checks=None, bus=0, enforce_checks=True):
@@ -39,6 +40,7 @@ cdef class CANParser:
 
     self.vl = {}
     self.vl_all = {}
+    self.ts = {}
     msg_name_to_address = {}
 
     for i in range(self.dbc[0].msgs.size()):
@@ -51,6 +53,8 @@ cdef class CANParser:
       self.vl[name] = self.vl[msg.address]
       self.vl_all[msg.address] = defaultdict(list)
       self.vl_all[name] = self.vl_all[msg.address]
+      self.ts[msg.address] = {}
+      self.ts[name] = self.ts[msg.address]
 
     # Convert message names into addresses
     for i in range(len(signals)):
@@ -108,6 +112,7 @@ cdef class CANParser:
       cv_name = <unicode>cv.name
       self.vl[cv.address][cv_name] = cv.value
       self.vl_all[cv.address][cv_name].extend(cv.all_values)
+      self.ts[cv.address][cv_name] = cv.ts
       updated_addrs.insert(cv.address)
 
     return updated_addrs

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -26,7 +26,7 @@ cdef class CANParser:
   cdef readonly:
     dict vl
     dict vl_all
-    dict ts
+    dict ts_nanos
     string dbc_name
 
   def __init__(self, dbc_name, signals, checks=None, bus=0, enforce_checks=True):
@@ -40,7 +40,7 @@ cdef class CANParser:
 
     self.vl = {}
     self.vl_all = {}
-    self.ts = {}
+    self.ts_nanos = {}
     msg_name_to_address = {}
 
     for i in range(self.dbc[0].msgs.size()):
@@ -53,8 +53,8 @@ cdef class CANParser:
       self.vl[name] = self.vl[msg.address]
       self.vl_all[msg.address] = defaultdict(list)
       self.vl_all[name] = self.vl_all[msg.address]
-      self.ts[msg.address] = {}
-      self.ts[name] = self.ts[msg.address]
+      self.ts_nanos[msg.address] = {}
+      self.ts_nanos[name] = self.ts_nanos[msg.address]
 
     # Convert message names into addresses
     for i in range(len(signals)):
@@ -112,7 +112,7 @@ cdef class CANParser:
       cv_name = <unicode>cv.name
       self.vl[cv.address][cv_name] = cv.value
       self.vl_all[cv.address][cv_name].extend(cv.all_values)
-      self.ts[cv.address][cv_name] = cv.ts
+      self.ts_nanos[cv.address][cv_name] = cv.ts_nanos
       updated_addrs.insert(cv.address)
 
     return updated_addrs


### PR DESCRIPTION
Reverts https://github.com/commaai/opendbc/pull/557 and fills out field with logMonoTime of `can` service packet