### PR TITLE
Add ISG state to HK generic

### DIFF
--- a/hyundai_kia_generic.dbc
+++ b/hyundai_kia_generic.dbc
@@ -698,7 +698,7 @@ BO_ 1365 FPCM11: 8 FPCM
 
 BO_ 871 LVR12: 8 LVR
  SG_ CF_Lvr_CruiseSet : 0|8@1+ (1.0,0.0) [0.0|255.0] "" CLU,TCU
- SG_ CF_Lvr_IsgState : 8|2@1+ (1.0,0.0) [0.0|3.0] "Idle Stop and Go. 0 = Engine running, 1 = Engine stopped, 3 = Disabled" CLU,TCU
+ SG_ CF_Lvr_IsgState : 8|2@1+ (1.0,0.0) [0.0|3.0] "Idle Stop and Go" CLU,TCU
  SG_ CF_Lvr_Gear : 32|4@1+ (1.0,0.0) [0.0|15.0] ""  CLU,TCU
 
 BO_ 872 LVR11: 8 LVR
@@ -1645,6 +1645,7 @@ CM_ "BO_ E_EMS11: All (plug-in) hybrids use this gas signal: CR_Vcu_AccPedDep_Po
 CM_ SG_ 1348 SpeedLim_Nav_Clu "Speed limit displayed on Nav, Cluster and HUD";
 
 VAL_ 274 CUR_GR 1 "D" 2 "D" 3 "D" 4 "D" 5 "D" 6 "D" 7 "D" 8 "D" 14 "R" 0 "P";
+VAL_ 871 CF_Lvr_IsgState 0 "enabled" 1 "activated" 2 "unknown" 3 "disabled";
 VAL_ 871 CF_Lvr_Gear 12 "T" 5 "D" 8 "S" 6 "N" 7 "R" 0 "P";
 VAL_ 882 Elect_Gear_Shifter 5 "D" 8 "S" 6 "N" 7 "R" 0 "P";
 VAL_ 905 ACCMode 0 "off" 1 "enabled" 2 "driver_override" 3 "off_maybe_fault" 4 "cancelled";

--- a/hyundai_kia_generic.dbc
+++ b/hyundai_kia_generic.dbc
@@ -698,6 +698,7 @@ BO_ 1365 FPCM11: 8 FPCM
 
 BO_ 871 LVR12: 8 LVR
  SG_ CF_Lvr_CruiseSet : 0|8@1+ (1.0,0.0) [0.0|255.0] "" CLU,TCU
+ SG_ CF_Lvr_IsgState : 8|2@1+ (1.0,0.0) [0.0|3.0] "Idle Stop and Go. 0 = Engine running, 1 = Engine stopped, 3 = Disabled" CLU,TCU
  SG_ CF_Lvr_Gear : 32|4@1+ (1.0,0.0) [0.0|15.0] ""  CLU,TCU
 
 BO_ 872 LVR11: 8 LVR

--- a/hyundai_kia_generic.dbc
+++ b/hyundai_kia_generic.dbc
@@ -698,7 +698,7 @@ BO_ 1365 FPCM11: 8 FPCM
 
 BO_ 871 LVR12: 8 LVR
  SG_ CF_Lvr_CruiseSet : 0|8@1+ (1.0,0.0) [0.0|255.0] "" CLU,TCU
- SG_ CF_Lvr_IsgState : 8|2@1+ (1.0,0.0) [0.0|3.0] "Idle Stop and Go" CLU,TCU
+ SG_ CF_Lvr_IsgState : 8|2@1+ (1.0,0.0) [0.0|3.0] "" CLU,TCU
  SG_ CF_Lvr_Gear : 32|4@1+ (1.0,0.0) [0.0|15.0] ""  CLU,TCU
 
 BO_ 872 LVR11: 8 LVR
@@ -1642,6 +1642,7 @@ BO_ 1348 Navi_HU: 8 XXX
  SG_ SpeedLim_Nav_Clu : 7|8@0+ (1,0) [0|255] "" XXX
 
 CM_ "BO_ E_EMS11: All (plug-in) hybrids use this gas signal: CR_Vcu_AccPedDep_Pos, and all EVs use the Accel_Pedal_Pos signal. See hyundai/values.py for a specific car list";
+CM_ SG_ 871 CF_Lvr_IsgState "Idle Stop and Go";
 CM_ SG_ 1348 SpeedLim_Nav_Clu "Speed limit displayed on Nav, Cluster and HUD";
 
 VAL_ 274 CUR_GR 1 "D" 2 "D" 3 "D" 4 "D" 5 "D" 6 "D" 7 "D" 8 "D" 14 "R" 0 "P";


### PR DESCRIPTION
Adds the readout for the Hyundai and Kia Idle Stop & Go system states

This has only been verified to be correct on the Kia Ceed 2019, but based on other values lining up correctly it is fairly certain this is applicable to other cars with this system.