### PR TITLE
CANParser: process all signals before updating values

### DIFF
--- a/can/parser.cc
+++ b/can/parser.cc
@@ -61,7 +61,6 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
 
     tmp_vals.push_back(tmp * sig.factor + sig.offset);
   }
-  last_seen_nanos = nanos;
 
   // only update values if both checksum and counter are valid
   if (checksum_failed || counter_failed) {
@@ -73,6 +72,7 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
     vals[i] = tmp_vals[i];
     all_vals[i].push_back(vals[i]);
   }
+  last_seen_nanos = nanos;
 
   return true;
 }

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -34,8 +34,10 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 
 
 bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
+  std::vector<double> tmp_vals(parse_sigs.size());
   bool checksum_failed = false;
   bool counter_failed = false;
+
   for (int i = 0; i < parse_sigs.size(); i++) {
     const auto &sig = parse_sigs[i];
 
@@ -58,7 +60,7 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
       }
     }
 
-    vals[i] = tmp * sig.factor + sig.offset;
+    tmp_vals[i] = tmp * sig.factor + sig.offset;
   }
 
   // only update values if both checksum and counter are valid
@@ -68,6 +70,7 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
   }
 
   for (int i = 0; i < parse_sigs.size(); i++) {
+    vals[i] = tmp_vals[i];
     all_vals[i].push_back(vals[i]);
   }
   last_seen_nanos = nanos;

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -34,7 +34,6 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 
 
 bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
-  std::vector<double> tmp_vals;
   bool checksum_failed = false;
   bool counter_failed = false;
   for (int i = 0; i < parse_sigs.size(); i++) {
@@ -59,7 +58,7 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
       }
     }
 
-    tmp_vals.push_back(tmp * sig.factor + sig.offset);
+    vals[i] = tmp * sig.factor + sig.offset;
   }
 
   // only update values if both checksum and counter are valid
@@ -69,7 +68,6 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
   }
 
   for (int i = 0; i < parse_sigs.size(); i++) {
-    vals[i] = tmp_vals[i];
     all_vals[i].push_back(vals[i]);
   }
   last_seen_nanos = nanos;

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -34,9 +34,9 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 
 
 bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
-  std::vector<double> tmp_vals;
   bool checksum_failed = false;
   bool counter_failed = false;
+  std::vector<double> tmp_vals;
   for (int i = 0; i < parse_sigs.size(); i++) {
     const auto &sig = parse_sigs[i];
 

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -34,9 +34,9 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 
 
 bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
+  std::vector<double> tmp_vals;
   bool checksum_failed = false;
   bool counter_failed = false;
-  std::vector<double> tmp_vals;
   for (int i = 0; i < parse_sigs.size(); i++) {
     const auto &sig = parse_sigs[i];
 

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -34,10 +34,9 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 
 
 bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
-  // only updates values if both checksum and counter are valid
+  std::vector<double> tmp_vals;
   bool checksum_failed = false;
   bool counter_failed = false;
-  std::vector<double> tmp_vals;
   for (int i = 0; i < parse_sigs.size(); i++) {
     const auto &sig = parse_sigs[i];
 
@@ -55,8 +54,8 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
     }
 
     if (!ignore_counter) {
-      if (sig.type == SignalType::COUNTER) {
-        counter_failed = !update_counter_generic(tmp, sig.size);
+      if (sig.type == SignalType::COUNTER && !update_counter_generic(tmp, sig.size)) {
+        counter_failed = true;
       }
     }
 
@@ -64,6 +63,7 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
   }
   last_seen_nanos = nanos;
 
+  // only update values if both checksum and counter are valid
   if (checksum_failed || counter_failed) {
     LOGE("0x%X message checks failed, checksum failed %d, counter failed %d", address, checksum_failed, counter_failed);
     return false;

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -151,6 +151,7 @@ class TestCanParserPacker(unittest.TestCase):
       self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 100)
       self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [])
 
+    # Even if CANParser doesn't update instantaneous vl, make sure it didn't add invalid values to vl_all
     rx_steering_msg({"STEER_TORQUE": 300}, break_checksum=False)
     self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 300)
     self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [300])

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -124,7 +124,8 @@ class TestCanParserPacker(unittest.TestCase):
   def test_parser_no_partial_update(self):
     """
     Ensure that the CANParser doesn't partially update messages with invalid signals (COUNTER/CHECKSUM).
-    Previously, the signal update loop would only break once it got to one of these invalid signals.
+    Previously, the signal update loop would only break once it got to one of these invalid signals,
+    after already updating most/all of the signals.
     """
     msgs = [
       ("STEERING_CONTROL", 0),

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -133,9 +133,9 @@ class TestCanParserPacker(unittest.TestCase):
     packer = CANPacker("honda_civic_touring_2016_can_generated")
     parser = CANParser("honda_civic_touring_2016_can_generated", msgs, 0)
 
-    def rx_steering_msg(values, break_checksum=False):
+    def rx_steering_msg(values, bad_checksum=False):
       msg = packer.make_can_msg("STEERING_CONTROL", 0, values)
-      if break_checksum:
+      if bad_checksum:
         # add 1 to checksum
         msg[2] = bytearray(msg[2])
         msg[2][4] = (msg[2][4] & 0xF0) | ((msg[2][4] & 0x0F) + 1)
@@ -143,17 +143,17 @@ class TestCanParserPacker(unittest.TestCase):
       bts = can_list_to_can_capnp([msg])
       parser.update_strings([bts])
 
-    rx_steering_msg({"STEER_TORQUE": 100}, break_checksum=False)
+    rx_steering_msg({"STEER_TORQUE": 100}, bad_checksum=False)
     self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 100)
     self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [100])
 
     for _ in range(5):
-      rx_steering_msg({"STEER_TORQUE": 200}, break_checksum=True)
+      rx_steering_msg({"STEER_TORQUE": 200}, bad_checksum=True)
       self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 100)
       self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [])
 
     # Even if CANParser doesn't update instantaneous vl, make sure it didn't add invalid values to vl_all
-    rx_steering_msg({"STEER_TORQUE": 300}, break_checksum=False)
+    rx_steering_msg({"STEER_TORQUE": 300}, bad_checksum=False)
     self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 300)
     self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [300])
 

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -121,6 +121,40 @@ class TestCanParserPacker(unittest.TestCase):
     parser.update_strings([bts])
     self.assertTrue(parser.can_valid)
 
+  def test_parser_no_partial_update(self):
+    """
+    Ensure that the CANParser doesn't partially update messages with invalid signals (COUNTER/CHECKSUM).
+    Previously, the signal update loop would only break once it got to one of these invalid signals.
+    """
+    msgs = [
+      ("STEERING_CONTROL", 0),
+    ]
+    packer = CANPacker("honda_civic_touring_2016_can_generated")
+    parser = CANParser("honda_civic_touring_2016_can_generated", msgs, 0)
+
+    def rx_steering_msg(values, break_checksum=False):
+      msg = packer.make_can_msg("STEERING_CONTROL", 0, values)
+      if break_checksum:
+        # add 1 to checksum
+        msg[2] = bytearray(msg[2])
+        msg[2][4] = (msg[2][4] & 0xF0) | ((msg[2][4] & 0x0F) + 1)
+
+      bts = can_list_to_can_capnp([msg])
+      parser.update_strings([bts])
+
+    rx_steering_msg({"STEER_TORQUE": 100}, break_checksum=False)
+    self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 100)
+    self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [100])
+
+    for _ in range(5):
+      rx_steering_msg({"STEER_TORQUE": 200}, break_checksum=True)
+      self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 100)
+      self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [])
+
+    rx_steering_msg({"STEER_TORQUE": 300}, break_checksum=False)
+    self.assertEqual(parser.vl["STEERING_CONTROL"]["STEER_TORQUE"], 300)
+    self.assertEqual(parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"], [300])
+
   def test_packer_parser(self):
     msgs = [
       ("Brake_Status", 0),


### PR DESCRIPTION
Previously, if the COUNTER and CHECKSUM signals were at the end of the message in the DBC, we could freely update `vl` and `vl_all` all we want (regardless of if those two signals were valid or not). If the two were at the beginning of the message, it would not update any values which makes more sense and matches panda's behavior of processing each message as they come in, with validity checks.

However another issue was that if CHECKSUM was before COUNTER and the checksum was invalid it would never actually update the last message counter, causing more mismatches when we later got valid checksums.

Both cases now match panda behavior, avoiding mismatches found in https://github.com/commaai/openpilot/pull/30443

Todo:
- [x] tests
- [x] ~still updates `last_seen_nanos` if message is invalid, will need to investigate if this is fine~ - copied original behavior, if any signal invalid: don't update `last_seen_nanos`