### PR TITLE
Toyota: add comment for LTA signal

### DIFF
--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -43,6 +43,7 @@ CM_ SG_ 401 BIT "has correlation to STEER_REQUEST";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
+CM_ SG_ 401 SETME_X3 "1 (or rarely 0) indicates vehicle is equipped with TSS 2.5 features or parts, 3 describes TSS 2.0";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";

--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -54,6 +54,7 @@ CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled 
 CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 
+VAL_ 401 SETME_X3 3 "TSS 2.0" 1 "TSS 2.5 or 2022 RAV4" 0 "TSS 2.0 on Alphard, Highlander, NX";
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
 VAL_ 610 LKA_STATE 25 "temporary_fault" 17 "permanent_fault" 11 "lka_missing_unavailable2" 9 "temporary_fault2" 5 "active" 3 "lka_missing_unavailable" 1 "standby";
 VAL_ 610 LTA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 3 "lta_missing_unavailable" 1 "standby";

--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -43,7 +43,7 @@ CM_ SG_ 401 BIT "has correlation to STEER_REQUEST";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
-CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
+CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, but may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";

--- a/generator/toyota/toyota_nodsu_pt.dbc
+++ b/generator/toyota/toyota_nodsu_pt.dbc
@@ -43,7 +43,7 @@ CM_ SG_ 401 BIT "has correlation to STEER_REQUEST";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
-CM_ SG_ 401 SETME_X3 "1 (or rarely 0) indicates vehicle is equipped with TSS 2.5 features or parts, 3 describes TSS 2.0";
+CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -604,6 +604,7 @@ CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled 
 CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 
+VAL_ 401 SETME_X3 3 "TSS 2.0" 1 "TSS 2.5 or 2022 RAV4" 0 "TSS 2.0 on Alphard, Highlander, NX";
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
 VAL_ 610 LKA_STATE 25 "temporary_fault" 17 "permanent_fault" 11 "lka_missing_unavailable2" 9 "temporary_fault2" 5 "active" 3 "lka_missing_unavailable" 1 "standby";
 VAL_ 610 LTA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 3 "lta_missing_unavailable" 1 "standby";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -593,7 +593,7 @@ CM_ SG_ 401 BIT "has correlation to STEER_REQUEST";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
-CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
+CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, but may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";

--- a/toyota_nodsu_pt_generated.dbc
+++ b/toyota_nodsu_pt_generated.dbc
@@ -593,6 +593,7 @@ CM_ SG_ 401 BIT "has correlation to STEER_REQUEST";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
+CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";


### PR DESCRIPTION
If TSS/LSS 2.5, this signal is always 1.0. If TSS 2.0, it's usually 3, but can be 0 with these exceptions:

- Highlander & Highlander Hybrid is 0 instead of 3 if TSS 2.0 (checked a few VINs for model years and cross referenced with TSS applicability chart)
- Lexus NX is also 0 if TSS 2.0 (LSS+ 3.0 is 2022 MY, have only seen 2021 MY)
- Alphard is also 0 (not US market car)

There's also one exception to the rule of all TSS 2.0 cars having this signal at either 0 or 3:
- RAV4 & RAV4 Hybrid 2022 (non-LTA, TSS 2.0) have the signal at 1. Interestingly, they also are the only cars we've seen use LKA_ACTIVE in the LTA signal, but still accept LKA.