### PR TITLE
Parser: disallow duplicate message checks

### DIFF
--- a/can/common.pxd
+++ b/can/common.pxd
@@ -67,7 +67,7 @@ cdef extern from "common.h":
   cdef cppclass CANParser:
     bool can_valid
     bool bus_timeout
-    CANParser(int, string, vector[pair[uint32_t, int]])
+    CANParser(int, string, vector[pair[uint32_t, int]]) except +
     void update_strings(vector[string]&, vector[SignalValue]&, bool) except +
 
   cdef cppclass CANPacker:

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -2,6 +2,8 @@
 #include <cassert>
 #include <cstring>
 #include <limits>
+#include <stdexcept>
+#include <sstream>
 
 #include <unistd.h>
 #include <fcntl.h>
@@ -98,6 +100,12 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
   bus_timeout_threshold = std::numeric_limits<uint64_t>::max();
 
   for (const auto& [address, frequency] : messages) {
+    if(message_states.find(address) != message_states.end()) { // disallow duplicate message checks
+      std::stringstream is;
+      is << "Duplicate Message Check: " << address;
+      throw std::runtime_error(is.str());
+    }
+
     MessageState &state = message_states[address];
     state.address = address;
     // state.check_frequency = op.check_frequency,

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -100,7 +100,8 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
   bus_timeout_threshold = std::numeric_limits<uint64_t>::max();
 
   for (const auto& [address, frequency] : messages) {
-    if(message_states.find(address) != message_states.end()) { // disallow duplicate message checks
+    // disallow duplicate message checks
+    if (message_states.find(address) != message_states.end()) { 
       std::stringstream is;
       is << "Duplicate Message Check: " << address;
       throw std::runtime_error(is.str());

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -308,7 +308,7 @@ class TestCanParserPacker(unittest.TestCase):
       "ACCEL_CMD_ALT": 0,
       "CHECKSUM": 0,
     })
-  
+
   def test_disallow_duplicate_messages(self):
     CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5)])
 

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -309,7 +309,7 @@ class TestCanParserPacker(unittest.TestCase):
       "CHECKSUM": 0,
     })
   
-  def test_disallow_dupliucate_messages(self):
+  def test_disallow_duplicate_messages(self):
     CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5)])
 
     with self.assertRaises(RuntimeError):

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -319,6 +319,5 @@ class TestCanParserPacker(unittest.TestCase):
       CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 10), ("ACC_CONTROL", 10)])
 
 
-
 if __name__ == "__main__":
   unittest.main()

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -313,8 +313,11 @@ class TestCanParserPacker(unittest.TestCase):
     CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5)])
 
     with self.assertRaises(RuntimeError):
-      CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 10), ("ACC_CONTROL", 10)])
       CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5), ("ACC_CONTROL", 10)])
+
+    with self.assertRaises(RuntimeError):
+      CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 10), ("ACC_CONTROL", 10)])
+
 
 
 if __name__ == "__main__":

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -313,6 +313,7 @@ class TestCanParserPacker(unittest.TestCase):
     CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5)])
 
     with self.assertRaises(RuntimeError):
+      CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 10), ("ACC_CONTROL", 10)])
       CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5), ("ACC_CONTROL", 10)])
 
 

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -308,6 +308,12 @@ class TestCanParserPacker(unittest.TestCase):
       "ACCEL_CMD_ALT": 0,
       "CHECKSUM": 0,
     })
+  
+  def test_disallow_dupliucate_messages(self):
+    CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5)])
+
+    with self.assertRaises(RuntimeError):
+      CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 5), ("ACC_CONTROL", 10)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
runtime error if message is checked twice

resolves: https://github.com/commaai/opendbc/issues/914