### PR TITLE
GM: fix ASCMGasRegenCmd scale and units

### DIFF
--- a/opendbc/car/gm/carcontroller.py
+++ b/opendbc/car/gm/carcontroller.py
@@ -89,7 +89,7 @@ class CarController(CarControllerBase):
           self.apply_gas = self.params.INACTIVE_REGEN
           self.apply_brake = 0
         else:
-          self.apply_gas = int(round(np.interp(actuators.accel, self.params.GAS_LOOKUP_BP, self.params.GAS_LOOKUP_V)))
+          self.apply_gas = float(np.interp(actuators.accel, self.params.GAS_LOOKUP_BP, self.params.GAS_LOOKUP_V))
           self.apply_brake = int(round(np.interp(actuators.accel, self.params.BRAKE_LOOKUP_BP, self.params.BRAKE_LOOKUP_V)))
           # Don't allow any gas above inactive regen while stopping
           # FIXME: brakes aren't applied immediately when enabling at a stop

--- a/opendbc/car/gm/gmcan.py
+++ b/opendbc/car/gm/gmcan.py
@@ -59,8 +59,6 @@ def create_gas_regen_command(packer, bus, throttle, idx, enabled, at_full_stop):
     "GasRegenCmd": throttle,
     "GasRegenFullStopActive": at_full_stop,
     "GasRegenAccType": 1,
-    "GasRegenAlwaysOne2": 1,
-    "GasRegenAlwaysOne3": 1,
   }
 
   dat = packer.make_can_msg("ASCMGasRegenCmd", bus, values)[1]

--- a/opendbc/car/gm/values.py
+++ b/opendbc/car/gm/values.py
@@ -32,10 +32,8 @@ class CarControllerParams:
   ACCEL_MAX = 2.  # m/s^2
   ACCEL_MIN = -4.  # m/s^2
 
-  # conversion: ((val | (0b0101 << 12)) << 3) * 0.125 - 22534
   def __init__(self, CP):
     # Gas/brake lookups
-    self.ZERO_GAS = -6.0  # Coasting
     self.MAX_BRAKE = 400  # ~ -4.0 m/s^2 with regen
 
     if CP.carFingerprint in (CAMERA_ACC_CAR | SDGM_CAR):
@@ -43,7 +41,7 @@ class CarControllerParams:
       self.MAX_ACC_REGEN = -540.0
       self.INACTIVE_REGEN = -500.0
       # Camera ACC vehicles have no regen while enabled.
-      # Camera transitions to MAX_ACC_REGEN from ZERO_GAS and uses friction brakes instantly
+      # Camera transitions to MAX_ACC_REGEN from zero gas and uses friction brakes instantly
       max_regen_acceleration = 0.
 
     else:
@@ -55,7 +53,7 @@ class CarControllerParams:
       max_regen_acceleration = -1. if CP.carFingerprint in EV_CAR else -0.1
 
     self.GAS_LOOKUP_BP = [max_regen_acceleration, 0., self.ACCEL_MAX]
-    self.GAS_LOOKUP_V = [self.MAX_ACC_REGEN, self.ZERO_GAS, self.MAX_GAS]
+    self.GAS_LOOKUP_V = [self.MAX_ACC_REGEN, 0., self.MAX_GAS]
 
     self.BRAKE_LOOKUP_BP = [self.ACCEL_MIN, max_regen_acceleration]
     self.BRAKE_LOOKUP_V = [self.MAX_BRAKE, 0.]

--- a/opendbc/car/gm/values.py
+++ b/opendbc/car/gm/values.py
@@ -45,7 +45,7 @@ class CarControllerParams:
       max_regen_acceleration = 0.
 
     else:
-      self.MAX_GAS = 1018.0  # Safety limit, not ACC max. Stock ACC >4096 from standstill.
+      self.MAX_GAS = 1018.0  # Safety limit, not ACC max. Stock ACC >2042 from standstill.
       self.MAX_ACC_REGEN = -650.0  # Max ACC regen is slightly less than max paddle regen
       self.INACTIVE_REGEN = -650.0
       # ICE has much less engine braking force compared to regen in EVs,

--- a/opendbc/car/gm/values.py
+++ b/opendbc/car/gm/values.py
@@ -32,23 +32,24 @@ class CarControllerParams:
   ACCEL_MAX = 2.  # m/s^2
   ACCEL_MIN = -4.  # m/s^2
 
+  # conversion: ((val | (0b0101 << 12)) << 3) * 0.125 - 22534
   def __init__(self, CP):
     # Gas/brake lookups
-    self.ZERO_GAS = 2048  # Coasting
+    self.ZERO_GAS = -6.0  # Coasting
     self.MAX_BRAKE = 400  # ~ -4.0 m/s^2 with regen
 
     if CP.carFingerprint in (CAMERA_ACC_CAR | SDGM_CAR):
-      self.MAX_GAS = 3400
-      self.MAX_ACC_REGEN = 1514
-      self.INACTIVE_REGEN = 1554
+      self.MAX_GAS = 1346.0
+      self.MAX_ACC_REGEN = -540.0
+      self.INACTIVE_REGEN = -500.0
       # Camera ACC vehicles have no regen while enabled.
       # Camera transitions to MAX_ACC_REGEN from ZERO_GAS and uses friction brakes instantly
       max_regen_acceleration = 0.
 
     else:
-      self.MAX_GAS = 3072  # Safety limit, not ACC max. Stock ACC >4096 from standstill.
-      self.MAX_ACC_REGEN = 1404  # Max ACC regen is slightly less than max paddle regen
-      self.INACTIVE_REGEN = 1404
+      self.MAX_GAS = 1018.0  # Safety limit, not ACC max. Stock ACC >4096 from standstill.
+      self.MAX_ACC_REGEN = -650.0  # Max ACC regen is slightly less than max paddle regen
+      self.INACTIVE_REGEN = -650.0
       # ICE has much less engine braking force compared to regen in EVs,
       # lower threshold removes some braking deadzone
       max_regen_acceleration = -1. if CP.carFingerprint in EV_CAR else -0.1

--- a/opendbc/dbc/generator/gm/gm_global_a_powertrain.dbc
+++ b/opendbc/dbc/generator/gm/gm_global_a_powertrain.dbc
@@ -194,14 +194,12 @@ BO_ 711 BECMBatteryVoltageCurrent: 6 K17_EBCM
  SG_ HVBatteryCurrent : 12|13@0- (0.15,0) [-614.4|614.25] "A"  NEO
 
 BO_ 715 ASCMGasRegenCmd: 8 K124_ASCM
- SG_ GasRegenAlwaysOne2 : 9|1@0+ (1,0) [0|1] ""  NEO
  SG_ GasRegenAccType : 15|2@0+ (1,0) [0|3] ""  NEO
  SG_ GasRegenChecksum : 32|25@0+ (1,0) [0|0] ""  NEO
  SG_ GasRegenFullStopActive : 13|1@0+ (1,0) [0|0] ""  NEO
  SG_ GasRegenCmdActive : 0|1@0+ (1,0) [0|0] ""  NEO
  SG_ RollingCounter : 7|2@0+ (1,0) [0|0] ""  NEO
- SG_ GasRegenAlwaysOne3 : 23|1@0+ (1,0) [0|1] ""  NEO
- SG_ GasRegenCmd : 22|12@0+ (1,0) [0|0] ""  NEO
+ SG_ GasRegenCmd : 10|19@0+ (0.125,-22534) [-22534|43001.875] "Nm"  NEO
 
 BO_ 717 ASCM_2CD: 5 K124_ASCM
 

--- a/opendbc/safety/safety/safety_gm.h
+++ b/opendbc/safety/safety/safety_gm.h
@@ -134,7 +134,8 @@ static bool gm_tx_hook(const CANPacket_t *to_send) {
   // GAS/REGEN: safety check
   if (addr == 0x2CB) {
     bool apply = GET_BIT(to_send, 0U);
-    int gas_regen = ((GET_BYTE(to_send, 2) & 0x7FU) << 5) + ((GET_BYTE(to_send, 3) & 0xF8U) >> 3);
+    // convert float CAN signal to an int for gas checks: 22534 / 0.125 = 180272
+    int gas_regen = (((GET_BYTE(to_send, 1) & 0x7U) << 16) | (GET_BYTE(to_send, 2) << 8) | GET_BYTE(to_send, 3)) - 180272U;
 
     bool violation = false;
     // Allow apply bit in pre-enabled and overriding states
@@ -188,10 +189,13 @@ static safety_config gm_init(uint16_t param) {
   const uint16_t GM_PARAM_HW_CAM = 1;
   const uint16_t GM_PARAM_EV = 4;
 
+  // common safety checks assume unscaled integer values
+  static const int GM_GAS_TO_CAN = 8;  // 1 / 0.125
+
   static const LongitudinalLimits GM_ASCM_LONG_LIMITS = {
-    .max_gas = 3072,
-    .min_gas = 1404,
-    .inactive_gas = 1404,
+    .max_gas = 1018 * GM_GAS_TO_CAN,
+    .min_gas = -650 * GM_GAS_TO_CAN,
+    .inactive_gas = -650 * GM_GAS_TO_CAN,
     .max_brake = 400,
   };
 
@@ -201,9 +205,9 @@ static safety_config gm_init(uint16_t param) {
 
 
   static const LongitudinalLimits GM_CAM_LONG_LIMITS = {
-    .max_gas = 3400,
-    .min_gas = 1514,
-    .inactive_gas = 1554,
+    .max_gas = 1346 * GM_GAS_TO_CAN,
+    .min_gas = -540 * GM_GAS_TO_CAN,
+    .inactive_gas = -500 * GM_GAS_TO_CAN,
     .max_brake = 400,
   };
 

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -166,8 +166,8 @@ class LongitudinalGasBrakeSafetyTest(PandaSafetyTestBase, abc.ABC):
   MIN_GAS: int = 0
   MAX_GAS: int | None = None
   INACTIVE_GAS = 0
-  MIN_POSSIBLE_GAS: float = 0.
-  MAX_POSSIBLE_GAS: float | None = None
+  MIN_POSSIBLE_GAS: int = 0.
+  MAX_POSSIBLE_GAS: int | None = None
 
   def test_gas_brake_limits_correct(self):
     self.assertIsNotNone(self.MAX_POSSIBLE_BRAKE)

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -166,7 +166,8 @@ class LongitudinalGasBrakeSafetyTest(PandaSafetyTestBase, abc.ABC):
   MIN_GAS: int = 0
   MAX_GAS: int | None = None
   INACTIVE_GAS = 0
-  MAX_POSSIBLE_GAS: int | None = None
+  MIN_POSSIBLE_GAS: float = 0.
+  MAX_POSSIBLE_GAS: float | None = None
 
   def test_gas_brake_limits_correct(self):
     self.assertIsNotNone(self.MAX_POSSIBLE_BRAKE)
@@ -187,7 +188,7 @@ class LongitudinalGasBrakeSafetyTest(PandaSafetyTestBase, abc.ABC):
     self._generic_limit_safety_check(self._send_brake_msg, self.MIN_BRAKE, self.MAX_BRAKE, 0, self.MAX_POSSIBLE_BRAKE, 1)
 
   def test_gas_safety_check(self):
-    self._generic_limit_safety_check(self._send_gas_msg, self.MIN_GAS, self.MAX_GAS, 0, self.MAX_POSSIBLE_GAS, 1, self.INACTIVE_GAS)
+    self._generic_limit_safety_check(self._send_gas_msg, self.MIN_GAS, self.MAX_GAS, self.MIN_POSSIBLE_GAS, self.MAX_POSSIBLE_GAS, 1, self.INACTIVE_GAS)
 
 
 class TorqueSteeringSafetyTestBase(PandaSafetyTestBase, abc.ABC):

--- a/opendbc/safety/tests/test_gm.py
+++ b/opendbc/safety/tests/test_gm.py
@@ -23,7 +23,8 @@ class GmLongitudinalBase(common.PandaCarSafetyTest, common.LongitudinalGasBrakeS
   MAX_POSSIBLE_BRAKE = 2 ** 12
   MAX_BRAKE = 400
 
-  MAX_POSSIBLE_GAS = 2 ** 12
+  MAX_POSSIBLE_GAS = 4000  # reasonably excessive limits, not signal max
+  MIN_POSSIBLE_GAS = -4000
 
   PCM_CRUISE = False  # openpilot can control the PCM state if longitudinal
 
@@ -150,9 +151,9 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
   FWD_BUS_LOOKUP: dict[int, int] = {}
   BRAKE_BUS = 2
 
-  MAX_GAS = 3072
-  MIN_GAS = 1404 # maximum regen
-  INACTIVE_GAS = 1404
+  MAX_GAS = 1018.0
+  MIN_GAS = -650.0  # maximum regen
+  INACTIVE_GAS = -650.0
 
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
@@ -210,9 +211,9 @@ class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase)
   FWD_BLACKLISTED_ADDRS = {2: [0x180, 0x2CB, 0x370, 0x315], 0: [0x184]}  # block LKAS, ACC messages and PSCMStatus
   BUTTONS_BUS = 0  # rx only
 
-  MAX_GAS = 3400
-  MIN_GAS = 1514 # maximum regen
-  INACTIVE_GAS = 1554
+  MAX_GAS = 1346.0
+  MIN_GAS = -540.0  # maximum regen
+  INACTIVE_GAS = -500.0
 
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")

--- a/opendbc/safety/tests/test_gm.py
+++ b/opendbc/safety/tests/test_gm.py
@@ -151,9 +151,9 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
   FWD_BUS_LOOKUP: dict[int, int] = {}
   BRAKE_BUS = 2
 
-  MAX_GAS = 1018.0
-  MIN_GAS = -650.0  # maximum regen
-  INACTIVE_GAS = -650.0
+  MAX_GAS = 1018
+  MIN_GAS = -650  # maximum regen
+  INACTIVE_GAS = -650
 
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
@@ -211,9 +211,9 @@ class TestGmCameraLongitudinalSafety(GmLongitudinalBase, TestGmCameraSafetyBase)
   FWD_BLACKLISTED_ADDRS = {2: [0x180, 0x2CB, 0x370, 0x315], 0: [0x184]}  # block LKAS, ACC messages and PSCMStatus
   BUTTONS_BUS = 0  # rx only
 
-  MAX_GAS = 1346.0
-  MIN_GAS = -540.0  # maximum regen
-  INACTIVE_GAS = -500.0
+  MAX_GAS = 1346
+  MIN_GAS = -540  # maximum regen
+  INACTIVE_GAS = -500
 
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")


### PR DESCRIPTION
Correct scaling and offset now. Plus checksum is 1 bit larger, which captures that fake inverse bit, removed some set mes.

Opened to preserve, will verify later.

This does not change behavior.