### PR TITLE
CANParser: check if signals exist

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -41,16 +41,16 @@ cdef class CANParser:
     self.vl_all = {}
     self.ts_nanos = {}
     msg_name_to_address = {}
-    msg_signals = {}
+    msg_address_to_signals = {}
 
     for i in range(self.dbc[0].msgs.size()):
       msg = self.dbc[0].msgs[i]
       name = msg.name.decode("utf8")
 
       msg_name_to_address[name] = msg.address
-      msg_signals[name] = set()
+      msg_address_to_signals[msg.address] = set()
       for sig in msg.sigs:
-        msg_signals[name].add(sig.name.decode("utf8"))
+        msg_address_to_signals[msg.address].add(sig.name.decode("utf8"))
 
       self.address_to_msg_name[msg.address] = name
       self.vl[msg.address] = {}
@@ -67,11 +67,16 @@ cdef class CANParser:
         if s[1] not in msg_name_to_address:
           print(msg_name_to_address)
           raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
-        if s[0] not in msg_signals[s[1]]:
+        if s[0] not in msg_address_to_signals[msg_name_to_address[s[1]]]:
           raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
 
         s = (s[0], msg_name_to_address[s[1]])
         signals[i] = s
+      else:
+        if s[1] not in msg_address_to_signals:
+          raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
+        if s[0] not in msg_address_to_signals[s[1]]:
+          raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
 
     for i in range(len(checks)):
       c = checks[i]

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -41,12 +41,17 @@ cdef class CANParser:
     self.vl_all = {}
     self.ts_nanos = {}
     msg_name_to_address = {}
+    msg_signals = {}
 
     for i in range(self.dbc[0].msgs.size()):
       msg = self.dbc[0].msgs[i]
       name = msg.name.decode("utf8")
 
       msg_name_to_address[name] = msg.address
+      msg_signals[name] = set()
+      for sig in msg.sigs:
+        msg_signals[name].add(sig.name.decode("utf8"))
+
       self.address_to_msg_name[msg.address] = name
       self.vl[msg.address] = {}
       self.vl[name] = self.vl[msg.address]
@@ -62,6 +67,9 @@ cdef class CANParser:
         if s[1] not in msg_name_to_address:
           print(msg_name_to_address)
           raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
+        if s[0] not in msg_signals[s[1]]:
+          raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
+
         s = (s[0], msg_name_to_address[s[1]])
         signals[i] = s
 

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -64,14 +64,14 @@ cdef class CANParser:
     for i in range(len(signals)):
       s = signals[i]
       if not isinstance(s[1], numbers.Number):
-        if s[1] not in msg_name_to_address:
+        address = msg_name_to_address.get(s[1])
+        if address is None:
           print(msg_name_to_address)
           raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
-        if s[0] not in msg_address_to_signals[msg_name_to_address[s[1]]]:
+        if s[0] not in msg_address_to_signals[address]:
           raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
 
-        s = (s[0], msg_name_to_address[s[1]])
-        signals[i] = s
+        signals[i] = (s[0], address)
       else:
         if s[1] not in msg_address_to_signals:
           raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -63,20 +63,13 @@ cdef class CANParser:
     # Convert message names into addresses
     for i in range(len(signals)):
       s = signals[i]
-      if not isinstance(s[1], numbers.Number):
-        address = msg_name_to_address.get(s[1])
-        if address is None:
-          print(msg_name_to_address)
-          raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
-        if s[0] not in msg_address_to_signals[address]:
-          raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
+      address = s[1] if isinstance(s[1], numbers.Number) else msg_name_to_address.get(s[1])
+      if address not in msg_address_to_signals:
+        raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
+      if s[0] not in msg_address_to_signals[address]:
+        raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
 
-        signals[i] = (s[0], address)
-      else:
-        if s[1] not in msg_address_to_signals:
-          raise RuntimeError(f"could not find message {repr(s[1])} in DBC {self.dbc_name}")
-        if s[0] not in msg_address_to_signals[s[1]]:
-          raise RuntimeError(f"could not find signal {repr(s[0])} in {repr(s[1])}, DBC {self.dbc_name}")
+      signals[i] = (s[0], address)
 
     for i in range(len(checks)):
       c = checks[i]

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -331,7 +331,7 @@ class TestCanParserPacker(unittest.TestCase):
       for sig in sigs:
         CANParser(TEST_DBC, [(sig, msg)], [(msg, 0)])
         new_msg = msg + "1" if isinstance(msg, str) else msg + 1
-        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig + "123", msg)], [(msg, 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig + "1", msg)], [(msg, 0)]))
         self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, new_msg)], [(msg, 0)]))
         self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg)], [(new_msg, 0)]))
         self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, new_msg)], [(new_msg, 0)]))

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -330,10 +330,11 @@ class TestCanParserPacker(unittest.TestCase):
     for msg, sigs in existing_signals.items():
       for sig in sigs:
         CANParser(TEST_DBC, [(sig, msg)], [(msg, 0)])
+        new_msg = msg + "1" if isinstance(msg, str) else msg + 1
         self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig + "123", msg)], [(msg, 0)]))
-        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg + "123")], [(msg, 0)]))
-        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg)], [(msg + "123", 0)]))
-        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg + "123")], [(msg + "123", 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, new_msg)], [(msg, 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg)], [(new_msg, 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, new_msg)], [(new_msg, 0)]))
 
 
 if __name__ == "__main__":

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -324,9 +324,11 @@ class TestCanParserPacker(unittest.TestCase):
 
     for msg, sigs in existing_signals.items():
       for sig in sigs:
-        CANParser(TEST_DBC, [(sig, msg)], [], 0, enforce_checks=False)
-        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig + "123", msg)], enforce_checks=False))
-        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg + "123")], enforce_checks=False))
+        CANParser(TEST_DBC, [(sig, msg)], [(msg, 0)])
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig + "123", msg)], [(msg, 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg + "123")], [(msg, 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg)], [(msg + "123", 0)]))
+        self.assertRaises(RuntimeError, partial(CANParser, TEST_DBC, [(sig, msg + "123")], [(msg + "123", 0)]))
 
 
 if __name__ == "__main__":

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -320,8 +320,12 @@ class TestCanParserPacker(unittest.TestCase):
 
   def test_undefined_signals(self):
     # Ensure we don't allow messages or signals not in the DBC
-    existing_signals = {"STEERING_CONTROL": ["STEER_TORQUE_REQUEST", "SET_ME_X00_2", "COUNTER"],
-                        "CAN_FD_MESSAGE": ["SIGNED", "64_BIT_LE", "64_BIT_BE", "COUNTER"]}
+    existing_signals = {
+      "STEERING_CONTROL": ["STEER_TORQUE_REQUEST", "SET_ME_X00_2", "COUNTER"],
+      228: ["STEER_TORQUE_REQUEST", "SET_ME_X00_2", "COUNTER"],
+      "CAN_FD_MESSAGE": ["SIGNED", "64_BIT_LE", "64_BIT_BE", "COUNTER"],
+      245: ["SIGNED", "64_BIT_LE", "64_BIT_BE", "COUNTER"],
+    }
 
     for msg, sigs in existing_signals.items():
       for sig in sigs:


### PR DESCRIPTION
resolve: https://github.com/commaai/opendbc/issues/869#issuecomment-1615219925
throw a runtime error if signal not exist:

`RuntimeError: could not find signal 'ACCEL_CMD1' in 'ACC_CONTROL', DBC b'toyota_new_mc_pt_generated'`