### PR TITLE
CANParser: capture C++ DBC parser exceptions

### DIFF
--- a/can/common.pxd
+++ b/can/common.pxd
@@ -62,7 +62,7 @@ cdef extern from "common_dbc.h":
 
 
 cdef extern from "common.h":
-  cdef const DBC* dbc_lookup(const string)
+  cdef const DBC* dbc_lookup(const string) except +
 
   cdef cppclass CANParser:
     bool can_valid


### PR DESCRIPTION
From:

```python
...terminate called after throwing an instance of 'std::runtime_error'
  what():  [chrysler_ram_hd_generated.dbc:121] Duplicate message name: CRUISE_BUTTONS
Aborted (core dumped)
```

to:

```python
======================================================================
ERROR: test_parse_all_dbcs (test_dbc_parser.TestDBCParser.test_parse_all_dbcs) (dbc='chrysler_ram_hd_generated')
Dynamic DBC parser checks:
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/batman/openpilot/opendbc/can/tests/test_dbc_parser.py", line 24, in test_parse_all_dbcs
    CANParser(dbc, [], 0)
  File "opendbc/can/parser_pyx.pyx", line 32, in opendbc.can.parser_pyx.CANParser.__init__
RuntimeError: [chrysler_ram_hd_generated.dbc:121] Duplicate message name: CRUISE_BUTTONS

======================================================================
ERROR: test_all_dbcs (test_define.TestCADNDefine.test_all_dbcs) (dbc='chrysler_ram_hd_generated')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/batman/openpilot/opendbc/can/tests/test_define.py", line 31, in test_all_dbcs
    CANDefine(dbc)
  File "opendbc/can/parser_pyx.pyx", line 111, in opendbc.can.parser_pyx.CANDefine.__init__
RuntimeError: [chrysler_ram_hd_generated.dbc:121] Duplicate message name: CRUISE_BUTTONS

----------------------------------------------------------------------
Ran 19 tests in 0.227s

FAILED (errors=2, skipped=1)
```