### PR TITLE
Subaru: Remove unrelated bit from transmission RPM signal

### DIFF
--- a/generator/subaru/subaru_global_2017.dbc
+++ b/generator/subaru/subaru_global_2017.dbc
@@ -4,7 +4,7 @@ BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
- SG_ RPM : 40|16@1+ (1,0) [0|65535] "" XXX
+ SG_ RPM : 40|15@1+ (1,0) [0|65535] "" XXX
 
 BO_ 73 CVT: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/subaru_global_2017_generated.dbc
+++ b/subaru_global_2017_generated.dbc
@@ -287,7 +287,7 @@ BO_ 72 Transmission: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Gear : 24|8@1+ (1,0) [0|255] "" XXX
- SG_ RPM : 40|16@1+ (1,0) [0|65535] "" XXX
+ SG_ RPM : 40|15@1+ (1,0) [0|65535] "" XXX
 
 BO_ 73 CVT: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX


### PR DESCRIPTION
Subaru Global Transmission RPM signal had an unrelated bit that switches on at about 60kph

Before:

Transmission RPM vs Engine RPM
<img width="478" alt="Screenshot 2023-08-16 at 06 00 18" src="https://github.com/commaai/opendbc/assets/148686/d750ab63-3bfb-4b20-8d4f-d6e41349d478">

Transmission RPM vs Cruise RPM
<img width="478" alt="Screenshot 2023-08-16 at 06 12 19" src="https://github.com/commaai/opendbc/assets/148686/0e911cac-514b-48fc-bbb8-60c74be8617a">

After:

Transmission RPM vs Cruse RPM / Engine RPM
<img width="476" alt="Screenshot 2023-08-16 at 06 42 30" src="https://github.com/commaai/opendbc/assets/148686/069287f5-a271-4a70-ad04-72f8497e8db5">

Route: `8de015561e1ea4a0|2023-08-12--13-09-08` (One Mile Challenge run 1, 0-184kph)