### PR TITLE
 honda_civic_touring_2016_can_generated.dbc: remove   `CM_ SG_ 450`

### DIFF
--- a/generator/honda/honda_civic_touring_2016_can.dbc
+++ b/generator/honda/honda_civic_touring_2016_can.dbc
@@ -83,7 +83,6 @@ BO_ 1302 ODOMETER: 8 XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 401 GEAR "10 = reverse, 11 = transition";
-CM_ SG_ 450 EPB_STATE "3 \"engaged\" 2 \"disengaging\" 1 \"engaging\" 0 \"disengaged\"";
 CM_ SG_ 806 REVERSE_LIGHT "Might be reverse gear selected and not the lights";
 
 VAL_ 399 STEER_STATUS 7 "permanent_fault" 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;

--- a/honda_civic_touring_2016_can_generated.dbc
+++ b/honda_civic_touring_2016_can_generated.dbc
@@ -374,7 +374,6 @@ BO_ 1302 ODOMETER: 8 XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
 
 CM_ SG_ 401 GEAR "10 = reverse, 11 = transition";
-CM_ SG_ 450 EPB_STATE "3 \"engaged\" 2 \"disengaging\" 1 \"engaging\" 0 \"disengaged\"";
 CM_ SG_ 806 REVERSE_LIGHT "Might be reverse gear selected and not the lights";
 
 VAL_ 399 STEER_STATUS 7 "permanent_fault" 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;


### PR DESCRIPTION
fix cabana parsing error.

remove the CM_SG_ 450, there is already a value description for 4550 EPB_STATE:

> VAL_ 450 EPB_STATE 3 "engaged" 2 "disengaging" 1 "engaging" 0 "disengaged" ;

