### PR TITLE
CI: Fix panda CI by not upgrading Cython

### DIFF
--- a/can/packer_pyx.pyx
+++ b/can/packer_pyx.pyx
@@ -29,7 +29,7 @@ cdef class CANPacker:
 
     return self.packer.pack(addr, values_thing)
 
-  cpdef make_can_msg(self, name_or_addr, bus, values) except +RuntimeError:
+  cpdef make_can_msg(self, name_or_addr, bus, values):
     cdef uint32_t addr
     if type(name_or_addr) == int:
       addr = name_or_addr

--- a/can/packer_pyx.pyx
+++ b/can/packer_pyx.pyx
@@ -29,7 +29,7 @@ cdef class CANPacker:
 
     return self.packer.pack(addr, values_thing)
 
-  cpdef make_can_msg(self, name_or_addr, bus, values):
+  cpdef make_can_msg(self, name_or_addr, bus, values) except +RuntimeError:
     cdef uint32_t addr
     if type(name_or_addr) == int:
       addr = name_or_addr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython
+Cython<3.0.0
 flake8
 Jinja2
 numpy


### PR DESCRIPTION
Cython 3.0.0 breaks opendbc, but now it wants to upgrade by default in the CI. Force to <3.0.0