### PR TITLE
dbc: add missing include for setlocale

### DIFF
--- a/can/dbc.cc
+++ b/can/dbc.cc
@@ -7,8 +7,9 @@
 #include <sstream>
 #include <vector>
 #include <mutex>
-#include <cstring>
 #include <iterator>
+#include <cstring>
+#include <clocale>
 
 #include "opendbc/can/common.h"
 #include "opendbc/can/common_dbc.h"


### PR DESCRIPTION
Missing include is causing build issues on macos