### PR TITLE
Hyundai SantaFe CM and Opel Omega B databases added

### DIFF
--- a/hyundai_santafe_2007.dbc
+++ b/hyundai_santafe_2007.dbc
@@ -1,0 +1,118 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: AWD ECU TCU ESP SAS ABS
+
+
+BO_ 339 ESP_Flags: 8 ESP
+ SG_ ABD_Active : 3|1@1+ (1,0) [0|1] "yes/no"  AWD,ECU,TCU
+ SG_ TCS_Active : 9|1@1+ (1,0) [0|1] "yes/no"  AWD,ECU,TCU
+ SG_ ABS_Active : 10|1@1+ (1,0) [0|1] "yes/no"  AWD,ECU,TCU
+ SG_ ESP_Off : 12|1@1+ (1,0) [0|1] "yes/no"  AWD,ECU,TCU
+ SG_ ESP_Active : 14|1@1+ (1,0) [0|1] "yes/no"  AWD,ECU,TCU
+ SG_ VehicleSpeed : 16|8@1+ (1,0) [0|254] "km/h"  AWD,ECU,TCU
+ SG_ TorqueRequestFast : 24|8@1+ (0.390625,0) [0|99.609375] "%"  ECU,TCU
+ SG_ TorqueRequestSlow : 40|8@1+ (0.390625,0) [0|99.609375] "%"  ECU,TCU
+
+BO_ 497 ESP_WheelSpeed: 8 ESP
+ SG_ FrontRightWheelSpeed : 16|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+ SG_ FrontLeftWheelSpeed : 28|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+ SG_ RearRightWheelSpeed : 40|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+ SG_ RearLeftWheelSpeed : 52|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+
+BO_ 608 ECU_Data1: 8 ECU
+ SG_ TorqueMin : 0|8@1+ (0.390625,0) [0|99.609375] "%"  ESP,TCU
+ SG_ Torque : 8|8@1+ (0.390625,0) [0|99.609375] "%"  ESP,TCU
+ SG_ TorqueTarget : 16|8@1+ (0.390625,0) [0|99.609375] "%"  ESP,TCU
+ SG_ CruiseEnabled : 25|1@1+ (1,0) [0|1] "yes/no"  TCU
+ SG_ CruiseActive : 26|1@1+ (1,0) [0|1] "yes/no"  TCU
+ SG_ TorqueMax : 40|8@1+ (0.390625,0) [0|99.609375] "%"  ESP,TCU
+
+BO_ 640 ECU_Data2: 8 ECU
+ SG_ RPM : 32|8@1+ (32,0) [0|8160] "rpm"  TCU
+ SG_ MAF : 40|8@1+ (5.447,0) [0|1388.985] "mg/TDC"  TCU
+ SG_ IAT : 48|8@1- (0.75,-48) [-48|143.25] "C"  TCU
+ SG_ MAP : 56|8@1+ (0.47058,0) [0|119.9979] "KPa"  TCU
+
+BO_ 688 SAS_Data: 5 SAS
+ SG_ SAS_Angle : 0|16@1- (0.1,0) [-3276.8|3276.7] "deg"  AWD,ECU,ESP,TCU
+ SG_ SAS_Speed : 16|8@1+ (4,0) [0|1016] "deg/s"  ESP,TCU
+ SG_ SAS_Status : 24|8@1+ (1,0) [0|255] ""  ESP,TCU
+ SG_ Msg_Count : 32|4@1+ (1,0) [0|15] ""  ESP
+ SG_ Check_Sum : 36|4@1+ (1,0) [0|15] ""  ECU,ESP
+
+BO_ 809 ECU_Data5: 8 ECU
+ SG_ ECT : 8|8@1- (0.75,-48) [-48|143.25] "C"  AWD,ABS,ESP,TCU
+ SG_ BrakeActive : 32|2@1+ (1,0) [0|3] "yes/no"  AWD,ABS,ESP,TCU
+ SG_ TPS : 40|8@1+ (0.47265625,-15) [-15|105.52734375] "%"  AWD,ABS,ESP,TCU
+
+BO_ 1064 AWD_Data1: 8 AWD
+ SG_ ClutchDuty : 16|8@1+ (1,0) [0|100] "%"  ABS,ESP
+ SG_ ClutchLocked : 44|1@1+ (1,0) [0|1] "yes/no"  ABS,ESP
+
+BO_ 1065 AWD_Data2: 8 AWD
+ SG_ SteeringWheelPosition : 0|16@1+ (1,-600) [-600|600] "deg"  ABS
+ SG_ FrontRightWheelSpeed : 16|8@1+ (1,0) [0|254] "km/h"  ABS
+ SG_ FrontLeftWheelSpeed : 24|8@1+ (1,0) [0|254] "km/h"  ABS
+ SG_ RearRightWheelSpeed : 32|8@1+ (1,0) [0|254] "km/h"  ABS
+ SG_ RearLeftWheelSpeed : 40|8@1+ (1,0) [0|254] "km/h"  ABS
+
+BO_ 1087 TCU_Data: 8 TCU
+ SG_ CurrentGear : 0|3@1+ (1,0) [0|7] ""  ECU
+ SG_ GearSwitch : 3|1@1+ (1,0) [0|1] "yes/no"  ECU
+ SG_ SelectorPosition : 8|4@1+ (1,0) [0|15] ""  ECU
+ SG_ InputShaftSpeed : 40|16@1+ (0.25,0) [0|16383.5] "rpm"  ECU
+
+BO_ 1349 ECU_Data6: 8 ECU
+ SG_ BatteryVoltage : 24|8@1+ (0.1015625,0) [0|25.8984375] "V"  ABS,ESP
+
+BO_ 1408 ABS_WheelSpeed: 8 ABS
+ SG_ FrontRightWheelSpeed : 16|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+ SG_ FrontLeftWheelSpeed : 28|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+ SG_ RearRightWheelSpeed : 40|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+ SG_ RearLeftWheelSpeed : 52|12@1+ (0.125,0) [0|511.875] "km/h"  AWD
+
+BO_ 1695 ECU_Data7: 8 ECU
+ SG_ ECU_Temperature : 8|8@1- (1,-28) [-28|227] "C"  TCU
+
+BO_ 1984 SAS_Calibration: 2 ESP
+ SG_ CCW : 0|4@1+ (1,0) [0|15] ""  SAS
+ SG_ CID : 4|11@1+ (1,0) [0|2047] ""  SAS
+
+
+
+VAL_ 1087 CurrentGear 7 "R" 0 "N" 1 "1" 2 "2" 3 "3" 4 "4" ;
+VAL_ 1087 SelectorPosition 7 "R" 6 "N" 5 "D" 8 "M" 15 "P" ;
+

--- a/opel_omega_2001.dbc
+++ b/opel_omega_2001.dbc
@@ -1,0 +1,104 @@
+VERSION ""
+
+
+NS_ : 
+	NS_DESC_
+	CM_
+	BA_DEF_
+	BA_
+	VAL_
+	CAT_DEF_
+	CAT_
+	FILTER
+	BA_DEF_DEF_
+	EV_DATA_
+	ENVVAR_DATA_
+	SGTYPE_
+	SGTYPE_VAL_
+	BA_DEF_SGTYPE_
+	BA_SGTYPE_
+	SIG_TYPE_REF_
+	VAL_TABLE_
+	SIG_GROUP_
+	SIG_VALTYPE_
+	SIGTYPE_VALTYPE_
+	BO_TX_BU_
+	BA_DEF_REL_
+	BA_REL_
+	BA_DEF_DEF_REL_
+	BU_SG_REL_
+	BU_EV_REL_
+	BU_BO_REL_
+	SG_MUL_VAL_
+
+BS_:
+
+BU_: ABS ESP ECU TCU SAS
+
+
+BO_ 272 TCU_Data1: 8 TCU
+ SG_ TorqueRequest1 : 15|8@0+ (1,0) [0|255] ""  ABS,ESP,ECU
+ SG_ TorqueRequest2 : 31|8@0+ (1,0) [0|255] ""  ABS,ESP,ECU
+ SG_ OutputShaftSpeed : 55|16@0+ (1,0) [0|65535] "rpm"  ABS,ESP,ECU
+
+BO_ 288 ESP_Data1: 8 ESP
+ SG_ ABD_Active : 4|1@0+ (1,0) [0|1] "yes/no"  ECU,TCU
+ SG_ TorqueRequestFast : 15|8@0+ (1,0) [0|255] ""  ECU,TCU
+ SG_ TorqueRequestSlow : 31|8@0+ (1,0) [0|255] ""  ECU,TCU
+
+BO_ 384 SAS_Data: 8 SAS
+ SG_ SteeringAngle : 0|16@1- (0.1,0) [-3276.8|3276.7] "yes/no"  ECU,TCU
+ SG_ SteeringSpeed : 16|8@1+ (1,0) [0|255] ""  ECU,TCU
+
+BO_ 416 ECU_Data1: 8 ECU
+ SG_ RPM : 15|16@0+ (1,0) [0|65535] "rpm"  ABS,ESP,TCU
+ SG_ TorqueResponse : 31|8@0+ (1,0) [0|255] ""  ABS,ESP,TCU
+ SG_ TorqueLost : 39|8@0+ (1,0) [0|255] ""  ABS,ESP,TCU
+ SG_ APP : 47|8@0+ (1,0) [0|102] ""  ABS,ESP,TCU
+ SG_ TorqueRequest : 63|8@0+ (1,0) [0|255] ""  ABS,ESP,TCU
+
+BO_ 448 ECU_Data2: 8 ECU
+ SG_ TPS : 23|8@0+ (1,0) [0|100] ""  ABS,ESP,TCU
+
+BO_ 640 ECU_Data3: 8 ECU
+ SG_ BrakeActive : 18|1@0+ (1,0) [0|1] "yes/no"  ABS,ESP,TCU
+ SG_ KickdownActive : 20|1@0+ (1,0) [0|1] "yes/no"  ABS,ESP,TCU
+ SG_ CruiseActive : 22|1@0+ (1,0) [0|1] "yes/no"  ABS,ESP,TCU
+
+BO_ 736 TCU_Data2: 8 TCU
+ SG_ TOT : 31|8@0- (1,-40) [-40|215] ""  ECU
+ SG_ InputShaftSpeed : 47|16@0+ (1,0) [0|65535] "rpm"  ECU
+
+BO_ 768 ABS_WheelSpeed: 8 ABS
+ SG_ FrontLeftWheelSpeed : 5|14@0+ (0.112,0) [0|255] "km/h"  ECU,TCU
+ SG_ FrontLeftWheelErrorFlag : 7|1@0+ (1,0) [0|1] ""  ECU,TCU
+ SG_ FrontRightWheelSpeed : 21|14@0+ (0.112,0) [0|255] "km/h"  ECU,TCU
+ SG_ FrontRightWheelErrorFlag : 23|1@0+ (1,0) [0|1] ""  ECU,TCU
+ SG_ RearLeftWheelSpeed : 37|14@0+ (0.112,0) [0|255] "km/h"  ECU,TCU
+ SG_ RearLeftWheelErrorFlag : 39|1@0+ (1,0) [0|1] ""  ECU,TCU
+ SG_ RearRightWheelSpeed : 53|14@0+ (0.112,0) [0|255] "km/h"  ECU,TCU
+ SG_ RearRightWheelErrorFlag : 55|1@0+ (1,0) [0|1] ""  ECU,TCU
+
+BO_ 792 ESP_Data2: 8 ESP
+ SG_ ABS_Active : 12|1@0+ (1,0) [0|1] "yes/no"  ECU,TCU
+ SG_ ESP_Off : 20|1@0+ (1,0) [0|1] "yes/no"  ECU,TCU
+ SG_ ESP_Active : 21|1@0+ (1,0) [0|1] "yes/no"  ECU,TCU
+
+BO_ 992 TCU_Data3: 8 TCU
+ SG_ CurrentGear : 11|4@0+ (1,0) [0|15] ""  ECU
+ SG_ SelectorPosition : 18|3@0+ (1,0) [0|7] ""  ECU
+ SG_ AutoNeutralActive : 26|1@0+ (1,0) [0|1] "yes/no"  ECU
+ SG_ WinterModeActive : 29|1@0+ (1,0) [0|1] "yes/no"  ECU
+ SG_ SportModeActive : 30|1@0+ (1,0) [0|1] "yes/no"  ECU
+ SG_ TCC_State : 37|2@0+ (1,0) [0|2] ""  ECU
+
+BO_ 1472 ECU_Data4: 8 ECU
+ SG_ ECT : 15|8@0- (1,-40) [-40|215] ""  TCU
+ SG_ IAT : 47|8@0- (1,-40) [-40|215] ""  TCU
+
+
+
+VAL_ 992 CurrentGear 5 "1" 6 "2" 7 "3" 8 "4" ;
+VAL_ 992 SelectorPosition 1 "P" 2 "R" 3 "N" 4 "D" 7 "3" 6 "2" 5 "1" ;
+VAL_ 992 TCC_State 0 "Off" 1 "Partially Locked" 2 "Locked" ;
+


### PR DESCRIPTION
Hyundai SantaFe 2007 2.7V6 4AT:
Now the signals have understandable names and all ones have been checked on my car.
Useless signals are removed at all.

Opel Omega B 2001 3.2V6 5MT:
New database for GM's Vectra B/Omega B with V6 engines.