### PR TITLE
parser: update_strings propagate cpp exceptions in py bindings

### DIFF
--- a/can/common.pxd
+++ b/can/common.pxd
@@ -75,7 +75,7 @@ cdef extern from "common.h":
     bool can_valid
     bool bus_timeout
     CANParser(int, string, vector[MessageParseOptions], vector[SignalParseOptions])
-    void update_strings(vector[string]&, vector[SignalValue]&, bool)
+    void update_strings(vector[string]&, vector[SignalValue]&, bool) except +
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/can/tests/test_dbc_exceptions.py
+++ b/can/tests/test_dbc_exceptions.py
@@ -28,6 +28,10 @@ class TestCanParserPackerExceptions(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       CANParser(dbc_file, signals, [], 0)
 
+    with self.assertRaises(RuntimeError):
+      parser = CANParser(dbc_file, signals, checks, 0)
+      parser.update_strings([b''])
+
     # Everything is supposed to work below
     CANParser(dbc_file, signals, checks, 0)
     CANPacker(dbc_file)

--- a/can/tests/test_dbc_exceptions.py
+++ b/can/tests/test_dbc_exceptions.py
@@ -28,8 +28,8 @@ class TestCanParserPackerExceptions(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       CANParser(dbc_file, signals, [], 0)
 
+    parser = CANParser(dbc_file, signals, checks, 0)
     with self.assertRaises(RuntimeError):
-      parser = CANParser(dbc_file, signals, checks, 0)
       parser.update_strings([b''])
 
     # Everything is supposed to work below


### PR DESCRIPTION
Right now, when `update_strings` is called with some corrupted/arbitrary bytes, cpp exception is thrown which crashes the process. With this, exception will be propagated as `RuntimeError`