### PR TITLE
honda_civic_ex_2022: add BRAKE_MODULE

### DIFF
--- a/generator/honda/honda_civic_ex_2022_can.dbc
+++ b/generator/honda/honda_civic_ex_2022_can.dbc
@@ -19,6 +19,12 @@ BO_ 432 STANDSTILL: 7 VSA
  SG_ COUNTER : 53|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 51|4@0+ (1,0) [0|15] "" EON
 
+BO_ 446 BRAKE_MODULE: 3 VSA
+ SG_ BRAKE_PRESSED : 4|1@0+ (1,0) [0|1] "" XXX
+ SG_ CRUISE_FAULT : 22|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 21|2@0+ (1,0) [0|3] "" XXX
+ SG_ CHECKSUM : 19|4@0+ (1,0) [0|15] "" XXX
+
 BO_ 456 ACC_CONTROL: 8 XXX
  SG_ ACCEL_COMMAND : 7|12@0- (0.01,0) [0|0] "m/s^2" XXX
  SG_ IDLESTOP_ALLOW : 8|1@0+ (1,0) [0|1] "" XXX
@@ -32,6 +38,9 @@ BO_ 456 ACC_CONTROL: 8 XXX
  SG_ FCW_2 : 54|1@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
+
+BO_ 467 CRUISE_RELATED: 8 XXX
+ SG_ CRUISE_FAULT : 3|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 829 LKAS_HUD: 8 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
@@ -70,6 +79,7 @@ BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
+CM_ 446 "Does not exist on all radarless platforms. May describe cruise faults and what the PCM uses for brake pressed.";
 CM_ SG_ 456 IDLESTOP_ALLOW "allows car to turn off engine at a standstill";
 CM_ SG_ 456 STANDSTILL "set to 1 when camera requests -4.0 m/s^2";
 

--- a/generator/honda/honda_civic_ex_2022_can.dbc
+++ b/generator/honda/honda_civic_ex_2022_can.dbc
@@ -39,9 +39,6 @@ BO_ 456 ACC_CONTROL: 8 XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
 
-BO_ 467 CRUISE_RELATED: 8 XXX
- SG_ CRUISE_FAULT : 3|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 829 LKAS_HUD: 8 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
@@ -79,7 +76,7 @@ BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
-CM_ 446 "Does not exist on all radarless platforms. May describe cruise faults and what the PCM uses for brake pressed.";
+CM_ 446 "If exists, describes cruise faults and what the PCM uses for brake press.";
 CM_ SG_ 456 IDLESTOP_ALLOW "allows car to turn off engine at a standstill";
 CM_ SG_ 456 STANDSTILL "set to 1 when camera requests -4.0 m/s^2";
 

--- a/generator/honda/honda_civic_ex_2022_can.dbc
+++ b/generator/honda/honda_civic_ex_2022_can.dbc
@@ -76,7 +76,7 @@ BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
-CM_ 446 "If exists, describes cruise faults and what the PCM uses for brake press.";
+CM_ 446 "If exists, describes cruise faults and what the PCM uses for brake press detection.";
 CM_ SG_ 456 IDLESTOP_ALLOW "allows car to turn off engine at a standstill";
 CM_ SG_ 456 STANDSTILL "set to 1 when camera requests -4.0 m/s^2";
 

--- a/honda_civic_ex_2022_can_generated.dbc
+++ b/honda_civic_ex_2022_can_generated.dbc
@@ -502,7 +502,7 @@ BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
-CM_ 446 "If exists, describes cruise faults and what the PCM uses for brake press.";
+CM_ 446 "If exists, describes cruise faults and what the PCM uses for brake press detection.";
 CM_ SG_ 456 IDLESTOP_ALLOW "allows car to turn off engine at a standstill";
 CM_ SG_ 456 STANDSTILL "set to 1 when camera requests -4.0 m/s^2";
 

--- a/honda_civic_ex_2022_can_generated.dbc
+++ b/honda_civic_ex_2022_can_generated.dbc
@@ -465,9 +465,6 @@ BO_ 456 ACC_CONTROL: 8 XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
 
-BO_ 467 CRUISE_RELATED: 8 XXX
- SG_ CRUISE_FAULT : 3|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 829 LKAS_HUD: 8 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
@@ -505,7 +502,7 @@ BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
-CM_ 446 "Does not exist on all radarless platforms. May describe cruise faults and what the PCM uses for brake pressed.";
+CM_ 446 "If exists, describes cruise faults and what the PCM uses for brake press.";
 CM_ SG_ 456 IDLESTOP_ALLOW "allows car to turn off engine at a standstill";
 CM_ SG_ 456 STANDSTILL "set to 1 when camera requests -4.0 m/s^2";
 

--- a/honda_civic_ex_2022_can_generated.dbc
+++ b/honda_civic_ex_2022_can_generated.dbc
@@ -445,6 +445,12 @@ BO_ 432 STANDSTILL: 7 VSA
  SG_ COUNTER : 53|2@0+ (1,0) [0|3] "" EON
  SG_ CHECKSUM : 51|4@0+ (1,0) [0|15] "" EON
 
+BO_ 446 BRAKE_MODULE: 3 VSA
+ SG_ BRAKE_PRESSED : 4|1@0+ (1,0) [0|1] "" XXX
+ SG_ CRUISE_FAULT : 22|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 21|2@0+ (1,0) [0|3] "" XXX
+ SG_ CHECKSUM : 19|4@0+ (1,0) [0|15] "" XXX
+
 BO_ 456 ACC_CONTROL: 8 XXX
  SG_ ACCEL_COMMAND : 7|12@0- (0.01,0) [0|0] "m/s^2" XXX
  SG_ IDLESTOP_ALLOW : 8|1@0+ (1,0) [0|1] "" XXX
@@ -458,6 +464,9 @@ BO_ 456 ACC_CONTROL: 8 XXX
  SG_ FCW_2 : 54|1@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
+
+BO_ 467 CRUISE_RELATED: 8 XXX
+ SG_ CRUISE_FAULT : 3|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 829 LKAS_HUD: 8 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
@@ -496,6 +505,7 @@ BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
 
+CM_ 446 "Does not exist on all radarless platforms. May describe cruise faults and what the PCM uses for brake pressed.";
 CM_ SG_ 456 IDLESTOP_ALLOW "allows car to turn off engine at a standstill";
 CM_ SG_ 456 STANDSTILL "set to 1 when camera requests -4.0 m/s^2";
 


### PR DESCRIPTION
Since this DBC is (hopefully) going to be used for the entire radarless platform, add the brake module message for the 2023 HR-V, which is what its PCM uses to disengage (there's lots of false positives for the other brake signals). Also has a cruise fault signal, and does _**NOT**_ exist on the 2022 Civic