### PR TITLE
CanPacker: removing unnecessary string copying

### DIFF
--- a/can/packer.cc
+++ b/can/packer.cc
@@ -35,7 +35,7 @@ CANPacker::CANPacker(const std::string& dbc_name) {
   for (const auto& msg : dbc->msgs) {
     message_lookup[msg.address] = msg;
     for (const auto& sig : msg.sigs) {
-      signal_lookup[std::make_pair(msg.address, std::string(sig.name))] = sig;
+      signal_lookup[std::make_pair(msg.address, sig.name)] = sig;
     }
   }
   init_crc_lookup_tables();


### PR DESCRIPTION
sig.name is already a std::string after https://github.com/commaai/opendbc/pull/602