### PR TITLE
Add single pedal mode signals for Bolt EV/EUV

### DIFF
--- a/generator/gm/gm_global_a_powertrain.dbc
+++ b/generator/gm/gm_global_a_powertrain.dbc
@@ -243,6 +243,11 @@ BO_ 880 ASCMActiveCruiseControlStatus: 6 K124_ASCM
  SG_ ACCCmdActive : 23|1@0+ (1,0) [0|0] ""  NEO
  SG_ FCWAlert : 41|2@0+ (1,0) [0|3] "" XXX
 
+BO_ 967 EVDriveMode: 4 XXX
+ SG_ SinglePedalModeActive : 7|1@0+ (1,0) [0|1] "" XXX
+ SG_ SinglePedalModeRisingEdge : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ SinglePedalModeFallingEdge : 22|1@0+ (1,0) [0|1] "" XXX
+
 BO_ 977 ECMCruiseControl: 8 K20_ECM
  SG_ CruiseActive : 39|1@0+ (1,0) [0|3] "" NEO
  SG_ CruiseSetSpeed : 19|12@0+ (0.0625,0) [0|0] "km/h" NEO

--- a/gm_global_a_powertrain_generated.dbc
+++ b/gm_global_a_powertrain_generated.dbc
@@ -263,6 +263,11 @@ BO_ 880 ASCMActiveCruiseControlStatus: 6 K124_ASCM
  SG_ ACCCmdActive : 23|1@0+ (1,0) [0|0] ""  NEO
  SG_ FCWAlert : 41|2@0+ (1,0) [0|3] "" XXX
 
+BO_ 967 EVDriveMode: 4 XXX
+ SG_ SinglePedalModeActive : 7|1@0+ (1,0) [0|1] "" XXX
+ SG_ SinglePedalModeRisingEdge : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ SinglePedalModeFallingEdge : 22|1@0+ (1,0) [0|1] "" XXX
+
 BO_ 977 ECMCruiseControl: 8 K20_ECM
  SG_ CruiseActive : 39|1@0+ (1,0) [0|3] "" NEO
  SG_ CruiseSetSpeed : 19|12@0+ (0.0625,0) [0|0] "km/h" NEO


### PR DESCRIPTION
See this image, where the driver of a 2023 Bolt EV toggled single pedal mode on and off a few times while driving. I have also confirmed this is accurate with a 2022 Bolt EUV. You should easily be able to verify this with your own EUV.
![Screenshot 2023-03-10 at 16 54 44](https://user-images.githubusercontent.com/13560103/224451166-7ba5983a-d004-4bcb-8944-454c456f73a9.jpg)