### PR TITLE
Subaru: add AEB actuation signal

### DIFF
--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -240,7 +240,9 @@ BO_ 1677 Dash_State: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
-CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why. Signal3 also often goes to 2 if this signal is 4.";
+CM_ SG_ 544 Brake_Pressure "Winds down after cruise disabled. Also can be non-zero when likely preparing for AEB";
+CM_ SG_ 544 Signal3 "Usually goes to 2 if AEB_Status is 4";
+CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";

--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -259,4 +259,4 @@ CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
 CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-VAL_ 544 AEB_Status 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
+VAL_ 544 AEB_Status 12 "AEB related" 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";

--- a/generator/subaru/_subaru_global.dbc
+++ b/generator/subaru/_subaru_global.dbc
@@ -132,7 +132,7 @@ BO_ 544 ES_Brake: 8 XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
  SG_ Brake_Pressure : 16|16@1+ (1,0) [0|65535] "" XXX
- SG_ Signal2 : 32|4@1+ (1,0) [0|15] "" XXX
+ SG_ AEB_Status : 32|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_Brake_Lights : 36|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Fault : 37|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Active : 38|1@1+ (1,0) [0|1] "" XXX
@@ -240,6 +240,7 @@ BO_ 1677 Dash_State: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
+CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why. Signal3 also often goes to 2 if this signal is 4.";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
@@ -256,3 +257,4 @@ CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
 CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
+VAL_ 544 AEB_Status 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -263,7 +263,7 @@ CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
 CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-VAL_ 544 AEB_Status 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
+VAL_ 544 AEB_Status 12 "AEB related" 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
 
 CM_ "subaru_global_2017.dbc starts here";
 

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -136,7 +136,7 @@ BO_ 544 ES_Brake: 8 XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
  SG_ Brake_Pressure : 16|16@1+ (1,0) [0|65535] "" XXX
- SG_ Signal2 : 32|4@1+ (1,0) [0|15] "" XXX
+ SG_ AEB_Status : 32|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_Brake_Lights : 36|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Fault : 37|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Active : 38|1@1+ (1,0) [0|1] "" XXX
@@ -244,6 +244,7 @@ BO_ 1677 Dash_State: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
+CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why. Signal3 also often goes to 2 if this signal is 4.";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
@@ -260,6 +261,7 @@ CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
 CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
+VAL_ 544 AEB_Status 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
 
 CM_ "subaru_global_2017.dbc starts here";
 

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -244,7 +244,9 @@ BO_ 1677 Dash_State: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
-CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why. Signal3 also often goes to 2 if this signal is 4.";
+CM_ SG_ 544 Brake_Pressure "Winds down after cruise disabled. Also can be non-zero when likely preparing for AEB";
+CM_ SG_ 544 Signal3 "Usually goes to 2 if AEB_Status is 4";
+CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -244,7 +244,9 @@ BO_ 1677 Dash_State: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
-CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why. Signal3 also often goes to 2 if this signal is 4.";
+CM_ SG_ 544 Brake_Pressure "Winds down after cruise disabled. Also can be non-zero when likely preparing for AEB";
+CM_ SG_ 544 Signal3 "Usually goes to 2 if AEB_Status is 4";
+CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -263,7 +263,7 @@ CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
 CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
-VAL_ 544 AEB_Status 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
+VAL_ 544 AEB_Status 12 "AEB related" 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
 
 CM_ "subaru_global_2020_hybrid.dbc starts here";
 

--- a/subaru_global_2020_hybrid_generated.dbc
+++ b/subaru_global_2020_hybrid_generated.dbc
@@ -136,7 +136,7 @@ BO_ 544 ES_Brake: 8 XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Signal1 : 12|4@1+ (1,0) [0|15] "" XXX
  SG_ Brake_Pressure : 16|16@1+ (1,0) [0|65535] "" XXX
- SG_ Signal2 : 32|4@1+ (1,0) [0|15] "" XXX
+ SG_ AEB_Status : 32|4@1+ (1,0) [0|15] "" XXX
  SG_ Cruise_Brake_Lights : 36|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Fault : 37|1@1+ (1,0) [0|1] "" XXX
  SG_ Cruise_Brake_Active : 38|1@1+ (1,0) [0|1] "" XXX
@@ -244,6 +244,7 @@ BO_ 1677 Dash_State: 8 XXX
 CM_ SG_ 64 Throttle_Combo "Throttle Cruise + Pedal";
 CM_ SG_ 313 Brake_Lights "Driver or Cruise Brake on";
 CM_ SG_ 544 Cruise_Brake_Lights "1 = switch on brake lights";
+CM_ SG_ 544 AEB_Status "Occasionally is 4 instead of 8 while Brake_Pressure is non-zero, unsure why. Signal3 also often goes to 2 if this signal is 4.";
 CM_ SG_ 801 PCB_Off "Pre-Collision Braking off";
 CM_ SG_ 801 Brake_Lights "Driver or Cruise brake on";
 CM_ SG_ 801 Cruise_State "0 = Normal, 1 = Hold+User Brake, 2 = Ready, 3 = Hold";
@@ -260,6 +261,7 @@ CM_ SG_ 802 LKAS_Dash_State "0 = Off, 1 = Ready, 2 = Active";
 CM_ SG_ 802 LKAS_Right_Line_Visible "0 = Off, 1 = White, 2 = Green, 3 = Orange";
 CM_ SG_ 912 UNITS "0 = Metric, 1 = Imperial";
 CM_ SG_ 912 ICY_ROAD "1 = DASHLIGHT ON, 2 = WARNING, 3 = OFF";
+VAL_ 544 AEB_Status 8 "AEB actuation" 4 "AEB related" 0 "No AEB actuation";
 
 CM_ "subaru_global_2020_hybrid.dbc starts here";
 


### PR DESCRIPTION
Looks like EyeSight communicates AEB preparation by setting Brake_Pressure commonly along with LKAS_Alert=2 (meaning FCW):

![image](https://github.com/commaai/opendbc/assets/25857203/f7c0d97f-fa5e-4a1b-b995-e9c28150af1b)

It also winds down brake pressure on disable if it was already braking hard, so we don't want to mark this as AEB:

![image](https://github.com/commaai/opendbc/assets/25857203/625a7051-1426-4496-9eaa-5a4388c8bc5a)

Here is a real AEB, disabled, with user pressing brake. Signal2 is 8 while it's actuating which looks good. The alert stays on for much longer, so we don't want to use that.

![image](https://github.com/commaai/opendbc/assets/25857203/076de1ff-5015-40e6-ab89-192605565ceb)

Here is an AEB after user pressed brake to cancel cruise. Only showed FCW while actuating, AEB UI after:

![image](https://github.com/commaai/opendbc/assets/25857203/33c4617e-1321-45cd-8036-ac65013d8a04)

Signal2 is 4, Signal3 is 2, looks like it's related to AEB prepare, not AEB actuation? Won't be logged as AEB:

![image](https://github.com/commaai/opendbc/assets/25857203/65ac25c7-45bc-46d7-852c-5538fbf7fd8d)

Here's one more unknown signal value for Signal2:

![image](https://github.com/commaai/opendbc/assets/25857203/9af95240-f6c8-40db-bf90-ae23dc6e2d3d)


And finally, here is AEB actuation without any message (only FCW alert):

![image](https://github.com/commaai/opendbc/assets/25857203/f85b5660-0a39-4933-a9df-27f232c9c718)
