### PR TITLE
common_dbc.h: remove ARRAYSIZE

### DIFF
--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -5,8 +5,6 @@
 #include <string>
 #include <vector>
 
-#define ARRAYSIZE(x) (sizeof(x)/sizeof(x[0]))
-
 struct SignalPackValue {
   std::string name;
   double value;


### PR DESCRIPTION
it's not used after https://github.com/commaai/opendbc/pull/602