### PR TITLE
CANParser: rename timestamp variables

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -54,7 +54,7 @@ public:
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
-  bool parse(uint64_t sec, const std::vector<uint8_t> &dat);
+  bool parse(uint64_t nanos, const std::vector<uint8_t> &dat);
   bool update_counter_generic(int64_t v, int cnt_size);
 };
 
@@ -69,9 +69,9 @@ private:
 public:
   bool can_valid = false;
   bool bus_timeout = false;
-  uint64_t first_sec = 0;
-  uint64_t last_sec = 0;
-  uint64_t last_nonempty_sec = 0;
+  uint64_t first_nanos = 0;
+  uint64_t last_nanos = 0;
+  uint64_t last_nonempty_nanos = 0;
   uint64_t bus_timeout_threshold = 0;
   uint64_t can_invalid_cnt = CAN_INVALID_CNT;
 
@@ -81,10 +81,10 @@ public:
   #ifndef DYNAMIC_CAPNP
   void update_string(const std::string &data, bool sendcan);
   void update_strings(const std::vector<std::string> &data, std::vector<SignalValue> &vals, bool sendcan);
-  void UpdateCans(uint64_t sec, const capnp::List<cereal::CanData>::Reader& cans);
+  void UpdateCans(uint64_t nanos, const capnp::List<cereal::CanData>::Reader& cans);
   #endif
-  void UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cans);
-  void UpdateValid(uint64_t sec);
+  void UpdateCans(uint64_t nanos, const capnp::DynamicStruct::Reader& cans);
+  void UpdateValid(uint64_t nanos);
   void query_latest(std::vector<SignalValue> &vals, uint64_t last_ts = 0);
 };
 

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -33,7 +33,7 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 }
 
 
-bool MessageState::parse(uint64_t sec, const std::vector<uint8_t> &dat) {
+bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
   for (int i = 0; i < parse_sigs.size(); i++) {
     const auto &sig = parse_sigs[i];
 
@@ -67,7 +67,7 @@ bool MessageState::parse(uint64_t sec, const std::vector<uint8_t> &dat) {
     vals[i] = tmp * sig.factor + sig.offset;
     all_vals[i].push_back(vals[i]);
   }
-  last_seen_nanos = sec;
+  last_seen_nanos = nanos;
 
   return true;
 }
@@ -101,7 +101,7 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
 
   for (const auto& [address, frequency] : messages) {
     // disallow duplicate message checks
-    if (message_states.find(address) != message_states.end()) { 
+    if (message_states.find(address) != message_states.end()) {
       std::stringstream is;
       is << "Duplicate Message Check: " << address;
       throw std::runtime_error(is.str());
@@ -182,29 +182,29 @@ void CANParser::update_string(const std::string &data, bool sendcan) {
   capnp::FlatArrayMessageReader cmsg(aligned_buf.slice(0, buf_size));
   cereal::Event::Reader event = cmsg.getRoot<cereal::Event>();
 
-  if (first_sec == 0) {
-    first_sec = event.getLogMonoTime();
+  if (first_nanos == 0) {
+    first_nanos = event.getLogMonoTime();
   }
-  last_sec = event.getLogMonoTime();
+  last_nanos = event.getLogMonoTime();
 
   auto cans = sendcan ? event.getSendcan() : event.getCan();
-  UpdateCans(last_sec, cans);
+  UpdateCans(last_nanos, cans);
 
-  UpdateValid(last_sec);
+  UpdateValid(last_nanos);
 }
 
 void CANParser::update_strings(const std::vector<std::string> &data, std::vector<SignalValue> &vals, bool sendcan) {
-  uint64_t current_sec = 0;
+  uint64_t current_nanos = 0;
   for (const auto &d : data) {
     update_string(d, sendcan);
-    if (current_sec == 0) {
-      current_sec = last_sec;
+    if (current_nanos == 0) {
+      current_nanos = last_nanos;
     }
   }
-  query_latest(vals, current_sec);
+  query_latest(vals, current_nanos);
 }
 
-void CANParser::UpdateCans(uint64_t sec, const capnp::List<cereal::CanData>::Reader& cans) {
+void CANParser::UpdateCans(uint64_t nanos, const capnp::List<cereal::CanData>::Reader& cans) {
   //DEBUG("got %d messages\n", cans.size());
 
   bool bus_empty = true;
@@ -238,18 +238,18 @@ void CANParser::UpdateCans(uint64_t sec, const capnp::List<cereal::CanData>::Rea
 
     std::vector<uint8_t> data(dat.size(), 0);
     memcpy(data.data(), dat.begin(), dat.size());
-    state_it->second.parse(sec, data);
+    state_it->second.parse(nanos, data);
   }
 
   // update bus timeout
   if (!bus_empty) {
-    last_nonempty_sec = sec;
+    last_nonempty_nanos = nanos;
   }
-  bus_timeout = (sec - last_nonempty_sec) > bus_timeout_threshold;
+  bus_timeout = (nanos - last_nonempty_nanos) > bus_timeout_threshold;
 }
 #endif
 
-void CANParser::UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cmsg) {
+void CANParser::UpdateCans(uint64_t nanos, const capnp::DynamicStruct::Reader& cmsg) {
   // assume message struct is `cereal::CanData` and parse
   assert(cmsg.has("address") && cmsg.has("src") && cmsg.has("dat") && cmsg.has("busTime"));
 
@@ -268,11 +268,11 @@ void CANParser::UpdateCans(uint64_t sec, const capnp::DynamicStruct::Reader& cms
   if (dat.size() > 64) return; // shouldn't ever happen
   std::vector<uint8_t> data(dat.size(), 0);
   memcpy(data.data(), dat.begin(), dat.size());
-  state_it->second.parse(sec, data);
+  state_it->second.parse(nanos, data);
 }
 
-void CANParser::UpdateValid(uint64_t sec) {
-  const bool show_missing = (last_sec - first_sec) > 8e9;
+void CANParser::UpdateValid(uint64_t nanos) {
+  const bool show_missing = (last_nanos - first_nanos) > 8e9;
 
   bool _valid = true;
   bool _counters_valid = true;
@@ -284,7 +284,7 @@ void CANParser::UpdateValid(uint64_t sec) {
     }
 
     const bool missing = state.last_seen_nanos == 0;
-    const bool timed_out = (sec - state.last_seen_nanos) > state.check_threshold;
+    const bool timed_out = (nanos - state.last_seen_nanos) > state.check_threshold;
     if (state.check_threshold > 0 && (missing || timed_out)) {
       if (show_missing && !bus_timeout) {
         if (missing) {
@@ -302,7 +302,7 @@ void CANParser::UpdateValid(uint64_t sec) {
 
 void CANParser::query_latest(std::vector<SignalValue> &vals, uint64_t last_ts) {
   if (last_ts == 0) {
-    last_ts = last_sec;
+    last_ts = last_nanos;
   }
   for (auto& kv : message_states) {
     auto& state = kv.second;


### PR DESCRIPTION
Split from https://github.com/commaai/opendbc/pull/971, makes reading the parser.cc file much eaiser.

Probably called sec because we originally passed in `sec_since_boot() * 1e9` in the first CANParser commit:

![image](https://github.com/commaai/opendbc/assets/25857203/986b5e8c-54a1-4864-9fad-e505cc91dd09)

![image](https://github.com/commaai/opendbc/assets/25857203/060caea2-c216-4c4e-a212-81bf2e50d265)
