### PR TITLE
parser: fix wrong message name check/print

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -47,6 +47,7 @@ cdef class CANParser:
     for i in range(self.dbc[0].msgs.size()):
       msg = self.dbc[0].msgs[i]
       name = msg.name.decode('utf8')
+      print(name)
 
       msg_name_to_address[name] = msg.address
       self.address_to_msg_name[msg.address] = name
@@ -61,6 +62,7 @@ cdef class CANParser:
     for i in range(len(signals)):
       s = signals[i]
       if not isinstance(s[1], numbers.Number):
+        name = s[1]
         if name not in msg_name_to_address:
           print(msg_name_to_address)
           raise RuntimeError(f"could not find message {repr(name)} in DBC {self.dbc_name}")
@@ -70,7 +72,8 @@ cdef class CANParser:
     for i in range(len(checks)):
       c = checks[i]
       if not isinstance(c[0], numbers.Number):
-        if c[0] not in msg_name_to_address:
+        name = c[0]
+        if name not in msg_name_to_address:
           print(msg_name_to_address)
           raise RuntimeError(f"could not find message {repr(name)} in DBC {self.dbc_name}")
         c = (msg_name_to_address[c[0]], c[1])

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -62,20 +62,18 @@ cdef class CANParser:
     for i in range(len(signals)):
       s = signals[i]
       if not isinstance(s[1], numbers.Number):
-        name = s[1]
-        if name not in msg_name_to_address:
+        if s[1] not in msg_name_to_address:
           print(msg_name_to_address)
-          raise RuntimeError(f"could not find message {repr(name)} in DBC {self.dbc_name}")
+          raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
         s = (s[0], msg_name_to_address[s[1]])
         signals[i] = s
 
     for i in range(len(checks)):
       c = checks[i]
       if not isinstance(c[0], numbers.Number):
-        name = c[0]
-        if name not in msg_name_to_address:
+        if c[0] not in msg_name_to_address:
           print(msg_name_to_address)
-          raise RuntimeError(f"could not find message {repr(name)} in DBC {self.dbc_name}")
+          raise RuntimeError(f"could not find message {repr(c[0])} in DBC {self.dbc_name}")
         c = (msg_name_to_address[c[0]], c[1])
         checks[i] = c
 

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -47,7 +47,6 @@ cdef class CANParser:
     for i in range(self.dbc[0].msgs.size()):
       msg = self.dbc[0].msgs[i]
       name = msg.name.decode('utf8')
-      print(name)
 
       msg_name_to_address[name] = msg.address
       self.address_to_msg_name[msg.address] = name


### PR DESCRIPTION
If message name in `signals` was wrong you'd get a key error:

```python
Traceback (most recent call last):
  File "/home/batman/.pyenv/versions/3.8.10/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-3-544abaa78a23>", line 2, in <module>
    cp = CANParser("nissan_x_trail_2017_generated", signals=[("GAS_PEAL", "CRUISE_THROTLE")], checks=[("CRUISE_THROTTLE", 10)])
  File "opendbc/can/parser_pyx.pyx", line 67, in opendbc.can.parser_pyx.CANParser.__init__
    s = (s[0], msg_name_to_address[s[1]])
KeyError: 'CRUISE_THROTLE'
```

and if message name in `checks` was wrong you'd get an incorrect print:

```python
Traceback (most recent call last):
  File "/home/batman/.pyenv/versions/3.8.10/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3378, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-4-4bb3e5567afa>", line 2, in <module>
    cp = CANParser("nissan_x_trail_2017_generated", signals=[("GAS_PEAL", "CRUISE_THROTTLE")], checks=[("CRUISE_THROTLE", 10)])
  File "opendbc/can/parser_pyx.pyx", line 75, in opendbc.can.parser_pyx.CANParser.__init__
    raise RuntimeError(f"could not find message {repr(name)} in DBC {self.dbc_name}")
RuntimeError: could not find message 'HUD' in DBC b'nissan_x_trail_2017_generated'
```