### PR TITLE
Honda: DBC updates

### DIFF
--- a/acura_ilx_2016_can_generated.dbc
+++ b/acura_ilx_2016_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/acura_ilx_2016_can_generated.dbc
+++ b/acura_ilx_2016_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_b.dbc starts here";

--- a/acura_ilx_2016_can_generated.dbc
+++ b/acura_ilx_2016_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/acura_ilx_2016_can_generated.dbc
+++ b/acura_ilx_2016_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/acura_ilx_2016_can_generated.dbc
+++ b/acura_ilx_2016_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/acura_rdx_2018_can_generated.dbc
+++ b/acura_rdx_2018_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/acura_rdx_2018_can_generated.dbc
+++ b/acura_rdx_2018_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_b.dbc starts here";

--- a/acura_rdx_2018_can_generated.dbc
+++ b/acura_rdx_2018_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/acura_rdx_2018_can_generated.dbc
+++ b/acura_rdx_2018_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/acura_rdx_2018_can_generated.dbc
+++ b/acura_rdx_2018_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/acura_rdx_2020_can_generated.dbc
+++ b/acura_rdx_2020_can_generated.dbc
@@ -91,7 +91,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/generator/honda/_honda_common.dbc
+++ b/generator/honda/_honda_common.dbc
@@ -87,7 +87,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/generator/honda/_nidec_common.dbc
+++ b/generator/honda/_nidec_common.dbc
@@ -88,7 +88,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/generator/honda/_nidec_common.dbc
+++ b/generator/honda/_nidec_common.dbc
@@ -70,7 +70,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/generator/honda/_nidec_common.dbc
+++ b/generator/honda/_nidec_common.dbc
@@ -60,14 +60,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -87,6 +88,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/generator/honda/_nidec_common.dbc
+++ b/generator/honda/_nidec_common.dbc
@@ -87,6 +87,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/generator/honda/_nidec_common.dbc
+++ b/generator/honda/_nidec_common.dbc
@@ -60,7 +60,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -93,4 +93,4 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";

--- a/honda_accord_2018_can_generated.dbc
+++ b/honda_accord_2018_can_generated.dbc
@@ -91,7 +91,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/honda_civic_ex_2022_can_generated.dbc
+++ b/honda_civic_ex_2022_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/honda_civic_hatchback_ex_2017_can_generated.dbc
+++ b/honda_civic_hatchback_ex_2017_can_generated.dbc
@@ -91,7 +91,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_a.dbc starts here";

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_clarity_hybrid_2018_can_generated.dbc
+++ b/honda_clarity_hybrid_2018_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_clarity_hybrid_2018_can_generated.dbc
+++ b/honda_clarity_hybrid_2018_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_a.dbc starts here";

--- a/honda_clarity_hybrid_2018_can_generated.dbc
+++ b/honda_clarity_hybrid_2018_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_clarity_hybrid_2018_can_generated.dbc
+++ b/honda_clarity_hybrid_2018_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_clarity_hybrid_2018_can_generated.dbc
+++ b/honda_clarity_hybrid_2018_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_crv_ex_2017_can_generated.dbc
+++ b/honda_crv_ex_2017_can_generated.dbc
@@ -91,7 +91,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/honda_crv_executive_2016_can_generated.dbc
+++ b/honda_crv_executive_2016_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 CM_ "honda_crv_executive_2016_can.dbc starts here";
 

--- a/honda_crv_executive_2016_can_generated.dbc
+++ b/honda_crv_executive_2016_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_crv_executive_2016_can_generated.dbc
+++ b/honda_crv_executive_2016_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_crv_executive_2016_can_generated.dbc
+++ b/honda_crv_executive_2016_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_crv_executive_2016_can_generated.dbc
+++ b/honda_crv_executive_2016_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_crv_touring_2016_can_generated.dbc
+++ b/honda_crv_touring_2016_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_crv_touring_2016_can_generated.dbc
+++ b/honda_crv_touring_2016_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_b.dbc starts here";

--- a/honda_crv_touring_2016_can_generated.dbc
+++ b/honda_crv_touring_2016_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_crv_touring_2016_can_generated.dbc
+++ b/honda_crv_touring_2016_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_crv_touring_2016_can_generated.dbc
+++ b/honda_crv_touring_2016_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_fit_ex_2018_can_generated.dbc
+++ b/honda_fit_ex_2018_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_fit_ex_2018_can_generated.dbc
+++ b/honda_fit_ex_2018_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_b.dbc starts here";

--- a/honda_fit_ex_2018_can_generated.dbc
+++ b/honda_fit_ex_2018_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_fit_ex_2018_can_generated.dbc
+++ b/honda_fit_ex_2018_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_fit_ex_2018_can_generated.dbc
+++ b/honda_fit_ex_2018_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_fit_hybrid_2018_can_generated.dbc
+++ b/honda_fit_hybrid_2018_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_fit_hybrid_2018_can_generated.dbc
+++ b/honda_fit_hybrid_2018_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 CM_ "honda_fit_hybrid_2018_can.dbc starts here";
 

--- a/honda_fit_hybrid_2018_can_generated.dbc
+++ b/honda_fit_hybrid_2018_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_fit_hybrid_2018_can_generated.dbc
+++ b/honda_fit_hybrid_2018_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_fit_hybrid_2018_can_generated.dbc
+++ b/honda_fit_hybrid_2018_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_insight_ex_2019_can_generated.dbc
+++ b/honda_insight_ex_2019_can_generated.dbc
@@ -91,7 +91,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY

--- a/honda_odyssey_exl_2018_generated.dbc
+++ b/honda_odyssey_exl_2018_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_odyssey_exl_2018_generated.dbc
+++ b/honda_odyssey_exl_2018_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 
 CM_ "Imported file _steering_sensors_b.dbc starts here";

--- a/honda_odyssey_exl_2018_generated.dbc
+++ b/honda_odyssey_exl_2018_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_odyssey_exl_2018_generated.dbc
+++ b/honda_odyssey_exl_2018_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_odyssey_exl_2018_generated.dbc
+++ b/honda_odyssey_exl_2018_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY

--- a/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
+++ b/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
@@ -275,6 +275,8 @@ CM_ SG_ 506 AEB_REQ_1 "set for duration of suspected AEB event";
 CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
+CM_ SG_ 829 CAM_TEMP_HIGH "Some Driver Assist Systems Cannot Operate: Camera Temperature Too High"
+CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";

--- a/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
+++ b/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
@@ -276,7 +276,6 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
-VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
+++ b/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
@@ -248,7 +248,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" BDY
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
@@ -281,7 +281,7 @@ CM_ SG_ 829 CAMERA_OVERHEAT "Lane Keeping Assist Cannot Operate: Camera Too Hot"
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";
-VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
+VAL_ 829 BEEP 5 "solid_beep" 4 "double_beep" 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";
 
 CM_ "honda_odyssey_extreme_edition_2018_china_can.dbc starts here";
 

--- a/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
+++ b/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
@@ -109,7 +109,7 @@ BO_ 780 ACC_HUD: 8 ADAS
  SG_ PCM_GAS : 23|8@0+ (1,0) [0|127] "" BDY
  SG_ CRUISE_SPEED : 31|8@0+ (1,0) [0|255] "kph" BDY
  SG_ DTC_MODE : 39|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH : 38|1@0+ (1,0) [0|1] "" BDY
+ SG_ BRAKE_SYSTEM_ICON : 38|1@0+ (1,0) [0|1] "" BDY
  SG_ ACC_PROBLEM : 37|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF : 35|1@0+ (1,0) [0|1] "" BDY
  SG_ FCM_OFF_2 : 36|1@0+ (1,0) [0|1] "" BDY
@@ -248,14 +248,15 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
  SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
+ SG_ CAMERA_OVERHEAT : 15|1@0+ (1,0) [0|1] "" XXX
  SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
  SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
  SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
  SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
+ SG_ LANE_DEPARTURE_ALERT : 9|1@0+ (1,0) [0|1] "" BDY
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
+ SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
  SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
@@ -275,6 +276,7 @@ CM_ SG_ 506 COMPUTER_BRAKE_ALT "Used by dual-can Nidec";
 CM_ SG_ 506 BRAKE_PUMP_REQUEST_ALT "Used by dual-can Nidec";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnngs etc...";
 
+VAL_ 829 BOH_2 1 "lane_departure_icon" 0 "no_icon";
 VAL_ 506 FCW 3 "fcw" 2 "fcw" 1 "fcw" 0 "no_fcw";
 VAL_ 506 CHIME 4 "double_chime" 3 "single_chime" 2 "continuous_chime" 1 "repeating_chime" 0 "no_chime";
 VAL_ 506 AEB_STATUS 3 "aeb_prepare" 2 "aeb_ready" 1 "aeb_braking" 0 "no_aeb";

--- a/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
+++ b/honda_odyssey_extreme_edition_2018_china_can_generated.dbc
@@ -258,7 +258,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_ICON : 22|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
+ SG_ BEEP : 18|3@0+ (1,0) [0|7] "" BDY
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY


### PR DESCRIPTION
Defined a second camera overheat message. Renamed LDW_RIGHT to LANE_DEPARTUE_ALERT, there is no individual direction alert for LDW's. BOH is a single bit dash light for Brake system problem. BOH_2 is the dash icon for LDW Fault 