### PR TITLE
CANPacker: assert signals w/ non-zero offsets be explicitly set

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -96,10 +96,11 @@ private:
   std::map<uint32_t, Msg> message_lookup;
   std::map<std::string, uint32_t> message_name_to_address;
   std::map<uint32_t, uint32_t> counters;
+  bool enforce_checks = false;
 
 public:
-  CANPacker(const std::string& dbc_name);
+  CANPacker(const std::string& dbc_name, bool enforce_checks);
   uint32_t address_from_name(const std::string &msg_name);
-  std::vector<uint8_t> pack(uint32_t address, const std::vector<SignalPackValue> &values, bool enforce_checks);
+  std::vector<uint8_t> pack(uint32_t address, const std::vector<SignalPackValue> &values);
   Msg* lookup_message(uint32_t address);
 };

--- a/can/common.h
+++ b/can/common.h
@@ -100,6 +100,6 @@ private:
 public:
   CANPacker(const std::string& dbc_name);
   uint32_t address_from_name(const std::string &msg_name);
-  std::vector<uint8_t> pack(uint32_t address, const std::vector<SignalPackValue> &values);
+  std::vector<uint8_t> pack(uint32_t address, const std::vector<SignalPackValue> &values, bool enforce_checks);
   Msg* lookup_message(uint32_t address);
 };

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -80,4 +80,4 @@ cdef extern from "common.h":
   cdef cppclass CANPacker:
    CANPacker(string)
    uint32_t address_from_name(const string&)
-   vector[uint8_t] pack(uint32_t, vector[SignalPackValue]&)
+   vector[uint8_t] pack(uint32_t, vector[SignalPackValue]&, bool)

--- a/can/common.pxd
+++ b/can/common.pxd
@@ -78,6 +78,6 @@ cdef extern from "common.h":
     void update_strings(vector[string]&, vector[SignalValue]&, bool)
 
   cdef cppclass CANPacker:
-   CANPacker(string)
+   CANPacker(string, bool)
    uint32_t address_from_name(const string&)
-   vector[uint8_t] pack(uint32_t, vector[SignalPackValue]&, bool)
+   vector[uint8_t] pack(uint32_t, vector[SignalPackValue]&)

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -59,13 +59,11 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
 
   // For signals with offsets, leaving bytes at zero results in non-zero parsed values.
   // Require those signals to be explicitly set
-  if (enforce_checks) {
-    for (const auto& dbc_signal : msg_it->second.sigs) {
-      if (dbc_signal.offset != 0) {
-        auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
-        if (sig_it == values.end()) {
-          throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
-        }
+  for (const auto& dbc_signal : msg_it->second.sigs) {
+    if (dbc_signal.offset != 0 && enforce_checks) {
+      auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
+      if (sig_it == values.end()) {
+        throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
       }
     }
   }

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -27,7 +27,7 @@ void set_value(std::vector<uint8_t> &msg, const Signal &sig, int64_t ival) {
   }
 }
 
-CANPacker::CANPacker(const std::string& dbc_name) {
+CANPacker::CANPacker(const std::string& dbc_name, bool enforce_checks) : enforce_checks(enforce_checks) {
   dbc = dbc_lookup(dbc_name);
   assert(dbc);
 
@@ -49,7 +49,7 @@ uint32_t CANPacker::address_from_name(const std::string &msg_name) {
   return msg_it->second;
 }
 
-std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &values, bool enforce_checks) {
+std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &values) {
   auto msg_it = message_lookup.find(address);
   if (msg_it == message_lookup.end()) {
     throw std::runtime_error("CANPacker::pack(): invalid address " + std::to_string(address));

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -65,6 +65,7 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
       continue;
     }
     const auto &sig = sig_it->second;
+
     int64_t ival = (int64_t)(round((sigval.value - sig.offset) / sig.factor));
     if (ival < 0) {
       ival = (1ULL << sig.size) + ival;

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -43,6 +43,18 @@ CANPacker::CANPacker(const std::string& dbc_name) {
 std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &signals) {
   std::vector<uint8_t> ret(message_lookup[address].size, 0);
 
+  auto msg_it = message_lookup.find(address);
+
+  // Check all signals with non-zero offsets have explicit values
+  for (const auto& dbc_signal : msg_it->second.sigs) {
+    if (dbc_signal.offset != 0) {
+      auto sig_it = std::find_if(signals.begin(), signals.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
+      if (sig_it == signals.end()) {
+        throw std::runtime_error("CanPacker::pack(): missing non-zero offset signal " + dbc_signal.name + " in address " + std::to_string(address));
+      }
+    }
+  }
+
   // set all values for all given signal/value pairs
   bool counter_set = false;
   for (const auto& sigval : signals) {
@@ -53,7 +65,6 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
       continue;
     }
     const auto &sig = sig_it->second;
-
     int64_t ival = (int64_t)(round((sigval.value - sig.offset) / sig.factor));
     if (ival < 0) {
       ival = (1ULL << sig.size) + ival;

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -57,8 +57,6 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
 
   std::vector<uint8_t> ret(message_lookup[address].size, 0);
 
-  auto msg_it = message_lookup.find(address);
-
   // Check all signals with non-zero offsets have explicit values
   for (const auto& dbc_signal : msg_it->second.sigs) {
     if (dbc_signal.offset != 0) {

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -49,7 +49,7 @@ uint32_t CANPacker::address_from_name(const std::string &msg_name) {
   return msg_it->second;
 }
 
-std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &values) {
+std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &values, bool enforce_checks) {
   auto msg_it = message_lookup.find(address);
   if (msg_it == message_lookup.end()) {
     throw std::runtime_error("CANPacker::pack(): invalid address " + std::to_string(address));
@@ -59,7 +59,7 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
 
   // Check all signals with non-zero offsets have explicit values
   for (const auto& dbc_signal : msg_it->second.sigs) {
-    if (dbc_signal.offset != 0) {
+    if (dbc_signal.offset != 0 && enforce_checks) {
       auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
       if (sig_it == values.end()) {
         throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -59,11 +59,11 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
 
   // For signals with offsets, leaving bytes at zero results in non-zero parsed values.
   // Require those signals to be explicitly set
-  for (const auto& dbc_signal : msg_it->second.sigs) {
-    if (dbc_signal.offset != 0 && enforce_checks) {
-      auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
+  for (const auto& signal : msg_it->second.sigs) {
+    if (signal.offset != 0 && enforce_checks) {
+      auto sig_it = std::find_if(values.begin(), values.end(), [&signal](const SignalPackValue& spv) { return spv.name == signal.name; });
       if (sig_it == values.end()) {
-        throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
+        throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + signal.name + " in address " + std::to_string(address));
       }
     }
   }

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -50,7 +50,7 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
     if (dbc_signal.offset != 0) {
       auto sig_it = std::find_if(signals.begin(), signals.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
       if (sig_it == signals.end()) {
-        throw std::runtime_error("CanPacker::pack(): missing non-zero offset signal " + dbc_signal.name + " in address " + std::to_string(address));
+        throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
       }
     }
   }

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -60,8 +60,8 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
   // Check all signals with non-zero offsets have explicit values
   for (const auto& dbc_signal : msg_it->second.sigs) {
     if (dbc_signal.offset != 0) {
-      auto sig_it = std::find_if(signals.begin(), signals.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
-      if (sig_it == signals.end()) {
+      auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
+      if (sig_it == values.end()) {
         throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
       }
     }

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -59,11 +59,13 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
 
   // For signals with offsets, leaving bytes at zero results in non-zero parsed values.
   // Require those signals to be explicitly set
-  for (const auto& dbc_signal : msg_it->second.sigs) {
-    if (dbc_signal.offset != 0 && enforce_checks) {
-      auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
-      if (sig_it == values.end()) {
-        throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
+  if (enforce_checks) {
+    for (const auto& dbc_signal : msg_it->second.sigs) {
+      if (dbc_signal.offset != 0) {
+        auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });
+        if (sig_it == values.end()) {
+          throw std::runtime_error("CANPacker::pack(): missing signal with non-zero offset: " + dbc_signal.name + " in address " + std::to_string(address));
+        }
       }
     }
   }

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -57,7 +57,8 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
 
   std::vector<uint8_t> ret(message_lookup[address].size, 0);
 
-  // Check all signals with non-zero offsets have explicit values
+  // For signals with offsets, leaving bytes at zero results in non-zero parsed values.
+  // Require those signals to be explicitly set
   for (const auto& dbc_signal : msg_it->second.sigs) {
     if (dbc_signal.offset != 0 && enforce_checks) {
       auto sig_it = std::find_if(values.begin(), values.end(), [&dbc_signal](const SignalPackValue& spv) { return spv.name == dbc_signal.name; });

--- a/can/packer_pyx.pyx
+++ b/can/packer_pyx.pyx
@@ -10,16 +10,13 @@ from .common cimport dbc_lookup, SignalPackValue
 
 
 cdef class CANPacker:
-  cdef:
-    cpp_CANPacker *packer
-    bool enforce_checks
+  cdef cpp_CANPacker *packer
 
   def __init__(self, dbc_name, enforce_checks=True):
     if not dbc_lookup(dbc_name):
       raise RuntimeError(f"Can't lookup {dbc_name}")
 
-    self.packer = new cpp_CANPacker(dbc_name)
-    self.enforce_checks = enforce_checks
+    self.packer = new cpp_CANPacker(dbc_name, enforce_checks)
 
   cdef vector[uint8_t] pack(self, addr, values):
     cdef vector[SignalPackValue] values_thing
@@ -31,7 +28,7 @@ cdef class CANPacker:
       spv.value = value
       values_thing.push_back(spv)
 
-    return self.packer.pack(addr, values_thing, self.enforce_checks)
+    return self.packer.pack(addr, values_thing)
 
   cpdef make_can_msg(self, name_or_addr, bus, values) except +RuntimeError:
     cdef uint32_t addr

--- a/can/packer_pyx.pyx
+++ b/can/packer_pyx.pyx
@@ -38,7 +38,7 @@ cdef class CANPacker:
 
     return self.packer.pack(addr, values_thing)
 
-  cpdef make_can_msg(self, name_or_addr, bus, values):
+  cpdef make_can_msg(self, name_or_addr, bus, values) except +RuntimeError:
     cdef int addr
     if type(name_or_addr) == int:
       addr = name_or_addr

--- a/can/packer_pyx.pyx
+++ b/can/packer_pyx.pyx
@@ -2,7 +2,6 @@
 # cython: c_string_encoding=ascii, language_level=3
 
 from libc.stdint cimport uint8_t, uint32_t
-from libcpp cimport bool
 from libcpp.vector cimport vector
 
 from .common cimport CANPacker as cpp_CANPacker


### PR DESCRIPTION
If the signal has a non-zero offset, require it to be explicitly set. Leaving the bytes at zero for any other signal doesn't change the parsed value, but it does for offset signals