### PR TITLE
dbc:  force C locale for numbers.

### DIFF
--- a/can/dbc.cc
+++ b/can/dbc.cc
@@ -106,6 +106,7 @@ DBC* dbc_parse_from_stream(const std::string &dbc_name, std::istream &stream, Ch
   std::map<uint32_t, std::vector<Signal>> signals;
   DBC* dbc = new DBC;
   dbc->name = dbc_name;
+  std::setlocale(LC_NUMERIC, "C");
 
   // used to find big endian LSB from MSB and size
   std::vector<int> be_bits;


### PR DESCRIPTION
related issue: https://github.com/commaai/openpilot/issues/28197

 the std::string conversion functions `std::stod`, `std::stoi` `std::stoul` is locale dependent.   It cannot correctly convert the strings in dbc files to number in some locale. for example, `std::stod` will convert 0.005 to 0 in the `ru_RU.UTF-`8 

