### PR TITLE
packer: import stdexcept

### DIFF
--- a/can/packer.cc
+++ b/can/packer.cc
@@ -1,8 +1,9 @@
-#include <cassert>
-#include <utility>
 #include <algorithm>
-#include <map>
+#include <cassert>
 #include <cmath>
+#include <map>
+#include <stdexcept>
+#include <utility>
 
 #include "opendbc/can/common.h"
 


### PR DESCRIPTION
This might just be required on Ubuntu 22.04? (clang 14)