### PR TITLE
Ford Edge 2022 DBC: Different PSCM SteeringPinion_Data ID

### DIFF
--- a/ford_edge_pt.dbc
+++ b/ford_edge_pt.dbc
@@ -1,0 +1,12695 @@
+VERSION ""
+
+
+NS_ :
+    NS_DESC_
+    CM_
+    BA_DEF_
+    BA_
+    VAL_
+    CAT_DEF_
+    CAT_
+    FILTER
+    BA_DEF_DEF_
+    EV_DATA_
+    ENVVAR_DATA_
+    SGTYPE_
+    SGTYPE_VAL_
+    BA_DEF_SGTYPE_
+    BA_SGTYPE_
+    SIG_TYPE_REF_
+    VAL_TABLE_
+    SIG_GROUP_
+    SIG_VALTYPE_
+    SIGTYPE_VALTYPE_
+    BO_TX_BU_
+    BA_DEF_REL_
+    BA_REL_
+    BA_DEF_DEF_REL_
+    BU_SG_REL_
+    BU_EV_REL_
+    BU_BO_REL_
+    SG_MUL_VAL_
+
+BS_:
+
+BU_: VDM CMR_DSMC SOBDMC_HPCM_FD1 IPMA_ADAS PSCM ABS_ESC TCCM TCM_DSL PCM_HEV PCM ECM_Diesel GENERIC_GWMWakeup GWM _delete TSTR
+
+VAL_TABLE_ DcacRdy_D_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "Faulted" 4 "ProtectionTempearture" 3 "ProtectionOverload" 2 "ProtectionGfci" 1 "Active" 0 "Idle";
+VAL_TABLE_ HvacCmprLim_D_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "CompressorHeadPressure" 4 "AvailableTorque" 3 "PedalPosition" 2 "RPM" 1 "ECT" 0 "NoLimit";
+VAL_TABLE_ AdvStrt_D_Stat 15 "NotUsed_15" 14 "NotUsed_14" 13 "NotUsed_13" 12 "NotUsed_12" 11 "NotUsed_11" 10 "NotUsed_10" 9 "NotUsed_9" 8 "NotUsed_8" 7 "NotUsed_7" 6 "NotUsed_6" 5 "NotUsed_5" 4 "NotUsed_4" 3 "NotUsed_3" 2 "NotUsed_2" 1 "NotUsed_1" 0 "NoAction";
+VAL_TABLE_ VehOnSrc_D_Stat 15 "NotUsed_11" 14 "NotUsed_10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "NotUsed_4" 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "OverTheAir" 3 "RemoteParkAssist" 2 "RemoteStart" 1 "Manual" 0 "Off";
+VAL_TABLE_ NoMessage_Msg1_63 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ TrlrRvrseEnbl_D2_Stat 7 "NotUsed" 6 "TbaActiveExpertActive" 5 "TbaActiveExpertAvail" 4 "TbaOffTrgActive" 3 "TbaOffTrgSetup" 2 "TbaSetup" 1 "TbaActive" 0 "Inactive";
+VAL_TABLE_ Off_On_FlashChime 7 "NotUsed_5" 6 "NotUsed_4" 5 "NotUsed_3" 4 "NotUsed_2" 3 "NotUsed_1" 2 "FlashChime" 1 "On" 0 "Off";
+VAL_TABLE_ DieslPrtcWarn_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "OCR_ExhFilterClean_Stopped" 10 "OCR_ExhFilterCleaned" 9 "RgnOff_AtLimit" 8 "RgnOff_OverLoaded" 7 "RgnOff_Loaded" 6 "Exhaust_Filter_Full" 5 "DPF_OverLimit" 4 "DPF_AtLimit" 3 "ExhFilter_Drive_Completed" 2 "Cleaning_Exhaust_Filter" 1 "DPF_OverLoaded" 0 "DPF_Normal_Operation";
+VAL_TABLE_ StrtrMtrCtlMsgTxt_D2_Rq 3 "NotUsed" 2 "ShiftToNeutralToStart" 1 "ShiftToParkToStart" 0 "NoRequest";
+VAL_TABLE_ PaakMyKey_D_Rq 3 "NotUsed" 2 "ConfirmNewPaakMyKey" 1 "RequestNewPaakMyKey" 0 "None";
+VAL_TABLE_ PaakMyKeySearch_D_Stat 7 "PhoneErased" 6 "LockButtonTimeOut" 5 "PressLockButton" 4 "ConfirmHmi" 3 "MyKeyPaakFound" 2 "StandardPaakFound" 1 "NoValidPaakFound" 0 "Null";
+VAL_TABLE_ TrlrIdType_D_Stat 3 "Gooseneck" 2 "FifthWheel" 1 "Conventional" 0 "Null";
+VAL_TABLE_ TrlrAidSetup_D2_Rq 15 "NotUsed_9" 14 "NotUsed_8" 13 "NotUsed_7" 12 "NotUsed_6" 11 "NotUsed_5" 10 "NotUsed_4" 9 "NotUsed_3" 8 "NotUsed_2" 7 "NotUsed_1" 6 "CompleteSetup" 5 "ReturnToSetup" 4 "StickerNotCircled" 3 "ConfirmSetup" 2 "EndSetup" 1 "BeginSetup" 0 "Inactive";
+VAL_TABLE_ TrlrAidEnbl_D2_Rq 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Deactivate" 2 "ActivateTrg" 1 "ActivateTba" 0 "Inactive";
+VAL_TABLE_ BattChrgMde_D_Actl 3 "NotUsed" 2 "ConstantCurrent" 1 "ConstantVoltage" 0 "NotCharging";
+VAL_TABLE_ LcwaLeft_D_Stat 7 "Faulty" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Disabled" 2 "TemporaryUnavailable" 1 "SensorBlocked" 0 "Available";
+VAL_TABLE_ LcwaMsgTxt_D_Stat 3 "SodXFaulty" 2 "SodXBlocked" 1 "TrailerConnected" 0 "NoMessage";
+VAL_TABLE_ Level_0_3 3 "Level_3" 2 "Level_2" 1 "Level_1" 0 "Level_0";
+VAL_TABLE_ SteWhlSwtchMde_D_Stat 3 "NotUsed_2" 2 "NotUsed_1" 1 "Dialog" 0 "Domain";
+VAL_TABLE_ TrlrRvrse_D_Stat 3 "Faulty" 2 "TrailerReverseGuidanceLite" 1 "On" 0 "Off";
+VAL_TABLE_ TrlrAid_D2_Stat 15 "Faulty" 14 "NotUsed_4" 13 "NotUsed_3" 12 "NotUsed_2" 11 "NotUsed_1" 10 "DirtyCamera" 9 "IncorrectLighting" 8 "TrackingLost" 7 "TrackingUnknownConfidence" 6 "TrackingHighConfidence" 5 "TrackingMediumConfidence" 4 "TrackingLowConfidence" 3 "TurnRequested" 2 "DriveStraighRequested" 1 "Initializing" 0 "NotTracking";
+VAL_TABLE_ AwdDrvMde_D2 15 "Faulty" 14 "NotUsed_7" 13 "NotUsed_6" 12 "NotUsed_5" 11 "NotUsed_4" 10 "NotUsed_3" 9 "NotUsed_2" 8 "NotUsed_1" 7 "NotAvailable" 6 "TowHaul" 5 "RockCrawl" 4 "Baja" 3 "MudAndSand" 2 "Weather" 1 "Sport" 0 "Normal";
+VAL_TABLE_ TrlrAidSetup_D2_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "SetupAcquisitionSuccess" 4 "TbaTadMonitor" 3 "SetupStartAcquisition" 2 "SetupPrepForAcquisition" 1 "TbaActive" 0 "Null";
+VAL_TABLE_ CamraRearOn_D2_Stat2 7 "Faulty" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Decommission" 2 "Activate" 1 "Deactivate" 0 "Null";
+VAL_TABLE_ AirCondClu_D_Stat 7 "NotUsed" 6 "FetLifeLimitReached" 5 "FetOpenCircuit" 4 "FetOutputShortToPower" 3 "FetOutputShortToGround" 2 "FetNotControlled" 1 "OnPowerToLoad" 0 "OffNoPowerToLoad";
+VAL_TABLE_ BattChrgTrgtSoC_D_Rq 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_TABLE_ OffNormalSoft 3 "NotUsed" 2 "Soft" 1 "Normal" 0 "Off";
+VAL_TABLE_ OffOnDisabledInhibited 3 "Inhibited" 2 "Disabled" 1 "On" 0 "Off";
+VAL_TABLE_ DgtlCommGtwyMde_D_Rq 15 "NotUsed_10" 14 "NotUsed_9" 13 "NotUsed_8" 12 "NotUsed_7" 11 "NotUsed_6" 10 "NotUsed_5" 9 "NotUsed_4" 8 "NotUsed_3" 7 "NotUsed_2" 6 "NotUsed_1" 5 "AcPnC" 4 "AcEIM" 3 "DcPnC" 2 "DcEIM" 1 "AttemptDgtlComm" 0 "NoDgtlComm";
+VAL_TABLE_ BattDcCnnct_D_Cmd 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "WeldCheck" 3 "OkToDischarge" 2 "Closed" 1 "Precharge" 0 "Open";
+VAL_TABLE_ Null_NoFault_Fault 3 "NotUsed" 2 "Fault" 1 "NoFault" 0 "Null";
+VAL_TABLE_ ModemReset_D_Rq 15 "NotUsed_11" 14 "NotUsed_10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "NotUsed_4" 7 "NotUsed_3" 6 "BrandConnectReset2" 5 "BrandConnectReset1" 4 "CcsReset" 3 "OnlineTrafficReset" 2 "PaakReset" 1 "WifiHotspotReset" 0 "Null";
+VAL_TABLE_ PrkAsstSlotId_D_Stat 7 "Faulty" 6 "Slot6" 5 "Slot5" 4 "Slot4" 3 "Slot3" 2 "Slot2" 1 "Slot1" 0 "NoSlotFound";
+VAL_TABLE_ RstrnOnPsngr_D_RqMnu 15 "Faulty" 14 "NotUsed_11" 13 "NotUsed_10" 12 "ConfiguredOff" 11 "NotUsed_9" 10 "On" 9 "NotUsed_8" 8 "NotUsed_7" 7 "NotUsed_6" 6 "NotUsed_5" 5 "Off" 4 "NotUsed_4" 3 "NotUsed_3" 2 "NotUsed_2" 1 "NotUsed_1" 0 "NoAction";
+VAL_TABLE_ BalrInnrLeft_D_Stat 3 "Reporting" 2 "NotReporting" 1 "SystemStandby" 0 "Initialization";
+VAL_TABLE_ Zero_1_2_4 3 "Four" 2 "Two" 1 "One" 0 "Zero";
+VAL_TABLE_ NoReq_AutoUp_Stop 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_TABLE_ BalrSnsLeft_D_Falt 3 "Invalid" 2 "SystemFailure" 1 "Blocked" 0 "Clear";
+VAL_TABLE_ Null_Low_Med_High 3 "High" 2 "Medium" 1 "Low" 0 "Null";
+VAL_TABLE_ Null_NotPressed_Pressed 3 "NotUsed" 2 "Pressed" 1 "NotPressed" 0 "Null";
+VAL_TABLE_ Low_Med_High 3 "NotUsed" 2 "High" 1 "Medium" 0 "Low";
+VAL_TABLE_ Null_NotAvail_Avail 3 "NotUsed" 2 "Available" 1 "NotAvailable" 0 "Null";
+VAL_TABLE_ ChrgGoTMnte_D_Stat 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Minute_55" 10 "Minute_50" 9 "Minute_45" 8 "Minute_40" 7 "Minute_35" 6 "Minute_30" 5 "Minute_25" 4 "Minute_20" 3 "Minute_15" 2 "Minute_10" 1 "Minute_5" 0 "Minute_0";
+VAL_TABLE_ NoData_Faulty_1E_1F 31 "Faulty" 30 "NoDataExists";
+VAL_TABLE_ PwFlwBatt_D_Dsply 15 "NotUsed_8" 14 "NotUsed_7" 13 "NotUsed_6" 12 "NotUsed_5" 11 "NotUsed_4" 10 "NotUsed_3" 9 "NotUsed_2" 8 "NotUsed_1" 7 "FlwFromWallToBatt" 6 "FlwFromAllWhlsToBatt" 5 "FlwFromBattToAllWhls" 4 "FlwFromFrontWhlsToBatt" 3 "FlwFromBattToFrontWhls" 2 "FlwFromRearWhlsToBatt" 1 "FlwFromBattToRearWhls" 0 "NoFlow";
+VAL_TABLE_ PwFlwFuelDrv_D_Dsply 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "FlwFromFuelToAllWhls" 2 "FlwFromFuelToFrontWhls" 1 "FlwFromFuelToRearWhls" 0 "NoFlow";
+VAL_TABLE_ TrlrAidMsgTxt_D2_Rq 63 "Message63" 62 "Message62" 61 "Message61" 60 "Message60" 55 "Message55" 50 "Message50" 45 "Message45" 40 "Message40" 35 "Message35" 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ TrlrAidEnbl_D2_Stat 7 "NotUsed_1" 6 "TbaActiveExpertActive" 5 "TbaActiveExpertAvail" 4 "TbaOffTrgActive" 3 "TbaOffTrgSetup" 2 "TbaSetup" 1 "TbaActive" 0 "Inactive";
+VAL_TABLE_ RbaCta_D_Stat 7 "Faulty" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Invalid" 3 "Disabled" 2 "On" 1 "Trailer_Tow_Off" 0 "Off";
+VAL_TABLE_ NoRequest_Mode1_2_3 3 "Mode_3" 2 "Mode_2" 1 "Mode_1" 0 "NoRequest";
+VAL_TABLE_ RvltnMatchAllw_D_Stat 3 "RevolutionMatchDisabled" 2 "RevolutionMatchEnabled" 1 "ChangeWithDriveMode" 0 "NoSelection";
+VAL_TABLE_ BattTracCnnct_D_Cmd 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "WeldCheck" 3 "OkToDischarge" 2 "Closed" 1 "Precharge" 0 "Open";
+VAL_TABLE_ NotDiagnose_FailPass 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_TABLE_ Null_Off_UnavailFaulty 3 "Faulty" 2 "Unavailable" 1 "Off" 0 "Null";
+VAL_TABLE_ OffOnDisabledNotUsed 3 "NotUsed" 2 "Disabled" 1 "On" 0 "Off";
+VAL_TABLE_ OffGraphicTextBoth 3 "Both" 2 "Text" 1 "Graphic" 0 "Off";
+VAL_TABLE_ NoneInactiveActive_NotUsed 3 "NotUsed" 2 "Active" 1 "Inactive" 0 "None";
+VAL_TABLE_ Off_On_NotUsed 3 "NotUsed_2" 2 "NotUsed_1" 1 "On" 0 "Off";
+VAL_TABLE_ RbaSys_D_Stat 3 "Faulty" 2 "Available" 1 "Suspended" 0 "Disabled";
+VAL_TABLE_ BrkAppl_D_RqPt 3 "BrakesSlowRelease" 2 "BrakesFastRelease" 1 "BrakesEngage" 0 "NotActive";
+VAL_TABLE_ Mtr2State_D_ActlMntr 7 "Faulty" 6 "NoDataExists" 5 "NotUsed_1" 4 "ReadinessState" 3 "DeactivationState" 2 "PowerGeneration" 1 "PowerConsumption" 0 "Null";
+VAL_TABLE_ HybVehMde_D_ActlMntr 7 "Faulty" 6 "NoDataExists" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Fuel" 2 "HybridElectric" 1 "AllElectric" 0 "Null";
+VAL_TABLE_ ChrgStat_D_ActlMntr 7 "Faulty" 6 "NoDataExists" 5 "NotUsed" 4 "ChargingCompleted" 3 "NotCharging" 2 "ChargingInDrivingState" 1 "ChargingInParkingState" 0 "Null";
+VAL_TABLE_ Null_HiPower_Low_Med 3 "MediumPower" 2 "LowPower" 1 "HighPower" 0 "Null";
+VAL_TABLE_ Inactive_Enable_Disable_NotUsed 0 "Inactive" 2 "Disable" 1 "Enable";
+VAL_TABLE_ Inactive_OffOn_NotUsed 0 "Inactive" 1 "On" 2 "Off" 3 "NotUsed";
+VAL_TABLE_ Null_NotPressed_Faulty 3 "Faulty" 2 "Pressed" 1 "NotPressed" 0 "Null";
+VAL_TABLE_ TrailCtl_D_Stat 7 "Faulty" 6 "DescentOnly" 5 "EnabledDeny" 4 "StandbyOverThreshold" 3 "StandbyOverride" 2 "Active" 1 "EnabledDescent" 0 "Off";
+VAL_TABLE_ Faulty_3F 63 "Faulty";
+VAL_TABLE_ ChrgOvrdExitScrn_D_Rq 3 "NotUsed_1" 2 "Request_override" 1 "Do_not_request_override" 0 "Inactive";
+VAL_TABLE_ Quality_Data_Faulty 3 "OK" 2 "Not_Within_Specifications" 1 "Eval_In_Progress" 0 "Faulty";
+VAL_TABLE_ TrlrHitchYaw_D_Stat 15 "Faulty" 14 "NotUsed_4" 13 "NotUsed_3" 12 "NotUsed_2" 11 "NotUsed_1" 10 "FaultyYrsuConnection" 9 "FaultyYrsu" 8 "HiConfdLrndAngle" 7 "LowConfdLrndAngle" 6 "HiConfdAngleMem" 5 "LowConfdAngleMem" 4 "InitNoTadAngle" 3 "InitInputs" 2 "TadTrlrDataOutOfRange" 1 "TadNotWithinSpecification" 0 "NoConnectionWithYrsu";
+VAL_TABLE_ NoData_Faulty_FFFFFFFFFFFE_FF -1 "Faulty_FFFFFFFFFFFF" -2 "NoDataExists_FFFFFFFFFFFE";
+VAL_TABLE_ NoFault_Fault 1 "Fault" 0 "No_Fault";
+VAL_TABLE_ OtaTrg_D_Stat 3 "NotUsed_1" 2 "Accepted" 1 "NotAccepted" 0 "Null";
+VAL_TABLE_ EdmMsgTxt_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "OverallGoodScore" 10 "WorkOnCompliance" 9 "GoodCompliance" 8 "WorkOnGearShifting" 7 "GoodGearShifting" 6 "WorkOnEfficientSpeed" 5 "GoodEfficientSpeed" 4 "WorkOnDeceleration" 3 "GoodDeceleration" 2 "WorkOnAcceleration" 1 "GoodAcceleration" 0 "NoMessage";
+VAL_TABLE_ EdmLamp_D_Dsply 15 "NotUsed_7" 14 "NotUsed_6" 13 "NotUsed_5" 12 "NotUsed_4" 11 "NotUsed_3" 10 "NotUsed_2" 9 "NotUsed_1" 8 "CoastingEngineBrake" 7 "CoastingShiftToNeutral" 6 "FreewayJunction" 5 "Curve2" 4 "Curve1" 3 "SpeedLimit" 2 "Crossing" 1 "FreewayExit" 0 "NoRecommendation";
+VAL_TABLE_ AwdCnnct_D_Stat 3 "Connecting" 2 "Disconnecting" 1 "Connected" 0 "Disconnected";
+VAL_TABLE_ EngAirFiltMsgTxt_D_Rq 7 "NotUsed_2" 6 "NotUsed_1" 5 "EngineAirFilterMonitorFalt" 4 "ResetComplete" 3 "Clogged" 2 "ReplaceNow" 1 "ReplaceSoon" 0 "NoMessage";
+VAL_TABLE_ ElPwPoint_D_Rq 3 "On" 2 "Off2" 1 "Off1" 0 "Null";
+VAL_TABLE_ EngExhMdeQuiet_D2_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Track" 3 "Sport" 2 "Normal" 1 "Stealth" 0 "Null";
+VAL_TABLE_ RearDiffThrml_D_Stat 3 "NotUsed_1" 2 "AboveThermalLimit" 1 "ThermalLimit" 0 "Normal";
+VAL_TABLE_ NoInhibit_Inhibit 1 "Inhibit" 0 "NoInhibit";
+VAL_TABLE_ PersRecallSrc_D_Actl 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "MemorySwitch" 3 "RemoteStart" 2 "KeyFob" 1 "CenterStack" 0 "Null";
+VAL_TABLE_ BattTracChiller_D_Stat 3 "NotUsed" 2 "ChillerNotAvailable" 1 "ChillerBrieflyAvailable" 0 "ChillerAvailable";
+VAL_TABLE_ SelDrvMdeChassis2_D_Rq 31 "Faulty" 30 "NotUsed17" 29 "NotUsed16" 28 "NotUsed15" 27 "NotUsed14" 26 "NotUsed13" 25 "NotUsed12" 24 "NotUsed11" 23 "NotUsed10" 22 "NotUsed9" 21 "NotUsed8" 20 "NotUsed7" 19 "NotUsed6" 18 "NotUsed5" 17 "NotUsed4" 16 "NotUsed3" 15 "NotUsed2" 14 "RoughRoadMode" 13 "TrackMode" 12 "HighSpeedDesertMode" 11 "TowHaulMode" 10 "RockCrawlMode" 9 "SandMode" 8 "MudAndRutsMode" 7 "LowMuMode" 6 "ComfortAdaptiveMode" 5 "ComfortMode" 4 "SportAdaptiveMode" 3 "SportMode" 2 "EconomyMode" 1 "NormalAdaptiveMode" 0 "NormalMode";
+VAL_TABLE_ TrnFaltOpenClu_B_Stat 1 "MayOpenClutch" 0 "Normal";
+VAL_TABLE_ UrbanAreaDetct_D_Stat 3 "NotUsed_1" 2 "City" 1 "Subdivision" 0 "None";
+VAL_TABLE_ Closed_Open 1 "Open" 0 "Closed";
+VAL_TABLE_ AdbBrdrDist 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_TABLE_ TCU_ESN_D_Rq 3 "NotUsed" 2 "TCU_ESN_Request" 1 "NoRequest" 0 "Inactive";
+VAL_TABLE_ FactoryReset_Rq 1 "ResetFactoryDefaults" 0 "Inactive";
+VAL_TABLE_ TCU_Init_Actvtn_St 3 "NotUsed" 2 "InitialActivateDeny" 1 "InitialActivateAccept" 0 "Invalid";
+VAL_TABLE_ TCU_Final_Actvtn_St 3 "NotUsed" 2 "FinalActivateDeny" 1 "FinalActivateAccept" 0 "Invalid";
+VAL_TABLE_ WaitToStartLamp_D_Falt 3 "NotUsed" 2 "Wait_to_start_lamp_failed" 1 "Diagnosis_not_ready" 0 "Wait_to_start_lamp_OK";
+VAL_TABLE_ BattTracCoolLvl_D_Rq 7 "Faulty" 6 "NotUsed" 5 "ChillerCoolingBattFirst" 4 "ChillerCoolingCabinFirst" 3 "ForcedCoolingRadiator" 2 "OpportunisticCoolingRad" 1 "CoolantFlowBypassLine" 0 "Off";
+VAL_TABLE_ BattClntVlvOvrrd_D_Rq 3 "NotUsed" 2 "OverrideTbcvToChiller" 1 "OverrideTbcvToRadiator" 0 "NoOverrideToTbcvCLogic";
+VAL_TABLE_ NonMagnetic_Magnetic 1 "Magnetic" 0 "NonMagnetic";
+VAL_TABLE_ RideHghtMde_D_Stat 15 "Faulty" 14 "NotUsed_5" 13 "NotUsed_4" 12 "NotUsed_3" 11 "NotUsed_2" 10 "NotUsed_1" 9 "AdjUpAero" 8 "AdjUpOffRoad" 7 "AdjUpNormal" 6 "AdjDownKneel" 5 "AdjDownAero" 4 "AdjDownNormal" 3 "OffRoad" 2 "Kneel" 1 "Aero" 0 "Normal";
+VAL_TABLE_ AutoTowAllw_D_StatMnu 3 "TowHaulCommandedOn" 2 "AutoTowHaulEnabled" 1 "AutoTowHaulDisabled" 0 "NoSelection";
+VAL_TABLE_ SrpEventRight_D_Stat 3 "Faulty" 2 "Bump" 1 "Pothole" 0 "NoEvent";
+VAL_TABLE_ RearDiff_D_Stat 15 "NotUsed_7" 14 "NotUsed_6" 13 "NotUsed_5" 12 "NotUsed_4" 11 "NotUsed_3" 10 "NotUsed_2" 9 "NotUsed_1" 8 "TorqueReqNotHonored" 7 "MissingSignal" 6 "ModuleFault" 5 "HydroTempSensorFault" 4 "ClutchPressSensorFault" 3 "AccumPressSensorFault" 2 "ControlValveFault" 1 "MotorFault" 0 "Normal";
+VAL_TABLE_ NotAllowed_Allowed 1 "Allowed" 0 "NotAllowed";
+VAL_TABLE_ EngTrlrCnnct_D_Stat 3 "NotUsed_1" 2 "UnverifiedTrailer" 1 "HeavyTrailer" 0 "NoTrailer";
+VAL_TABLE_ Faulty_FFFF 65535 "Faulty";
+VAL_TABLE_ NoData_Faulty_3FFE_3FFF 16383 "Faulty" 16382 "NoDataExists";
+VAL_TABLE_ Faulty_3FFF 16383 "Faulty";
+VAL_TABLE_ NotExceeded_Exceeded 1 "Exceeded" 0 "NotExceeded";
+VAL_TABLE_ EmgcyCall_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "ManualEmergencyCall" 3 "AutoEmergencyCall" 2 "NoEvent" 1 "EmergencyCallNotSupported" 0 "Null";
+VAL_TABLE_ NotAsserted_Asserted 1 "Asserted" 0 "NotAsserted";
+VAL_TABLE_ AirSprngRate_D_Stat 3 "Faulty" 2 "Firm" 1 "Medium" 0 "Soft";
+VAL_TABLE_ AirSprngRate_D_Rq 3 "NoRequest" 2 "Firm" 1 "Medium" 0 "Soft";
+VAL_TABLE_ GearLvr_D_ActlDrv 15 "Fault" 14 "Unknown_Position" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Range6" 10 "Range5" 9 "Range4" 8 "Range3_M3_L3" 7 "Range2_M2_L2" 6 "Range1_M1_L1" 5 "Low" 4 "Sport_DriveSport_Mposition" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_TABLE_ ChrgrInPwMde_D_Actl 15 "NotUsed_9" 14 "NotUsed_8" 13 "NotUsed_7" 12 "NotUsed_6" 11 "NotUsed_5" 10 "NotUsed_4" 9 "NotUsed_3" 8 "EvseFault" 7 "EvseNotCompatible" 6 "IcCharging" 5 "DcCharging" 4 "AcDigital" 3 "AcBasic" 2 "DigitalCommDetected" 1 "EvsePaused" 0 "EvseNotDetected";
+VAL_TABLE_ ChrgCordLck_D_Stat 7 "Faulty" 6 "LockFail" 5 "UnlockFail" 4 "LockInProgress" 3 "UnlockInProgress" 2 "Lock" 1 "Unlock" 0 "Retain";
+VAL_TABLE_ LkaActvStats_D2_Req 7 "NotUsed" 6 "LkaIncrIntervRight" 5 "LkaSupprRight" 4 "LkaStandIntervRight" 3 "LkaSupprLeft" 2 "LkaStandIntervLeft" 1 "LkaIncrIntervLeft" 0 "LkaNoInterv";
+VAL_TABLE_ OffOnNoDataFaulty 3 "Faulty" 2 "No_Data_Exists" 1 "On" 0 "Off";
+VAL_TABLE_ NoMessage_Msg1_3 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ TrnRng_D_RqGsm 15 "Fault" 14 "UnknownPosition" 13 "Undefined_2" 12 "Undefined_1" 11 "_6" 10 "_5" 9 "_4" 8 "_3" 7 "_2" 6 "_1" 5 "Low" 4 "Sport" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_TABLE_ PrkBrkActv_D_RqGsmGear 3 "NotUsed" 2 "RequestParkBrakeEngage" 1 "NoRequest" 0 "Null";
+VAL_TABLE_ TrnPrkSys_D_Actl 15 "Faulty" 14 "NotUsed_5" 13 "NotUsed_4" 12 "NotUsed_3" 11 "NotUsed_2" 10 "NotUsed_1" 9 "FrequencyError" 8 "OutOfRangeHigh" 7 "OutOfRangeLow" 6 "Override" 5 "OutOfPark" 4 "TransitionCloseToOutOfPark" 3 "AtNoSpring" 2 "TransitionCloseToPark" 1 "Park" 0 "NotKnown";
+VAL_TABLE_ OKLowUnknownInvalid 3 "Invalid" 2 "Unknown" 1 "Low" 0 "OK";
+VAL_TABLE_ Dsp_RotAddrBtnEv_St 15 "NotUsed_1" 14 "Pos_7Steps" 13 "Pos_6Steps" 12 "Pos_5Steps" 11 "Pos_4Steps" 10 "Pos_3Steps" 9 "Pos_2Steps" 8 "Pos_1Step" 7 "NotPressed" 6 "Neg_1Steps" 5 "Neg_2Steps" 4 "Neg_3Steps" 3 "Neg_4Steps" 2 "Neg_5Steps" 1 "Neg_6Steps" 0 "Neg_7Steps";
+VAL_TABLE_ PrkAidDrvDir_D_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "BackwardNegative" 4 "ForwardNegative" 3 "BackwardPositive" 2 "ForwardPositive" 1 "NoMotion" 0 "DirectionNotKnown";
+VAL_TABLE_ EngExhMdeQuiet_D2_Stat 7 "Faulty" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Track" 3 "Sport" 2 "Normal" 1 "Stealth" 0 "Null";
+VAL_TABLE_ GasPrtc_D_RqDsply 7 "NotUsed_5" 6 "NotUsed_4" 5 "NotUsed_3" 4 "NotUsed_2" 3 "NotUsed_1" 2 "GpfOverLimit" 1 "GpfAtLimit" 0 "NormalOperation";
+VAL_TABLE_ TjaWarn_D_Rq 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "HardTakeOverLevel2" 2 "HardTakeOverLevel1" 1 "TrafficJamAssistCancel" 0 "NoWarning";
+VAL_TABLE_ Faulty_7FF 2047 "Faulty";
+VAL_TABLE_ Tja_D_Stat 7 "NotUsed_1" 6 "ActiveWarningRight" 5 "ActiveWarningLeft" 4 "ActiveInterventionRight" 3 "ActiveInterventionLeft" 2 "Active" 1 "Standby" 0 "Off";
+VAL_TABLE_ TjaMsgTxt_D_Dsply 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "TurnOnAdaptCruiseControl" 2 "TrafficJamAssistSelected" 1 "TrafficJamAssistUnavailabl" 0 "NoMessage";
+VAL_TABLE_ PwSrcULowMde_D_Actl 3 "NotUsed_1" 2 "ReverseBoost" 1 "ForwardBuck" 0 "Standby";
+VAL_TABLE_ ApaTrgtDist_D_Stat 15 "Step15" 14 "Step14" 13 "Step13" 12 "Step12" 11 "Step11" 10 "Step10" 9 "Step9" 8 "Step8" 7 "Step7" 6 "Step6" 5 "Step5" 4 "Step4" 3 "Step3" 2 "Step2" 1 "Step1" 0 "Off";
+VAL_TABLE_ Memory_2_SwPsngr_Stat 1 "Pressed" 0 "Null";
+VAL_TABLE_ Pers3Key_D_Stat 3 "NotUsed_1" 2 "KeyUnAssociated" 1 "KeyAssociated" 0 "Null";
+VAL_TABLE_ PwSrcULoMde_D_Rq 3 "NotUsed_1" 2 "ReverseBoost" 1 "ForwardBuck" 0 "Standby";
+VAL_TABLE_ AccMsgTxt_D2_Rq 15 "NotUsed_1" 14 "NCC_Enabled_Warning" 13 "IACC_TJA_Selected" 12 "ACC_TJA_Selected" 11 "IACC_Selected" 10 "Press_Brake_To_Hold" 9 "Only_Following_In_Low_Spd" 8 "TJA_Unavailable" 7 "Shift_Down" 6 "IACC_Unavailable" 5 "ACC_Selected" 4 "ACC_Overridden" 3 "Brake_Capacity_Warning" 2 "ACC_Cancelled" 1 "ACC_Unavailable" 0 "No_Text";
+VAL_TABLE_ WakeAlarm0_B_Typ 1 "CanAndEcuDriveCircuit" 0 "CanOnly";
+VAL_TABLE_ WakeAlarm0_D_Stat 3 "PublisherReset" 2 "Wake" 1 "AlarmRunning" 0 "AlarmOff";
+VAL_TABLE_ EmPrflNo_D_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Pers4" 3 "Pers3" 2 "Pers2" 1 "Pers1" 0 "Null";
+VAL_TABLE_ EmPrflKeyAssoc_D_Rq 7 "NotUsed_3" 6 "DisassociatePhone" 5 "EnterPhoneAssociation" 4 "OverwriteKey" 3 "DisassociateKey" 2 "ExitKeyAssociation" 1 "EnterKeyAssociation" 0 "Null";
+VAL_TABLE_ Em_D_Stat 3 "NotSupported" 2 "ProfilesOff" 1 "ProfilesOn" 0 "Null";
+VAL_TABLE_ EmPrflButtnAssoc_D_Rq 3 "NotUsed" 2 "ExitButtonAssociation" 1 "EnterButtonAssociation" 0 "Null";
+VAL_TABLE_ EmPrflNo_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Pers4" 3 "Pers3" 2 "Pers2" 1 "Pers1" 0 "Null";
+VAL_TABLE_ EmPrflKeyAssoc_D_Stat 7 "WrongDevice" 6 "KeyAssociateFailed" 5 "KeyAssociateSuccess" 4 "KeyAlreadyInUse" 3 "KeyDisassociated" 2 "KeyAssociationExited" 1 "KeyAssociationEntered" 0 "Null";
+VAL_TABLE_ EsaEnbl_D2_Rq 3 "NotConfigured" 2 "Enabled" 1 "Pending" 0 "Disabled";
+VAL_TABLE_ PersNo_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "NotDetermined" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_TABLE_ WiprFront_D_Stat2 15 "NO_DATA_EXISTS" 14 "STALLED" 13 "NotUsed" 12 "AUTO_ADJUST" 11 "COURTESYWIPE" 10 "AUTO_HIGH" 9 "AUTO_LOW" 8 "WASH" 7 "MIST_FLICK" 6 "MAN_HIGH" 5 "MAN_LOW" 4 "MAN_INT_ON" 3 "MAN_INT_OFF" 2 "OFF_MOVING" 1 "AUTO_OFF" 0 "OFF";
+VAL_TABLE_ TurnLghtSwtch_D_Stat2 3 "NotUsed" 2 "Right" 1 "Left" 0 "Off";
+VAL_TABLE_ CcButtnOnOffCnclPress3 1 "Pressed" 0 "Not pressed";
+VAL_TABLE_ SelDrvMdePos01_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_TABLE_ SelDrvMdePos01_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_TABLE_ ImmedFastMediumSlow 3 "Slow" 2 "Medium" 1 "Fast" 0 "Immediately";
+VAL_TABLE_ AdbHiBeamKeepOff_D_Rq 3 "KeepBothOff" 2 "KeepLeftOff" 1 "KeepRightOff" 0 "BothFreeRunning";
+VAL_TABLE_ AdbLampOnOff_D_Rq 3 "BothOn" 2 "LeftOnRightOff" 1 "RightOnLeftOff" 0 "BothOff";
+VAL_TABLE_ AdbMde1_D_Rq 3 "MarkerLightFlashing" 2 "MarkerLightConstant" 1 "Spot" 0 "None";
+VAL_TABLE_ Closed_Open_Active_Denied 3 "Denied" 2 "Active" 1 "Open" 0 "Closed";
+VAL_TABLE_ OffLowMedMax 3 "Maximum" 2 "Medium" 1 "Low" 0 "Off";
+VAL_TABLE_ IaccLamp_D_Rq 3 "NotUsed_2" 2 "NotUsed_1" 1 "DisplayIaccIcon" 0 "DoNotDisplayIaccIcon";
+VAL_TABLE_ Low_High_Confidence 1 "High_Confidence" 0 "Low_Confidence";
+VAL_TABLE_ Fault_Occupied_Empty_Un 3 "Unknown" 2 "Empty" 1 "Occupied" 0 "Fault";
+VAL_TABLE_ Off_On_Flash_Triggered 3 "Triggered" 2 "Flash" 1 "On" 0 "Off";
+VAL_TABLE_ IaccVLim_D_Rq 252 "NotUsed_2" 250 "LimitSpeed_250" 240 "LimitSpeed_240" 230 "LimitSpeed_230" 220 "LimitSpeed_220" 210 "LimitSpeed_210" 200 "LimitSpeed_200" 190 "LimitSpeed_190" 150 "LimitSpeed_150" 140 "LimitSpeed_140" 130 "LimitSpeed_130" 120 "LimitSpeed_120" 110 "LimitSpeed_110" 100 "LimitSpeed_100" 90 "LimitSpeed_90" 80 "LimitSpeed_80" 70 "LimitSpeed_70" 60 "LimitSpeed_60" 50 "LimitSpeed_50" 40 "LimitSpeed_40" 30 "LimitSpeed_30" 20 "LimtSpeed_20" 251 "NotUsed_1" 255 "Faulty" 254 "NoDataExists" 253 "NotUsed_3" 180 "LimitSpeed_180" 179 "LimitSpeed_179" 178 "LimitSpeed_178" 177 "LimitSpeed_177" 176 "LimitSpeed_176" 175 "LimitSpeed_175" 174 "LimitSpeed_174" 173 "LimitSpeed_173" 172 "LimitSpeed_172" 171 "LimitSpeed_171" 170 "LimitSpeed_170" 169 "LimitSpeed_169" 168 "LimitSpeed_168" 167 "LimitSpeed_167" 166 "LimitSpeed_166" 165 "LimitSpeed_165" 164 "LimitSpeed_164" 163 "LimitSpeed_163" 162 "LimitSpeed_162" 161 "LimitSpeed_161" 160 "LimitSpeed_160" 15 "LimitSpeed_15" 14 "LimitSpeed_14" 13 "LimitSpeed_13" 12 "LimitSpeed_12" 11 "LimitSpeed_11" 10 "LimitSpeed_10" 9 "LimitSpeed_9" 8 "LimitSpeed_8" 7 "LimitSpeed_7" 6 "LimitSpeed_6" 5 "LimitSpeed_5" 4 "LimitSpeed_4" 3 "LimitSpeed_3" 2 "LimitSpeed_2" 1 "LimitSpeed_1" 0 "LimitSpeed_0";
+VAL_TABLE_ IaccVLimUnit_D_Rq 3 "NoDataExists" 2 "Mph" 1 "Kph" 0 "Null";
+VAL_TABLE_ SelDrvMdeAwd_D_Rq 31 "Faulty" 30 "NotUsed_17" 29 "NotUsed_16" 28 "NotUsed_15" 27 "NotUsed_14" 26 "NotUsed_13" 25 "NotUsed_12" 24 "NotUsed_11" 23 "NotUsed_10" 22 "NotUsed_9" 21 "NotUsed_8" 20 "NotUsed_7" 19 "NotUsed_6" 18 "NotUsed_5" 17 "EvLaterChargeMode" 16 "EvNowMode" 15 "TrackMode" 14 "RoughRoadMode" 13 "NotAvailable" 12 "HighSpeedDesertMode_Baja" 11 "SportAdaptiveMode" 10 "RockCrawlMode" 9 "MudRutsMode" 8 "SandMode" 7 "EconomyMode" 6 "GrassGravelSnow" 5 "TowHaulMode" 4 "SportMode" 3 "Normal_4L" 2 "Normal_4A" 1 "Normal_2H" 0 "NormalMode";
+VAL_TABLE_ SelDrvMdeAwd_D_Stat 0 "NotAvailable" 1 "Available" 2 "TemporarilyNotAvailable" 3 "Faulty";
+VAL_TABLE_ SelDrvMdeAwd2_D_Stat 31 "Faulty" 30 "NotUsed_17" 29 "NotUsed_16" 28 "NotUsed_15" 27 "NotUsed_14" 26 "NotUsed_13" 25 "NotUsed_12" 24 "NotUsed_11" 23 "NotUsed_10" 22 "NotUsed_9" 21 "NotUsed_8" 20 "NotUsed_7" 19 "NotUsed_6" 18 "NotUsed_5" 17 "EvLaterChargeMode" 16 "EvNowMode" 15 "TrackMode" 14 "RoughRoadMode" 13 "NotAvailable" 12 "HighSpeedDesertMode_Baja" 11 "SportAdaptiveMode" 10 "RockCrawlMode" 9 "MudRutsMode" 8 "SandMode" 7 "EconomyMode" 6 "GrassGravelSnow" 5 "TowHaulMode" 4 "SportMode" 3 "Normal_4L" 2 "Normal_4A" 1 "Normal_2H" 0 "NormalMode";
+VAL_TABLE_ RearDiffLckMsg2_D_Rq 15 "NotUsed_3" 14 "NotUsed_2" 13 "NotUsed_1" 12 "ElsdReduced" 11 "LockingFeatureNotAvailable" 10 "EsldOff" 9 "ElsdRestored" 8 "ElsdOverheated" 7 "Locker_Disabled" 6 "Locker_Enabled" 5 "LockerSpeed5" 4 "LockerSpeed4" 3 "LockerSpeed3" 2 "LockerSpeed2" 1 "LockerSpeed1" 0 "NormalNoMessage ";
+VAL_TABLE_ Counts_ZeroToSeven 4 "FourCounts" 3 "ThreeCounts" 2 "TwoCounts" 1 "OneCount" 0 "ZeroCounts" 7 "SevenOrMoreCounts" 6 "SixCounts" 5 "FiveCounts";
+VAL_TABLE_ HeadLghtHiPrmsn_D_Stat 3 "CancelAndSuppress" 2 "Cancel" 1 "Hold" 0 "AllowChange";
+VAL_TABLE_ SelDrvMdeSwtch 3 "Faulty" 2 "SwitchState2" 1 "SwitchState1" 0 "NotPressed";
+VAL_TABLE_ NotAvail_Temp_Faulty 3 "Faulty" 2 "TemporarilyNotAvailable" 1 "Available" 0 "NotAvailable";
+VAL_TABLE_ AwdDrvMde 7 "Faulty" 6 "NotAvailable" 5 "RockCrawl" 4 "Baja" 3 "MudAndSand" 2 "Weather" 1 "Sport" 0 "Normal";
+VAL_TABLE_ SelDrvMdePt_D_Rq 31 "Faulty" 30 "NotUsed15" 29 "NotUsed14" 28 "NotUsed13" 27 "NotUsed12" 26 "NotUsed11" 25 "NotUsed10" 24 "NotUsed9" 23 "NotUsed8" 22 "NotUsed7" 21 "NotUsed6" 20 "NotUsed5" 19 "NotUsed4" 18 "EvLaterChargerMode" 17 "EvNowMode" 16 "DragMode" 15 "HighSpeedDesertMode_Baja" 14 "SportAdaptiveMode" 13 "NotAvailable_13" 12 "NotAvailable_12" 11 "NotAvailable_11" 10 "NotAvailable_10" 9 "RockCrawlMode" 8 "MudRutsMode" 7 "SandMode" 6 "EconomyMode" 5 "GrassGravelSnow" 4 "NotAvailable_04" 3 "TowHaulMode" 2 "NotAvailable_02" 1 "SportMode" 0 "NormalMode";
+VAL_TABLE_ SelDrvMde_D_Stat 3 "NotUsed" 2 "DriveModeChangeRequest" 1 "DriveModeChangeSelection" 0 "NoDriveModeChangeRequest";
+VAL_TABLE_ NoMessage_Msg1_15 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ SelDrvMdeChassis_D_Rq 31 "Faulty" 30 "NotUsed17" 29 "NotUsed16" 28 "NotUsed15" 27 "NotUsed14" 26 "NotUsed13" 25 "NotUsed12" 24 "NotUsed11" 23 "NotUsed10" 22 "NotUsed9" 21 "NotUsed8" 20 "NotUsed7" 19 "NotUsed6" 18 "NotUsed5" 17 "NotUsed4" 16 "NotUsed3" 15 "NotUsed2" 14 "NotUsed1" 13 "TrackMode" 12 "HighSpeedDesertMode" 11 "TowHaulMode" 10 "RockCrawlMode" 9 "SandMode" 8 "MudAndRutsMode" 7 "LowMuMode" 6 "ComfortAdaptiveMode" 5 "ComfortMode" 4 "SportAdaptiveMode" 3 "SportMode" 2 "EconomyMode" 1 "NormalAdaptiveMode" 0 "NormalMode";
+VAL_TABLE_ NotAvailable_Available 1 "Available" 0 "NotAvailable";
+VAL_TABLE_ PwStep_D_Stat 3 "PositionNotKnown" 2 "StepsNotStowed" 1 "StepsStowed" 0 "Off";
+VAL_TABLE_ PwStep_D_DrvInhbt 3 "NotUsed" 2 "DriveInhibitMalfunction" 1 "DriveInhibited" 0 "DriveNotInhibited";
+VAL_TABLE_ NoMessage_Msg1_31 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ VehTrvlDir_D_Stat 7 "Faulty" 6 "NoDataExists" 5 "NotUsed2" 4 "NotUsed1" 3 "Reverse" 2 "LikelyReverse" 1 "Forward" 0 "LikelyForward";
+VAL_TABLE_ TrnRng_D_RqFap 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Backwards" 3 "Forwards" 2 "NoMotion" 1 "Immobilize" 0 "NoRequest";
+VAL_TABLE_ SelDrvMdeSusp_D_Stat 3 "Faulty" 2 "TemporarilyNotAvailable" 1 "Available" 0 "NotAvailable";
+VAL_TABLE_ OffOnNoReqFaulty 3 "Faulty" 2 "NoRequest" 1 "On" 0 "Off";
+VAL_TABLE_ LatCtl_D_Rq 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "InterventionRight" 2 "InterventionLeft" 1 "ContinuousPathFollowing" 0 "NoLateralControl";
+VAL_TABLE_ LatCtlSte_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Denied" 3 "RampOut" 2 "ContLatControlInProgress" 1 "Available" 0 "Unavailable";
+VAL_TABLE_ SlowMedFastImmed 3 "Immediately" 2 "Fast" 1 "Medium" 0 "Slow";
+VAL_TABLE_ ComfortablePreciseNotUsed 3 "NotUsed2" 2 "NotUsed1" 1 "Precise" 0 "Comfortable";
+VAL_TABLE_ LatCtlLim_D_Stat 3 "LimitWithDriverActive" 2 "LimitReached" 1 "LimitClose" 0 "LimitNotReached";
+VAL_TABLE_ FuelLvlWarn_D_ActlEng 7 "DteLevel5Lowest" 6 "DteLevel4" 5 "DteLevel3" 4 "DteLevel2NonMyKey" 3 "DteLevel1MyKey" 2 "VeryLow" 1 "Low" 0 "OK";
+VAL_TABLE_ AwdMde_D_RqDrv 7 "Faulty" 6 "NotUsed2" 5 "NoRequest" 4 "Neutral" 3 "FourByFourLow" 2 "FourByFourHigh" 1 "FourByFourAuto" 0 "FourByTwo";
+VAL_TABLE_ ApaBrk_D_Stat 3 "Denied" 2 "Active" 1 "Open" 0 "Closed";
+VAL_TABLE_ AdptDrvMdePt_D_Rq 7 "Faulty" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "Powertrain2Sport" 2 "Powertrain2Normal" 1 "Powertrain2Comfort" 0 "AdaptiveNotActive";
+VAL_TABLE_ AdptDrvMdeChassis_D_Rq 7 "Faulty" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "Chassis2Sport" 2 "Chassis2Normal" 1 "Chassis2Comfort" 0 "AdaptiveNotActive";
+VAL_TABLE_ PwStepMsgTxt_D_Rq 1 "DriveInhibited" 0 "NoMessage" 3 "NotUsed" 2 "Malfunction";
+VAL_TABLE_ OffLowMedHigh 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_TABLE_ NotDeterminedLowMedHigh 3 "High" 2 "Medium" 1 "Low" 0 "NotDetermined";
+VAL_TABLE_ CmbbObjClass_D_Stat 15 "NotUsed_9" 14 "NotUsed_8" 13 "NotUsed_7" 12 "NotUsed_6" 11 "NotUsed_5" 10 "NotUsed_4" 9 "NotUsed_3" 8 "NotUsed_2" 7 "NotUsed_1" 6 "Unclassified_Vehicle" 5 "Bicycle" 4 "Pedestrian" 3 "Truck" 2 "Motorcycle" 1 "Vehicle" 0 "Undetermined";
+VAL_TABLE_ HeadLghtHiCtrl_D_RqAhb 7 "NotUsed2" 6 "NotUsed1" 5 "Auto_HiBeam" 4 "Auto_LoBeam" 3 "Flash" 2 "Man_HiBeam" 1 "Man_LoBeam" 0 "Null";
+VAL_TABLE_ AhbHiBeam_D_Rq 3 "NotUsed" 2 "HighBeamRecommended" 1 "LowBeamRecommended" 0 "DeactivatedUnavailable";
+VAL_TABLE_ AhbStatGfhbFdbk_D_Actl 3 "GfhbHighBeamFullyOn" 2 "GfhbHighBeamPartlyOn" 1 "GfhbHighBeamOff" 0 "GfhbUnavailable";
+VAL_TABLE_ AhbcRampingV_D_Rq 3 "Slow" 2 "Medium" 1 "Fast" 0 "Immediately";
+VAL_TABLE_ ApaGearShif_D_RqDrv 7 "NotUSed2" 6 "NotUsed1" 5 "ShiftToP" 4 "ShiftToN" 3 "ShiftToD" 2 "ShiftToR" 1 "NoRequest" 0 "Null";
+VAL_TABLE_ ApaLongCtl_D_RqDrv 7 "NotUsed3" 6 "NotUsed2" 5 "ReleaseBrake" 4 "DriveBackward" 3 "DriveForward" 2 "Stop" 1 "NoRequest" 0 "Null";
+VAL_TABLE_ ApaActvSide2_D_Stat 3 "NoSide" 2 "Right" 1 "Left" 0 "Null";
+VAL_TABLE_ ApaScan_D_Stat 3 "ParkSlotReady" 2 "ParkSlotFound" 1 "NoParkSlot" 0 "Null";
+VAL_TABLE_ ApaSelSapp_D_Stat 3 "NotConfigured" 2 "NotSelectable" 1 "Selectable" 0 "Null";
+VAL_TABLE_ ApaSys_D_Stat 7 "Faulty" 6 "Finished" 5 "NotAccessible" 4 "ApaCancelled" 3 "Overspeed" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ ApaSteScanMde_D_Stat 3 "Steering" 2 "Scanning" 1 "NotScanning" 0 "Null";
+VAL_TABLE_ ApaAcsy_D_RqDrv 7 "CloseDoor" 6 "SelectSideRight" 5 "SelectSideLeft" 4 "CheckForObject" 3 "PressApaButton" 2 "SelectSide" 1 "NoRequest" 0 "Null";
+VAL_TABLE_ ApaSteWhl_D_RqDrv 3 "TakeControl" 2 "RemoveHands" 1 "NoRequest" 0 "Null";
+VAL_TABLE_ WiprFrontSwtch_D_Stat 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "PositionNotDetermined" 8 "High" 7 "Low" 6 "Position6" 5 "Position5" 4 "Position4" 3 "Position3" 2 "Position2" 1 "Position1" 0 "Off";
+VAL_TABLE_ Off_On_Unknown_Invalid 3 "Invalid" 2 "Unknown" 1 "On" 0 "Off";
+VAL_TABLE_ Unknown_7FFE_Invalid_7FFF 32767 "Invalid" 32766 "Unknown";
+VAL_TABLE_ OffOnNotUsedFaulty 3 "Faulty" 2 "NotUsed" 1 "On" 0 "Off";
+VAL_TABLE_ BrkBstrVac_D_Stat 3 "NotUsed" 2 "BoosterVacEstimator" 1 "BoosterVacSensor" 0 "NoBoosterVacuumMonitor";
+VAL_TABLE_ AwdMde_D_RqArb 7 "Faulty" 6 "NotUsed2" 5 "NoRequest" 4 "Neutral" 3 "FourByFourLow" 2 "FourByFourHigh" 1 "FourByFourAuto" 0 "FourByTwo";
+VAL_TABLE_ CtaAlrt2_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "AlertZone4" 3 "AlertZone3" 2 "AlertZone2" 1 "AlertZone1" 0 "Off";
+VAL_TABLE_ BttRightLeft_D_Stat 7 "NotUsed" 6 "Disabled" 5 "Off" 4 "OffTemp" 3 "NotConnected" 2 "Pending" 1 "Connected" 0 "NotDetermined";
+VAL_TABLE_ Null_NoRequest_Request 3 "NotUsed" 2 "Request" 1 "NoRequest" 0 "Null";
+VAL_TABLE_ PoliceIdlMde_D_Stat 15 "NotUsed_7" 14 "NotUsed_6" 13 "NotUsed_5" 12 "NotUsed_4" 11 "NotUsed_3" 10 "NotUsed_2" 9 "PepsActive" 8 "Decommissioned" 7 "ActiveFault" 6 "ArmFault" 5 "PrearmedFault" 4 "OffFault" 3 "Active" 2 "Arm" 1 "Prearmed" 0 "Off";
+VAL_TABLE_ TripComputerMetricImperial 0 "TripComputer_metric" 1 "TripComputer_imperial";
+VAL_TABLE_ GrdAsstAllw_D_DsplyPt 3 "NotUsed" 2 "On" 1 "Off" 0 "NoModeSelected";
+VAL_TABLE_ PrkBrkMsgTxt_D_Rq 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "No_Message";
+VAL_TABLE_ AutoHoldMsgTxt_D_Rq 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ AutoHoldMde_D_Ind 3 "Indication_3" 2 "Indication_2" 1 "Indication_1" 0 "Off";
+VAL_TABLE_ AutoRgenTxt_B_RqDsply 1 "AutExhFilterCleanOFF" 0 "AutExhFilterCleanON";
+VAL_TABLE_ TrnMsgTxt2_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "TransTooHot_LoudChime" 3 "PressBrake_LoudChime" 2 "PressBrake_SoftChime" 1 "PressBrake_NoChime" 0 "NoText_NoChime";
+VAL_TABLE_ TrnGearMsgTxt_D_Rq 15 "Message_15" 14 "Message_14" 13 "Message_13" 12 "Message_12" 11 "Message_11" 10 "Message_10" 9 "Message_9" 8 "Message_8" 7 "Message_7" 6 "Message_6" 5 "Message_5" 4 "Message_4" 3 "Message_3" 2 "Message_2" 1 "Message_1" 0 "NoMessage";
+VAL_TABLE_ ChargeProfIDPref_Rq 3 "NotUsed" 2 "Value" 1 "ChargeNow" 0 "Inactive";
+VAL_TABLE_ EngExhMdeQuiet_D_Stat 3 "Faulty" 2 "QuietExhaust" 1 "LoudExhaust" 0 "Null";
+VAL_TABLE_ ConsAvgTrip_No_Dsply 4095 "Faulty" 4094 "No_Data_Exists";
+VAL_TABLE_ ElTrip_L_Dsply 65535 "Fault" 65534 "No_Data_Exists";
+VAL_TABLE_ ElLongTerm_L_Dsply 16777215 "Fault" 16777214 "No_Data_Exists";
+VAL_TABLE_ GearSelLck_D_Rq 3 "PreventionBlocker" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_TABLE_ BrkPadMsgTxt_D_Rq 3 "Faulty" 2 "PadsOk" 1 "ReplacePads" 0 "Null";
+VAL_TABLE_ BrkAutoHold_D_Stat 7 "Faulty" 6 "NotUsed" 5 "Releasing" 4 "HeldSecondary" 3 "HeldSecure" 2 "Held" 1 "Inactive" 0 "Off";
+VAL_TABLE_ SuspDrvMde_D_Rq 7 "Faulty" 6 "NotUsed2" 5 "NotUsed1" 4 "Drag" 3 "Track" 2 "Snow_Wet" 1 "Sport" 0 "Normal";
+VAL_TABLE_ NotPressed_PressedNotUsed 3 "NotUsed2" 2 "NotUsed1" 1 "Pressed" 0 "Not_Pressed";
+VAL_TABLE_ WhlRearDual_D_Stat 3 "NotUsed" 2 "Dual" 1 "Single" 0 "NoDataExists";
+VAL_TABLE_ TracKeyMde_D_Stat 3 "NotUsed" 2 "NotActive" 1 "Active" 0 "ModeNotDetermined";
+VAL_TABLE_ HudMde_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Manual" 3 "Drag" 2 "RoadCourse" 1 "Tach" 0 "Off";
+VAL_TABLE_ TrnManShifGear_D_IndDrv 7 "Indicate_Reverse_Gear" 6 "Indicate_Gear6" 5 "Indicate_Gear5" 4 "Indicate_Gear4" 3 "Indicate_Gear3" 2 "Indicate_Gear2" 1 "Indicate_Gear1" 0 "No_Indication";
+VAL_TABLE_ TrnStrtStop_D_Stat 3 "NotUsed_2" 2 "NotUsed_1" 1 "LowTransmissionTemperature" 0 "NoDriverIndicationRequired";
+VAL_TABLE_ LsmcBrkDecel_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Denied" 3 "FaultDegraded" 2 "FaultExt" 1 "On" 0 "Off";
+VAL_TABLE_ StePinOffst_D_Stat 3 "FineOffset" 2 "CoarseOffset" 1 "StoredOffset" 0 "OffsetNotCalculated";
+VAL_TABLE_ NoMessage_Override_Faulty 3 "NotUsed" 2 "Faulty" 1 "Override" 0 "NoMessage";
+VAL_TABLE_ TrnIpcDsplyRng2_D_Actl 15 "No_Range_Selected" 14 "Range_14" 13 "Range_13" 12 "Range_12" 11 "Range_11" 10 "Range_10" 9 "Range_9" 8 "Range_8" 7 "Range_7" 6 "Range_6" 5 "Range_5" 4 "Range_4" 3 "Range_3" 2 "Range_2" 1 "Range_1" 0 "NotUsed";
+VAL_TABLE_ OffOn_RampUpDown 3 "Ramp_Down" 2 "Ramp_Up" 1 "On" 0 "Off";
+VAL_TABLE_ DieslMsgTxt_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "ReducedEnginePower" 0 "NoMessage";
+VAL_TABLE_ NoMessage_Msg1_7 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ TrnAltShifMde_D_Rdy 3 "Faulty" 2 "NotUsed" 1 "UnavailDueToDynCond" 0 "ModeChangeAvailable";
+VAL_TABLE_ LnchCtl 3 "NotUsed2" 2 "NotUsed1" 1 "LC_On" 0 "LC_Off";
+VAL_TABLE_ BrkLineLck_D_Rq 3 "Off" 2 "Engage" 1 "Initiate" 0 "NoRequest";
+VAL_TABLE_ BrkLineLck_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "NotAvailable" 3 "Off" 2 "Engaged" 1 "Initiated" 0 "Available";
+VAL_TABLE_ LnchCtlSys_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "On_LC_Unavailable_TC_On" 3 "On_LC_Unavailable" 2 "On_LC_Available" 1 "On_LC_Active" 0 "LC_OFF";
+VAL_TABLE_ ActvFrontSteLck_D_Stat 3 "Test_passed" 2 "Test_failed" 1 "Test_cannot_run" 0 "Test_incomplete";
+VAL_TABLE_ Rght_Lefthand_Traffic 1 "Left_Hand_Traffic" 0 "Right_Hand_Traffic";
+VAL_TABLE_ NotPressed_Pressed_Faulty 3 "Faulty" 2 "NotUsed" 1 "Pressed" 0 "Not_Pressed";
+VAL_TABLE_ TrlrTrgtAcquire_D_Rq 7 "NotUsed_2" 6 "NotUsed_1" 5 "ActivateRVCforTBA" 4 "CancelAcquisition" 3 "RetryAcquisition" 2 "AcquisitionSuccessful" 1 "StartAcquisition" 0 "Inactive";
+VAL_TABLE_ TrlrTrgtAcquire_D_Stat 7 "Faulty" 6 "NotUsed_2" 5 "NotUsed_1" 4 "RVCforTBA_Activated" 3 "Processing" 2 "TargetNotAcquired" 1 "TargetAcquired" 0 "Null";
+VAL_TABLE_ TrlrAidSetup_D_Rq 3 "ConfirmSetup" 2 "EndSetup" 1 "BeginSetup" 0 "Inactive";
+VAL_TABLE_ TrlBrkInitOut 3 "Heavy" 2 "Medium" 1 "Light" 0 "Null";
+VAL_TABLE_ IsaOffst_D_Stat 15 "Faulty" 14 "Null" 13 "Thirteen" 12 "Twelve" 11 "Eleven" 10 "Ten" 9 "Nine" 8 "Eight" 7 "Seven" 6 "Six" 5 "Five" 4 "Four" 3 "Three" 2 "Two" 1 "One" 0 "Zero";
+VAL_TABLE_ IsaVLimUnit_D_Rq 3 "NoDataExists" 2 "Mph" 1 "Kph" 0 "Null";
+VAL_TABLE_ ApaChime_D_Rq 7 "NotUsed2" 6 "NotUsed1" 5 "Warning_Chime" 4 "Finish_Chime" 3 "Stop_Now_Chime" 2 "Spot_Ready_Chime" 1 "Spot_Found_Chime" 0 "No_Chime";
+VAL_TABLE_ SlMde_D_RqDsply 3 "NotUsed" 2 "ManualSpeed_LimiterSymbol" 1 "AutoSpeed_LimiterSymbol" 0 "NoSpeed_LimiterSymbol";
+VAL_TABLE_ SlMde_D_Rq 3 "IsaNotConfigured" 2 "Manual_Mode" 1 "Auto_Mode" 0 "Null";
+VAL_TABLE_ NotSupported_Supported 1 "Supported" 0 "NotSupported";
+VAL_TABLE_ OffOn_NotUsed_NoData 3 "No_Data_Present" 2 "NotUsed" 1 "On" 0 "Off";
+VAL_TABLE_ Faulty_FF 255 "Faulty";
+VAL_TABLE_ BrkDrvMde_D_Rq 7 "Faulty" 6 "RockCrawl" 5 "Baja" 4 "DragOrMudAndSand" 3 "Track" 2 "Snow_Wet" 1 "Sport" 0 "Normal";
+VAL_TABLE_ TrnIpcDsplyRng_D_Stat 3 "NotUsed" 2 "Flash" 1 "On" 0 "Blank_No_Display";
+VAL_TABLE_ NoYesNoDataFaulty 3 "Faulty" 2 "NoDataExists" 1 "Yes" 0 "No";
+VAL_TABLE_ SidePrkSnsR4_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_TABLE_ TsrVlPrmntMsgTxt_D_Rq 3 "NotUsed" 2 "ShowPermanentlyWithSupp" 1 "ShowPermanentlyWithoutSupp" 0 "DoNotShowSignPermanent";
+VAL_TABLE_ TsrVl1RstrcMsgTxt2_D_Rq 7 "NotUsed" 6 "Time" 5 "Trailer" 4 "Snow" 3 "RainWet" 2 "NoRecognizableRestrictn" 1 "NoSpeedLimitRestrictn" 0 "Null";
+VAL_TABLE_ PtDrvMde_D_Rq 15 "Faulty" 14 "NotUsed11" 13 "NotUsed10" 12 "NotUsed9" 11 "NotUsed8" 10 "NotUsed7" 9 "NotUsed6" 8 "NotUsed5" 7 "Drag" 6 "Rock" 5 "Baja" 4 "Sand" 3 "TowHaulGradeAssist" 2 "SnowWet" 1 "Sport" 0 "Normal";
+VAL_TABLE_ SteEffort_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "SpecialMode_2" 3 "SpecialMode_1" 2 "Comfort" 1 "Sport" 0 "Normal";
+VAL_TABLE_ TsrOvtkMsgTxt2_D_Rq 15 "NotUsed5" 14 "NotUsed4" 13 "NotUsed3" 12 "NotUsed2" 11 "NotUsed1" 10 "LimForTrucksCancelled" 9 "LimForTrucksWoQlfdRstrc" 8 "LimForTrucksWithoutRstrc" 7 "LimAllCancelled" 6 "LimAllWithRstrcTime" 5 "LimAllWithRstrcTrailer" 4 "LimAllWithRstrcSnow" 3 "LimAllWithRstrcRain" 2 "LimAllWithoutQlfdRstrc" 1 "LimAllWithoutRestriction" 0 "OvertakingAllowed";
+VAL_TABLE_ TrlrAnOffstDir 3 "NotUSed" 2 "Right" 1 "Left_or_Center" 0 "Null";
+VAL_TABLE_ Null_Off_On 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ TrlrBrkMde_D_Rq 1 "ElectricOverHydraulic" 0 "Electric";
+VAL_TABLE_ TrlrAidSetup_D_Stat 7 "Faulty" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "EnterParameters" 2 "EndSetup" 1 "BeginSetup" 0 "Null";
+VAL_TABLE_ TrlrAidMsgTxt_D_Rq 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ Invalid_7F 127 "Invalid";
+VAL_TABLE_ Faulty_1FFF 8191 "Faulty";
+VAL_TABLE_ VehStab_D_Stat 15 "Faulty" 14 "No_Data_Exists" 13 "NotUsed6" 12 "NotUsed5" 11 "NotUsed4" 10 "NotUsed3" 9 "NotUsed2" 8 "NotUsed1" 7 "High_SSRA_no_OS" 6 "Straight" 5 "Post_Oversteer" 4 "Post_Transition" 3 "Countersteer" 2 "Understeer" 1 "Oversteer" 0 "Linear";
+VAL_TABLE_ NoData_Faulty_1FF_1FE 511 "Faulty" 510 "NoDataExists";
+VAL_TABLE_ TrlrAidEnbl_D_Rq 3 "NotAvailable" 2 "DeactivateTba" 1 "ActivateTba" 0 "Inactive";
+VAL_TABLE_ FohEng_D_Rq 3 "AutoEnable_ParkEnable" 2 "AutoDisable_ParkEnable" 1 "AutoEnable_ParkDisable" 0 "Disable_Stop";
+VAL_TABLE_ Null_Hi_NotUsed_Low 3 "Low" 2 "Not_Used" 1 "High" 0 "Null";
+VAL_TABLE_ Current_Color 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "NotUsed3" 10 "NotUsed2" 9 "NotUsed1" 8 "Null" 7 "Color7" 6 "Color6" 5 "Color5" 4 "Color4" 3 "Color3" 2 "Color2" 1 "Color1" 0 "Off";
+VAL_TABLE_ Blended_Color 15 "NotUsed10" 14 "NotUsed9" 13 "NotUsed8" 12 "NotUsed7" 11 "NotUsed6" 10 "NotUsed5" 9 "NotUsed4" 8 "NotUsed3" 7 "NotUsed2" 6 "NotUsed1" 5 "_5" 4 "_4" 3 "_3" 2 "_2" 1 "_1" 0 "Null";
+VAL_TABLE_ OffOn_Null_NotUsed 3 "NotUsed" 2 "Null" 1 "On" 0 "Off";
+VAL_TABLE_ DieslPrtc2_D_RqDsply 15 "NotUsed4" 14 "NotUsed3" 13 "NotUsed2" 12 "NotUsed1" 11 "OCR_ExhFilterClean_Stopped" 10 "OCR_ExhFilterCleaned" 9 "RgnOff_AtLimit" 8 "RgnOff_Overloaded" 7 "RgnOff_Loaded" 6 "Exhaust_Filter_Full" 5 "DPF_Overlimit" 4 "DPF_AtLimit" 3 "ExhFilter_Drive_Completed" 2 "Cleaning_Exhaust_Filter" 1 "DPF_Overloaded" 0 "DPF_Normal_Operation";
+VAL_TABLE_ Null_Pers1_4_Vehicle 7 "Unused_2" 6 "Unused_1" 5 "Vehicle" 4 "PERS_4" 3 "PERS_3" 2 "PERS_2" 1 "PERS_1" 0 "Null";
+VAL_TABLE_ PrkLckCtlEnbl_D_RqIpc 3 "Rq_Towing" 2 "Rq_Enable" 1 "Rq_Disable" 0 "Null";
+VAL_TABLE_ PrkLckCtlUnlck_D_Stat 3 "Trans_And_Steer_Unlckd" 2 "Steering_Unlckd" 1 "Transmission_Unlckd" 0 "Null";
+VAL_TABLE_ VehKeyActv_D_Stat 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "NotUsed3" 10 "NotUsed2" 9 "NotUsed1" 8 "Key8Active" 7 "Key7Active" 6 "Key6Active" 5 "Key5Active" 4 "Key4Active" 3 "Key3Active" 2 "Key2Active" 1 "Key1Active" 0 "NoKeyActive";
+VAL_TABLE_ VehLckInd_D_Rq 3 "NotUsed" 2 "On_Day" 1 "On_Night" 0 "Off";
+VAL_TABLE_ PrkBrkDynmc_D_Allw 3 "NotUsed" 2 "EPB_ECD_NotPossible" 1 "EPB_ECD_Possible" 0 "Used_at_Start_Up";
+VAL_TABLE_ TowBarMsgTxt_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "TowBar_Ext_No_Trlr" 3 "Error_Dealer_Fix" 2 "Start_Engine_Swivel" 1 "Check_Tow_Bar" 0 "Null";
+VAL_TABLE_ PrkBrk_D_Stat 7 "Gen_Faults_or_Maint_Mode" 6 "ECD_by_Brake_ECU_Active" 5 "EPB_Limphome_Active" 4 "Rear_Caliper_Open" 3 "RWU_by_EPB_Active" 2 "Rear_Caliper_Transition" 1 "Rear_Caliper_Closed" 0 "Not_Supported";
+VAL_TABLE_ NoData_Faulty_3E_3F 63 "Faulty" 62 "NoDataExists";
+VAL_TABLE_ Unknown_Invalid_1FE_1FF 511 "Invalid" 510 "Unknown";
+VAL_TABLE_ Invalid_0x0 0 "Invalid";
+VAL_TABLE_ Unknown_Invalid_3E_3F 63 "Invalid" 62 "Unknown";
+VAL_TABLE_ Faulty_1FF 511 "Faulty";
+VAL_TABLE_ NoData_Faulty_1FFF_1FFE 8191 "Faulty" 8190 "NoDataExists";
+VAL_TABLE_ Null_Off_On_Faulty 3 "Faulty" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ EngOilSrvcMsgTxt_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "ResetComplete" 3 "ResetInProgress" 2 "ChangeOilNow" 1 "ChangeOilSoon" 0 "NoText";
+VAL_TABLE_ AirSusp_D_RqDrv 3 "NotUsed" 2 "On" 1 "Off" 0 "NoModeSelected";
+VAL_TABLE_ AwdSys_D_Stat 3 "Faulty" 2 "NotUsed" 1 "_4x4_L_H_Active" 0 "_4x4_L_H_Inactive";
+VAL_TABLE_ EmotiveType_D_Dsply 3 "EmotiveDisplay_3" 2 "EmotiveDisplay_2" 1 "EmotiveDisplay_1" 0 "Null";
+VAL_TABLE_ AutoRgen_D_Rq 3 "NotUsed" 2 "AutExhFilterCleanOFF" 1 "AutExhFilterCleanON" 0 "No_Mode_Selected";
+VAL_TABLE_ TrnSrvcRqd_B_Rq 1 "On" 0 "Off";
+VAL_TABLE_ PlgOvrrdStrt_D_Cmd 3 "NotUsed" 2 "Override_Plug_Status" 1 "Dont_Override_Plug_Status" 0 "Null_State";
+VAL_TABLE_ immoSecureIdleMode 3 "NotUsed2" 2 "NotUsed1" 1 "Active" 0 "Inactive";
+VAL_TABLE_ SteWhlOffstRq_D_Stat 3 "Faulty" 2 "NoDataExists" 1 "Allow_External_Angle_Req" 0 "Deny_External_Angle_Req";
+VAL_TABLE_ SteMdule_D_Stat 7 "NotUsed" 6 "EPAS_Failure3" 5 "EPAS_Failure2" 4 "System_Failure" 3 "EPAS_Shutdown" 2 "Normal_Op_Full_Assist" 1 "Normal_Op_Limited_Assist" 0 "EPAS_Initialization";
+VAL_TABLE_ Faulty_FFF 4095 "Faulty";
+VAL_TABLE_ Faulty_3FF 1023 "Faulty";
+VAL_TABLE_ NoData_Faulty_FE_FF 255 "Faulty" 254 "NoDataExists";
+VAL_TABLE_ ChkPlgtoStrt_D_Dsply 3 "NotUsed" 2 "Is_VehicleUnplugged_Prompt" 1 "Check_Plug_to_Start" 0 "No_Message_Display";
+VAL_TABLE_ PwrFlowTxt_D_Dsply 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "Disply_Rgen_Chrg_Txt" 10 "Disp_Fast_Charge_Txt" 9 "Disp_Fast_Charge_Cmplt_Txt" 8 "Disp_Charge_Cmplt_Txt" 7 "Disp_Remote_Start_Txt" 6 "Disp_Eng_Drv_Txt" 5 "Disp_Elec_Drv_Txt" 4 "Disp_Idle_with_Chrg_Txt" 3 "Disp_Idle_Txt" 2 "Disp_Charg_HV_Batt_Txt" 1 "Disp_Hyb_Drive_Txt" 0 "No_Text";
+VAL_TABLE_ EngOnMsg_D_Dsply 14 "_0xE_to_1F_NotUsed" 12 "Battery_Temperature" 11 "Hill_Decent_Control" 10 "Fuel_Maintenance" 9 "Oil_Maintenance" 8 "Normal_Operation" 7 "Low_Gear" 6 "Batt_Charging" 5 "Engine_Cold" 4 "Neutral_Gear" 3 "Heater_Setting" 2 "High_Speed" 1 "Acceleration" 0 "No_Display" 13 "Drive_Mode_Selection";
+VAL_TABLE_ PtDataKeyId_D_Stat 15 "NotUsed5" 14 "NotUsed4" 13 "NotUsed3" 12 "NotUsed2" 11 "NotUsed1" 10 "Tot_Veh_NUT" 9 "Cust_4_NUT" 8 "Cust_3_NUT" 7 "Cust_2_NUT" 6 "Cust_1_NUT" 5 "Tot_Veh_Stat" 4 "Cust_4_Stat" 3 "Cust_3_Stat" 2 "Cust_2_Stat" 1 "Cust_1_Stat" 0 "Null";
+VAL_TABLE_ ChrgStat_D_Dsply 7 "NotUsed" 6 "Complete" 5 "Scheduled" 4 "In_Progress" 3 "Fault_Outside_Car" 2 "Fault_Inside_Car" 1 "Fault_Unknown_Location" 0 "Not_Ready";
+VAL_TABLE_ TrnLvrV_D_Rq 3 "Full_Speed" 2 "Aggressive" 1 "Normal" 0 "Quiet";
+VAL_TABLE_ EngStrtStop_B_SrcOil 1 "Eng_start_stop_for_oilmnt" 0 "Not_Requested";
+VAL_TABLE_ FuelMaintMde_D_Rq 3 "Feature_Not_Present" 2 "Fuel_Maint_Req_Now" 1 "Fuel_Maint_Req_Soon" 0 "NoRequest";
+VAL_TABLE_ FuelMaintMde_D_Dsply 3 "Feature_Not_Present" 2 "In_Fuel_Maint_Mode" 1 "Close_to_Fuel_Maint" 0 "OK";
+VAL_TABLE_ DynoMde_B_Cmd 1 "Two_Wheel_Dyno" 0 "Normal_Operation";
+VAL_TABLE_ HvacPrecondRecirc_D_Rq 3 "Last_User_Setting" 2 "Auto" 1 "Recirc" 0 "Outside";
+VAL_TABLE_ HvacPrecondAC_D_Rq 3 "Last_User_Setting" 2 "Auto" 1 "On" 0 "Off";
+VAL_TABLE_ HybMdeStat_D_Dsply 7 "NotUsed2" 6 "EV_Charge" 5 "EV_Override" 4 "Forced_EV_Mode" 3 "Forced_Charge_Sustain_Mode" 2 "Auto_Charge_Sustain_Mode" 1 "Auto_Charge_Deplete_Mode" 0 "Null_State";
+VAL_TABLE_ PwFlowPlgBatt_D_Dsply 3 "NotUsed" 2 "Flow_from_Plug_to_Batt" 1 "Flow_from_Batt_to_Plug" 0 "No_Flow";
+VAL_TABLE_ PwFlowEngMtr_D_Dsply 3 "NotUsed" 2 "Flow_from_Eng_to_Mtr" 1 "Flow_from_Mtr_to_Eng" 0 "No_Flow";
+VAL_TABLE_ PwFlowEngFuel_D_Dsply 3 "NotUsed" 2 "Flow_from_Eng_to_Fuel" 1 "Flow_from_Fuel_to_Eng" 0 "No_Flow";
+VAL_TABLE_ PwFlowMtrDrv_D_Dsply 3 "NotUsed" 2 "Flow_from_Mtr_to_Axle" 1 "Flow_from_Axle_to_Mtr" 0 "No_FLow";
+VAL_TABLE_ PwFlowEngDrv_D_Dsply 3 "NotUsed" 2 "Flow_from_Eng_to_Axle" 1 "Flow_from_Axle_to_Eng" 0 "No_Flow";
+VAL_TABLE_ PwFlowBattMtr_D_Dsply 3 "NotUsed" 2 "Flow_from_Batt_to_Mtr" 1 "Flow_from_Mtr_to_Batt" 0 "No_Flow";
+VAL_TABLE_ Null_Override_Invalid 3 "NotUsed" 2 "Invalid" 1 "Override" 0 "Null";
+VAL_TABLE_ HybMdeMsgTxt_D_Rq 7 "NotUsed2" 6 "NotUsed1" 5 "EV_Not_Avail_Message" 4 "EV_Mode_Message" 3 "Delayed_Discharge_Message" 2 "Override_Available_Message" 1 "AutoMode_Message" 0 "Null_NoMessage_Request";
+VAL_TABLE_ HybMdeLimMsgTxt_D_Rq 3 "Limited_Req_Full_Defrost" 2 "Limited_Climate_Defrost" 1 "Limited_System_Performance" 0 "Null";
+VAL_TABLE_ CenterStackRing_D_Actl 3 "LimitedOn" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ NoData_Faulty_FFFE_FFFF 65535 "Faulty" 65534 "NoDataExists";
+VAL_TABLE_ NoData_Faulty_FFE_FFF 4095 "Faulty" 4094 "NoDataExists";
+VAL_TABLE_ NoData_Faulty_7FFE_7FFF 32767 "Faulty" 32766 "NoDataExists";
+VAL_TABLE_ NoData_Faulty_3FE_3FF 1023 "Faulty" 1022 "NoDataExists";
+VAL_TABLE_ ReFuelSysStat_D_Dsply 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Refuel_Err" 3 "Close_Fuel_Door" 2 "Refuel_Ready" 1 "Wait_To_Fuel" 0 "Null";
+VAL_TABLE_ OffOn_NotUsed 3 "NotUsed2" 2 "NotUsed1" 1 "On" 0 "Off";
+VAL_TABLE_ DrQltyDrv_D_StatGsm 7 "Faulty" 6 "NoDataExists" 5 "NotUsed2" 4 "NotUsed1" 3 "ClosedDegraded" 2 "OpenDegraded" 1 "ClosedOkay" 0 "OpenOkay";
+VAL_TABLE_ ChrgrInPwType_D_Actl 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "DC_Fast_Charging" 2 "AC_Level2_240v" 1 "AC_Level1_120v" 0 "EVSE_Not_Detected";
+VAL_TABLE_ ChrgCrdLck_D_Falt 3 "NotUsed" 2 "HardwareFault" 1 "CsiFault" 0 "NoFault";
+VAL_TABLE_ ChrgStat_D2_Dsply 15 "NotUsed_2" 14 "NotUsed_1" 13 "ChargeTargetReached" 12 "DriveConditioning" 11 "CabinPreconditioning" 10 "ChargingSystemMaintain" 9 "ChargingInductive" 8 "ChargingDCFastChange" 7 "ChargingAC" 6 "ChargeScheduled" 5 "EvsePaused" 4 "EvseNotDetected" 3 "EvseNotCompatible" 2 "FaultOutsideCar" 1 "FaultInsideCar" 0 "NotReady";
+VAL_TABLE_ EngMdeMsgTxt_D_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Charge" 3 "GlowingCharge" 2 "Hybrid" 1 "Ev" 0 "NoMessage";
+VAL_TABLE_ BattRgenLoStat_D_Qlty 3 "OK" 2 "Not_Within_Spec" 1 "Eval_In_Progress" 0 "Faulty";
+VAL_TABLE_ OpenClosedRetainDisable 3 "Disable" 2 "Retain" 1 "Closed" 0 "Open";
+VAL_TABLE_ OpenClosedStuckOpenClosed 3 "StuckClosed" 2 "StuckOpen" 1 "Closed" 0 "Open";
+VAL_TABLE_ NoData_Faulty_7FE_7FF 2047 "Faulty" 2046 "NoDataExists";
+VAL_TABLE_ DrTgateChime2_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Long_Repeated" 3 "Fast" 2 "Short" 1 "Long" 0 "Off";
+VAL_TABLE_ EngIdlShutDwnTxt_D_Rq 3 "NotUsed" 2 "EngineShutdownOnPrevDrive" 1 "FeatureDisabledDueToFault" 0 "NoMessage";
+VAL_TABLE_ DrvPerfMde 3 "Sport" 2 "Normal" 1 "NotUsed" 0 "NoModeSelected";
+VAL_TABLE_ NoData_Fault_1FF_1FE 511 "Fault" 510 "NoDataExists";
+VAL_TABLE_ NoData_Fault_FFE_FFF 4095 "Fault" 4094 "NoDataExists";
+VAL_TABLE_ WeekdayEndHR_St 31 "Invalid" 30 "Unknown" 29 "Reserved_29" 28 "Reserved_28" 27 "Reserved_27" 26 "Reserved_26" 25 "Reserved_25" 24 "Reserved_24";
+VAL_TABLE_ WeekdayEndMin_St 63 "Faulty" 62 "No_data_exists" 61 "Reserverd" 60 "Reserverd";
+VAL_TABLE_ WeekdayStartHR_St 31 "Invalid" 30 "Unknown" 29 "Reserved_29" 28 "Reserved_28" 27 "Reserved_27" 26 "Reserved_26" 25 "Reserved_25" 24 "Reserved_24";
+VAL_TABLE_ WeekdayStartMin_St 63 "Faulty" 62 "No_data_exists" 61 "Reserverd" 60 "Reserverd";
+VAL_TABLE_ EngIdlShutDown_D_Stat 3 "Not_used" 2 "Engine_Shutdown" 1 "Initiated_Countdown" 0 "Normal_Operation";
+VAL_TABLE_ StopStrtDrvMde_D_Indic 3 "NotUsed" 2 "StartStop_IndirectDeselect" 1 "StopStart_Deselected" 0 "StopStart_Selected";
+VAL_TABLE_ StopStrtDrvMde_D_RqMnu 3 "NotUsed2" 2 "NotUsed1" 1 "StopStart_Deselected" 0 "StopStart_Selected";
+VAL_TABLE_ StopStrtStdby_D_Indic 6 "NotUsed2" 5 "Telltale_Struck_Out" 4 "Telltale_Flashing_Amber" 3 "Telltale_On_Amber" 2 "Telltale_Flashing_Green" 1 "Telltale_On_Green" 0 "Telltale_Off" 7 "NotUsed3";
+VAL_TABLE_ Quality_Faulty 3 "OK" 2 "Degraded" 1 "No_Data_Exists" 0 "Faulty";
+VAL_TABLE_ TrnDtpCmd_D_Actl 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "Relatch" 3 "Deploy" 2 "Self_Test" 1 "No_Command" 0 "NotUsed1";
+VAL_TABLE_ TrnGsmNtmState_D_Actl 3 "Faulty" 2 "Neutral_Tow_Mode" 1 "Car_Wash_Mode" 0 "None";
+VAL_TABLE_ TrnTrcmPwmSig_D_Actl 15 "Faulty" 14 "NoDataExists" 13 "NotUsed5" 12 "NotUsed4" 11 "NotUsed3" 10 "NotUsed2" 9 "NotUsed1" 8 "Default_To_Park" 7 "Neutral_Tow" 6 "Car_Wash_Mode" 5 "Manual" 4 "Drive" 3 "Neutral" 2 "Reverse" 1 "Park" 0 "No_Gear";
+VAL_TABLE_ RgenBrkDynoMde_B_Actl 1 "TwoWheelDyno" 0 "NormalOperation";
+VAL_TABLE_ Fault_3FFF 16383 "Fault";
+VAL_TABLE_ CtaInnr_D_Stat 3 "Reporting" 2 "Not_Reporting" 1 "System_Standby" 0 "Initialization";
+VAL_TABLE_ PrkBrkActv_D_RqTrnGear 3 "NotUsed2" 2 "RequestParkBrakeEngage" 1 "NoRequest" 0 "NotUsed1";
+VAL_TABLE_ NoRequest_Request 1 "Request" 0 "NoRequest";
+VAL_TABLE_ Fault_FFF_NoData 4094 "NoDataExists" 4095 "Fault";
+VAL_TABLE_ Fault_3FF_NoData 1022 "NoDataExists" 1023 "Fault";
+VAL_TABLE_ Foh_D_Stat 7 "Unused3" 6 "Unused2" 5 "Unused1" 4 "Stopping" 3 "Running" 2 "Starting" 1 "Prestart" 0 "Off";
+VAL_TABLE_ OffOnNoDataUnused 3 "Unused" 2 "NoDataExists" 1 "On" 0 "Off";
+VAL_TABLE_ FohFalt_D_Stat 15 "NotUsed4" 14 "NotUsed3" 13 "NotUsed2" 12 "NotUsed1" 11 "FuelTypeDoesNotMatchFOH" 10 "Lifecycle_ModeNotSet" 9 "AuxElectricCoolantPumpInop" 8 "TimeDelayAvoidExcessCycl" 7 "Fuel_Level_OutofRange" 6 "External_Fault" 5 "Internal_Fault" 4 "Voltage_limitation" 3 "Impact_Event" 2 "CoolantTemp_OutofRange" 1 "AmbientTemp_OutofRange" 0 "No_Disable";
+VAL_TABLE_ FohRqRun_B_Rq 1 "SubmitRequest_toRun" 0 "DoesNotSubmitRequest_toRun";
+VAL_TABLE_ OKLowVeryLow 3 "NotUsed" 2 "VeryLow" 1 "Low" 0 "OK";
+VAL_TABLE_ Fault_1FF 511 "Fault";
+VAL_TABLE_ SteWhlHeat 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "Reserved_3" 8 "Reserved_2" 7 "Reserved_1" 6 "Level_3_Heating" 5 "Level_3_Heating_LS" 4 "Level_2_Heating" 3 "Level_2_Heating_LS" 2 "Level_1_Heating" 1 "Level_1_Heating_LS" 0 "Off";
+VAL_TABLE_ OffOnUnusedFault 3 "Fault" 2 "Unused" 1 "On" 0 "Off";
+VAL_TABLE_ NullKphMph 3 "NoDataExists" 2 "Mph" 1 "Kph" 0 "Null";
+VAL_TABLE_ TsrVLim1MsgTxt_D_Rq 255 "NoLimit" 254 "NotUsed2" 253 "NotUsed1" 252 "NotToBeDisplayed" 251 "LimitCancelled" 31 "1F_FA_Message31_250" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "Null";
+VAL_TABLE_ TsrVl1RstrcMsgTxt_D_Rq 3 "NotUsed" 2 "NoRecognizableRestriction" 1 "NoSpeedLimitRestriction" 0 "Null";
+VAL_TABLE_ TsrMsgTxt_D_Rq 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "RecgnzdSignNotUsblForDsply" 8 "LimitedSystemPerformance" 7 "OffRoad" 6 "RegionNotSupported" 5 "CountryNotSupported" 4 "WrngNavDatIncompDatCarrier" 3 "NoNavDataAvailable" 2 "NoNavAvailableSwitchedOff" 1 "NoInformationAllOK" 0 "Null";
+VAL_TABLE_ TsrOvtkTypeMsgTxt_D_Rq 3 "NotUsed" 2 "Explicit" 1 "Implicit" 0 "Null";
+VAL_TABLE_ TsrOvtkStatMsgTxt_D_Rq 3 "LimitOutdated" 2 "LimitReiable" 1 "LimitChanged" 0 "Null";
+VAL_TABLE_ TsrOvtkMsgTxt_D_Rq 7 "LimForTrucksCancelled" 6 "LimForTrucksWoQlfdRstrc" 5 "LimForTrucksWithoutRstrc" 4 "LimAllCancelled" 3 "LimAllWithoutQlfdRstrc" 2 "LimAllWithoutRestriction" 1 "OvertakingAllowed" 0 "Null";
+VAL_TABLE_ Null_False_True 3 "NotUsed" 2 "True" 1 "False" 0 "Null";
+VAL_TABLE_ TsrStatMsgTxt_D_Rq 7 "NotUsed" 6 "NoDataExists" 5 "TSR_Error" 4 "Available_NavigationOnly" 3 "Available_CameraOnly" 2 "Available_FusionMode" 1 "TSR_Off" 0 "Null";
+VAL_TABLE_ NoMessage_DisplayMessage 1 "DisplayMessage" 0 "NoMessage";
+VAL_TABLE_ FdsmTrgRight 1 "Object_in_Right_Lobe" 0 "No_Object";
+VAL_TABLE_ FdsmTrgCntr 1 "Object_in_Center_Lobe" 0 "No_Object";
+VAL_TABLE_ FdsmTrgLeft 1 "Object_in_Left_Lobe" 0 "No_Object";
+VAL_TABLE_ EngineBrakeOff_Active 1 "Engine_Braking_Activated" 0 "Engine_Braking_Off";
+VAL_TABLE_ NoEngineBrake_Brake 1 "Engine_Braking" 0 "No_Engine_Braking";
+VAL_TABLE_ PlgActv_D_ActlChrgr 3 "Faulty" 2 "Not used_2" 1 "On_Plug__Connected_" 0 "Off_Plug__Disconnected_";
+VAL_TABLE_ EngSrvcRqd_B_Rq 1 "Engine_Service_Required" 0 "No_engine_service_required";
+VAL_TABLE_ WeekendEndHR_St 31 "Invalid" 30 "Unknown" 29 "Reserved_29" 28 "Reserved_28" 27 "Reserved_27" 26 "Reserved_26" 25 "Reserved_25" 24 "Reserved_24";
+VAL_TABLE_ WeekendEndMin_St 63 "Faulty" 62 "No_data_exists" 61 "Reserverd" 60 "Reserverd";
+VAL_TABLE_ WeekendStartHR_St 31 "Invalid" 30 "Unknown" 29 "Reserved_29" 28 "Reserved_28" 27 "Reserved_27" 26 "Reserved_26" 25 "Reserved_25" 24 "Reserved_24";
+VAL_TABLE_ WeekendStartMin_St 63 "Faulty" 62 "No_data_exists" 61 "Reserverd" 60 "Reserverd";
+VAL_TABLE_ LscmbbBaSens_D_Rq 3 "Level3_EBA" 2 "Level2_EBA" 1 "Level1_EBA" 0 "Norman_EBA";
+VAL_TABLE_ Allowed_Denied 1 "Denied" 0 "Allowed";
+VAL_TABLE_ LscmbbBrkPrchg_D_Rq 3 "NotUsed" 2 "Level2_PreCharge" 1 "Level1_PreCharge" 0 "No_Precharge";
+VAL_TABLE_ LscmbbBrkDecel_B_Enabl 1 "ConductLSCMbBDecelReq" 0 "DoNotConductLSCMbBDecelReq";
+VAL_TABLE_ PrkAidMsgTxt_D_Rq 15 "All_Sns_Blk" 14 "R_Sns_ON_F_Sns_Blk" 13 "R_Sns_Blk_F_Sns_ON" 12 "R_Sns_Inactive_Trlr_atch" 11 "Not_Avail_Trlr_attchd" 10 "Fail_Mode_no_Chime" 9 "Fail_Mode_with_Chime" 8 "R_Sns_Trlr_F_Sns_Blk" 7 "NotUsed3" 6 "Park_Sys_Alternate_Mode" 5 "R_Snsrs_On_F_Snsrs_On" 4 "NotUsed2" 3 "Reset_Message_Warn" 2 "R_Snsrs_Off_F_Snsrs_On" 1 "R_Snsrs_On_F_Snsrs_Off" 0 "All_Park_Sensors_Off";
+VAL_TABLE_ PrkAidSns_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_TABLE_ PrkAid_D_Falt 7 "NotUsed2" 6 "NotUsed1" 5 "Failure_Front_PSM_Sensors" 4 "No_Data_Exists" 3 "Failure_Rear_Sensors" 2 "Speaker_Fault" 1 "ECU_Fault" 0 "No_Fault";
+VAL_TABLE_ OffOnNoDataFault 3 "Fault" 2 "No_Data_Exists" 1 "On" 0 "Off";
+VAL_TABLE_ ApaActvSd_D_Actl 3 "Dirver_Side" 2 "Passenger_Side" 1 "No_Side" 0 "Null";
+VAL_TABLE_ ApaMdeStat_D_RqDrv 7 "Faulty" 6 "Off" 5 "NotUsed2" 4 "NotUsed1" 3 "POA" 2 "PPA" 1 "SAPP" 0 "Inactive";
+VAL_TABLE_ ApaMde_D_Avail 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "NotUsed3" 10 "NotUsed2" 9 "NotUsed1" 8 "PPA_POA" 7 "SAPP_POA" 6 "POA" 5 "PPA" 4 "SAPP" 3 "SAPP_PPA_POA" 2 "SAPP_PPA" 1 "None" 0 "Null";
+VAL_TABLE_ ApaMde_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "POA" 3 "PPA" 2 "SAPP" 1 "Off" 0 "Null";
+VAL_TABLE_ FrostWarn_D_Stat 3 "NotUsed" 2 "On_Amber" 1 "On_Red" 0 "Off";
+VAL_TABLE_ SteWhlLckMsgTxt_D_Rq 3 "NotUsed" 2 "Message_2" 1 "Message_1" 0 "No_Message";
+VAL_TABLE_ GearRvrse_D_Actl 7 "Fault" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Active_confirmed" 2 "Active_not_confirmed" 1 "Inactive_confirmed" 0 "Inactive_not_confirmed";
+VAL_TABLE_ SideDetect_SnStat_Invalid 3 "Invalid" 2 "System_Failure" 1 "Blocked" 0 "Clear";
+VAL_TABLE_ SideDetect_OpStat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Invalid" 3 "Disabled" 2 "On" 1 "Trailer_Tow_Off" 0 "Off";
+VAL_TABLE_ SideDetect_Present 4 "Sensor_Blocked" 3 "Sensor_Fault" 2 "Flash_On" 1 "Alert_On" 0 "AlertOff_FlashOff_SensrClr";
+VAL_TABLE_ Off_On_Flash_BulbProveout 3 "Bulb_Proveout" 2 "Flash" 1 "On" 0 "Off";
+VAL_TABLE_ SideDetect_BLIS_Off_On 2 "BLIS_On_Second_Warning_ON" 1 "BLIS_On_Second_Warning_OFF" 0 "Off";
+VAL_TABLE_ SideDetect_report 3 "Reporting" 2 "Not_Reporting" 1 "System_Standby" 0 "Initialization";
+VAL_TABLE_ DrTGate_D_Rq 3 "NotUsed" 2 "Closing" 1 "Opening" 0 "Not_Moving";
+VAL_TABLE_ WndwSide_D_Stat 3 "BothWindow_Operating" 2 "RearWindow_Operating" 1 "FrontWindow_Operating" 0 "NoWindows_Operating";
+VAL_TABLE_ DcacElPw_D_Rq 3 "NotUsed" 2 "AC_HighPower_Requested" 1 "AC_LowPower_Requested" 0 "AC_Power_NotRequested";
+VAL_TABLE_ False_True 1 "True" 0 "False";
+VAL_TABLE_ Null_Reset 1 "Reset" 0 "Null";
+VAL_TABLE_ HvacBlwrFront_D_Stat 31 "Not_Used" 20 "Full_On" 19 "95_Percent" 18 "90_Percent" 17 "85_Percent" 16 "80_Percent" 15 "75_Percent" 14 "70_Percent" 13 "65_Percent" 12 "60_Percent" 11 "55_Percent" 10 "50_Percent" 9 "45_Percent" 8 "40_Percent" 7 "35_Percent" 6 "30_Percent" 5 "25_Percent" 4 "20_Percent" 3 "15_Percent" 2 "10_Percent" 1 "5_Percent" 0 "Off";
+VAL_TABLE_ immoMsgTxt_D_Rq 15 "Immo_Msg_15" 14 "Immo_Msg_14" 13 "Immo_Msg_13" 12 "Immo_Msg_12" 11 "Immo_Msg_11" 10 "Immo_Msg_10" 9 "Immo_Msg_9" 8 "Immo_Msg_8" 7 "Immo_Msg_7" 6 "Immo_Msg_6" 5 "Immo_Msg_5" 4 "Immo_Msg_4" 3 "Immo_Msg_3" 2 "Immo_Msg_2" 1 "Immo_Msg_1" 0 "Immo_Msg_0_Null";
+VAL_TABLE_ BattTracWarnLamp_B_Rq 1 "On" 0 "Off";
+VAL_TABLE_ BattTracSrvcRqd_B_Rq 1 "On" 0 "Off";
+VAL_TABLE_ HtrnWarnLamp_B_Dsply 1 "On" 0 "Off";
+VAL_TABLE_ HtrnSrvcRqd_B_Dsply 1 "On" 0 "Off";
+VAL_TABLE_ NoData_Faulty_7E_7F 127 "Faulty" 126 "NoDataExists";
+VAL_TABLE_ PreCondACSet_D_Actl 3 "Last_User_Setting" 2 "Auto" 1 "On" 0 "Off";
+VAL_TABLE_ PreCondFanSet_D_Actl 15 "Not_used" 14 "Not_used" 13 "Not_used" 12 "Not_used" 11 "Not_used" 10 "Not_used" 9 "Last_user_setting" 8 "Auto" 7 "Speed_7" 6 "Speed_6" 5 "Speed_5" 4 "Speed_4" 3 "Speed_3" 2 "Speed_2" 1 "Speed_1" 0 "OFF";
+VAL_TABLE_ PreCondID_No_Actl 0 "Invalid";
+VAL_TABLE_ PreCondRecrcSet_D_Actl 3 "Last_User_Setting" 2 "Auto" 1 "Recirc" 0 "Outside/Fresh";
+VAL_TABLE_ PreCondTeSet_Te_Actl 31 "HI" 1 "LO" 0 "Last_driver_setting";
+VAL_TABLE_ PreCondTPRDef_D_Actl 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ PreCondModeSet_D_Actl 15 "Not_used" 14 "Not_used" 13 "Not_used" 12 "Not_used" 11 "LastUserSetting" 10 "Auto" 9 "Max_Defrost" 8 "Windshield_Panel_Floor" 7 "Windshield_Panel" 6 "Windshield_(Defrost)" 5 "Windshield_Floor" 4 "Floor" 3 "Panel_Floor" 2 "Panel_(Vent)" 1 "Max_A/C" 0 "Off";
+VAL_TABLE_ ChargePortPwr_St 2 "LowPower" 1 "HighPower" 0 "Null";
+VAL_TABLE_ ChargeProfIDPref_St 3 "NotUsed" 2 "Value" 1 "ChargeNow" 0 "Null";
+VAL_TABLE_ ChrgGlobSched_D_Actl 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ ChrgLocEndHr_No_Actl 31 "Invalid" 30 "Unknown";
+VAL_TABLE_ ChrgLocEndMin_No_Actl 63 "Invalid" 62 "Unknown";
+VAL_TABLE_ ChrgLocProgram_D_Actl 7 "Not_used" 6 "Not_used" 5 "Not_used" 4 "Manual" 3 "TimeofUse" 2 "SmMet" 1 "ChargeImm" 0 "Null";
+VAL_TABLE_ ChrgLocSchedCat_D_Actl 11 "Reserved" 10 "Window_10" 9 "Window_9" 8 "Window_8" 7 "Window_7" 6 "Window_6" 5 "Window_5" 4 "Window_4" 3 "Window_3" 2 "Window_2" 1 "Window_1" 0 "Null";
+VAL_TABLE_ ChrgLocHsphs_D_Actl 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "SouthEast_Lat-_Long+" 3 "SouthWest_Lat-_Long-" 2 "NorthEast_Lat+_Long+" 1 "NorthWest_Lat+_Long-" 0 "NoDataExists";
+VAL_TABLE_ FuelPumpPwr_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Power_Off_Default" 3 "Power_Off_Command" 2 "Power_Off_Service" 1 "Power_Off_Impact" 0 "Power_On";
+VAL_TABLE_ ChrgrRdyStat_D_Actl 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "Charging" 2 "ChargerFault" 1 "ChargerReady" 0 "NotReady";
+VAL_TABLE_ PrmtrAlrmEvnt_D_Stat 15 "Diag_Tamper" 14 "Trailer" 13 "Shock_Sensor" 12 "Post_Crash" 11 "Panic" 10 "Intrusion" 9 "Inclination" 8 "Ign_Tamper" 7 "LG_Door" 6 "Decklid" 5 "Hood" 4 "PR_Door" 3 "PF_Door" 2 "DR_Door" 1 "DF_Door" 0 "Null";
+VAL_TABLE_ SecurityMsgTxt_D_Rq 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ BattChrgRdyStat_D_Actl 7 "NotUsed2" 6 "NotUsed1" 5 "Faulted" 4 "ChargeComplete" 3 "Charging" 2 "BatteryChargeReady" 1 "ChargeWait" 0 "NotReady";
+VAL_TABLE_ BattChrgInhbt_D_Rq 3 "MaintainTargetSoc" 2 "NotUsed" 1 "InhibitChargingThermal" 0 "Enable_Charging";
+VAL_TABLE_ Fault_7FF_NoData 2047 "Fault" 2046 "NoDataExists";
+VAL_TABLE_ Deactivate_Activate 1 "Activate" 0 "Deactivate";
+VAL_TABLE_ PtcHtr_D_Stat 3 "Faulty" 2 "NotUsed" 1 "On" 0 "Off";
+VAL_TABLE_ PtcHtr_D_Cmd 3 "TurnOn" 2 "AutoMode" 1 "TurnOff" 0 "NoDecision_Initializing";
+VAL_TABLE_ Fault_FFFFFF 16777215 "Fault";
+VAL_TABLE_ NoData_Fault_FFFE_FFFF 65535 "Fault" 65534 "NoDataExists";
+VAL_TABLE_ EngOffTe_B_Dsply 1 "Eng_warm_engh_for_pd" 0 "Eng_not_warm_engh_for_pd";
+VAL_TABLE_ Fault_FFFF_NoData_FFFE 65535 "Fault" 65534 "NoDataExists";
+VAL_TABLE_ Fault_1FFF 8191 "Fault";
+VAL_TABLE_ TrlrBattChrg_D_Stat 3 "Reverse" 2 "Normal" 1 "Low" 0 "Null";
+VAL_TABLE_ TrlrLampCtl_D_Stat 3 "NotUsed" 2 "TrlrLampCnnctDrvFailure" 1 "TrlrLampNotCnnctDrvFailure" 0 "Null";
+VAL_TABLE_ ElPw_D_StatStrtStop 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "Supported_Level_4" 8 "Supported_Level_3" 7 "Supported_Level_2" 6 "Supported_Level_1" 5 "Limited_Support" 4 "Fault_Limited" 3 "LV_Event_in_Progress" 2 "Not_Supported_Imminent" 1 "Supported_All" 0 "Not_Supported";
+VAL_TABLE_ ImpactEvntFdbck_D_Stat 3 "NotUsed" 2 "EventComplete" 1 "EventInProgress" 0 "Normal";
+VAL_TABLE_ StopStrtIODTxt_D_Rq 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_TABLE_ NoData_Fault_7FFE_7FFF 32767 "Fault" 32766 "NoDataExists";
+VAL_TABLE_ NoData_Fault_3E_3F 63 "Fault" 62 "NoDataExists";
+VAL_TABLE_ DrvSte_D_Stat 15 "NotUsed10" 14 "NotUsed9" 13 "NotUsed8" 12 "NotUsed7" 11 "NotUsed6" 10 "NotUsed5" 9 "NotUsed4" 8 "NotUsed3" 7 "NotUsed2" 6 "NotUsed1" 5 "Request_Active" 4 "Ignition_Off" 3 "DSR_in_Normal_Idle_Mode" 2 "EPAS_Comm_Disturbed" 1 "DSR_Request_Not_Applicable" 0 "DSR_Deactivated";
+VAL_TABLE_ StrtrMtrCtlMsgTxt_D_Rq 7 "Start_In_Gear_Allowed" 6 "Pending_Start_Cancelled" 5 "Start_Pending_Please_Wait" 4 "Cranking_Limit_Exceeded" 3 "Press_Brk_and_Shift_to_P_N" 2 "Press_Clutch_and_Brake" 1 "Press_Clutch_To_Start" 0 "No_Display";
+VAL_TABLE_ Null_Open 1 "Open" 0 "Null";
+VAL_TABLE_ Invalid_OffOn 0 "Invalid" 1 "Off" 2 "On";
+VAL_TABLE_ TempDegreesC_DegreesF 0 "Temperature_deg_c" 1 "Temperature_deg_f";
+VAL_TABLE_ BeltminderAudioMute 2 "On" 1 "Off" 0 "Invalid";
+VAL_TABLE_ Chime_Source 2 "Cluster" 1 "Infotainment_Sys" 0 "Invalid";
+VAL_TABLE_ Invalid_DayNight 2 "Night" 1 "Day" 0 "Invalid";
+VAL_TABLE_ Invalid_12h_24h 2 "24h_mode" 1 "12h_mode" 0 "Invalid";
+VAL_TABLE_ Invalid_Theme1_2 2 "Theme_2" 1 "Theme_1" 0 "Invalid";
+VAL_TABLE_ LanguageSelect_St 30 "Slovak" 29 "Arabic" 28 "Cantonese" 27 "Mandarin_Chinese" 26 "Korean" 25 "Japanese_Kanji" 24 "Japanese_Katakana" 23 "Braz_Portuguese" 22 "EU_Portuguese" 21 "Finish" 20 "Norwegian" 19 "Danish" 18 "Swedish" 17 "Hungarian" 16 "Greek" 15 "Czech" 14 "Polish" 13 "Flemish" 12 "Dutch" 11 "Russian" 10 "Turkish" 9 "Mex_Spanish" 8 "EU_Spanish" 7 "Cana_French" 6 "EU_French" 5 "Italian" 4 "German" 3 "NA_English" 2 "UK_English" 1 "Unknown" 0 "Invalid";
+VAL_TABLE_ Blower_Indicate 15 "Display_Blank" 14 "14_Indicators_On" 13 "13_Indicators_On" 12 "12_Indicators_On" 11 "11_Indicators_On" 10 "10_Indicators_On" 9 "9_Indicators_On" 8 "8_Indicators_On" 7 "7_Indicators_On" 6 "6_Indicators_On" 5 "5_Indicators_On" 4 "4_Indicators_On" 3 "3_Indicators_On" 2 "2_Indicators_On" 1 "1_Indicator_On" 0 "Indicators_Off";
+VAL_TABLE_ CC_Fr_Stat_User_Adj 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "Fr_Blwr_Spd_Selection" 2 "FRHS_SetPt_Selection" 1 "FLHS_SetPt_Selection" 0 "None";
+VAL_TABLE_ HeadLghtHiFdbck_D_Stat 3 "NotUsed" 2 "Cancel" 1 "Hold" 0 "Allow_Change";
+VAL_TABLE_ Backlit_LED_Status 15 "Unused3" 14 "Unused2" 13 "Unused1" 12 "Night_12" 11 "Night_11" 10 "Night_10" 9 "Night_9" 8 "Night_8" 7 "Night_7" 6 "Night_6" 5 "Night_5" 4 "Night_4" 3 "Night_3" 2 "Night_2" 1 "Night_1" 0 "Off";
+VAL_TABLE_ Veh_Lock_Status 3 "UNLOCK_DRV" 2 "UNLOCK_ALL" 1 "LOCK_ALL" 0 "LOCK_DBL";
+VAL_TABLE_ PrkLckCtlMsgTxt_D_Rq 3 "BTSI_DI_3" 2 "BTSI_DI_2" 1 "BTSI_DI_1" 0 "Null_BTSI_DI";
+VAL_TABLE_ NoShift_Shift 1 "Shift" 0 "NoShift";
+VAL_TABLE_ CcdMsgTxt_D_RqDsply 15 "Unused8" 14 "Unused7" 13 "Unused6" 12 "Unused5" 11 "Unused4" 10 "Unused3" 9 "Unused2" 8 "StationaryMode" 7 "Mode_Change_Unavailable" 6 "CCD_Temporarily_Off" 5 "CCD_Service_Required" 4 "Faulty" 3 "Sport" 2 "Normal" 1 "Comfort" 0 "No_Mode_Selected";
+VAL_TABLE_ CrashEvnt_D_Stat 3 "Invalid" 2 "Fuel_Cutoff_Event" 1 "Deploy_Event" 0 "No_Event";
+VAL_TABLE_ ReducedGuard_D_Stat 3 "NotUsed" 2 "Alarm_On" 1 "Alarm_Off_Previously_On" 0 "Alarm_Off";
+VAL_TABLE_ HvacPrecondBlwr_D_Rq 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "Last_User_Setting" 8 "Auto" 7 "Speed7" 6 "Speed6" 5 "Speed5" 4 "Speed4" 3 "Speed3" 2 "Speed2" 1 "Speed1" 0 "Off";
+VAL_TABLE_ HvacPrecondMode_D_Rq 15 "NotUsed4" 14 "NotUsed3" 13 "NotUsed2" 12 "NotUsed1" 11 "Last_User_Settings" 10 "Auto" 9 "Max_Defrost" 8 "Windshield_Panel_Floor" 7 "Windshield_Panel" 6 "Windshield" 5 "Windshield_Floor" 4 "Floor" 3 "Panel_Floor" 2 "Panel" 1 "MAX_AC" 0 "Off";
+VAL_TABLE_ ButtonNotPressed 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_TABLE_ Null_Pressed 1 "Pressed" 0 "Null";
+VAL_TABLE_ FobComm_D_Stat 3 "NotUsed" 2 "RemEngStartOK" 1 "RemEngStartFail" 0 "Null";
+VAL_TABLE_ PudLamp_D_Rq 3 "RAMP_DOWN" 2 "RAMP_UP" 1 "ON" 0 "OFF";
+VAL_TABLE_ WndwGlbl_D_Cmd 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "GLEARN" 3 "GCLOSE" 2 "GOPEN" 1 "GSTOP" 0 "Null";
+VAL_TABLE_ LockMsg 7 "MSG7" 6 "MSG6" 5 "MSG5" 4 "MSG4" 3 "MSG3" 2 "MSG2" 1 "MSG1" 0 "NO_WARNING";
+VAL_TABLE_ ChildLockDisplay 3 "NOT_SUPPORTED" 2 "ERROR" 1 "CHILD_UNLOCK" 0 "CHILD_LOCK";
+VAL_TABLE_ Null_Lock_Unlock 3 "NotUsed" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_TABLE_ Wiper 15 "NO_DATA_EXISTS" 14 "STALLED" 13 "RESERVED" 12 "AUTO_ADJUST" 11 "COURTESYWIPE" 10 "AUTO_HIGH" 9 "AUTO_LOW" 8 "WASH" 7 "MIST_FLICK" 6 "MAN_HIGH" 5 "MAN_LOW" 4 "MAN_INT_ON" 3 "MAN_INT_OFF" 2 "OFF_MOVING" 1 "AUTO_OFF" 0 "OFF";
+VAL_TABLE_ Turn_switch 3 "Unused_Treat_As_Off" 2 "Right" 1 "Left" 0 "Off";
+VAL_TABLE_ PrkLght_D_Stat 3 "Park_Both" 2 "Park_Right" 1 "Park_Left" 0 "Off";
+VAL_TABLE_ LghtAmb_D_Sns 7 "No_Data_Exists" 6 "Unused2" 5 "Unused1" 4 "Tunnel_Off" 3 "Tunnel_On" 2 "Twilight" 1 "Light" 0 "Dark";
+VAL_TABLE_ HeadLghtSwtch_D_Stat 3 "Autolamp" 2 "Headlamp" 1 "Parklamp" 0 "Off";
+VAL_TABLE_ EmgcyBrkLamp_D_Rq 3 "NotUsed" 2 "Active_at_standstill" 1 "Active_at_speed" 0 "Inactive";
+VAL_TABLE_ GearLvrPos_D_Unfilt 7 "Invalid" 6 "NotUsed" 5 "In_between" 4 "Low" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_TABLE_ EDrvTqMntrRconfg_D_Cmd 7 "OK" 6 "Disable_Cruise" 5 "NotUsed4" 4 "Supercreep" 3 "NotUsed3" 2 "NotUsed2" 1 "Engine_shutdown" 0 "NotUsed";
+VAL_TABLE_ OpenPressedFault 3 "Fault" 2 "Unused" 1 "Pressed" 0 "Open";
+VAL_TABLE_ LaHandsOff_D_Dsply 3 "Suppressed" 2 "Level2" 1 "Level1" 0 "HandsOn";
+VAL_TABLE_ Avail_Unavail 1 "Unavailable" 0 "Available";
+VAL_TABLE_ LaActvStats_D_Dsply 31 "Unused7" 30 "LA_Off" 29 "Unused5" 28 "Unused4" 27 "Unused3" 26 "Unused2" 25 "Unused1" 24 "InerveneLeft_InterveneRght" 23 "WarnLeft_InterveneRight" 22 "SuppressLeft_InterveneRght" 21 "AvailLeft_InterveneRhtt" 20 "NoLeft_InterveneRight" 19 "InterveneLeft_WarnRight" 18 "WarnLeft_WarnRight" 17 "SuppressLeft_WarnRight" 16 "AvailableLeft_WarnRight" 15 "NoLeft_WarnRight" 14 "InterveneLeft_SuppressRght" 13 "WarnLeft_SuppressRight" 12 "SuppressLeft_SuppressRight" 11 "AvailLeft_SuppressRight" 10 "NoLeft_SuppressRight" 9 "InterveneLeft_AvailRight" 8 "WarnLeft_AvailRight" 7 "SuppressLeft_AvailRight" 6 "AvailableLeft_AvailRight" 5 "NoLeft_AvailableRight" 4 "InterveneLeft_NoRight" 3 "WarnLeft_NoRight" 2 "SuppressLeft_NoRight" 1 "AvailableLeft_NoRight" 0 "NoLeft_NoRight";
+VAL_TABLE_ AhbcHiBeam_D_Rq 3 "Deactivated_Unavailabl" 2 "Unused" 1 "Main_HighBeamRecommend" 0 "Dipped_LowBeamRecommend";
+VAL_TABLE_ GrllShtrPos_D_Cmd 15 "Fully_Open" 14 "Position14" 13 "Position13" 12 "Position12" 11 "Position11" 10 "Position10" 9 "Position9" 8 "Position8" 7 "Position7" 6 "Position6" 5 "Position5" 4 "Position4" 3 "Position3" 2 "Position2" 1 "Position1" 0 "Fully_Closed";
+VAL_TABLE_ LifeCycMde_D_Actl 3 "Transport" 2 "NotUsed" 1 "Factory" 0 "Normal";
+VAL_TABLE_ TrnMsgTxt_D_Rq 15 "Message_15" 14 "Message_14" 13 "Message_13" 12 "Message_12" 11 "Message_11" 10 "Message_10" 9 "Message_9" 8 "Message_8" 7 "Message_7" 6 "Message_6" 5 "Message_5" 4 "Message_4" 3 "Message_3" 2 "Message_2" 1 "Message_1" 0 "NoMessage";
+VAL_TABLE_ DieslPrtcRgen_D_Rq 7 "Unused_2" 6 "Unused_1" 5 "Full_Regen_2" 4 "Full_Regen_1" 3 "HeatUp_3" 2 "HeatUp_2" 1 "HeatUp_1" 0 "Normal_Mode_NoRegen";
+VAL_TABLE_ ClimtHeat_D_Rq 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "PtcHtrTestMde" 3 "Defrost_Defog" 2 "FastTempPullDownHeatingReq" 1 "OpportunisticHeatingReq" 0 "NoHeatingRequest";
+VAL_TABLE_ TrnCapHlth_Actl 3 "Capacitor_OK" 2 "Degraded_Capacitor" 1 "Capacitor_State_Unknown" 0 "Capacitor_Fault";
+VAL_TABLE_ TrnSecPrkStat_D_Actl 7 "Faulty" 6 "Fault_Released" 5 "Fault_Latched" 4 "Recouple_in_Progress" 3 "Mechanism_Released" 2 "RTP_in_Progress" 1 "Pending" 0 "Latched";
+VAL_TABLE_ TrnGear_D_Actl 7 "Fault" 6 "NotUsed" 5 "Manual" 4 "Drive" 3 "Neutral" 2 "Reverse" 1 "Park" 0 "Transition_State";
+VAL_TABLE_ TrnNtrlTowCmd_D_Actl 3 "NotUsed" 2 "Neutral_Tow_Entry" 1 "Car_Wash_Mode" 0 "Normal_Mode";
+VAL_TABLE_ TrnValidGear_D_Cnfm 3 "Accept" 2 "Reject" 1 "Internal_Request" 0 "No_Command";
+VAL_TABLE_ TrnGear_D_RqPt 7 "Fault" 6 "NotUsed" 5 "Manual" 4 "Drive" 3 "Neutral" 2 "Reverse" 1 "Park" 0 "No_Gear";
+VAL_TABLE_ TrnValidGearRq_D_Stat 3 "Valid_Request" 2 "Valid_Degraded_Request" 1 "Invalid_Request" 0 "No_Request";
+VAL_TABLE_ NoData_Fault_3FE_3FF 1023 "Fault" 1022 "NoDataExists";
+VAL_TABLE_ ClimtCool_D_Rq 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "ElACTestMde" 3 "Defrost_Defog" 2 "FastTempPullDownCoolReq" 1 "OpportunisticCoolingReq" 0 "NoCoolingRequest";
+VAL_TABLE_ HtrnHvilOpen_B_Actl 1 "HVIL_is_Open" 0 "Normal_Operation";
+VAL_TABLE_ EngTeHi_B_Actl 1 "EngineTempHigh" 0 "Normal";
+VAL_TABLE_ Eng_D_StatPwPck 7 "NotUsed3" 6 "NotUsed2" 5 "Engine_Start_Cold_Cat" 4 "Engine_Disabled" 3 "Engine_Running" 2 "Engine_Run_CSER" 1 "Engine_Start" 0 "Off";
+VAL_TABLE_ EngFuelCutFull_B_Inhbt 1 "Inhibit_DFSO" 0 "Normal";
+VAL_TABLE_ EngFuelCutFull_B_Rq 1 "FuelCutRequest" 0 "NormalOperation";
+VAL_TABLE_ Fault_7FF 2047 "Fault";
+VAL_TABLE_ EngStopFst_B_Rq 1 "FastEngineShutdown" 0 "NormalOperation";
+VAL_TABLE_ EngStrtCold_B_Rq 1 "ExtremeColdStart" 0 "NormalStart";
+VAL_TABLE_ EngStrtSmooth_D_Rq 7 "NotUsed" 6 "Smooth_NoPedal" 5 "Smooth_LightPedal" 4 "Smooth_MediumPedal" 3 "Smooth_HeavyPedal" 2 "Smooth_WOP" 1 "Smooth_Cold" 0 "Smooth_ExtremeCold";
+VAL_TABLE_ Fault_FFF 4095 "Fault";
+VAL_TABLE_ VehStrtStop_D_Rq 3 "NotUsed" 2 "Vehicle_Start_Request" 1 "Vehicle_Stop_Request" 0 "NoRequest";
+VAL_TABLE_ HvacRec_D_RqMxBatt 15 "NotUsed5" 14 "NotUsed4" 13 "NotUsed3" 12 "NotUsed2" 11 "NotUsed1" 10 "No_Override" 9 "90Percent_RecircMax" 8 "80Percent_RecircMax" 7 "70Percent_RecircMax" 6 "60Percent_RecircMax" 5 "50Percent_RecircMax" 4 "40Percent_RecircMax" 3 "30Percent_RecircMax" 2 "20Percent_RecircMax" 1 "10Percent_RecircMax" 0 "0Percent_RecircFullOpen";
+VAL_TABLE_ FuelCtlOpenLp_B_Inhbt 1 " Inhibit_FullPedal_Actions" 0 "Normal_Operation";
+VAL_TABLE_ EngStrtStop_B_SrcSrvc 1 "Eng_StartStop_for_Service" 0 "Not_Requested";
+VAL_TABLE_ EngStrtStop_B_SrcCat 1 "Eng_StartStop_for_Catalyst" 0 "Not_Requested";
+VAL_TABLE_ PrkBrkStatus 7 "GeneralFault_MaintenceMode" 6 "ECD_by_Brake_ECU_Active" 5 "EPB_Limphome_Active" 4 "Rear_Caliper_Open" 3 "RWU_By_EPB_Active" 2 "Rear_Caliper_Transition" 1 "Rear_Caliper_Closed" 0 "Not_Supported";
+VAL_TABLE_ ElLoadCtl_D_Rq 7 "Unused3" 6 "Unused2" 5 "Unused1" 4 "HoldAllDrvrInvisibleLoads" 3 "StdDriverInvisibleLoadsOn" 2 "AllDriverInvisibleLoadsOn" 1 "All_Possible_Loads_Off" 0 "No_Request";
+VAL_TABLE_ BattTracCool 3 "NotUsed" 2 "DCDC_Overtemperature" 1 "CoolingRequiredbyDCDC" 0 "NoCoolingRequiredbyDCDC";
+VAL_TABLE_ NotReady_Active_Fault 3 "Fault" 2 "Active" 1 "Ready" 0 "Not_Ready";
+VAL_TABLE_ Quality_Data 3 "OK" 2 "Not_Within_Specifications" 1 "Eval_In_Progress" 0 "Fault";
+VAL_TABLE_ PwSrcULoFalt_D_Stat 3 "Fault_No_Output" 2 "Fault_Reduced_Output" 1 "Fault_NonSpecific" 0 "No_Fault";
+VAL_TABLE_ Connect_Discon_Loose 1 "Loose_or_Disconnected" 0 "Connected";
+VAL_TABLE_ DontCare_StartInhibit 1 "Start_Inhibit" 0 "Dont_Care";
+VAL_TABLE_ BattULoChrg_D_Rq 3 "Low_Battery_Temperature" 2 "Charging_Requested" 1 "Chrg_Requested_HighCurrent" 0 "No_Request";
+VAL_TABLE_ PwSysULoFalt_D_Stat 15 "Not_Used_6" 14 "LowBatterySOC" 13 "PSS_Shed2_Contin" 12 "Not_Used_4" 11 "Not_Used_3" 10 "Not_Used_2" 9 "BattMonitoringSensorFault" 8 "LowBattVoltDuringPwSrcOn" 7 "LowBatt2_PowerSaveMode" 6 "LowBatt1_Warning" 5 "Overvoltage" 4 "Fault_NoOutput" 3 "Fault_ReducedOutput" 2 "Fault_Nonspecific" 1 "Cluster_Proveout" 0 "No_Fault";
+VAL_TABLE_ AccStopMde_D_Rq 3 "Stop_Mode_Active" 2 "EPBApplyOrBrakeReleaseWarn" 1 "Limit_Rolling_Speed" 0 "Stop_Mode_Not_Active";
+VAL_TABLE_ EngFuelCutFull_B_Sched 1 "DFSO_Event_Scheduled" 0 "Normal";
+VAL_TABLE_ Eng_D_Stat 3 "NotUsed" 2 "EngAutoStopped" 1 "EngOn" 0 "EngOff";
+VAL_TABLE_ ElPw_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Fault_Limited" 3 "LV_Event_In_Progress" 2 "Not_Supported_Imminent" 1 "Supported" 0 "Not_Supported";
+VAL_TABLE_ PwPckTq_D_Stat 3 "PwPckOn_TqAvailable" 2 "StartInPrgrss_TqNotAvail" 1 "PwPckOn_TqNotAvailable" 0 "PwPckOff_TqNotAvailable";
+VAL_TABLE_ BattTracCool_D_Falt 3 "NotUsed" 2 "CoolSysPartialyOperational" 1 "Cooling_System_Faulted" 0 "Cooling_System_Operational";
+VAL_TABLE_ Fault_FF 255 "Fault";
+VAL_TABLE_ ElCmprOverTe_D_Stat 3 "OverTempStop" 2 "OverTempWarning" 1 "Normal" 0 "Undefined";
+VAL_TABLE_ ElCmprUHi_D_Stat 3 "Overvoltage" 2 "Undervoltage" 1 "InRange" 0 "Undetermined";
+VAL_TABLE_ ElCmpr_D_Stat 7 "Signal_Invalid" 6 "Comp_Off_ActlSpd_Abnormal" 5 "Comp_Off_TrgtSpd_OutRange" 4 "Comp_Shutdown" 3 "Comp_Stopped_Self_Protect" 2 "Comp_Degraded" 1 "Comp_On" 0 "Comp_Off";
+VAL_TABLE_ Southern_Northern 3 "Fault" 2 "Northern" 1 "Southern" 0 "Invalid";
+VAL_TABLE_ PsngrFrntDetct_D_Actl 3 "Unknown" 2 "Empty" 0 "Faulty" 1 "Occupied";
+VAL_TABLE_ Normal_Mode1_2 3 "Undefined" 2 "Mode2" 1 "Mode1" 0 "Normal_Mode";
+VAL_TABLE_ LaActvAvail 3 "LKA_LCA_LDW_Avail" 2 "LCA_LKA_Avail_LDW_Suppress" 1 "LCA_LKA_Suppress_LDW_Avail" 0 "LCA_LKA_LDW_Suppress";
+VAL_TABLE_ LA_NotDenied 1 "LA_Denied" 0 "LA_Not_Denied";
+VAL_TABLE_ HandsOn_Off 1 "Hands_Off" 0 "Hands_On";
+VAL_TABLE_ Smooth_Quick 1 "Quick" 0 "Smooth";
+VAL_TABLE_ None_Low_Med_High 3 "High" 2 "Medium" 1 "Low" 0 "None";
+VAL_TABLE_ LdwActvStats 7 "LDW_Suppress_Right_Left" 6 "Not_Used2" 5 "LDW_Suppress_Right" 4 "LDW_Warning_Right" 3 "LDW_Suppress_Left" 2 "LDW_Warning_Left" 1 "LDW_DemoVibration" 0 "LDW_Idle";
+VAL_TABLE_ Fault_3FF 1023 "Fault";
+VAL_TABLE_ EngStrtStop 15 "Unused_7" 14 "Unused_6" 13 "Unused_5" 12 "Unused_4" 11 "Unused_3" 10 "Unused_2" 9 "Unused_1" 8 "Force_Pull_Down" 7 "Force_Pull_Up" 6 "Pull_Down_Inhibit_Pull_Up" 5 "Inhibit_Change" 4 "Inhibit_Pull_Up" 3 "Pull_Down" 2 "Inhibit_Pull_Down" 1 "Pull_Up" 0 "No_Request";
+VAL_TABLE_ TrnMde_D_Rq 15 "Unused_4" 14 "Unused_3" 13 "Unused_2" 12 "Unused_1" 11 "InOutLckedHydStandby" 10 "InputOutputLocked" 9 "OutputLockedHydStandby" 8 "OutputLocked" 7 "ReducedOutTqHydStandby" 6 "Reduced_Output_Torque" 5 "TransInTqHydStandby" 4 "Transmit_Input_Torque" 3 "ActNeutralHydStandby" 2 "Active_Neutral" 1 "NeutralHydraulicStdby" 0 "Neutral";
+VAL_TABLE_ Fault_F 15 "Fault";
+VAL_TABLE_ Fault_1F 31 "Fault";
+VAL_TABLE_ TmsStatRqDsply 15 "Reserved4" 14 "Reserved3" 13 "Reserved2" 12 "Crawl_Mode_4LOW_Reqd" 11 "Economy_Mode_Select" 10 "ModeChangeNotAvailable" 9 "Terrain_Sys_Not_Avail" 8 "Terrain_System_Fault" 7 "Mode_Change_InProgress" 6 "Dynamics_Mode_Select" 5 "Rock_Crawl_Mode_Select" 4 "Sand_Mode_Select" 3 "Mud_Ruts_Mode_Select" 2 "Low_Mu_Mode_Select" 1 "Special_Modes_Off" 0 "No_Message";
+VAL_TABLE_ LockInhibit 1 "Inhibit" 0 "No_Inhibit";
+VAL_TABLE_ DieslFuelBio_B_ActlDrv 1 "Biodiesel_User" 0 "Non_Biodiesel_User";
+VAL_TABLE_ Invalid_FFF 4095 "Invalid";
+VAL_TABLE_ ParkAid_Chime 15 "Zone15_Chime" 14 "Zone14_Chime" 13 "Zone13_Chime" 12 "Zone12_Chime" 11 "Zone11_Chime" 10 "Zone10_Chime" 9 "Zone9_Chime" 8 "Zone8_Chime" 7 "Zone7_Chime" 6 "Zone6_Chime" 5 "Zone5_Chime" 4 "Zone4_Chime" 3 "Zone3_Chime" 2 "Zone2_Chime" 1 "Zone1_Chime" 0 "No_Chime";
+VAL_TABLE_ Shed_Feature_Group_ID 16 "PtcHeater" 14 "HtdMirr" 13 "HvacRearBlwr_Third" 12 "HvacRearBlwr_Second" 11 "HvacRearBlwr_First" 31 "All LSHED1 Features" 10 "Htd_Windscrn" 9 "SpltHtdBcklight_HtdMirr" 8 "HtdBcklight_HtdMirr" 7 "HtdCoolSeat_FrtDriver" 6 "HtdCoolSeat_FrtPass" 5 "HtdCoolSeat_RearPass" 4 "HtdCoolSeat_RearDriver" 3 "SmartTrlrTowBattCharge" 2 "Htd_StrWhl" 1 "Htd_Washer_Fluid" 0 "No_LSHED1_Features" 15 "Engine_Coolant_Fan";
+VAL_TABLE_ CoolantFanStepAct 31 "Unused7" 30 "Unused6" 29 "Unused5" 28 "Unused4" 27 "Unused3" 26 "Unused2" 25 "Unused1" 23 "Step23" 22 "Step22" 21 "Step21" 20 "Step20" 19 "Step19" 18 "Step18" 17 "Step17" 16 "Step16" 15 "Step15" 14 "Step14" 13 "Step13" 12 "Step12" 11 "Step11" 10 "Step10" 9 "Step9" 8 "Step8" 7 "Step7" 6 "Step6" 5 "Step5" 4 "Step4" 3 "Step3" 2 "Step2" 1 "Step1" 24 "Max_Fan_Speed_Req" 0 "Fan_Cmd_Off";
+VAL_TABLE_ Null_Cancel 1 "Cancel" 0 "Null";
+VAL_TABLE_ Veh_Lock_Requestor 31 "Unused8" 30 "Unused7" 29 "Unused6" 28 "Rgtm_Shutlock_Switch" 27 "Boundary_Alert" 26 "Transit_Vehicle_Relock" 25 "Transit_Cargo_Relock" 24 "Transit_Ajar_Lock" 23 "Diagnostics" 22 "Console_Lock" 21 "Child_Lock" 20 "Double_Lock" 19 "Passive_Pasenger" 18 "Passive_Driver" 17 "Slam_Lock_Protect" 16 "SYNC" 15 "Passport" 14 "Passive_Smart_Unlock" 13 "Autorelock" 12 "RemoteStart" 0 "Null" 1 "Autolock" 11 "Smart_Unlock" 10 "Sliding_Door" 9 "Passive" 8 "Remote" 7 "Programming" 6 "Powerslide" 5 "Keypad" 4 "Key_Cylinder" 3 "Interior" 2 "Auto_Unlock";
+VAL_TABLE_ EPAS_FAILURE 3 "SERVICE_POWER_STEERING_NOW" 2 "SERVICE_POWER_STEERING" 1 "POWER_STRG_ASSIST_FAULT" 0 "EPAS_OK_NO_MESSAGE";
+VAL_TABLE_ Perimeter_Alarm_Mode 3 "Activated" 2 "Armed" 1 "Prearmed" 0 "Disarmed";
+VAL_TABLE_ Invalid_FFFF 65535 "Invalid";
+VAL_TABLE_ FdaStat_D_Dsply 7 "Undefined_3" 6 "Undefined_2" 5 "Undefined_1" 4 "Distance_Alert_Unavailable" 3 "DistanceAlertUnavail_Low" 2 "DistanceAlertUnavailActive" 1 "Distance_Alert_Available" 0 "Distance_Alert_Off";
+VAL_TABLE_ OilPressureWarning 1 "Low_Pressure_Lamp_On" 0 "Normal_Pressure_Lamp_Off";
+VAL_TABLE_ MyKey_KeyTypeChangeReq 3 "Search_PE_BackupSlot" 2 "Clear_All_MyKeys" 1 "Request_New_MyKey" 0 "None";
+VAL_TABLE_ MyKey_Key_Count 13 "Thirteen" 12 "Twelve" 11 "Eleven" 10 "Ten" 9 "Nine" 8 "Eight" 7 "Seven" 6 "Six" 5 "Five" 4 "Four" 3 "Three" 2 "Two" 1 "One" 0 "Zero" 15 "Invalid" 14 "Unlimited";
+VAL_TABLE_ GearEngag_D_Actl 7 "Undefined" 6 "Fwd_Clutch_Fully_Engaged" 5 "Neutral_Idle" 4 "Disengaged_to_Neutral_Idle" 3 "Disengaged_to_Neutral_Park" 2 "Engagement_in_Progress" 1 "InitializeFwdClutchEngagmt" 0 "Park_Neutral";
+VAL_TABLE_ Shed_Level_Req 7 "Unused_2" 6 "Loads_On" 5 "SHED_ENG_OFF" 4 "SOON_ENG_OFF" 3 "SHED2_CONTIN" 2 "SHED2_TRANS" 1 "SHED1" 0 "NO_SHED";
+VAL_TABLE_ BpedMove_D_Actl 3 "Unknown" 2 "DriverApplyingBrakePedal" 1 "NoAutonomousBrkPdlMovement" 0 "AutonomousBrkPedalMove";
+VAL_TABLE_ Eastern_Western 0 "Invalid" 1 "Eastern" 2 "Western" 3 "Fault";
+VAL_TABLE_ EATC_Temp_Digit3 2 "_5" 1 "_0" 0 "OFF";
+VAL_TABLE_ EATC_Units 2 "Fahrenheit" 1 "Celsius" 0 "Off";
+VAL_TABLE_ BattTracOffFst_D_Actl 3 "Unexpected_Contactor_Open" 2 "Restraints_Impact_Event" 1 "Interlock_Open" 0 "Normal";
+VAL_TABLE_ Invalid_1FF 511 "Invalid";
+VAL_TABLE_ ChargeMode 7 "Undefined_2" 6 "Undefined_1" 5 "Battery_Identify" 4 "Battery_Refresh" 3 "SlowRegenAllowNoDischarge" 2 "Fast_Regen_Allowed" 1 "Slow_Regen_Allowed" 0 "Conventional_Charging";
+VAL_TABLE_ Unknown_FFFE_Invalid_FFFF 65535 "Invalid" 65534 "Unknown";
+VAL_TABLE_ SAPPAngleControlStat5 1 "StrgColTorqueExceed_EAROn" 0 "ExternalSigContentOKforEAC";
+VAL_TABLE_ Closed_Open_Active_Fault 3 "Fault" 2 "Active" 1 "Open" 0 "Closed";
+VAL_TABLE_ SAPPAngleControlStat2 1 "Rel_ExtSteeringAngleReqx" 0 "NoRel_ExtSteeringAngleReqx";
+VAL_TABLE_ SAPPAngleControlStat3 1 "EARactiveNoReverseEngage" 0 "ExternalSigContentOKforEAC";
+VAL_TABLE_ RstrnImpactEvntStatus 7 "Invalid" 6 "Not_Used_4" 5 "Threshold_2_Exceeded" 4 "Not_Used_3" 3 "Threshold_1_Exceeded" 2 "Not_Used_2" 1 "Not_Used_1" 0 "Normal";
+VAL_TABLE_ EDRTriggerEvntSync 1 "Threshold_Exceeded" 0 "Normal";
+VAL_TABLE_ EngTeColdPrtct_D_Stats 3 "Engine_Warm_RdcPwr" 2 "OK_to_Drive" 1 "Engine_Warm_PlsWait" 0 "Normal_Operation";
+VAL_TABLE_ HILL_DESC_MC 7 "Fault_Detected" 6 "Cooling_Down" 5 "Abort_Apply_Brakes" 4 "Active" 3 "Disabled" 2 "Enabled" 1 "Off_Road" 0 "Normal";
+VAL_TABLE_ Closed_Ajar 1 "Ajar" 0 "Closed";
+VAL_TABLE_ CADS_Autio_Mute 7 "Unknown" 6 "Attenuation_6" 5 "Attenuation_5" 4 "Attenuation_4" 3 "Attenuation_3" 2 "Attenuation_2" 1 "Attenuation_1" 0 "No_Attenuation_of_Audio";
+VAL_TABLE_ Quality_Factor 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_TABLE_ Null_Day_Night 3 "NotUsed" 2 "Night" 1 "Day" 0 "Null";
+VAL_TABLE_ Null_Flash_High 3 "NotUsed" 2 "High" 1 "Flash_to_Pass" 0 "Null";
+VAL_TABLE_ GearPos_D_Actl 15 "Unknown" 14 "Reverse" 13 "Undefined_5" 12 "Undefined_4" 11 "Undefined_3" 10 "Tenth" 9 "Ninth" 8 "Eighth" 7 "Seventh" 6 "Sixth" 5 "Fifth" 4 "Fourth" 3 "Third" 2 "Second" 1 "First" 0 "Neutral";
+VAL_TABLE_ OffOn_SlowFast_Flash 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_TABLE_ AwdStat_D_RqDsply 31 "NotUsed9" 30 "NotUsed8" 29 "NotUsed7" 28 "To_Engage_4x4_Release_Aped" 27 "To_Engage_4x4_Slow_To_3MPH" 26 "Shift_To_Neutral" 25 "Lkr_Mode_Unavail_TMS" 24 " _4x4_Mode_Unavail_TMS" 23 "Out_of_4Low_Crawl" 22 "AWD_PTU_Oil_Changed" 21 "Change_AWD_PTU_Oil" 20 "Neutral_Tow_Disabled" 19 "Neutral_Tow_Enabled" 18 "AWD_OFF" 17 "_4x4_Off_Road_Speed" 16 "_4x4_Extreme_Off_Road_Mode" 15 "_4x4_Exiting_Off_Road" 14 "_4x4_Off_Road_Mode" 10 "_4x4_Locked_Temporarily" 9 "Shift_In_Progress" 13 "Blocked_Shift_Assist" 12 "_4x4_Auto_Restored" 11 "_4x4_Disabled_Temporarily" 7 "Out_of_4Low__Neutral" 6 "Out_of_4Low__Brake" 5 "Out_of_4Low__Speed" 4 "Into_4Low__Clutch" 3 "Into_4Low__Neutral" 2 "Into_4Low__Brake" 1 "Into_4Low__Speed" 0 "Normal__No_Message" 8 "Out_of_4Low__Clutch";
+VAL_TABLE_ AngleReached 1 "RequestedAngleNotReached" 0 "RequestedAngleCanBeReached";
+VAL_TABLE_ WhlDir 3 "Failed" 2 "Unknown" 1 "Backward" 0 "Forward";
+VAL_TABLE_ VehVLimStat_D_Actl 7 "Undefined_3" 6 "Undefined_2" 5 "Undefined_1" 4 "ASL_Fault_Condition" 3 "Active_and_Limiting" 2 "Active_but_Not_Limiting" 1 "Standby" 0 "Off";
+VAL_TABLE_ Unknown_Fault_1FE_1FF 511 "Fault" 510 "Unknown";
+VAL_TABLE_ Fault_NoFault 1 "Fault" 0 "No_Fault";
+VAL_TABLE_ TrnIpcDsplyMde_D_Actl 7 "Manual_3" 6 "Manual_2" 5 "Manual_1_Low" 4 "Sport" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_TABLE_ TrnIpcDsplyMde_D_Stat 3 "Reserved_Blank_No_Display" 2 "Flash" 1 "On" 0 "Blank_No_Display";
+VAL_TABLE_ TrnIpcDsplyGear_D_Actl 15 "No_Gear_Selected" 14 "_14th_Gear" 13 "_13th_Gear" 12 "_12th_Gear" 11 "_11th_Gear" 10 "_10th_Gear" 9 "_9th_Gear" 8 "_8th_Gear" 7 "_7th_Gear" 6 "_6th_Gear" 5 "_5th_Gear" 4 "_4th_Gear" 3 "_3rd_Gear" 2 "_2nd_Gear" 1 "_1st_Gear" 0 "Neutral";
+VAL_TABLE_ TerrMde_D_Actl 7 "Fail_Safe_Default" 6 "Dynamic_Mode" 5 "Rock_Crawl_Mode" 4 "Mud_Ruts_Mode" 3 "Sand_Mode" 2 "Undefined" 1 "Low_Mu_Mode" 0 "Special_Operating_Mode_Off";
+VAL_TABLE_ TerrMdeChng_D_Rdy 7 "Fault" 6 "Undefined_2" 5 "Undefined_1" 4 "ModeUnavailDrInputRqd" 3 "SpOpModes_NotSupported" 2 "ModeUnavailDynamicCond" 1 "Module_In_Initialization" 0 "Mode_Change_Available";
+VAL_TABLE_ Unknown_Fault_FFFE_FFFF 65535 "Fault" 65534 "Unknown";
+VAL_TABLE_ Invalid_FFFFFF 16777215 "Invalid";
+VAL_TABLE_ AutoParkSpdExitCond 1 "SpeedLimitExceededEAROn" 0 "ExternalSigContentOKforEAC";
+VAL_TABLE_ EngOilLvlDsply_D_Rq 15 "EngOil_LevelSys_CheckFault" 14 "Reserved_2" 13 "Reserved_1" 12 "Conditions_Unsuitable" 11 "Dipstick_Below_Minimum" 10 "Dipstick_Above_Maximum" 9 "Dipstick_Minimum" 8 "Dipstick_12_5_MinMaxRange" 7 "Dipstick_25_MinMaxRange" 6 "Dipstick_37_5_MinMaxRange" 5 "Dipstick_50_MinMaxRange" 4 "Dipstick_62_5_MinMaxRange" 3 "Dipstick_75_MinMaxRange" 2 "Dipstick_87_5_MinMaxRange" 1 "Dipstick_Maximum_Displayed" 0 "No_Message";
+VAL_TABLE_ HdcMde_D_Actl 7 "Fault" 6 "Temporarily_Unavailable" 5 "NotEnabled_WrongGearSel" 4 "NotEnabled_SpdLimitExceed" 3 "Active_Braking" 2 "Not_Active_Braking" 1 "Off" 0 "Undefined";
+VAL_TABLE_ GearLvrPos_D_Actl 15 "Fault" 14 "Unknown_Position" 13 "Undefined_Treat_as__Fault" 12 "Undefined_Treat_as_Fault" 11 "sixth" 10 "fifth" 9 "fourth" 8 "third" 7 "second" 6 "first" 5 "Low" 4 "Sport_DriveSport" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_TABLE_ FcwMsgTxt_D_Rq 7 "Undefined_3" 6 "Undefined_2" 5 "Low_Visibility" 4 "Unavailable_DueTo_LowSpeed" 3 "Available" 2 "Unavailable" 1 "Off" 0 "No_Text";
+VAL_TABLE_ FcwSens_B_Actl 3 "FCW_Sensitivity_3" 2 "FCW_Sensitivity_2" 1 "FCW_Sensitivity_1" 0 "Not_Used";
+VAL_TABLE_ LastSettind_DefaultOn 1 "Default_On" 0 "Last_Setting";
+VAL_TABLE_ EngTurboMde_D_Actl 3 "Fault" 2 "One_Turbo_Active" 1 "Two_Turbos_Active" 0 "Initializing";
+VAL_TABLE_ EngPullUpPullDown 15 "Undefined_7" 14 "Undefined_6" 13 "Undefined_5" 12 "Undefined_4" 8 "Force_Pull_Down" 7 "Force_Pull_Up" 6 "PullDown_Inhibit_PullUp" 5 "Inhibit_Change" 4 "Inhibit_Pull_Up" 3 "Pull_Down" 2 "Inhibit_Pull_Down" 1 "Pull_Up" 0 "No_Request" 11 "Undefined_3" 10 "Undefined_2" 9 "Undefined_1";
+VAL_TABLE_ EngMde_D_Rq 8 "VSC_Sets_Speed_Type_3" 7 "VSC_Sets_Speed_Type_2" 6 "VSC_Sets_Torque_Type_2" 5 "Dependability_Shutdown" 4 "Dependability_Follow" 3 "Start" 2 "VSC_Sets_Torque_Type_1" 1 "VSC_Sets_Speed_Type_1" 0 "Off" 15 "Undefined_7" 14 "Undefined_6" 13 "Undefined_5" 12 "Undefined_4" 11 "Undefined_3" 10 "Undefined_2" 9 "Undefined_1";
+VAL_TABLE_ DrvHdcMsg_D_Rq 7 "Undefined" 6 "Speed_too_High" 5 "Temporarily_Unavailable" 4 "System_Fault" 3 "Select_Gear" 2 "Off" 1 "On" 0 "No_Message";
+VAL_TABLE_ CmbbBrkPrchg_B_Rq 3 "Undefined" 2 "Level_2_PreCharge_Request" 1 "Level_1_PreCharge_Request" 0 "No_PreCharge_Request";
+VAL_TABLE_ CmbbBaSens_D_Rq 3 "Level_3" 2 "Level_2" 1 "Level_1" 0 "Normal";
+VAL_TABLE_ CcStat_D_Actl 7 "Undefined_2" 6 "Undefined_1" 5 "Active" 4 "Active_Que_Assist" 3 "Standby" 2 "Standby_Denied" 1 "Denied" 0 "Off";
+VAL_TABLE_ CadsAudioMute_D_Rq 3 "Reserved" 2 "Partial_Audio_Mute" 1 "Full_Audio_Mute" 0 "No_Audio_Mute";
+VAL_TABLE_ BpedDrvAppl_D_Actl 3 "_Not_Allowed" 2 "Driver_Braking" 1 "Driver_Not_Braking" 0 "Not_Allowed";
+VAL_TABLE_ AslIconDsply_D_Rq 3 "On_Passive_Overridden" 2 "On_Active" 1 "On_Passive" 0 "Off";
+VAL_TABLE_ Unknown_Fault_3E_3F 63 "Fault" 62 "Unknown";
+VAL_TABLE_ AccWarn_D_Dsply 3 "BrakeReleaseWarn_In_StopMd" 2 "Brake_Capacity_Warning" 1 "Cancel_Warning" 0 "No_Warning";
+VAL_TABLE_ AccTrgDist2_D_Dsply 15 "DIST_ACTIVE_13_Farthest" 14 "DIST_ACTIVE_12" 13 "DIST_ACTIVE_11" 12 "DIST_ACTIVE_10" 11 "DIST_ACTIVE_9" 10 "DIST_ACTIVE_8" 9 "DIST_ACTIVE_7" 8 "DIST_ACTIVE_6" 7 "DIST_ACTIVE_5" 6 "DIST_ACTIVE_4" 5 "DIST_ACTIVE_3" 4 "DIST_ACTIVE_2" 3 "DIST_ACTIVE_1_Closest" 2 "DIST_ACTIVE_No_Target" 1 "DIST_STANDBY" 0 "DIST_OFF";
+VAL_TABLE_ AccTGap_D_Dsply 7 "Undefined_2" 6 "Undefined_1" 5 "Time_Gap_5" 4 "Time_Gap_4" 3 "Time_Gap_3" 2 "Time_Gap_2" 1 "Time_Gap_1" 0 "Not_Used";
+VAL_TABLE_ AccEngStat_D_Actl 7 "Undefined_2" 6 "Undefined_1" 5 "ACCSoonCancel_due_Low_Spd" 4 "Shift_Down_Recommendation" 3 "Shift_Up_Recommendation" 2 "ACCNotAllowedToBeActivated" 1 "ACCStandby_due_Auto_Cancel" 0 "Normal_Operation";
+VAL_TABLE_ NotPressed_Pressed 1 "Pressed" 0 "Not_Pressed";
+VAL_TABLE_ TrnGear_D_RqDrv 31 "Fault" 30 "NotUsed_25" 29 "NotUsed_24" 28 "NotUsed_23" 27 "NotUsed_22" 26 "Return_to_Park" 25 "NotUsed_20" 24 "NotUsed_19" 23 "NotUsed_18" 22 "NotUsed_17" 21 "Return_To_Park" 20 "NotUsed_15" 19 "NotUsed_14" 18 "NotUsed_13" 17 "NotUsed_12" 16 "Manual" 15 "Not_Used11" 14 "Not_Used10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "Drive" 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "Neutral" 3 "NotUsed_1" 2 "Reverse" 1 "Park" 0 "No_Gear";
+VAL_TABLE_ Open_Close 1 "Close" 0 "Open";
+VAL_TABLE_ OpenCloseRetainUndef 3 "Undefined" 2 "Retain" 1 "Close" 0 "Open";
+VAL_TABLE_ DasWarn 3 "Undefined" 2 "Warning_Level_2" 1 "Warning_Level_1" 0 "No_Warning";
+VAL_TABLE_ DasAlert 5 "Alertness_Level_5" 4 "Alertness_Level_4" 3 "Alertness_Level_3" 2 "Alertness_Level_2" 1 "Alertness_Level_1" 0 "Undefined";
+VAL_TABLE_ DasStat 3 "Available" 2 "Unavailable_Other" 1 "Feedback_due_to_Speed" 0 "Off";
+VAL_TABLE_ No_Crank_Req 1 "Crank_Request" 0 "No_Crank_Request";
+VAL_TABLE_ DrvSlipCtlMde_D_Rq 3 "App_Specific_Off_Mode_3" 2 "App_Specific_Off_Mode_2" 1 "App_Specific_Off_Mode_1" 0 "Default_Mode";
+VAL_TABLE_ AwdOffRoadMode 3 "Invalid" 2 "Extreme_Off_Road" 1 "Off_Road" 0 "Normal_Mode";
+VAL_TABLE_ NotQuiet_Quiet 1 "Quiet" 0 "Not_Quiet";
+VAL_TABLE_ Normal_AdaptiveCruise 1 "Adaptive_Cruise" 0 "Normal_Cruise";
+VAL_TABLE_ Remote_Device_Feedback 7 "Unused3" 6 "Unused2" 5 "Unused1" 4 "Shutdown" 3 "Running" 2 "Starting" 1 "Acknowledge" 0 "Null";
+VAL_TABLE_ TrnManShif_D_IndDrv 7 "Undefined_3" 6 "Undefined_2" 5 "Shift_to_Neutral" 4 "Downshift_Recommendation" 3 "Upshift_Warning" 2 "Upshift_Performance" 1 "Upshift_Fuel_Economy" 0 "No_Indication";
+VAL_TABLE_ Unlock_Lock 1 "Locked" 0 "Unlock";
+VAL_TABLE_ DieslPrtc_D_RqDsply 7 "Unused_2" 6 "Unused_1" 5 "DPF_SOOT_Level3_Blocked" 4 "DPFSootLvl2_SevereOverload" 3 "DPFRegen_ExhFilterComplete" 2 "DPFRegen_CleanExhFilter" 1 "DPF_Soot_Level1_Overloaded" 0 "DPF_OK_Normal_Operation";
+VAL_TABLE_ PE_BackupSlot_Status 3 "No_Valid_FOB_In_Slot" 2 "MyKey_FOB_In_Slot" 1 "Standard_FOB_In_Slot" 0 "Null";
+VAL_TABLE_ Unknown_Fault_FFE_FFF 4095 "Fault" 4094 "Unknown";
+VAL_TABLE_ Unknown_Fault_1FFE_1FFF 8191 "Fault" 8190 "Unknown";
+VAL_TABLE_ TrnCnvtClu_D_Actl 3 "Transition_or_Micro_Slip" 2 "Lock_Up_Fixed" 1 "Lock_Up_Slip" 0 "No_Lock_Up";
+VAL_TABLE_ InhibitNoinhibit 1 "Inhibit" 0 "No_Inibit";
+VAL_TABLE_ DisableEnable 1 "Enable" 0 "Disable";
+VAL_TABLE_ Unknown_Fault_7FFE_7FFF 32767 "Fault" 32766 "Unknown";
+VAL_TABLE_ Side_Detect_Sn_State 3 "Second_Warning_Audio" 2 "System_Failure" 1 "Blocked" 0 "Clear";
+VAL_TABLE_ Litval_values 255 "Invalid" 254 "Unknown" 5 "Day" 4 "Twilight_4" 3 "Twilight_3" 2 "Twilight_2" 1 "Twilight_1" 0 "Night";
+VAL_TABLE_ Dimming_Lvl 255 "Invalid" 254 "Unknown" 18 "Day_6" 17 "Day_5" 16 "Day_4" 15 "Day_3" 14 "Day_2" 13 "Day_1" 12 "Night_12" 11 "Night_11" 10 "Night_10" 9 "Night_9" 8 "Night_8" 7 "Night_7" 6 "Night_6" 5 "Night_5" 4 "Night_4" 3 "Night_3" 2 "Night_2" 1 "Night_1" 0 "Off";
+VAL_TABLE_ EngStrtStop_B_SrcChtLo 1 "Eng_StartStop_for_CHT_Low" 0 "Not_Requested";
+VAL_TABLE_ EngStrtStop_B_SrcChtHi 1 "Eng_StartStop_for_CHT_Hi" 0 "Not_Requested";
+VAL_TABLE_ EngDiag_D_RqHtrn 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "NoUsed1" 3 "Eng_Diag_Cstdn" 2 "Eng_Diag_Run" 1 "Eng_Diag_Crank" 0 "Eng_Diag_Normal";
+VAL_TABLE_ NotOperating 1 "Operating" 0 "Not_Operating";
+VAL_TABLE_ CamraStat 3 "FrtCam_TempUnavailOther" 2 "FrtCam_TempUnavailVisibile" 1 "Front_Camera_Service_Reqd" 0 "Front_Camera_OK";
+VAL_TABLE_ EngPtoMde_D_Actl 7 "Undefined" 6 "Split_Shaft_Stationary" 5 "Not_Used_2" 4 "PTO_Mobile" 3 "Not_Used_1" 2 "PTO_Stationary" 1 "BCP" 0 "Off";
+VAL_TABLE_ ManRgen_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "CustInitManExhFilterClean" 0 "No_Customer_Request";
+VAL_TABLE_ Remote_Start_Status 3 "Invalid" 2 "Unknown" 1 "Remote" 0 "Null";
+VAL_TABLE_ Lock_Subld 15 "Unused7" 14 "Unused6" 13 "Unused5" 12 "Unused4" 11 "Unused3" 10 "Unused2" 9 "Unused1" 8 "Customer_8" 7 "Customer_7" 6 "Customer_6" 5 "Customer_5" 4 "Customer_4" 3 "Customer_3" 2 "Customer_2" 1 "Customer_1" 0 "Null";
+VAL_TABLE_ Brake_Fluid 3 "Invalid" 2 "Unknown" 1 "Low" 0 "OK";
+VAL_TABLE_ Unknown_Invalid_FE_FF 255 "Invalid" 254 "Unknown";
+VAL_TABLE_ Invalid_FF 255 "Invalid";
+VAL_TABLE_ NotLow_Low 1 "Low" 0 "Not_Low";
+VAL_TABLE_ Disabled_Enabled_Status 2 "Status" 3 "NotUsed" 1 "Enabled" 0 "Disabled";
+VAL_TABLE_ Key_In_Ignition_Status 1 "In" 0 "Out";
+VAL_TABLE_ Ignition_Status 0 "Unknown" 1 "Off" 15 "Invalid" 8 "Start" 4 "Run" 2 "Accessory";
+VAL_TABLE_ Disabled_Enabled_Faulted 3 "Faulted" 2 "Unused" 1 "Enabled" 0 "Disabled";
+VAL_TABLE_ Disabled_Enabled_NoSupport 2 "Unused" 3 "Not_Supported" 1 "Enabled" 0 "Disabled";
+VAL_TABLE_ Unknown_Fault_FE_FF 255 "Fault" 254 "Unknown";
+VAL_TABLE_ Null_Unlock 1 "Unlock" 0 "Null";
+VAL_TABLE_ Null_Active 1 "Active" 0 "Null";
+VAL_TABLE_ HsaStat_D_Actl 7 "Faulty" 6 "FaultyWithDriverIndication" 5 "SlowRelease" 4 "FastRelease" 3 "ActiveBrakePedalReleased" 2 "ActiveBrakePedalPressed" 1 "FindingGradient" 0 "Inactive";
+VAL_TABLE_ Off_Auto_Manual 3 "Undefined" 2 "Manual" 1 "Automatic" 0 "Off";
+VAL_TABLE_ HsaStat_D_Dsply 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "NotAvailable" 3 "SlowReleaseWithChime" 2 "SlowReleaseWithoutChime" 1 "Active" 0 "Inactive";
+VAL_TABLE_ EngMsgTxt_D_Rq 3 "Undefined_2" 2 "Undefined_1" 1 "Power_Reduced_to_LowerTemp" 0 "No_Message";
+VAL_TABLE_ PassRstrnInd_Req 3 "ABOnNotIllum_OffNotIllum" 2 "AirbagOnNot_Illum_OffIllum" 1 "AirbagOn_Illum_OffNotIllum" 0 "AirbagOn_Illum_Off_Illum";
+VAL_TABLE_ RearDiffLckMsg_D_Rq 7 "Locker_Disabled" 6 "Locker_Enabled" 5 "Locker_Accel_Pedal" 4 "Speed4" 3 "Speed3" 2 "Spee2" 1 "Speed1" 0 "Normal__No_Message ";
+VAL_TABLE_ GPS_Compass_dirctn 7 "NorthWest" 6 "West" 5 "SouthWest" 4 "South" 3 "SouthEast" 2 "East" 1 "NorthEast" 0 "North";
+VAL_TABLE_ GPS_Actual_Infer 1 "Inferred_Position" 0 "Actual_Postition";
+VAL_TABLE_ DrvHdcWarnInfo_D_Rq 3 "Undefined" 2 "Lamp_On_Continuously" 1 "Lamp_Flashing" 0 "Lamp_Off_Continuously";
+VAL_TABLE_ DieslPrtcRgen_D_Actl 3 "Undefined" 2 "Regen_Level_2" 1 "Regen_Level_1" 0 "No_regen";
+VAL_TABLE_ Off_On 1 "On" 0 "Off";
+VAL_TABLE_ CcMde_D_Actl 7 "TapDownWaiting" 6 "TapUpWaiting" 5 "Resuming_Low" 4 "Resuming_High" 3 "Decelerating" 2 "Accelerating" 1 "Keeping_Speed" 0 "Not_Active";
+VAL_TABLE_ InactiveActive 1 "Active" 0 "Inactive";
+VAL_TABLE_ ManRgenTxt_D_RqDsply 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Cleaning_Aborted_Stopped" 3 "Cleaning_Completed" 2 "Cleaning_In_Progress" 1 "Cleaning_Allowed" 0 "Cleaning_Not_Allowed";
+VAL_TABLE_ Fault_FFFF 65535 "Fault";
+VAL_TABLE_ Fault_7F 127 "Fault";
+VAL_TABLE_ EngOilLvlWarn_D_Rq 7 "Undefined_3" 6 "Undefined_2" 5 "Engine_Oil_Monitor_Fault" 3 "Engine_Oil_High" 2 "Engine_Oil_Critical_Low" 1 "Engine_Oil_Low" 0 "No_Message" 4 "Engine_Oil_Critical_High";
+VAL_TABLE_ UreaQltySys_D_RqDsply 7 "Undefined" 6 "ZZ_Overrides" 5 "EngineIdled" 4 "Engine_Idle_Upon_Refuel" 3 "SPEED_LIMITED_to_YY_mph" 2 "YY_MPH_MAX_UPON_Restart" 1 "CONTAMINATED_ExhFluid" 0 "NoQualityProblem";
+VAL_TABLE_ Unknown_Invalid_1E_1F 31 "Invalid" 30 "Unknown";
+VAL_TABLE_ Unknown_Invalid_3FFE_3FFF 16383 "Invalid" 16382 "Unknown";
+VAL_TABLE_ NoYes 1 "Yes" 0 "No";
+VAL_TABLE_ AwdRnge_D_Actl 7 "Unknown" 6 "High_Range_2wd" 5 "High_Range_Auto" 4 "High_Range_Locked" 3 "Neutral" 2 "Low_Range_2wd" 1 "Low_Range_Auto" 0 "Low_Range_Locked";
+VAL_TABLE_ AwdLck_D_Stat 9 "Undefined" 8 "Under_External_Torque_Ctrl" 7 "Torque_Limited_by_Cmd" 6 "Fully_Locked_by_Cmd" 5 "Disabled" 4 "Warning" 3 "Fault" 2 "Inactive" 1 "Completely_Opened_by_Cmd" 0 "OK";
+VAL_TABLE_ Unknown_Fault_3FE_3FF 1023 "Fault" 1022 "Unknown";
+VAL_TABLE_ LockSwStat 3 "Invalid" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_TABLE_ Null_Override 1 "Override" 0 "Null";
+VAL_TABLE_ Off_On_Flash 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_TABLE_ immoTargetStatCoding 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "DISABLED_RESET  " 2 "ENABLED_NONMOTIVE_START" 1 "ENABLED_MOTIVE_START" 0 "DISABLED";
+VAL_TABLE_ BeltBuckle 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_TABLE_ RILReqCoding 3 "Not_Used" 2 "Plant_Mode" 1 "On" 0 "Off";
+VAL_TABLE_ Update_Bit 1 "Fresh_data" 0 "Unchanged_data";
+VAL_TABLE_ Running_Board 3 "Unused" 2 "Manually_Deployed" 1 "All_Enabled" 0 "All_Disabled";
+VAL_TABLE_ HudFlashRate 3 "Unused" 2 "Flash_4Hz_50Prct_DutyCycle" 1 "On" 0 "Off";
+VAL_TABLE_ Turn_Seq 3 "Seq" 2 "On" 1 "Off" 0 "Null";
+VAL_TABLE_ immoTargetCmdCoding 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "TARGET1_IDBLOCK2" 2 "TARGET1_IDBLOCK1" 1 "CHALLENGE" 0 "IDLE";
+VAL_TABLE_ immoSubTargetCmdCoding 7 "Unused3" 6 "Unused2" 5 "ECHO_TARGET1_IDBLOCK2" 4 "Unused1" 3 "RQST_TARGET1_IDBLOCK2" 2 "RQST_TARGET1_IDBLOCK1" 1 "RESPONSE" 0 "IDLE";
+VAL_TABLE_ immoCtrlCmdCoding 0 "IDLE" 1 "MOTIVE_START_RQST" 2 "NONMOTIVE_START_RQST" 3 "RQST_TARGET1_IDBLOCK1" 4 "RQST_TARGET1_IDBLOCK2" 5 "Unused" 6 "ECHO_TARGET1_IDBLOCK2" 7 "SHUTDOWN";
+VAL_TABLE_ Rvc_Zoom 7 "Unknown" 6 "Invalid" 5 "Zoom_Level_V" 4 "Zoom_Level_IV" 3 "Zoom_Level_III" 2 "Zoom_Level_II" 1 "Zoom_Level_I" 0 "Off";
+VAL_TABLE_ NotPark 1 "Park" 0 "Not_Park";
+VAL_TABLE_ Electric_EOH 1 "Electric_Over_Hydraulic" 0 "Electric";
+VAL_TABLE_ PersOptIn 1 "OPTED_IN" 0 "NOT_OPTED_IN";
+VAL_TABLE_ PersonalSetUp 3 "Non_Moveable_Person" 2 "Moveable_Person" 1 "Vehicle" 0 "Factory";
+VAL_TABLE_ Full_Limited 1 "Limited" 0 "Full";
+VAL_TABLE_ NoConflict_Conflict 1 "Conflict" 0 "No_Conflict";
+VAL_TABLE_ Assoc_Confirm 0 "None" 7 "Associate" 6 "Keycode_Rejected" 5 "Keycode_Accepted" 4 "In_Progress" 3 "Erase" 2 "Duplicate" 1 "Disassociate";
+VAL_TABLE_ Pers1_4 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_TABLE_ Null_Query 7 "Unused_2" 6 "Unused_1" 5 "Copy" 4 "Restore" 3 "Upload" 2 "Set" 1 "Query" 0 "Null";
+VAL_TABLE_ EngExhBrkMde_D_Actl 6 "ExhBrkDisable_NoError" 5 "ExhBrkActive_AUTO" 4 "ExhBrkActive_ON" 3 "ExhBrkRequest_AUTO" 2 "ExhBrkRequest_ON" 1 "ExhBrkNoRequest_OFF" 0 "ExhBrkUnavailable_Error";
+VAL_TABLE_ UreaLvlTxt_D_RqDsply 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "System_Error" 10 "Engine_Idled_See_Manual" 9 "Engine_Idled_Upon_Refuel" 8 "Speed_Limited_To_XX_mph" 7 "XXmph_Max_Upon_Restart" 6 "Speed_Limited_To_YY_mph" 5 "YYmph_Max_Upon_Restart" 4 "SpdLimtd_YYmph_In_XXmiles" 3 "ExFlRange_XXMiles_ScndWarn" 2 "Exh_Fluid_Range_XX_Miles" 1 "Exh_Fluid_Under_Half_Full" 0 "Exh_Fluid_Over_Half_Full";
+VAL_TABLE_ RearDiffFalt_D_Stat 3 "Diff_Failed_Closed" 2 "Diff_Failed_Open" 1 "Fault_Non_Specific" 0 "No_Fault";
+VAL_TABLE_ CCOverridden 1 "Cruise_Overridden" 0 "Cruise_Req_Not_Overridden";
+VAL_TABLE_ Ign_Key_Device_Type 15 "Invalid" 14 "Unknown" 3 "Key_Not_Prgrm_Read_Failure" 2 "Key_In_Ign_My_Key" 1 "Key_In_Ign_Standard_Key" 0 "Key_Read_In_Progress";
+VAL_TABLE_ Off_No_Eff_Unknown_Invalid 3 "Invalid" 2 "Unknown" 1 "No_Effect" 0 "Off";
+VAL_TABLE_ Null_Out 1 "Out" 0 "Null";
+VAL_TABLE_ FUEL_SENSORS 1 "Dual_Sensors" 0 "Single_Sensor";
+
+
+BO_ 823 DTE_HPCMtoECG: 8 Vector__XXX
+ SG_ DteVehPwId_No_Actl : 47|5@0+ (1,0) [0|31] "unitless" GWM
+ SG_ DteVehEId_No_Actl : 39|8@0+ (1,0) [0|255] "unitless" GWM
+ SG_ DteVehEffId_No_Actl : 6|7@0+ (1,0) [0|127] "unitless" GWM
+ SG_ DteVeh_Pw_Actl : 31|8@0+ (50,0) [0|12750] "watts" GWM
+ SG_ DteVeh_Eff_Actl : 23|8@0+ (10,-1000) [-1000|1550] "watt*hour/km" GWM
+ SG_ DteVeh_E_Actl : 15|8@0+ (100,0) [0|25500] "watt*hour" GWM
+ SG_ DteAcceptNew_B_Rq : 7|1@0+ (1,0) [0|1] "SED" GWM
+
+BO_ 824 DTE_ECGtoHPCM: 8 GWM
+ SG_ DteCldTrlrOn_B_Stat : 51|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldTrlrOff_B_Stat : 52|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldTrip_L_Actl : 47|8@0+ (10,-1000) [-1000|1550] "watt*hour/km" Vector__XXX
+ SG_ DteCldTraffic_B_Stat : 53|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldTerrain_B_Stat : 54|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldRoute_B_Stat : 55|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldPayload_B_Stat : 16|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldId_No_Actl : 21|5@0+ (1,0) [0|31] "unitless" Vector__XXX
+ SG_ DteCldExtTe_B_Stat : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldExt_Eff_Actl : 39|8@0+ (10,-1000) [-1000|1550] "watt*hour/km" Vector__XXX
+ SG_ DteCldDrv_Eff_Actl : 31|8@0+ (10,-1000) [-1000|1550] "watt*hour/km" Vector__XXX
+ SG_ DteCldDcac_B_Stat : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DteCldClimt_Eff_Actl : 15|8@0+ (10,-1000) [-1000|1550] "watt*hour/km" Vector__XXX
+ SG_ DteCldBattULo_Eff_Actl : 7|8@0+ (10,-1000) [-1000|1550] "watt*hour/km" Vector__XXX
+
+BO_ 949 Tire_Pressure_Data_FD1: 8 GWM
+ SG_ Tire_Press_RR_ORR_Data : 39|16@0+ (1,0) [0|65533] "kilopascal" VDM
+ SG_ Tire_Press_LR_OLR_Data : 55|16@0+ (1,0) [0|65533] "kilopascal" VDM
+ SG_ Tire_Press_LF_Data : 7|16@0+ (1,0) [0|65533] "kilopascal" VDM
+ SG_ Tire_Press_RF_Data : 23|16@0+ (1,0) [0|65533] "kilopascal" VDM
+
+BO_ 1825 TesterPhysicalReqVDM_FD1: 64 GWM
+ SG_ TesterPhysicalReqVDM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless" VDM
+
+BO_ 524 AWD_Torque_Data: 8 TCCM
+ SG_ PrplWhlTotTqRqMxAwd_No_Cs : 23|8@0+ (1,0) [0|255] "Unitless" ECM_Diesel
+ SG_ PrplWhlTot_Tq_RqMxAwd : 7|16@0+ (4,-131072) [-131072|131068] "Nm" ECM_Diesel
+ SG_ PrplWhlTotTqRqMxAwd_No_Cnt : 31|4@0+ (1,0) [0|15] "Unitless" ECM_Diesel
+
+BO_ 740 PHEV_Battery_Data1_FD1: 8 GWM
+ SG_ BattAuxCnnct_B_Cmd : 53|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+
+BO_ 1160 ECG_Data2_FD1: 8 GWM
+ SG_ DgtlCommPncReset_B_Req : 62|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DataMntrSustn_B_Rq : 63|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PwSustnRdata_B_RqTelem : 60|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 776 SmartChargingData_ECG_3: 8 GWM
+ SG_ ScMnSoc_Pc_RqCld : 55|7@0+ (1,0) [0|127] "percent" Vector__XXX
+ SG_ ScChrgrPwMax_Pw_RqCld : 39|12@0+ (50,0) [0|204700] "watts" Vector__XXX
+ SG_ ScLocPwId_No_RqCld : 43|3@0+ (1,0) [0|7] "unitless" Vector__XXX
+ SG_ PrcondEdit_D_RqCld : 10|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ GoTEditMnte_T_RqCld : 29|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ GoTEditHr_T_RqCld : 15|5@0+ (1,0) [0|29] "SED" Vector__XXX
+ SG_ ChrgToPcEdit_Pc_RqCld : 7|7@0+ (1,0) [0|125] "percent" Vector__XXX
+ SG_ AirAmb_Te_ActlCld : 23|10@0+ (0.25,-128) [-128|127.75] "degC" Vector__XXX
+ SG_ ScFreshDataEnbl_B_Rq : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ScEnbl_D_RqCld : 25|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 775 SmartChargingData_ECG_2: 8 GWM
+ SG_ ScDayOfWeekId_D_RqCld : 63|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ScLocSetId_No_RqCld : 10|3@0+ (1,0) [0|7] "unitless" Vector__XXX
+ SG_ ScLocRdius_L_RqCld : 55|7@0+ (100,0) [0|12700] "meter" Vector__XXX
+ SG_ ScChrgToPc_Pc_RqCld : 47|7@0+ (1,0) [0|127] "percent" Vector__XXX
+ SG_ ScChrgPrfl_No_RqCld : 23|24@0+ (1,0) [0|16777215] "unitless" Vector__XXX
+ SG_ ScChrgDurSet_D_RqCld : 12|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ScChrgDur_T_RqCld : 7|11@0+ (1,0) [0|2045] "minute" Vector__XXX
+
+BO_ 774 SmartChargingData_ECG_1: 8 GWM
+ SG_ ScLocLongPostv_B_RqCld : 8|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ScLocLongFrct_An_RqCld : 35|20@0+ (1E-006,0) [0|1.048575] "degrees" Vector__XXX
+ SG_ ScLocLongDeg_An_RqCld : 63|8@0+ (1,0) [0|255] "degrees" Vector__XXX
+ SG_ ScLocLattPostv_B_RqCld : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ScLocLattFrct_An_RqCld : 23|20@0+ (1E-006,0) [0|1.048575] "degrees" Vector__XXX
+ SG_ ScLocLattDeg_An_RqCld : 15|7@0+ (1,0) [0|127] "percent" Vector__XXX
+ SG_ ScLocId_No_RqCld : 6|3@0+ (1,0) [0|7] "unitless" Vector__XXX
+ SG_ ScLocDelete_B_RqCld : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 811 APIM_Data_FD1: 8 GWM
+ SG_ DistToStopover_L_Actl : 31|16@0+ (0.1,0) [0|6553.4] "kilometer" Vector__XXX
+ SG_ StopoverType_D_Stat : 47|3@0+ (1,0) [0|0] "SED" Vector__XXX
+ SG_ ExtLghtDsply_D_Stat : 7|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ExtLghtRight_D_RqMnu : 11|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ AutoLghtOvrrd_B_RqDrv : 8|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ExtLghtRear_D_RqMnu : 14|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ExtLghtLeft_D_RqMnu : 1|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ExtLghtFront_D_RqMnu : 4|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ GoTEditMnte_T_RqMnu : 63|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ GoTEditHr_T_RqMnu : 44|5@0+ (1,0) [0|29] "SED" Vector__XXX
+
+BO_ 850 HEV_ChargeStat_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ VehElRngeNut_L_Dsply : 11|12@0+ (0.1,0) [0|409.3] "km" GWM
+ SG_ NxtUsgSocEst_Pc_Dsply : 7|8@0+ (0.5,0) [0|126.5] "unitless" GWM
+ SG_ EstmChrgTimeLP_St : 39|8@0+ (0.1,0) [0|25.4] "hour" GWM
+ SG_ EstmChrgTimeHP_St : 47|8@0+ (0.1,0) [0|25.4] "hour" GWM
+ SG_ ChargeNowDuration_St : 31|8@0+ (0.1,0) [0|25.4] "hour" GWM
+
+BO_ 563 MasterReset_HS3_ECGDat_FD1: 8 GWM
+ SG_ DrvBhavWarn_B_Rq : 12|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ OfbChrgSetSync_D_Rq : 1|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ KeyOffPwMde_D_Stat : 15|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ModemReset_D_Stat : 5|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ FactoryReset_St : 7|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 1833 TesterPhysicalResVDM: 64 VDM
+ SG_ TesterPhysicalResVDM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless" TSTR
+
+BO_ 570 Suspension_Data: 8 VDM
+ SG_ SuspClkSync_No_Rq : 63|8@0+ (1,0) [0|253] "unitless" GWM
+ SG_ SuspRearRight_L_Actl : 42|9@0+ (0.782779,-200) [-200|199.21729] "millimeter" GWM
+ SG_ SuspFrntRight_L_Actl : 35|9@0+ (0.782779,-200) [-200|199.21729] "millimeter" GWM
+ SG_ SuspRear_L_Prev : 28|9@0+ (0.782779,-200) [-200|199.21729] "millimeter" GWM
+ SG_ SuspRear_L_Actl : 21|9@0+ (0.782779,-200) [-200|199.21729] "millimeter" GWM
+ SG_ SuspFrnt_L_Prev : 14|9@0+ (0.782779,-200) [-200|199.21729] "millimeter" GWM
+ SG_ SuspFrnt_L_Actl : 7|9@0+ (0.782779,-200) [-200|199.21729] "millimeter" GWM
+
+BO_ 837 VeyDynamics_Data: 8 VDM
+ SG_ Ccd_B_Falt : 24|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ SelDrvMdeSusp_D_Stat : 20|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ AdptDrvMdePt_D_Rq : 23|3@0+ (1,0) [0|7] "SED" GWM
+ SG_ AdptDrvMdeChassis_D_Rq : 10|3@0+ (1,0) [0|7] "SED" GWM
+ SG_ CcdMsgTxt_D_RqDsply : 7|4@0+ (1,0) [0|15] "SED" ECM_Diesel,GWM
+
+BO_ 885 ECG_Data3_FD1: 8 GWM
+ SG_ BattULoChrg_D_RqOta : 55|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ VehStrtInhbt_T_Dsply : 39|16@0+ (1,0) [0|65535] "second" Vector__XXX
+ SG_ VehStrtInhbt_D_Dsply : 27|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ VehOnRqstr_D_Stat : 21|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ VehStrtInhbt_D_RqCld : 23|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ VehOn_D_RqCld : 17|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ CanMsg375_No_Cnt : 11|4@0+ (1,0) [0|15] "unitless" Vector__XXX
+ SG_ CanMsg375_No_Crc : 7|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ OtaActv_D_Stat : 31|4@0+ (1,0) [0|15] "SED" Vector__XXX
+
+BO_ 1150 LocationServices_Data1_FD1: 8 GWM
+ SG_ LocationServices_1 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless" SOBDMC_HPCM_FD1,IPMA_ADAS
+
+BO_ 542 LocationServices_3_FD1: 8 GWM
+ SG_ LocationServices_3 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless" Vector__XXX
+
+BO_ 2612224016 PARSEDPushPCMtoGWM_ECG: 8 PCM_HEV
+ SG_ PARSEDPushPCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 810 ECG_Data_FD1: 8 GWM
+ SG_ OBCCSerial_D_Rq : 45|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TlghtTest_D_RqArb : 47|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ChrgrPncSustn_B_Rq : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ NtfyDrvTrgtDist_L_Rq : 23|12@0+ (0.1,0) [0.1|409.4] "Km" SOBDMC_HPCM_FD1
+ SG_ NtfyDrvSocLvl1_Pc_Rq : 39|7@0+ (1,0) [1|100] "%" SOBDMC_HPCM_FD1
+ SG_ PtRmtRprt_D_Stat : 27|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ ChrgrPncEnbl_D_Rq : 9|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ExtLghtDsply_B_StatArb : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ExtLghtRight_D_RqOta : 12|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ExtLghtRear_D_RqOta : 15|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ExtLghtLeft_D_RqOta : 3|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ExtLghtFront_D_RqOta : 6|3@0+ (1,0) [0|7] "SED" Vector__XXX
+
+BO_ 550 ECG_Data4_FD1: 8 GWM
+ SG_ PtWakeupActv1_B_Rq : 7|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+
+BO_ 639 OffBrdChrg_Signals2: 8 GWM
+ SG_ OfbChrgPrflUpdate_B_Rq : 31|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgClearAll_B_Rq : 7|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTTouch_D_Rq : 17|2@0+ (1,0) [0|3] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTPrcond_D_Rq : 19|2@0+ (1,0) [0|3] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTOn_D_Rq : 10|2@0+ (1,0) [0|3] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTMnte_D_Rq : 23|4@0+ (1,0) [0|15] "minute" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTHr_T_Rq : 15|5@0+ (1,0) [0|29] "hour" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTExtHtr_D_Rq : 1|2@0+ (1,0) [0|3] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTElement_D_Rq : 5|4@0+ (1,0) [0|15] "Unitless" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTDelete_B_Rq : 6|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgGoTUpdate_B_Rq : 8|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+
+BO_ 530 OffBrdChrg_Signals: 8 GWM
+ SG_ OfbChrgLocIdTrgt_No_Rq : 7|4@0+ (1,0) [0|15] "Unitless" SOBDMC_HPCM_FD1
+ SG_ OfbChrgToPcWknd_D_Actl : 58|3@0+ (1,0) [0|7] "percent" SOBDMC_HPCM_FD1
+ SG_ OfbChrgToPcWkdy_D_Actl : 61|3@0+ (1,0) [0|7] "percent" SOBDMC_HPCM_FD1
+ SG_ OfbChrgSetNow_D_Rq : 63|2@0+ (1,0) [0|3] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgSetDelete_B_Rq : 2|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+ SG_ OfbChrgPrflWknd_No_Rq : 39|24@0+ (1,0) [0|16777215] "unitless" SOBDMC_HPCM_FD1
+ SG_ OfbChrgPrflWkdy_No_Rq : 15|24@0+ (1,0) [0|16777215] "unitless" SOBDMC_HPCM_FD1
+ SG_ OfbChrgLocIdUns_B_Rq : 3|1@0+ (1,0) [0|1] "SED" SOBDMC_HPCM_FD1
+
+BO_ 1142 ConsTip_Data_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ConsTipV_No_Dsply : 49|10@0+ (0.1,0) [0|102.1] "percent" GWM
+
+BO_ 817 Locking_Systems_2_FD1: 8 GWM
+ SG_ ChildLckMde_B_Stat : 56|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ VehLckInd_D_Rq : 58|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ DrTgateOpen_B_Rq : 59|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DrTgateExtSwMde_B_Stat : 32|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Remote_Device_Feedback : 50|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ Veh_Lock_Requestor : 55|5@0+ (1,0) [0|31] "SED" Vector__XXX
+ SG_ R_Pwr_Sliding_Dr_Rqst : 36|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Power_Liftgate_Rqst : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Veh_Lock_EvNum : 47|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ Power_Decklid_Rqst : 1|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ L_Pwr_Sliding_Dr_Rqst : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Keyfob_Pad_Msg_Count : 15|8@0+ (1,0) [0|255] "Counts" Vector__XXX
+ SG_ Veh_Lock_Sub_Id : 63|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ Veh_Lock_Status : 34|2@0+ (1,0) [0|3] "SED" CMR_DSMC
+ SG_ ChildLck_D_Dsply : 7|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ WindowLockout_B_Stat : 35|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ RollCodeUnlock : 23|16@0+ (1,0) [0|65535] "Unitless" Vector__XXX
+ SG_ Lockmsgtxt_D_Rq : 39|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ FobComm_D_Stat : 5|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ LockInhibit : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 879 BCMC_Data_FD1: 8 GWM
+ SG_ WndwRearHeat_I_Actl : 7|11@0+ (0.1,0) [0|204.6] "ampere" ECM_Diesel
+ SG_ WndwRearHeat_D_Stat : 12|3@0+ (1,0) [0|7] "SED" ECM_Diesel
+
+BO_ 878 DCACA_Data4: 8 PCM_HEV
+ SG_ DcacGfciTest_B_Rq : 0|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ DcacOut_Pw_DsplyMx : 23|10@0+ (10,0) [0|10220] "watts" GWM
+ SG_ DcacOut1_Pw_Dsply : 39|7@0+ (100,0) [0|12600] "watts" GWM
+ SG_ DcacOut2_Pw_Dsply : 47|7@0+ (100,0) [0|12600] "watts" GWM
+ SG_ DcacHw_D_Confg : 11|4@0+ (1,0) [0|15] "SED" GWM
+ SG_ DcacFaltMsgTxt_D_Rq : 15|4@0+ (1,0) [0|15] "SED" GWM
+ SG_ DcacLoFuelMsgTxt_D_Rq : 29|5@0+ (1,0) [0|31] "SED" GWM
+ SG_ DcacEngOnMsgTxt_D_Rq : 55|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ DcacElPw_D_Stat : 2|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ PwBedPnlEnbl_B_Rq : 3|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ DcacOn_B_Rq : 4|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ DcacSys_B_Falt : 5|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ DcacLedCtl_D_Rq : 7|2@0+ (1,0) [0|3] "SED" GWM
+
+BO_ 395 HeadUpDisplayReq_FD1: 8 GWM
+ SG_ SelDrvMdeCnfm_D_Stat : 35|2@0+ (1,0) [0|3] "SED" ABS_ESC
+
+BO_ 2611055832 PARSEDPhysGWM_ECGtoSODR: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoSODR : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2611054808 PARSEDPhysGWM_ECGtoSODL: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoSODL : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2611026136 PARSEDPhysGWM_ECGtoSODCMD: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoSODCMD : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2611025112 PARSEDPhysGWM_ECGtoSODCMC: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoSODCMC : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2610975960 PARSEDPhysGWM_ECGtoCCM: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoCCM : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2610007256 OTAPhysGWM_ECGtoSODR: 8 GWM
+ SG_ OTAPhysGWM_ECGtoSODR : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2610006232 OTAPhysGWM_ECGtoSODL: 8 GWM
+ SG_ OTAPhysGWM_ECGtoSODL : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2609977560 OTAPhysGWM_ECGtoSODCMD: 8 GWM
+ SG_ OTAPhysGWM_ECGtoSODCMD : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2609976536 OTAPhysGWM_ECGtoSODCMC: 8 GWM
+ SG_ OTAPhysGWM_ECGtoSODCMC : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2609927384 OTAPhysGWM_ECGtoCCM: 8 GWM
+ SG_ OTAPhysGWM_ECGtoCCM : 7|29@0+ (1,0) [0|536870911] "unitless" IPMA_ADAS
+
+BO_ 2611175523 PARSEDPhysSODRtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODRtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2612224099 PARSEDPushSODRtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODR2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2611175522 PARSEDPhysSODLtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODLtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2612224098 PARSEDPushSODLtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODL2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2611175494 PARSEDPhysSODCMDtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODCMDtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2612224070 PARSEDPushSODCMDtoGWM: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODCMD2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2611175493 PARSEDPhysSODCMCtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODCMCtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2612224069 PARSEDPushSODCMCtoGWM: 8 IPMA_ADAS
+ SG_ PARSEDPhysSODCMC2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2611175445 PARSEDPhysCCMtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysCCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2612224021 PARSEDPushCCMtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysCCM2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2610126947 OTAPhysSODRtoGWM_ECG: 8 IPMA_ADAS
+ SG_ OTAPhysSODRtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2610126946 OTAPhysSODLtoGWM_ECG: 8 IPMA_ADAS
+ SG_ OTAPhysSODLtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2610126918 OTAPhysSODCMDtoGWM_ECG: 8 IPMA_ADAS
+ SG_ OTAPhysSODCMDtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2610126917 OTAPhysSODCMCtoGWM_ECG: 8 IPMA_ADAS
+ SG_ OTAPhysSODCMCtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 2610126869 OTAPhysCCMtoGWM_ECG: 8 IPMA_ADAS
+ SG_ OTAPhysCCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless" GWM
+
+BO_ 984 IPMA_Data: 8 IPMA_ADAS
+ SG_ FeatConfigIpmaActl : 7|16@0+ (1,0) [0|65535] "Undefined" GWM
+ SG_ FeatNoIpmaActl : 23|16@0+ (1,0) [0|65535] "Number" GWM
+ SG_ PersIndexIpma_D_Actl : 39|3@0+ (1,0) [0|7] "SED" GWM
+ SG_ AhbcRampingV_D_Rq : 57|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ LaActvStats_D_Dsply : 55|5@0+ (1,0) [0|31] "SED" GWM
+ SG_ LaDenyStats_B_Dsply : 32|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ LaHandsOff_D_Dsply : 50|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ CamraDefog_B_Req : 36|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ CamraStats_D_Dsply : 35|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ DasAlrtLvl_D_Dsply : 42|3@0+ (1,0) [0|7] "SED" GWM
+ SG_ DasStats_D_Dsply : 47|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ DasWarn_D_Dsply : 44|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ AhbHiBeam_D_Rq : 59|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ Passthru_63 : 63|4@0+ (1,0) [0|15] "" XXX
+ SG_ Passthru_48 : 48|1@0+ (1,0) [0|1] "" XXX
+
+BO_ 985 IPMA_Data2: 8 IPMA_ADAS
+ SG_ LdwChime_B_Rq : 34|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ TsrRegionTxt_D_Stat : 47|5@0+ (1,0) [0|31] "SED" GWM
+ SG_ SblmPedCrossScnr_B_Stat : 33|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ LongCtrlEnbl_D_Rq : 42|3@0+ (1,0) [0|7] "SED" ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ SblmRndAbtScnr_B_Stat : 9|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ DasAlrtInfo_D_Dsply : 13|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ IaccVLim_D_Rq : 23|8@0+ (1,0) [0|255] "SED" ECM_Diesel,GWM
+ SG_ IaccVLimUnit_D_Rq : 11|2@0+ (1,0) [0|3] "SED" ECM_Diesel,GWM
+ SG_ IsaVLim_D_Rq : 7|8@0+ (1,0) [0|255] "SED" ECM_Diesel,GWM
+ SG_ SblmStopScnr_B_Stat : 8|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ SblmYieldScnr_B_Stat : 31|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ IsaVLimUnit_D_Rq : 15|2@0+ (1,0) [0|3] "SED" ECM_Diesel,GWM
+ SG_ AdbDividedRoad_B_Stat : 30|1@0+ (1,0) [0|1] "SED" GWM
+ SG_ LcwaMsgTxt_D_Stat : 37|2@0+ (1,0) [0|3] "SED" GWM
+ SG_ AdbDrvSide_B_Stat : 35|1@0+ (1,0) [0|1] "SED" GWM
+
+BO_ 992 Personality_Data_FD1: 8 GWM
+ SG_ MsgCntrDsplyOp_D_Rq : 36|3@0+ (1,0) [0|7] "SED" IPMA_ADAS
+ SG_ MsgCntrFeatNoRq : 7|16@0+ (1,0) [0|65535] "Number" IPMA_ADAS
+ SG_ MsgCntrFeatConfigRq : 23|16@0+ (1,0) [0|65535] "unitless" IPMA_ADAS
+ SG_ MsgCntrPersIndex_D_Rq : 39|3@0+ (1,0) [0|7] "SED" IPMA_ADAS
+
+BO_ 2612019416 PARSEDPushFcGWM_ECGtoPCM: 8 GWM
+ SG_ PARSEDPhysGWM_ECG2toPCM : 7|29@0+ (1,0) [0|536870911] "unitless" PCM,PCM_HEV,ECM_Diesel
+
+BO_ 943 IPMA_Data4: 8 IPMA_ADAS
+ SG_ VehVActlAdas_D_Qf : 9|2@0+ (1,0) [0|3] "SED" PCM,PCM_HEV,ECM_Diesel
+ SG_ Veh_V_RqLsc : 23|14@0+ (0.01,0) [0|163.83] "kph" PCM,PCM_HEV,ECM_Diesel
+ SG_ Veh_V_ActlAdas : 7|14@0+ (0.01,0) [0|163.83] "kph" PCM,PCM_HEV,ECM_Diesel
+ SG_ AdasLcDistToObj_L_Actl : 39|12@0+ (0.002,0) [0|8.186] "meter" PCM,PCM_HEV,ECM_Diesel
+
+BO_ 515 PowertrainData_12: 8 ECM_Diesel
+ SG_ PtIgnSwtch_No_Cs : 15|8@0+ (1,0) [0|255] "Unitless" GWM
+ SG_ PtIgnSwtch_No_Cnt : 5|4@0+ (1,0) [0|15] "Unitless" GWM
+ SG_ PtIgnSwtch_D_Stat : 7|2@0+ (1,0) [0|3] "SED" GWM
+
+BO_ 1111 TrailerAid_Stat2_FD1: 8 GWM
+ SG_ TrlrYawWActl_D_Qf : 43|2@0+ (1,0) [0|3] "SED" IPMA_ADAS,PSCM
+ SG_ TrlrYaw_W_Actl : 7|16@0+ (0.0002,-6.5) [-6.5|6.6066] "radians/second" IPMA_ADAS,PSCM
+ SG_ TrlrHitYaw_AnRate_Actl : 27|12@0+ (0.1,-50) [-50|359.3] "degrees/second" IPMA_ADAS,PSCM
+ SG_ TrlrHitchYaw_D_Stat : 47|4@0+ (1,0) [0|15] "SED" IPMA_ADAS,PSCM
+ SG_ TrlrHitchYaw_An_Actl : 23|12@0+ (0.1,-90) [-90|319.3] "degrees" IPMA_ADAS,PSCM
+
+BO_ 1106 TrailerAid_Stat1_FD1: 8 GWM
+ SG_ TrlrSnsId_No_Actl : 7|48@0+ (1,0) [0|281474976710653] "unitless" IPMA_ADAS,PSCM
+
+BO_ 1985 TesterPhysicalReqCMR_DSMC: 64 TSTR
+ SG_ TesterPhysicalReqCMR_DSMC : 7|64@0+ (1,0) [0|1.84467E+019] "unitless" CMR_DSMC
+
+BO_ 1993 TesterPhysicalResCMR_DSMC: 64 CMR_DSMC
+ SG_ TesterPhysicalResCMR_DSMC : 7|64@0+ (1,0) [0|1.84467E+019] "unitless" TSTR
+
+BO_ 1104 DrvStatMonData: 8 CMR_DSMC
+ SG_ DrvEngageLevel_No_Cs : 31|8@0+ (1,0) [0|255] "Unitless" IPMA_ADAS
+ SG_ DrvEngageLevel_No_Cnt : 19|4@0+ (1,0) [0|15] "Unitless" IPMA_ADAS
+ SG_ DrvEngageLevel_D_Stat : 13|3@0+ (1,0) [0|7] "SED" IPMA_ADAS
+ SG_ DrvImpLvlConfid_D_Stat : 39|3@0+ (1,0) [0|7] "SED" IPMA_ADAS
+ SG_ DrvImpairLvl_D_Stat : 23|4@0+ (1,0) [0|15] "SED" IPMA_ADAS
+ SG_ DrvEngLvlConfid_D_Stat : 10|3@0+ (1,0) [0|7] "SED" IPMA_ADAS
+ SG_ DrvCamPassIR_D_Stat : 36|2@0+ (1,0) [0|3] "SED" IPMA_ADAS
+ SG_ DrvCamera_D_Stat : 15|2@0+ (1,0) [0|3] "SED" IPMA_ADAS
+ SG_ DrvCamDrvIR_D_Stat : 1|2@0+ (1,0) [0|3] "SED" IPMA_ADAS
+ SG_ DrvAttentZone_D_Stat : 5|4@0+ (1,0) [0|15] "SED" IPMA_ADAS
+ SG_ DrvAlertSt_D_Stat : 7|2@0+ (1,0) [0|3] "SED" IPMA_ADAS
+
+BO_ 1503 CMR_DSMC_AutoSar_NetwrkMgt: 8 CMR_DSMC
+ SG_ CMR_DSMC_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_GWNMProxY : 47|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_AutoSarNMReserved : 63|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_AutoSarNMReserve4 : 55|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_AutoSarNMReserve3 : 31|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_AutoSarNMReserve2 : 23|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CMR_DSMC_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+
+BO_ 2610995416 PARSEDPhysGWM_ECGtoABS: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoABS : 7|29@0+ (1,0) [0|536870911] "unitless"  ABS_ESC
+
+BO_ 2612043992 PARSEDPushFcGWM_ECGtoABS: 8 GWM
+ SG_ PARSEDPhysGWM_ECG2toABS : 7|29@0+ (1,0) [0|536870911] "unitless"  ABS_ESC
+
+BO_ 2609946840 OTAPhysGWM_ECGtoABS: 8 GWM
+ SG_ OTAPhysGWM_ECGtoABS : 7|29@0+ (1,0) [0|536870911] "unitless"  ABS_ESC
+
+BO_ 2611175464 PARSEDPhysABStoGWM_ECG: 8 ABS_ESC
+ SG_ PARSEDPhysABStoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "Unitless"  GWM
+
+BO_ 2612224040 PARSEDPushABStoGWM_ECG: 8 ABS_ESC
+ SG_ PARSEDPhysABS2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2610126888 OTAPhysABStoGWM_ECG: 8 ABS_ESC
+ SG_ OTAPhysABStoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2610988248 PARSEDPhysGWM_ECGtoIPMA: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoIPMA : 7|29@0+ (1,0) [0|536870911] "unitless"  IPMA_ADAS
+
+BO_ 2609939672 OTAPhysGWM_ECGtoIPMA: 8 GWM
+ SG_ OTAPhysGWM_ECGtoIPMA : 7|29@0+ (1,0) [0|536870911] "unitless"  IPMA_ADAS
+
+BO_ 1114 TrailerAid_Data_FD1: 8 GWM
+ SG_ TrailCtlSwtch_B_Stat2 : 16|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ TrlBrkInitOut_D_Rq : 60|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 1116 TrailerAid_Data3_FD1: 8 GWM
+ SG_ TrlrAidSetup_D2_Rq : 4|4@0+ (1,0) [0|15] "SED"  IPMA_ADAS,PSCM
+ SG_ TrlrAidEnbl_D2_Rq : 7|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS,PSCM
+ SG_ TrlrTrgtToBmpr_L_Actl : 38|7@0+ (0.0127,0) [0|1.6129] "meter"  IPMA_ADAS
+ SG_ TrlrTrgtPtrnId_No_Mem : 45|6@0+ (1,0) [0|63] "unitless"  IPMA_ADAS
+ SG_ TrlrRvrseCancl_B_Rq : 0|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,PSCM
+ SG_ TrlrIdType_D_Stat : 51|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,PSCM
+ SG_ TrlrId_No_Actl : 55|4@0+ (1,0) [0|15] "unitless"  IPMA_ADAS,PSCM
+ SG_ TrlrBallToBmpr_L_Actl : 22|7@0+ (0.0127,0) [0|1.6129] "meter"  IPMA_ADAS,PSCM
+ SG_ TrlrAxleToBmpr_L_Actl : 31|9@0+ (0.0254,0) [0|12.9794] "meter"  IPMA_ADAS,PSCM
+ SG_ TrlrAnOffstDir_D_Mem : 47|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,PSCM
+ SG_ TrlrAnOffst_An_Mem : 15|9@0+ (0.1,0) [0|51.1] "degrees"  IPMA_ADAS
+ SG_ TrlrTrgtOffst_L_Actl : 63|7@0+ (0.0127,0) [0|1.6129] "meter"  IPMA_ADAS
+
+BO_ 2611175457 PARSEDPhysIPMAtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysIPMAtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2612224033 PARSEDPushIPMAtoGWM_ECG: 8 IPMA_ADAS
+ SG_ PARSEDPhysIPMA2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2610126881 OTAPhysIPMAtoGWM_ECG: 8 IPMA_ADAS
+ SG_ OTAPhysIPMAtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 1085 Low_Voltage_Power_Data_FD1: 8 PCM
+ SG_ ULoRgenTestMde_B_Stat : 50|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwSrcULoOvrTe_B_Actl : 7|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwSrcULoFalt_D_Stat : 5|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PwSrcULoDcnnt_B_Stat : 3|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwSrcULo_Pc_Mx : 31|8@0+ (0.4,0) [0|101.6] "%"  GWM
+ SG_ PwSrcULoComm_B_Falt : 2|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwSrcULo_I_Mx : 23|8@0+ (1,0) [0|254] "ampere"  PCM_HEV,GWM
+ SG_ PwSrcULo_I_Actl : 15|8@0+ (1,0) [0|254] "ampere"  PCM_HEV,GWM
+
+BO_ 791 Cluster_HEV_Data8_FD1: 8 GWM
+ SG_ EngAirFilt_B_RqReset : 48|1@0+ (1,0) [0|1] "SED"  ECM_Diesel
+ SG_ GpsElMdeSel_B_Rq : 50|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ LongTermReset_B_Rq : 49|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DrvEffLvl_No_Stat : 61|6@0+ (1,0) [0|61] "unitless" Vector__XXX
+ SG_ ConsAvgTrip_Fe_Dsply : 31|24@0+ (0.0001,0) [0|1677.7215] "litre/100km" Vector__XXX
+
+BO_ 2610970840 PARSEDPhysGWM_ECGtoPCM: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoPCM : 7|29@0+ (1,0) [0|536870911] "unitless"  ECM_Diesel,PCM_HEV,PCM
+
+BO_ 2609922264 OTAPhysGWM_ECGtoPCM: 8 GWM
+ SG_ OTAPhysGWM_ECGtoPCM : 7|29@0+ (1,0) [0|536870911] "unitless"  ECM_Diesel,PCM_HEV,PCM
+
+BO_ 868 BattRgenLo_4_FD1: 8 GWM
+ SG_ BattRgenLoStat_D_Qlty : 25|2@0+ (1,0) [0|3] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLoSoc_Pc_Actl : 23|7@0+ (1,0) [0|100] "percent"  PCM_HEV,PCM
+ SG_ BattRgenLoPulse_U_Pred : 15|8@0+ (0.0625,0) [0|15.9375] "volt"  PCM_HEV,PCM
+ SG_ BattRgenLoPrtct_B_Stat : 39|1@0+ (1,0) [0|1] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLoDChrg_D_Stat : 27|2@0+ (1,0) [0|3] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLoDchrg_B_Rq : 28|1@0+ (1,0) [0|1] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLoChrg_D_Stat : 30|2@0+ (1,0) [0|3] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLoChrg_B_Rq : 31|1@0+ (1,0) [0|1] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLo_T_Est : 7|8@0+ (8,0) [0|2040] "second"  PCM_HEV,PCM
+ SG_ BattRgenLo_B_Falt : 16|1@0+ (1,0) [0|1] "SED"  PCM_HEV,PCM
+
+BO_ 867 BattRgenLo_3_FD1: 8 GWM
+ SG_ BattRgenLoBalnc_B_Rq : 16|1@0+ (1,0) [0|1] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLo_Te_Hi : 55|8@0+ (1,-20) [-20|235] "degC"  PCM_HEV,PCM
+ SG_ BattRgenLo_Te_Actl : 47|8@0+ (1,-60) [-60|194] "degC"  PCM_HEV,PCM
+ SG_ BattRgenLo_R_Actl : 31|9@0+ (0.0625,0) [0|31.9375] "milliohm"  PCM_HEV,PCM
+ SG_ BattRgenLo_AhRide_Actl : 15|15@0+ (0.0078125,-100) [-100|155.9921875] "amperehour"  PCM_HEV,PCM
+ SG_ BattRgenLo_Ah_Actl : 7|8@0+ (0.1,0) [0|25.5] "amperehour"  PCM_HEV,PCM
+
+BO_ 866 BattRgenLo_2_FD1: 8 GWM
+ SG_ BattRgenLoOpen_U_Actl : 55|9@0+ (0.025,8.5) [8.5|21.275] "volt"  PCM_HEV,PCM
+ SG_ BattRgenLoDchrg_U_Mn : 39|9@0+ (0.025,4) [4|16.775] "volt"  PCM_HEV,PCM
+ SG_ BattRgenLoDchrg_I_Mx : 31|8@0+ (2,0) [0|510] "ampere"  PCM_HEV,PCM
+ SG_ BattRgenLoChrg_U_Mx : 15|9@0+ (0.025,10.6) [10.6|23.375] "volt"  PCM_HEV,PCM
+ SG_ BattRgenLoChrg_I_Mx : 7|8@0+ (2,0) [0|510] "ampere"  PCM_HEV,PCM
+
+BO_ 865 BattRgenLo_1_FD1: 8 GWM
+ SG_ BattRgenLo_U_Actl : 23|11@0+ (0.015625,0) [0|31.96875] "volt"  PCM_HEV,PCM
+ SG_ BattRgenLo_I_Actl : 7|16@0+ (0.015625,-512) [-512|511.96875] "ampere"  PCM_HEV,PCM
+
+BO_ 2611175440 PARSEDPhysPCMtoGWM_ECG: 8 PCM
+ SG_ PARSEDPhysPCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2610126864 OTAPhysPCMtoGWM_ECG: 8 PCM
+ SG_ OTAPhysPCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2611175441 PARSEDHPCMtoGWM_ECG_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ PARSEDPhysHPCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2612224017 PARSEDPushSOBDMCtoGWM_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ PARSEDPhysHPCM2toGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 2610126865 OTAPhysSOBDMCtoGWM_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ OTAPhysHPCMtoGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  GWM
+
+BO_ 1679 SOBDMC_RapidData_Resp4_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ UUDTSOBDMCResponse4 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1678 SOBDMC_RapidData_Resp3_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ UUDTSOBDMCResponse3 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1677 SOBDMC_RapidData_Resp2_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ UUDTSOBDMCResponse2 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1676 SOBDMC_RapidData_Resp1_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ UUDTSOBDMCResponse1 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1445 SOBDMC_AutoSar_NetMgmt_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ SOBDMC_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ SOBDMC_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+
+BO_ 1144 MHT_EV_Wakeup_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ WakeAlarm0_T_Rq : 7|15@0+ (1,0) [0|32767] "minute"  GWM
+ SG_ WakeAlarm0_B_Typ : 21|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PreCondBatt_B_Actl : 32|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HtrnDcdcDis_B_Rq : 26|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgNowEvnt_B_Stat : 22|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CabinDrvSustn_B_Rq : 23|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BattChrgTrgtSoC_D_Rq : 35|3@0+ (1,0) [0|7] "Percent"  GWM
+ SG_ CabnEvapSovFront_B_Rq : 38|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HeatCoreSovRear_B_Rq : 36|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BattChlrSov_B_Rq : 39|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CabnEvapSovRear_B_Rq : 37|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BrkAppl_D_RqPt : 25|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ HtrnCnnctPwr_B_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PtcHtr_D_Stat : 18|2@0+ (1,0) [0|3] "SED"  GWM,PCM_HEV
+ SG_ HtrnClntFlw_D_Rq : 20|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BattTracDrvSustn_B_Rq : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BattTracClntVlv_B_Rq : 47|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 1141 Cluster_HEV_Data9_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ OfbChrgSetSync_D_Stat : 31|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PtRmtRprt_D_Rq : 59|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ MtrTrac2_Tq_Actl : 29|12@0+ (1,-2047) [-2047|2048] "Nm"  GWM
+ SG_ NtfctnConflict1_D_Rq : 53|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 1140 Cluster_HEV_Data7_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ RgenEvntLvl_Pc_Dsply : 9|10@0+ (0.1,0) [0|102.1] "percent"  GWM
+ SG_ BrkEvntComplt_B_Dsply : 31|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PreCondStat_D_Dsply : 12|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 1139 GWM_HPCM_i_FrP11_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ActChrgStrtYr_No2_Actl : 7|7@0+ (1,2017) [2017|2144] "year"  GWM
+ SG_ BattChrgTrgtLMax_T_Est : 10|11@0+ (1,0) [0|2045] "minute"  GWM
+ SG_ ActChrgStrtYr_No_Actl : 60|5@0+ (1,2010) [2010|2040] "year"  GWM
+ SG_ ActChrgStrtMin_No_Actl : 29|6@0+ (1,0) [0|61] "minute"  GWM
+ SG_ ActChrgStrtHr_No_Actl : 36|5@0+ (1,0) [0|29] "hour"  GWM
+ SG_ ActChrgStrtDay_No_Actl : 44|5@0+ (1,1) [1|31] "days"  GWM
+ SG_ ActChrgStrMnth_No_Actl : 51|4@0+ (1,1) [1|15] "month"  GWM
+
+BO_ 1138 GWM_HPCM_i_FrP10_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ActChrgEndYr_No2_Actl : 7|7@0+ (1,2017) [2017|2144] "year"  GWM
+ SG_ BattChrgTrgtLMin_T_Est : 10|11@0+ (1,0) [0|2045] "minute"  GWM
+ SG_ ActChrgEndYr_No_Actl : 60|5@0+ (1,2010) [2010|2040] "year"  GWM
+ SG_ ActChrgEndMnth_No_Actl : 51|4@0+ (1,1) [1|15] "month"  GWM
+ SG_ ActChrgEndMin_No_Actl : 29|6@0+ (1,0) [0|61] "minute"  GWM
+ SG_ ActChrgEndHr_No_Actl : 36|5@0+ (1,0) [0|29] "hour"  GWM
+ SG_ ActChrgEndDay_No_Actl : 44|5@0+ (1,1) [1|31] "days"  GWM
+
+BO_ 1089 MtrTracData_1_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ Mtr2Aout_W_ActlMntr : 45|10@0+ (6.28,-3209) [-3209|3209.16] "radians/sec"  GWM
+ SG_ Inv1_Te_Actl : 63|8@0+ (1,-40) [-40|213] "degC"  GWM
+ SG_ MtrTrac2Coil_Te_Actl : 23|8@0+ (1,-40) [-40|213] "degC"  GWM
+ SG_ MtrTrac2_U_Actl : 39|10@0+ (1,0) [0|1023] "volt"  GWM
+ SG_ MtrTrac2Falt_B_Stat : 50|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ MtrTrac2TeAlrm_B_Stat : 49|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ Mtr2CntlTeAlrm_B_Stat : 51|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ MtrTrac2Inv_Te_Actl : 31|8@0+ (1,-40) [-40|213] "degC"  GWM
+ SG_ MtrTrac2_I_Actl : 7|16@0+ (0.1,-1000) [-1000|5553.4] "ampere"  GWM
+
+BO_ 1088 PreCond_Hev_Data1_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ChrgTMatch_B_Stat : 55|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgStat_D2_Dsply : 7|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ HvacPrecondRecirc_D_Rq : 63|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ HvacPrecondMode2_D_Rq : 51|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ HvacPrecondBlwr2_D_Rq : 61|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ HvacPrecondAC_D_Rq : 57|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ HvacPrecond_Te_Rq : 44|5@0+ (0.5,14.5) [14.5|30] "deg C"  GWM
+ SG_ BattChrgInhbt_D_Rq : 53|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 1040 AC_Compressor_Req_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ElCmprEnbl_B_Rq : 23|1@0+ (1,0) [0|1] "SED"  GWM,PCM_HEV
+ SG_ ElCmpr_N_Rq : 15|8@0+ (50,0) [0|12750] "RPM"  GWM
+
+BO_ 1016 GoTimeSettings_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ChrgGoTElement_B_Dsply : 27|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocIdCurnt_D_Uns : 31|4@0+ (1,0) [0|15] "unitless"  GWM
+ SG_ ChrgGoTTouchEnbl_B_Rq : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgGoTTouch_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgGoTPrcond_D_Stat : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ChrgGoTNext_D_Stat : 19|4@0+ (1,0) [0|15] "Unitless"  GWM
+ SG_ ChrgGoTMnte_D_Stat : 23|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ ChrgGoTHr_T_Stat : 15|5@0+ (1,0) [0|29] "hour"  GWM
+ SG_ ChrgGoTExtHtrEnbl_B_Rq : 1|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgGoTExtHtr_B_Stat : 2|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgGoTElement_D_Stat : 6|4@0+ (1,0) [0|15] "Unitless"  GWM
+ SG_ ChrgGoTAllOn_B_Stat : 7|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 1013 ChargeSettings_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ChrgToPcWkndSav_D_Stat : 60|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ChrgToPcWkdySav_D_Stat : 63|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ChrgProgIdSaved_D_Stat : 51|4@0+ (1,0) [0|15] "Unitless"  GWM
+ SG_ ChrgNowEnbl_B_Saved : 56|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocIdUnsAck_B_Stat : 57|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocIdCurnt_D_Sav : 55|4@0+ (1,0) [0|15] "unitless"  GWM
+ SG_ ChrgPrflWknd_No_Actl : 31|24@0+ (1,0) [0|16777215] "unitless"  GWM
+ SG_ ChrgPrflWkdy_No_Actl : 7|24@0+ (1,0) [0|16777215] "unitless"  GWM
+
+BO_ 1012 Saved_Charge_Location_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ ChrgNowCurnt_B_Dsply : 58|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocSaved_B_Dsply : 57|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocLongPostv_B_Sav : 59|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocLongFrct_An_Sav : 47|20@0+ (1E-006,0) [0|1.048575] "degrees"  GWM
+ SG_ ChrgLocLongDeg_An_Sav : 39|8@0+ (1,0) [0|255] "degrees"  GWM
+ SG_ ChrgLocLattPostv_B_Sav : 24|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocLattFrct_An_Sav : 7|20@0+ (1E-006,0) [0|1.048575] "degrees"  GWM
+ SG_ ChrgLocLattDeg_An_Sav : 31|7@0+ (1,0) [0|127] "unitless"  GWM
+ SG_ ChrgLocId_D_Sav : 19|4@0+ (1,0) [0|15] "unitless"  GWM
+
+BO_ 1011 Unsaved_Charge_LocationFD1: 8 SOBDMC_HPCM_FD1
+ SG_ ChrgLocLongPostv_B_Uns : 59|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocLongFrct_An_Uns : 47|20@0+ (1E-006,0) [0|1.048575] "degrees"  GWM
+ SG_ ChrgLocLongDeg_An_Uns : 39|8@0+ (1,0) [0|255] "degrees"  GWM
+ SG_ ChrgLocLattPostv_B_Uns : 24|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ChrgLocLattFrct_An_Uns : 7|20@0+ (1E-006,0) [0|1.048575] "degrees"  GWM
+ SG_ ChrgLocLattDeg_An_Uns : 31|7@0+ (1,0) [0|127] "unitless"  GWM
+ SG_ ChrgLocId_D_Uns : 19|4@0+ (1,0) [0|15] "unitless"  GWM
+
+BO_ 871 Cluster_HEV_Data4_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ BattElecPerf_D_Actl : 55|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ BattChrgTrgtLPt_T_Est : 2|11@0+ (1,0) [0|2045] "minute"  GWM
+ SG_ BattChrgTrgSocPt_T_Est : 18|11@0+ (1,0) [0|2045] "minute"  GWM
+ SG_ BattChrgCmpltPt_T_Est : 34|11@0+ (1,0) [0|2045] "minute"  GWM
+
+BO_ 786 Cluster_HEV_Data1_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ RgenTrip_Pc_Dsply : 33|10@0+ (0.1,0) [0|102.3] "percent"  GWM
+ SG_ RgenTrip_L_Dsply : 55|16@0+ (0.1,0) [0|6553.3] "kilometer"  GWM
+ SG_ ChrgStat_D_Dsply : 36|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 72 Global_PATS_Target2_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ immoTarget2Status : 7|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ immoTarget2Data : 15|40@0+ (1,0) [0|1099511627775] "Encrypted"  GWM
+ SG_ immoTarget2Cmd : 4|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 912 PowerDist_Data1_FD1: 8 GWM
+ SG_ CabnEvapSovFront_D_Stat : 15|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattChlrSov_D_Stat : 7|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracClntVlv_D_Stat : 28|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 874 PowerDistData_2_FD1: 8 GWM
+ SG_ AirCondCluOpen_D_Falt : 17|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ AirCondCluLife_D_Falt : 19|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ AirCondCluGnd_D_Falt : 21|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ AirCondClu_D_Stat : 31|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ AirCondCluBatt_D_Falt : 23|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ BattTracShrtGrnd_D_Falt : 9|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracShrtBatt_D_Falt : 11|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracOpnCirct_D_Falt : 13|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracLifeLim_D_Falt : 15|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattChlrShrtGrnd_D_Falt : 1|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattChlrShrtBatt_D_Falt : 3|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattChlrOpnCirct_D_Falt : 5|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattChlrLifeLim_D_Falt : 7|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracLow_D_Falt : 28|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 651 TCU_Send_Signals_FD1: 8 GWM
+ SG_ TelematicsSrvc_D_St : 47|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+ SG_ EmgcyCallMute_D_Stat : 39|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ OfbChrgSetSync_D_Rq : 3|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 529 APIM_Request_Signals_5_FD1: 8 GWM
+ SG_ OnbChrgToPcWknd_D_Actl : 2|3@0+ (1,0) [0|7] "percent"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgToPcWkdy_D_Actl : 60|3@0+ (1,0) [0|7] "percent"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgSetNow_D_Rq : 63|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgSetDelete_B_Rq : 3|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgPrflWknd_No_Rq : 39|24@0+ (1,0) [0|16777215] "unitless"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgPrflWkdy_No_Rq : 15|24@0+ (1,0) [0|16777215] "unitless"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgPrflUpdate_B_Rq : 56|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgLocIdUns_B_Rq : 57|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgLocIdTrgt_No_Rq : 7|4@0+ (1,0) [0|15] "Unitless"  SOBDMC_HPCM_FD1
+
+BO_ 66 Global_PATS_Ctrl_Info2_FD1: 8 GWM
+ SG_ immoControlData_T2 : 15|40@0+ (1,0) [0|1099511627775] "Encrypted"  SOBDMC_HPCM_FD1
+ SG_ immoControlCmd_T2 : 7|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 2610971864 PARSEDPhysGWMtoSOBDMC_FD1: 8 GWM
+ SG_ PARSEDPhysGWM_ECGtoHPCM : 7|29@0+ (1,0) [0|536870911] "unitless"  SOBDMC_HPCM_FD1
+
+BO_ 2612002008 PARSEDFuncGWM_ECG_FD1: 8 GWM
+ SG_ PARSEDFuncGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  ABS_ESC,IPMA_ADAS,ECM_Diesel,PCM_HEV,PCM,SOBDMC_HPCM_FD1
+
+BO_ 2609923288 OTAPhysGWM_ECGtoSOBDMC_FD1: 8 GWM
+ SG_ OTAPhysGWM_ECGtoHPCM : 7|29@0+ (1,0) [0|536870911] "unitless"  SOBDMC_HPCM_FD1
+
+BO_ 2610953432 OTAFuncGWM_ECG_FD1: 8 GWM
+ SG_ OTAFuncGWM_ECG : 7|29@0+ (1,0) [0|536870911] "unitless"  ABS_ESC,IPMA_ADAS,ECM_Diesel,PCM_HEV,PCM,SOBDMC_HPCM_FD1
+
+BO_ 2022 TesterPhysicalReqSOBDMC_FD: 64 TSTR
+ SG_ TesterPhysicalReqSOBDMC : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  SOBDMC_HPCM_FD1
+
+BO_ 1124 APIMGPS_Data_Nav_3_FD1: 8 GWM
+ SG_ GPS_Vdop : 63|5@0+ (0.2,0) [0|5.8] "unitless"  IPMA_ADAS
+ SG_ GPS_Speed : 47|8@0+ (1,0) [0|253] "MPH" Vector__XXX
+ SG_ GPS_Sat_num_in_view : 7|5@0+ (1,0) [0|29] "unitless"  SOBDMC_HPCM_FD1
+ SG_ GPS_MSL_altitude : 15|12@0+ (10,-20460) [-20460|20470] "feet" Vector__XXX
+ SG_ GPS_Heading : 31|16@0+ (0.01,0) [0|655.33] "Degrees"  IPMA_ADAS
+ SG_ GPS_Hdop : 55|5@0+ (0.2,0) [0|5.8] "unitless"  IPMA_ADAS
+ SG_ GPS_dimension : 2|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 1119 Voltage_Power_Data2_FD1: 8 GWM
+ SG_ CoolFanDcdc_D_Rq : 5|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ DcdcClntFlw_D_Rq : 7|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 132 GlobalClock_Data_FD1: 8 GWM
+ SG_ GlblClkYr_No_Actl : 7|8@0+ (1,2000) [2000|2255] "year"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GlblClkScnd_No_Actl : 47|8@0+ (1,0) [0|255] "second"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GlblClkMnte_No_Actl : 39|8@0+ (1,0) [0|255] "minute"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GlblClkHr_No_Actl : 55|8@0+ (1,0) [0|255] "hour"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GlblClkDay_No_Actl : 23|16@0+ (1,0) [0|65535] "julian day"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS
+
+BO_ 1990 TesterPhysicalReqSODR: 64 TSTR
+ SG_ TesterPhysicalReqSODR : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  IPMA_ADAS
+
+BO_ 1892 TesterPhysicalReqCCM: 64 TSTR
+ SG_ TesterPhysicalReqCCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  IPMA_ADAS
+
+BO_ 1798 TesterPhysicalReqIPMA: 64 TSTR
+ SG_ TesterPhysicalReqIPMA : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  IPMA_ADAS
+
+BO_ 1123 APIMGPS_Data_Nav_2_FD1: 8 GWM
+ SG_ GpsUtcYr_No_Actl : 55|5@0+ (1,2010) [2010|2040] "Year"  IPMA_ADAS
+ SG_ GpsUtcMnth_No_Actl : 47|4@0+ (1,1) [1|15] "Month"  IPMA_ADAS
+ SG_ GpsUtcDay_No_Actl : 37|5@0+ (1,1) [1|32] "Day"  IPMA_ADAS
+ SG_ GPS_UTC_seconds : 23|6@0+ (1,0) [0|59] "seconds"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GPS_UTC_minutes : 15|6@0+ (1,0) [0|59] "Minutes"  IPMA_ADAS
+ SG_ GPS_UTC_hours : 7|5@0+ (1,0) [0|23] "Hours"  IPMA_ADAS
+ SG_ GPS_Pdop : 31|5@0+ (0.2,0) [0|5.8] "unitless"  IPMA_ADAS
+ SG_ GPS_Compass_direction : 26|4@0+ (1,0) [0|15] "SED"  IPMA_ADAS
+ SG_ GPS_Actual_vs_Infer_pos : 38|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ Gps_B_Falt : 2|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,IPMA_ADAS
+
+BO_ 1122 APIMGPS_Data_Nav_1_FD1: 8 GWM
+ SG_ GpsHsphLongEast_D_Actl : 9|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,SOBDMC_HPCM_FD1
+ SG_ GpsHsphLattSth_D_Actl : 25|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,SOBDMC_HPCM_FD1
+ SG_ GPS_Longitude_Minutes : 46|6@0+ (1,0) [0|61] "Minutes"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GPS_Longitude_Min_dec : 55|14@0+ (0.0001,0) [0|1.6381] "Minutes"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GPS_Longitude_Degrees : 39|9@0+ (1,-179) [-179|330] "Degrees"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GPS_Latitude_Minutes : 15|6@0+ (1,0) [0|61] "Minutes"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GPS_Latitude_Min_dec : 23|14@0+ (0.0001,0) [0|1.6381] "Minutes"  SOBDMC_HPCM_FD1,IPMA_ADAS
+ SG_ GPS_Latitude_Degrees : 7|8@0+ (1,-89) [-89|164] "Degrees"  SOBDMC_HPCM_FD1,IPMA_ADAS
+
+BO_ 1003 Personality_BCM2_Data_FD1: 8 GWM
+ SG_ PersRecallSrc_D_Actl : 63|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ Pers4Key_D_Stat : 49|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Pers3Key_D_Stat : 41|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Pers2Key_D_Stat : 43|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Pers1Key_D_Stat : 12|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ EmPrflNo_D_Stat : 52|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ EmPrflKeyAssoc_D_Stat : 55|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ VehKeyActv_D_Stat : 47|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ PersNoPos_D_Actl : 18|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ PersSetupRestr_D_Actl : 21|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PersSetupAccessCtrl : 19|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PersSetup_No_Actl : 31|16@0+ (1,0) [0|65535] "Number" Vector__XXX
+ SG_ PersConflict_D_Actl : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AssocConfirm_D_Actl : 15|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ RecallEvent_No_Cnt : 7|8@0+ (1,0) [0|255] "Counts"  IPMA_ADAS
+ SG_ PersNo_D_Actl : 10|3@0+ (1,0) [0|7] "SED"  ABS_ESC,IPMA_ADAS
+
+BO_ 994 Personality_APIM_Data_FD1: 8 GWM
+ SG_ PersStore_D_Rq : 36|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ Pers4OptIn_B_Stats : 43|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Pers3OptIn_B_Stats : 33|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Pers2OptIn_B_Stats : 32|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Pers1OptIn_B_Stats : 44|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CtrStkPersIndex_D_Actl : 39|3@0+ (1,0) [0|7] "SED"  ABS_ESC,IPMA_ADAS
+ SG_ CtrStkFeatNoActl : 23|16@0+ (1,0) [0|65535] "Undefined"  ABS_ESC,IPMA_ADAS
+ SG_ CtrStkFeatConfigActl : 7|16@0+ (1,0) [0|65535] "Undefined"  ABS_ESC,IPMA_ADAS
+ SG_ CtrStkDsplyOp_D_Rq : 47|3@0+ (1,0) [0|7] "SED"  ABS_ESC,IPMA_ADAS
+
+BO_ 778 ParkAid_Aud_Warn_CmdM_FD1: 8 GWM
+ SG_ PrkAidFront_D_RqDrv : 5|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ PrkAidAcsyRear_D_RqDrv : 13|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ PrkAidAcsyFront_D_RqDrv : 15|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ Cta_D_Rq : 1|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ PrkAidRear_D_RqDrv : 3|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ SteEffort_D_Rq : 10|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ Sod_D_Rq : 7|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+
+BO_ 549 IPC_Infotainment_FD1: 8 GWM
+ SG_ Veh_V2_Dsply : 39|9@0+ (1,0) [0|511] "unitless"  IPMA_ADAS
+ SG_ IPC_MyKeyVolLimit_St : 9|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ HdcOn_B_Rq : 19|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ IPC_Attn_Info_Audio : 4|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ BeltminderAudioMute : 6|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Power_Up_Chime_Modules : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Chime_Source : 15|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ IPC_New_Attn_Event : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 551 APIM_Request_Signals_1_FD1: 8 GWM
+ SG_ PmCabnLvl_D_Stat : 36|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ PmCabn_D_Stat : 38|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Cntr_Plg_Mode_Cmd : 39|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ChrgCrdLckEnbl_B_Stat : 47|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PwRnngBoardT_D_Rq : 25|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PwRnngBoardSwtch_D_Rq : 27|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PwRnngBoardMde_D_Rq : 29|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Btt_L_Actl2 : 55|7@0+ (0.1,0) [0|12.5] "meter"  IPMA_ADAS
+ SG_ Rba_D_Rq : 31|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ EmPrflNo_D_Rq : 61|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ EmPrflButtnAssoc_D_Rq : 33|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ EmPrflKeyAssoc_D_Rq : 46|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ Em_D_Stat : 63|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ChrgOvrdExitScrn_D_Rq : 58|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 1010 IPMA_Data3: 8 IPMA_ADAS
+ SG_ MbdblActv_B_RqAdas : 48|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CbdblActv_B_RqAdas : 49|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AdbUrbanArea_B_Stat : 40|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ LightRng_L_Max : 55|6@0+ (2,0) [0|126] "meter"  GWM
+ SG_ LightPathOffst_L_Actl : 31|10@0+ (0.01,-5.12) [-5.12|5.11] "meter"  GWM
+ SG_ LightPath_An_Actl : 12|11@0+ (0.0005,-0.5) [-0.5|0.5235] "radians"  GWM
+ SG_ LightCurv_NoRate_Actl : 37|13@0+ (2.5E-007,-0.001024) [-0.001024|0.00102375] "1/meter"  GWM
+ SG_ LightCurv_No_Actl : 7|11@0+ (2E-005,-0.02) [-0.02|0.02094] "1/meter"  GWM
+
+BO_ 1070 Battery_Mgmt_24V_FD1: 8 GWM
+ SG_ BattULo24_D_Falt : 55|2@0+ (1,0) [0|3] "SED"  PCM
+ SG_ BattULo24_Te_Actl : 47|7@0+ (1,-40) [-40|86] "degC"  PCM
+ SG_ BattULo24State_D_Qlty : 25|2@0+ (1,0) [0|3] "SED"  PCM
+ SG_ BattULo24Soc_Pc_Actl : 39|7@0+ (1,0) [0|127] "percent"  PCM
+ SG_ BattULo24_I_Actl : 23|14@0+ (0.0625,-512) [-512|511.875] "ampere"  PCM
+ SG_ BattULo24_B_Falt : 8|1@0+ (1,0) [0|1] "SED"  PCM
+ SG_ BattULo24_Ah_DeltaRide : 7|15@0+ (0.0078125,-100) [-100|155.9921875] "amperehour"  PCM
+
+BO_ 1186 Driveline_Data_2: 8 TCCM
+ SG_ SelDrvMdeAwd2_D_Stat : 31|5@0+ (1,0) [0|31] "SED"  ABS_ESC,GWM
+ SG_ RearDiffLckMsg_D_Rq : 20|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ RearDiffLckLamp_D_Rq : 11|2@0+ (1,0) [0|3] "SED"  VDM,GWM,ABS_ESC
+ SG_ RearDiffLck_Tq_Actl : 7|12@0+ (1,0) [0|4093] "Nm"  ABS_ESC,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ RearDiffFalt_D_Stat : 23|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+ SG_ LsdSrvcRqd_B_Rq : 21|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 611 Driveline_Data_1: 8 TCCM
+ SG_ AwdSys_D_Stat : 27|2@0+ (1,0) [0|3] "SED"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ AwdStat_D_RqDsply : 63|5@0+ (1,0) [0|31] "SED"  TCM_DSL,ABS_ESC,GWM
+ SG_ AwdLck_D_Stat : 31|4@0+ (1,0) [0|15] "SED"  TCM_DSL,GWM,ABS_ESC
+ SG_ AwdSrvcRqd_B_Rq : 0|1@0+ (1,0) [0|1] "SED"  GWM,PCM,PCM_HEV,TCM_DSL,ABS_ESC
+ SG_ NtrlTowAvail_B_Stat : 4|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AwdLck_Tq_Rq : 15|12@0+ (1,0) [0|4093] "Nm"  PCM_HEV,GWM,ABS_ESC
+ SG_ TrnAout_Tq_RqMx : 47|13@0+ (1,-1250) [-1250|6941] "Nm"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ AwdOffRoadMode_D_Stats : 25|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ AwdLoLamp_D_RqDsply : 35|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AwdHiLamp_D_RqDsply : 19|2@0+ (1,0) [0|3] "SED"  GWM,ABS_ESC
+ SG_ AwdAutoLamp_D_RqDsply : 17|2@0+ (1,0) [0|3] "SED"  GWM,ABS_ESC
+ SG_ Awd2wdLamp_D_RqDsply : 2|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AwdRnge_D_Actl : 7|3@0+ (1,0) [0|7] "SED"  VDM,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,ABS_ESC,GWM,IPMA_ADAS
+
+BO_ 1461 PSCM_AutoSar_NetwrkMgmt: 8 PSCM
+ SG_ PSCM_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+ SG_ PSCM_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless"  GWM,ABS_ESC
+
+BO_ 1047 TrailerAid_Data2: 8 PSCM
+ SG_ TrlrAnOffst_An2_Calc : 39|8@0+ (0.5,-64) [-64|63.5] "degrees"  IPMA_ADAS
+ SG_ TrlrAn_An_WarnCalc : 28|5@0+ (1,0) [0|31] "degrees"  IPMA_ADAS
+ SG_ TrlrAn_An_MxCalc : 55|7@0+ (1,0) [0|127] "degrees"  IPMA_ADAS
+ SG_ TrlrAidTrlrId_No_Rq : 63|4@0+ (1,0) [0|15] "unitless"  GWM
+ SG_ TrlrAidTrgtId_No_Rq : 44|5@0+ (1,0) [0|31] "unitless"  IPMA_ADAS
+ SG_ TrlrAidSetup_D2_Stat : 47|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS
+ SG_ TrlrAidEnbl_D2_Stat : 31|3@0+ (1,0) [0|7] "SED"  ABS_ESC,IPMA_ADAS,GWM,PCM,ECM_Diesel
+ SG_ TrlrAidMsgTxt_D2_Rq : 14|6@0+ (1,0) [0|63] "SED"  IPMA_ADAS,GWM,ABS_ESC
+ SG_ EsaOn_B_Stat : 23|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HitchToTrlrAxle_L_Calc : 7|9@0+ (0.0254,0) [0|12.9794] "meter"  IPMA_ADAS
+ SG_ SelDrvMdeSte_D_Stat : 17|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+
+BO_ 972 Lane_Assist_Data3_FD1: 8 PSCM
+ SG_ LatCtlSte_D_Stat : 18|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS,GWM
+ SG_ LatCtlLim_D_Stat : 33|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ LatCtlCpblty_D_Stat : 39|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ LatCtlCpbltyDStat_No_Cnt : 37|4@0+ (1,0) [0|15] "Unitless"  IPMA_ADAS,GWM
+ SG_ LatCtlCpbltyDStat_No_Cs : 47|8@0+ (1,0) [0|255] "Unitless"  IPMA_ADAS,GWM
+ SG_ TrlrAn_An_TrgtCalc : 31|8@0+ (1,-128) [-128|127] "degrees"  IPMA_ADAS
+ SG_ LsmcBrkDecelEnbl_D_Rq : 1|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ TjaHandsOnCnfdnc_B_Est : 3|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ LaHandsOff_B_Actl : 7|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ LaActDeny_B_Actl : 6|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ LaActAvail_D_Actl : 5|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ LsmcBrk_Tq_Rq : 15|13@0+ (4,0) [0|32764] "Nm"  ABS_ESC
+
+BO_ 130 EPAS_INFO: 8 PSCM
+ SG_ TrlrHitchLamp_D_Rqst : 24|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ VehVTrlrAid_B_Rq : 25|1@0+ (1,0) [0|1] "SED"  PCM_HEV,GWM,ECM_Diesel,PCM
+ SG_ Veh_V_RqMxTrlrAid : 63|8@0+ (0.1,0) [0|25.5] "km/h"  PCM_HEV,GWM,ECM_Diesel,PCM
+ SG_ DrvSteActv_B_Stat : 10|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ DrvSte_Tq_Actl : 47|8@0+ (0.0625,-8) [-8|7.8125] "Nm"  GWM,ABS_ESC
+ SG_ SteMdule_D_Stat : 55|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ SteMdule_U_Meas : 39|8@0+ (0.05,6) [6|18.7] "Volts"  GWM
+ SG_ SteMdule_I_Est : 21|12@0+ (0.05,-64) [-64|140.7] "Amps"  GWM
+ SG_ EPAS_Failure : 9|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ SteeringColumnTorque : 7|8@0+ (0.0625,-8) [-8|7.8125] "Nm"  GWM,IPMA_ADAS,ABS_ESC
+ SG_ SAPPAngleControlStat6 : 15|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ SAPPAngleControlStat5 : 14|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ SAPPAngleControlStat4 : 13|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ SAPPAngleControlStat3 : 12|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ SAPPAngleControlStat2 : 11|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ SAPPAngleControlStat1 : 23|2@0+ (1,0) [0|3] "SED"  GWM,IPMA_ADAS
+
+BO_ 133 SteeringPinion_Data: 8 PSCM
+ SG_ StePw_B_Rq : 23|1@0+ (1,0) [0|1] "SED"  GWM,ECM_Diesel,PCM
+ SG_ StePinRelInit_An_Sns : 7|16@0+ (0.1,-3200) [-3200|3353.3] "degrees"  VDM,IPMA_ADAS,GWM,ECM_Diesel,PCM,PCM_HEV,ABS_ESC,TCCM
+ SG_ StePinCompAnEst_D_Qf : 43|2@0+ (1,0) [0|3] "SED"  VDM,CMR_DSMC,IPMA_ADAS,TCM_DSL,ECM_Diesel,PCM,PCM_HEV,ABS_ESC,TCCM,GWM
+ SG_ StePinComp_An_Est : 22|15@0+ (0.1,-1600) [-1600|1676.7] "degrees"  VDM,CMR_DSMC,IPMA_ADAS,TCM_DSL,ECM_Diesel,PCM,PCM_HEV,ABS_ESC,TCCM,GWM
+ SG_ StePinAn_No_Cs : 39|8@0+ (1,0) [0|255] "Unitless"  VDM,ABS_ESC,TCCM,GWM
+ SG_ StePinAn_No_Cnt : 47|4@0+ (1,0) [0|15] "unitless"  VDM,TCCM,GWM,ABS_ESC
+
+BO_ 1430 ABS_AutoSar_NetworkMgt: 8 ABS_ESC
+ SG_ ABS_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ABS_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless"  GWM
+
+BO_ 1200 ABS_BrkBst_Data: 8 ABS_ESC
+ SG_ BrkHold_D_Stat : 34|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,GWM,IPMA_ADAS,PCM,PCM_HEV
+ SG_ HsaTrnAout_Tq_Rq : 23|16@0+ (4,-131072) [-131072|131060] "Nm"  GWM
+ SG_ BrkBstrVac_P_Actl : 7|7@0+ (8,0) [0|1008] "Millibar"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ YawStabilityIndex : 0|9@0+ (1,-256) [-256|255] "%"  VDM,IPMA_ADAS,PSCM,GWM
+ SG_ BrkTot_Tq_RqDrv : 47|13@0+ (4,0) [0|32760] "Nm"  IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,GWM,TCCM,PSCM
+ SG_ BrkTotTqRqDrv_No_Cnt : 39|4@0+ (1,0) [0|15] "unitless"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ BrkTotTqRqDrv_No_Cs : 63|8@0+ (1,0) [0|255] "unitless"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ HsaStat_D_Dsply : 50|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 1102 SelectDriveModeData2: 8 ABS_ESC
+ SG_ SelDrvMdePos12_D_Stat : 34|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos11_D_Stat : 45|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos10_D_Stat : 55|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos09_D_Stat : 50|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos08_D_Stat : 61|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos07_D_Stat : 39|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos06_D_Stat : 29|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos05_D_Stat : 18|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos04_D_Stat : 23|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos03_D_Stat : 13|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos02_D_Stat : 2|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePos01_D_Stat : 7|5@0+ (1,0) [0|31] "SED"  GWM
+
+BO_ 1056 SelectDriveModeData: 8 ABS_ESC
+ SG_ AutoEpbMsgTxt_D_Rq : 58|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ AutoEpbDsply_D_Stat : 37|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AutoEpbButtnOn_B_Stat : 48|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos12_B_Avail : 54|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos11_B_Avail : 55|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos10_B_Avail : 40|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos09_B_Avail : 41|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos08_B_Avail : 42|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos07_B_Avail : 43|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos06_B_Avail : 44|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos05_B_Avail : 45|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos04_B_Avail : 46|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos03_B_Avail : 47|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos02_B_Avail : 32|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SelDrvMdePos01_B_Avail : 24|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ActvDrvMde_D2_Stat : 53|5@0+ (1,0) [0|31] "SED"  IPMA_ADAS,GWM
+ SG_ SelDrvMde_D2_Rq : 63|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ SelDrvMdePt_D_Rq : 31|5@0+ (1,0) [0|31] "SED"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ SelDrvMdeMsgTxt_D_Rq : 19|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ SelDrvMde_D_Stat : 26|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AwdMde_D_RqBrk : 35|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 1054 BrakeSysFeatures_3: 8 ABS_ESC
+ SG_ AirDamUp_B_RqBrk : 32|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM_HEV,PCM
+ SG_ RbaBrk_D_Stat : 63|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ SelDrvMdeChassis2_D_Rq : 45|5@0+ (1,0) [0|31] "SED"  PSCM,GWM
+ SG_ TrailCtl_D_Stat : 55|3@0+ (1,0) [0|7] "SED"  TCCM,PCM,GWM
+ SG_ TrailCtlMsgTxt_D_Rq : 52|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ BrkBstrVac_D_Stat : 18|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ DrvSlipCtlOffLamp_D_Rq : 23|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ DrvSlipCtlMdeMsg_D_Rq : 13|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ AutoHoldMsgTxt_D_Rq : 4|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ CtaBrk_D_Stat : 47|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ SelDrvMdeAwd_D_Rq : 29|5@0+ (1,0) [0|31] "SED"  TCCM,GWM
+ SG_ AutoHoldSwMde_B_Ind : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AutoHoldMde_D_Ind : 15|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SelDrvMdeChassis_D_Rq : 39|5@0+ (1,0) [0|31] "SED"  VDM,GWM
+ SG_ ApaBrk_D_Stat : 34|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,GWM
+
+BO_ 1046 BrakeSysFeatures_2: 8 ABS_ESC
+ SG_ HsaMde_D_Mem : 33|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BrkBstrVac_B_Rq : 27|1@0+ (1,0) [0|1] "Discrete"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ HdcMde_D_Actl : 31|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ RearDiffLck_Tq2_RqMx : 51|12@0+ (4,0) [0|16376] "Nm"  GWM
+ SG_ TRLR_SWAY_EVNT_IN_PROG : 25|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TRLR_SWAY_CONFIG_STAT : 26|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TCMode : 15|1@0+ (1,0) [0|1] "SED"  VDM,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ DrvSlipCtlLamp_D_Rq : 42|2@0+ (1,0) [0|3] "SED"  VDM,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ Abs_B_Falt : 5|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ DrvSlipCtlMde_D_Ind : 44|2@0+ (1,0) [0|3] "SED"  TCCM,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ DrvAntiLckLamp_D_Rq : 55|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,GWM,IPMA_ADAS
+ SG_ BpedMove_No_Cnt : 3|4@0+ (1,0) [0|15] "Unitless"  ECM_Diesel,GWM
+ SG_ StabCtlBrk_B_Avail : 4|1@0+ (1,0) [0|1] "SED"  VDM,TCCM,GWM
+ SG_ DrvHdcWarnInfo_D_Rq : 35|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ DrvHdcMsg_D_Rq : 10|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ DrvHdcLampInfo_D_Rq : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BpedMove_D_Actl : 7|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,GWM
+ SG_ ChimeBrk_B_Rq : 14|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BrkLamp_B_Rq : 13|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HILL_DESC_MC : 47|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ RearDiffElckrOpen_B_Rq : 40|1@0+ (1,0) [0|1] "SED"  GWM,TCCM
+
+BO_ 1045 BrakeSysFeatures: 8 ABS_ESC
+ SG_ VehStab_D_Stat : 55|4@0+ (1,0) [0|15] "SED"  TCCM,PCM_HEV,PCM,GWM
+ SG_ BrkFluidLvl_D_Stat : 17|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ LsmcBrkDecel_D_Stat : 39|3@0+ (1,0) [0|7] "SED"  PSCM,GWM
+ SG_ VehYawNonLin_W_Rq : 51|12@0+ (0.03663,-75) [-75|74.92659] "deg/s"  ECM_Diesel,GWM
+ SG_ VehYawLin_W_Rq : 35|12@0+ (0.03663,-75) [-75|74.92659] "deg/s"  ECM_Diesel,GWM
+ SG_ VehVActlBrk_No_Cs : 31|8@0+ (1,0) [0|255] "Unitless"  TCCM,CMR_DSMC,SOBDMC_HPCM_FD1,ECM_Diesel,PCM,PCM_HEV,PSCM,TCM_DSL,GWM,IPMA_ADAS
+ SG_ Veh_V_ActlBrk : 7|16@0+ (0.01,0) [0|655.35] "kph"  TCCM,CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,PSCM,TCM_DSL,GWM
+ SG_ VehVActlBrk_No_Cnt : 21|4@0+ (1,0) [0|15] "Unitless"  TCCM,CMR_DSMC,SOBDMC_HPCM_FD1,ECM_Diesel,PCM,PCM_HEV,PSCM,TCM_DSL,GWM,IPMA_ADAS
+ SG_ VehVActlBrk_D_Qf : 23|2@0+ (1,0) [0|3] "SED"  TCCM,CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,PSCM,TCM_DSL,GWM
+
+BO_ 1044 BrakeSnData_6: 8 ABS_ESC
+ SG_ StePinOffst_An_Est : 7|16@0+ (0.1,-3200) [-3200|3353.3] "degrees"  GWM,PSCM
+ SG_ StePinOffst_No_Cs : 31|8@0+ (1,0) [0|255] "Unitless"  GWM,PSCM
+ SG_ StePinOffst_No_Cnt : 21|4@0+ (1,0) [0|15] "unitless"  GWM,PSCM
+ SG_ StePinOffst_D_Stat : 23|2@0+ (1,0) [0|3] "SED"  GWM,PSCM
+
+BO_ 1042 TrailerBrakeData: 8 ABS_ESC
+ SG_ VehRol_An_Dsply : 31|7@0+ (1,-64) [-64|61] "degrees"  GWM
+ SG_ VehPtch_An_Dsply : 23|7@0+ (1,-64) [-64|61] "degrees"  GWM,TCCM
+ SG_ TrlrBrk_Pc_Rq : 14|7@0+ (1,0) [0|127] "percent"  GWM
+
+BO_ 535 WheelSpeed: 8 ABS_ESC
+ SG_ WhlRr_W_Meas : 54|15@0+ (0.01,0) [0|327.65] "rad/s"  VDM,IPMA_ADAS,GWM,ECM_Diesel,PCM,PCM_HEV,PSCM,TCCM,TCM_DSL
+ SG_ WhlRl_W_Meas : 38|15@0+ (0.01,0) [0|327.65] "rad/s"  VDM,IPMA_ADAS,GWM,ECM_Diesel,PCM,PCM_HEV,PSCM,TCCM,TCM_DSL
+ SG_ WhlFr_W_Meas : 22|15@0+ (0.01,0) [0|327.65] "rad/s"  VDM,IPMA_ADAS,GWM,ECM_Diesel,PCM,PCM_HEV,PSCM,TCCM,TCM_DSL
+ SG_ WhlFl_W_Meas : 6|15@0+ (0.01,0) [0|327.65] "rad/s"  VDM,IPMA_ADAS,GWM,ECM_Diesel,PCM,PCM_HEV,PSCM,TCCM,TCM_DSL
+
+BO_ 534 WheelData: 8 ABS_ESC
+ SG_ BrkObdData_No_Actl : 63|8@0+ (1,0) [0|255] "unitless"  SOBDMC_HPCM_FD1,GWM
+ SG_ BrkObdIndex_No_Actl : 53|6@0+ (1,0) [0|63] "unitless"  SOBDMC_HPCM_FD1,GWM
+ SG_ WhlRotatRr_No_Cnt : 23|8@0+ (1,0) [0|255] "Unitless"  IPMA_ADAS,GWM,PSCM
+ SG_ WhlDirRr_D_Actl : 33|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM,ECM_Diesel,PCM_HEV,PSCM
+ SG_ WhlDirRl_D_Actl : 39|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM,PSCM,ECM_Diesel,PCM_HEV
+ SG_ WhlDirFr_D_Actl : 37|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM,ECM_Diesel,PCM_HEV,PSCM
+ SG_ WhlDirFl_D_Actl : 35|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM,ECM_Diesel,PCM_HEV,PSCM
+ SG_ WhlRotatRl_No_Cnt : 31|8@0+ (1,0) [0|255] "Unitless"  IPMA_ADAS,GWM,PSCM
+ SG_ WhlRotatFr_No_Cnt : 7|8@0+ (1,0) [0|255] "Unitless"  IPMA_ADAS,GWM,PSCM
+ SG_ WhlRotatFl_No_Cnt : 15|8@0+ (1,0) [0|255] "Unitless"  IPMA_ADAS,GWM,PSCM
+
+BO_ 532 DesiredTorqBrk_2: 8 ABS_ESC
+ SG_ RgenTqFalt_B_Actl : 59|1@0+ (1,0) [0|1] "SED"  GWM,PCM_HEV
+ SG_ RgenBrkDynoMde_B_Actl : 58|1@0+ (1,0) [0|1] "SED"  GWM,PCM_HEV
+ SG_ PrplWhlTqRqMn_No_Cs : 55|8@0+ (1,0) [0|255] "Unitless"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ PrplWhlTot_Tq_RqMn : 7|16@0+ (4,-131072) [-131072|131068] "Nm"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ PrplWhlTqRqMn_No_Cnt : 63|4@0+ (1,0) [0|15] "Unitless"  GWM,ECM_Diesel,PCM,PCM_HEV
+
+BO_ 531 DesiredTorqBrk: 8 ABS_ESC
+ SG_ VehStop_D_Stat : 28|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM
+ SG_ TracCtlPtActv_B_Actl : 31|1@0+ (1,0) [0|1] "SED"  VDM,IPMA_ADAS,TCCM,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,GWM
+ SG_ LscmbbMntr_B_Err : 17|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ LscmbbBrkDis_B_Actl : 19|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ LscmbbDeny_B_ActlBrk : 18|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PrkBrkYwLamp_D_Rq : 38|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PrkBrkRedLamp_D_Rq : 30|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ LscmbbBrkDecel_B_Actl : 20|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AbsActv_B_Actl : 45|1@0+ (1,0) [0|1] "SED"  VDM,SOBDMC_HPCM_FD1,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,PSCM,GWM
+ SG_ StabCtlBrkActv_B_Actl : 23|1@0+ (1,0) [0|1] "SED"  VDM,IPMA_ADAS,PCM,PCM_HEV,TCM_DSL,PSCM,TCCM,ECM_Diesel,GWM
+ SG_ CmbbBrkPrchg_B_Actl : 59|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ CmbbBrkDecel_B_Actl : 58|1@0+ (1,0) [0|1] "SED"  CMR_DSMC,IPMA_ADAS,GWM
+ SG_ CmbbBaSensInc_B_Actl : 57|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ AccBrkWarm_B_Actl : 63|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ AccBrkTotTqMn_B_Actl : 62|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ AccBrkPrchgActv_B_Actl : 61|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ AccBrkDis_B_Actl : 44|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ AccBrkDeny_B_Actl : 42|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ AccBrkActv_B_Actl : 43|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,ECM_Diesel,GWM
+ SG_ PrplDrgCtlActv_B_Actl : 46|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV,TCM_DSL,GWM
+ SG_ PrplWhlTot_Tq_RqMx : 7|16@0+ (4,-131072) [-131072|131068] "Nm"  ECM_Diesel,PCM,PCM_HEV,TCCM,GWM
+ SG_ LscmbbBaSensInc_B_Actl : 21|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CmbbBrkDis_B_Actl : 56|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,PSCM,GWM
+ SG_ CmbbDeny_B_ActlBrk : 60|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,PSCM,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ CcDis_B_Cmd : 47|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,GWM
+ SG_ VehLongOvrGnd_A_Est : 41|10@0+ (0.035,-17.9) [-17.9|17.835] "m/s^2"  VDM,IPMA_ADAS,TCCM,GWM
+ SG_ LscmbBrkPrchg_B_Actl : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AccStopActv_B_ActlBrk : 22|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ AccDis_B_ActlEpb : 32|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ PrkBrkMsgTxt_D_Rq : 36|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkBrkStatus : 26|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,GWM
+
+BO_ 136 ActiveFronSteering_Req: 8 ABS_ESC
+ SG_ SteWhlBrkOffst_An_Rq : 7|15@0+ (0.1,-1600) [-1600|1676.5] "degrees"  GWM
+ SG_ SteWhlBrkAnRq_No_Cs : 23|8@0+ (1,0) [0|255] "Unitless"  GWM
+ SG_ SteWhlBrkAnRq_No_Cnt : 31|4@0+ (1,0) [0|15] "Unitless"  GWM
+
+BO_ 125 BrakeSnData_4: 8 ABS_ESC
+ SG_ VehRolComp_W_Actl : 51|12@0+ (0.03663,-75) [-75|74.92659] "degrees/sec"  VDM,GWM
+ SG_ VehVertComp_A_Actl : 45|10@0+ (0.035,-17.9) [-17.9|17.835] "m/s^2"  VDM,PSCM,GWM
+ SG_ BrkTotTqRqArb_No_Cs : 23|8@0+ (1,0) [0|255] "Unitless"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ BrkTotTqRqArb_No_Cnt : 31|4@0+ (1,0) [0|15] "Unitless"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ BrkTot_Tq_RqArb : 4|13@0+ (4,0) [0|32756] "Nm"  VDM,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,PSCM,GWM
+ SG_ BrkTot_Tq_Actl : 27|13@0+ (4,0) [0|32756] "Nm"  ECM_Diesel,PCM,PCM_HEV,PSCM,GWM,TCCM
+ SG_ HsaStat_D_Actl : 7|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,PCM,PCM_HEV,TCM_DSL,GWM
+
+BO_ 119 BrakeSnData_3: 8 ABS_ESC
+ SG_ VehTrvlDir_D_Stat : 23|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ VehOverGnd_V_Est : 7|16@0+ (0.01,0) [0|655.33] "kph"  VDM,IPMA_ADAS,TCCM,PSCM,GWM
+ SG_ VehLongComp_A_Actl : 49|10@0+ (0.035,-17.9) [-17.9|17.835] "m/s^2"  VDM,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,PSCM,GWM
+ SG_ VehLatComp_A_Actl : 43|10@0+ (0.035,-17.9) [-17.9|17.835] "m/s^2"  VDM,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,PSCM,TCCM,GWM
+ SG_ VehYawComp_W_Actl : 19|12@0+ (0.03663,-75) [-75|74.92659] "deg/s"  VDM,TCCM,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,PSCM,GWM
+
+BO_ 118 BrakeSnData_5: 8 ABS_ESC
+ SG_ BrkCtrFnd_B_Stat : 39|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AwdLck_Tq_RqMx : 35|12@0+ (1,0) [0|4095] "Nm"  GWM,TCCM
+ SG_ AwdLck_Tq_RqMn : 51|12@0+ (1,0) [0|4095] "Nm"  GWM,TCCM
+ SG_ DrvSte_D_Stat : 19|4@0+ (1,0) [0|15] "SED"  PSCM,GWM
+ SG_ DrvSte_Tq_Rq : 31|8@0+ (0.0625,-8) [-8|7.8125] "Nm"  PSCM,GWM
+ SG_ EmgcyBrkLamp_D_Rq : 21|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ StopLamp_B_RqBrk : 7|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 73 Global_PATS_SubTarget: 8 ABS_ESC
+ SG_ immoSubTarget1Data_T1 : 15|40@0+ (1,0) [0|1099511627775] "Encrypted"  ECM_Diesel,GWM,PCM,PCM_HEV
+ SG_ immoSubTarget1Cmd_T1 : 7|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,GWM,PCM,PCM_HEV
+
+BO_ 1034 GGCC_Config_Mgmt_ID_1_FD1: 8 GWM
+ SG_ VehicleGGCCData : 7|64@0+ (1,0) [0|1.84467E+019] "mixed"  VDM,CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,ECM_Diesel,PCM,PCM_HEV,PSCM,TCCM,TCM_DSL
+
+BO_ 1440 TCM_AutoSar_NetworkMgt: 8 TCM_DSL
+ SG_ TCM_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCM_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+
+BO_ 561 TransGearData_2: 8 TCM_DSL
+ SG_ TrnMsgTxt2_D_Rq : 39|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TrnMsgTxt_D_Rq : 23|4@0+ (1,0) [0|15] "SED"  GWM
+
+BO_ 330 TransData_3: 8 TCM_DSL
+ SG_ TrnAout_W_ActlUnfilt : 22|15@0+ (0.1,0) [0|3276.5] "rad/s"  ECM_Diesel,GWM
+
+BO_ 1090 MtrTrac_Data2_FD1: 8 PCM_HEV
+ SG_ Mtr2State_D_ActlMntr : 31|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ Inv1Ain_I_ActlMntr : 7|15@0+ (0.1,-1000) [-1000|2276.5] "ampere"  GWM
+ SG_ HybVehMde_D_ActlMntr : 20|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ChrgStat_D_ActlMntr : 23|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ VehElRnge_L_Dsply : 28|12@0+ (0.1,0) [0|409.3] "kilometer"  GWM
+
+BO_ 870 Cluster_HEV_Data3_FD1: 8 PCM_HEV
+ SG_ EngMdeMsgTxt_D_Rq : 12|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ EffRgenThres_Pc_Dsply : 9|10@0+ (0.1,-102.3) [-102.3|0] "percent"  GWM
+ SG_ RngPerChrgInst_L_Dsply : 45|12@0+ (0.1,0) [0|409.3] "km"  GWM
+
+BO_ 869 Cluster_HEV_Data2: 8 PCM_HEV
+ SG_ PwrFlowTxt_D_Dsply : 21|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ EngOnMsg2_D_Dsply : 54|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ EngOnMsg1_D_Dsply : 38|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ FuelMaintMde_D_Dsply : 23|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ EffWhlLvl2_Pc_Dsply : 17|10@0+ (0.2,-102.2) [-102.2|102.4] "percent"  GWM
+ SG_ EffWhlThres_Pc_Dsply : 49|10@0+ (0.1,0) [0|102.3] "percent"  GWM
+ SG_ EngPwLvl_Pc_Dsply : 1|10@0+ (0.1,0) [0|102.3] "percent"  GWM
+ SG_ EngActv_B_Dsply : 2|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EffWhlThresOn_B_Dsply : 3|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 606 HEV_Powertrain_Data8_FD1: 8 PCM_HEV
+ SG_ ElVehLaterMde_D_Stat : 7|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ElVehNowMde_D_Stat : 5|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 374 PowertrainData_10: 8 PCM
+ SG_ GearEngag_D_Actl : 47|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TrnRng_D_Rq : 27|4@0+ (1,0) [0|15] "SED"  SOBDMC_HPCM_FD1,ABS_ESC,IPMA_ADAS,PSCM,ECM_Diesel,GWM
+ SG_ TrnPrkSys_D_Actl : 31|4@0+ (1,0) [0|15] "SED"  SOBDMC_HPCM_FD1,ABS_ESC,IPMA_ADAS,ECM_Diesel,GWM
+ SG_ GearLvr_D_ActlDrv : 7|4@0+ (1,0) [0|15] "SED"  SOBDMC_HPCM_FD1,ABS_ESC,IPMA_ADAS,TCCM,ECM_Diesel,GWM
+ SG_ GearPos_No_Cs : 23|8@0+ (1,0) [0|255] "unitless"  SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,ECM_Diesel,GWM
+ SG_ GearPos_D_Trg : 15|4@0+ (1,0) [0|15] "SED"  SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,TCCM,ECM_Diesel,GWM
+ SG_ GearPos_No_Cnt : 11|4@0+ (1,0) [0|15] "unitless"  SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,ECM_Diesel,GWM
+ SG_ TrnIgnOffDly_T_Rq : 39|8@0+ (4,0) [0|1020] "ms"  GWM
+ SG_ GearPos_D_Actl : 3|4@0+ (1,0) [0|15] "SED"  SOBDMC_HPCM_FD1,PSCM,IPMA_ADAS,ABS_ESC,ECM_Diesel,GWM
+
+BO_ 603 HEV_Powertrain_Data2: 8 PCM_HEV
+ SG_ WhlDirAvgDrv_D_Actl : 6|2@0+ (1,0) [0|3] "SED"  ABS_ESC,IPMA_ADAS,GWM
+ SG_ PrplTqMnRgen_B_Actl : 7|1@0+ (1,0) [0|1] "SED"  ABS_ESC,GWM
+ SG_ BattTracCnnct_D_Rq : 20|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 602 HEV_Powertrain_Data: 8 PCM_HEV
+ SG_ HtrnWarnLamp_B_Dsply : 3|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HybPwLimOn_B_Stat : 7|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwPckTqRdy_B_Dsply : 31|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 1152 HEV_Powertrain_Data6: 8 PCM_HEV
+ SG_ BattTracDiagClr_B_Stat : 2|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EngTeHi_B_Actl : 5|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,GWM
+ SG_ DcdcOn_B_Rq : 6|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ULoBattSpprtSustn_B_Rq : 7|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,GWM
+ SG_ VehElEff_No_Avg : 15|7@0+ (10,-100) [-100|1150] "watt*hr/km"  SOBDMC_HPCM_FD1,GWM
+
+BO_ 872 Cluster_HEV_Data5: 8 PCM_HEV
+ SG_ PlgActvArb_B_Dsply : 51|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HybMdeStat_D_Dsply : 39|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1,GWM
+
+BO_ 560 TransGearData: 8 TCM_DSL
+ SG_ SelDrvMdeSwtch_D_Stat3 : 15|2@0+ (1,0) [0|3] "SED"  GWM,ABS_ESC
+ SG_ TrnSrvcRqd_B_Rq : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TrnShifActv_B_Actl : 0|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC,ECM_Diesel
+ SG_ GearLvrPos_D_Actl : 12|4@0+ (1,0) [0|15] "SED"  VDM,IPMA_ADAS,GWM,ABS_ESC,PSCM,TCCM,ECM_Diesel
+ SG_ GboxOil_Te_Actl : 39|8@0+ (1,-60) [-60|193] "degC"  SOBDMC_HPCM_FD1,GWM,TCCM,ECM_Diesel
+
+BO_ 369 EngineData_1: 8 PCM
+ SG_ SeatWorkSrfc_B_Falt : 12|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TrnIpcDsplyRng2_D_Actl : 23|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ TrnIpcDsplyRng_D_Stat : 9|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrnIpcDsplyGear_D_Actl : 7|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ TrnIpcDsplyMde_D_Stat : 3|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrnIpcDsplyMde_D_Actl : 15|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TrnIpcDsplyGear_D_Stat : 1|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 92 Gear_Shift_by_Wire_3: 8 PCM_HEV
+ SG_ TrnLvrV_D_Rq : 43|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrnSbwSysHlth_D_Actl : 1|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrnGearNtmAllow_B_Stat : 47|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TrnDtpCmd_D_Actl : 46|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ GearSelLck_D_Rq : 41|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrnGearCmd_No_Cs : 31|8@0+ (1,0) [0|255] "Unitless"  GWM
+ SG_ TrnValidGear_D_Cnfm : 11|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrnNtrlTowCmd_D_Actl : 6|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,GWM,ABS_ESC
+ SG_ TrnGearCmd_Pc_ActlPt : 9|10@0+ (0.1,0) [0|102.2] "percent duty cycle"  GWM
+ SG_ TrnGear_D_RqPt : 4|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TrnCmdState_B_Actl : 39|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TrnCmdCnt_B_Actl : 7|1@0+ (1,0) [0|1] "unitless"  GWM
+ SG_ PrkBrkActv_D_RqTrnGear : 38|2@0+ (1,0) [0|3] "SED"  GWM,ABS_ESC
+ SG_ TrnGearMsgTxt_D_Rq : 36|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ TrnGearCmd_No_Cnt : 15|4@0+ (1,0) [0|15] "Unitless"  GWM
+
+BO_ 2030 TesterPhysicalResSOBDMCFD1: 64 ECM_Diesel
+ SG_ TesterPhysicalResSOBDMC : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1087 Powertrain_Data_5: 8 PCM_HEV
+ SG_ BattRgenLoChrg_D_RqEng : 15|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdasLcObtclAbrt_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ BattRgenLoDChrg_D_RqEng : 13|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AirDamPos_D_Stat : 11|2@0+ (1,0) [0|3] "SED"  GWM,ABS_ESC
+ SG_ FapLcInhbt_B_Rq : 1|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ FapLcStopHold_B_Rq : 2|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ FapLcPrchgBrk_B_Rq : 3|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ FapLcObstcl_B_Stat : 4|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ FapLcMaxGrdInhbt_B_Stat : 5|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ FapLcMaxGrdAbrt_B_Stat : 6|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+ SG_ FapLcActv_B_Stat : 7|1@0+ (1,0) [0|1] "SED"  GWM,IPMA_ADAS
+
+BO_ 332 CGEA_Urea_Strategy: 8 ECM_Diesel
+ SG_ UreaLvlQlty_D_RqDsply : 51|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ UreaLvlTxtWarn_D_Rq : 63|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ UreaQltySysWarn_D_Rq : 59|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ DieslPrtcWarn_D_Rq : 55|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ UreaQltyFlg_B_RqDsply : 24|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ UreaLvl_Pc_Actl : 47|8@0+ (0.4,0) [0|102] "percent"  GWM
+ SG_ VehUreaRnge2_L_DsplyMx : 3|12@0+ (1,0) [0|4095] "kilometer"  GWM
+ SG_ UreaQltySys_D_RqDsply : 27|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ UreaLvlTxt_D_RqDsply : 31|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ VehUreaWarn_V_DsplyMx : 23|7@0+ (1,0) [0|127] "km/h"  GWM
+
+BO_ 1896 TesterPhysicalResABS: 64 ABS_ESC
+ SG_ TesterPhysicalResABS : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1889 TesterPhysicalReqTCCM: 64 TSTR
+ SG_ TesterPhysicalReqTCCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TCCM
+
+BO_ 1888 TesterPhysicalReqABS: 64 TSTR
+ SG_ TesterPhysicalReqABS : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  ABS_ESC
+
+BO_ 1848 TesterPhysicalResPSCM: 64 PSCM
+ SG_ TesterPhysicalResPSCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1840 TesterPhysicalReqPSCM: 64 TSTR
+ SG_ TesterPhysicalReqPSCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  PSCM
+
+BO_ 1713 ABS_Rapid_Data_Response_2: 8 ABS_ESC
+ SG_ UUDTABSResponse2 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1712 ABS_Rapid_Data_Response_1: 8 ABS_ESC
+ SG_ UUDTABSResponse1 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 2025 TesterPhysicalResTCM: 64 TCM_DSL
+ SG_ TesterPhysicalResTCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 2024 TesterPhysicalResPCM: 64 PCM_HEV
+ SG_ TesterPhysicalResPCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 2017 TesterPhysicalReqTCM: 64 TSTR
+ SG_ TesterPhysicalReqTCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TCM_DSL
+
+BO_ 2016 TesterPhysicalReqPCM: 64 TSTR
+ SG_ TesterPhysicalReqPCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  ECM_Diesel,PCM,PCM_HEV
+
+BO_ 2015 TesterFunctionalReq_FD1: 64 TSTR
+ SG_ TesterFunctionalReq : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  VDM,CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCCM,TCM_DSL,PSCM,ABS_ESC,GWM
+
+BO_ 1897 TesterPhysicalResTCCM: 64 TCCM
+ SG_ TesterPhysicalResTCCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1814 TesterPhysicalReqGWM_FD1: 64 TSTR
+ SG_ TesterPhysicalReqGWM_F1 : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  GWM
+
+BO_ 1701 TCM_Rapid_Data_Response_2: 8 TCM_DSL
+ SG_ UUDTTCMResponse2 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1700 TCM_Rapid_Data_Response_1: 8 TCM_DSL
+ SG_ UUDTTCMResponse1 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1697 PCM_Rapid_Data_Response_2: 8 PCM_HEV
+ SG_ UUDTPCMResponse2 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1696 PCM_Rapid_Data_Response_1: 8 PCM_HEV
+ SG_ UUDTPCMResponse1 : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  TSTR
+
+BO_ 1429 PCM_AutoSar_NetworkMgmt: 8 PCM_HEV
+ SG_ PCM_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+ SG_ PCM_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless"  TCM_DSL
+
+BO_ 1100 PowertrainData_9: 8 PCM_HEV
+ SG_ EngExhMdeQuiet_D2_Stat : 28|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ HvacCmprLim_D_Stat : 34|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ WakeAlarm1_T_Rq : 55|15@0+ (1,0) [0|32767] "minute"  GWM
+ SG_ WakeAlarm1_B_Typ : 56|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ Veh_V_DsplyTrailCtlSet : 47|6@0+ (0.5,0) [0|31] "unitless"  GWM
+ SG_ TrailCtlPt_B_Falt : 36|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+ SG_ AutoTowAllw_D_StatMnu : 25|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AutoTowActv_B_Stat : 39|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ GrossTrainWeight_M_Est : 7|8@0+ (100,0) [0|25300] "kilogram"  VDM,ABS_ESC,PSCM,IPMA_ADAS,TCCM,TCM_DSL,GWM
+
+BO_ 1098 EffDrvModeData: 8 ECM_Diesel
+ SG_ EdmVeh_V_Dsply : 31|5@0+ (5,0) [0|155] "km/h"  GWM
+ SG_ EdmSailMdeOn_B_Stat : 25|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EdmPrev_Fe_Dsply : 23|8@0+ (0.1,0) [0|25.5] "litre/100km"  GWM
+ SG_ EdmMsgTxt_D_Rq : 11|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ EdmLamp_D_Dsply : 15|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ EdmCurrent_Fe_Dsply : 7|8@0+ (0.1,0) [0|25.5] "litre/100km"  GWM
+ SG_ EdmCmplnc_B_Dsply : 26|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EdmCmplnc_Pc_Dsply : 24|8@0+ (0.392157,0) [0|100.000035] "percent"  GWM
+
+BO_ 1086 PowertrainData_3: 8 PCM_HEV
+ SG_ EngMnfld_P_Actl : 47|13@0+ (0.1,-206.8) [-206.8|612.3] "kilopascal"  GWM
+ SG_ FuelPumpPwr_B_Rq : 20|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BattULoChrg_U_Cmd : 15|8@0+ (0.025,10.6) [10.6|16.975] "volt"  GWM
+ SG_ ElLoadCtl_D_Rq : 23|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 1071 Engine_Clutch_Data: 8 PCM_HEV
+ SG_ EngAout_N_Dsply : 52|13@0+ (2,0) [0|16382] "rpm"  GWM
+ SG_ CluPdl_PcRate_Actl : 7|8@0+ (0.04,-5) [-5|5.2] "%/ms"  GWM
+ SG_ CluPdlPosPcMeas_D_Qf : 11|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+ SG_ CluPdlPos_Pc_Meas : 9|10@0+ (0.1,0) [0|102.3] "%"  ABS_ESC,GWM
+ SG_ EngAoutIdl_N_Ntrl : 31|11@0+ (2,0) [0|4094] "rpm"  ABS_ESC,GWM
+
+BO_ 1069 PowertrainData_2: 8 PCM_HEV
+ SG_ SlMde_D_Stat : 57|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SlMde_D_RqDsply : 59|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ IsaOffst_D_Stat : 63|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ GrllShtrPos_D_Cmd : 55|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ GrllShtrPos_B_Falt : 51|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ObdWarmUp_B_Complt : 12|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,GWM
+ SG_ EngMsgTxt_D_Rq : 11|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ EngClnt_Te_ActlDiag : 39|8@0+ (1,-40) [-40|215] "degC"  SOBDMC_HPCM_FD1,TCM_DSL,GWM
+ SG_ EngLoad_Pc_CalcDiag : 47|8@0+ (0.392157,0) [0|100.000035] "%"  SOBDMC_HPCM_FD1,TCM_DSL,GWM
+ SG_ EngAirIn_Te_Actl : 9|10@0+ (0.25,-128) [-128|127.25] "degC"  GWM,TCM_DSL
+ SG_ ApedPos_Pc_ActlDiag : 31|8@0+ (0.392157,0) [0|100.000035] "%"  SOBDMC_HPCM_FD1,TCM_DSL,GWM
+
+BO_ 1060 Powertrain_Data_4: 8 PCM_HEV
+ SG_ RearDiffOilTeWarn_B_Rq : 20|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ RearDiffOil_Te_Actl : 15|9@0+ (1,-40) [-40|470] "degC"  GWM
+ SG_ BpedDrvMsgTxt_B_Dsply : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ FuelLvl_Pc_DsplyEng : 41|10@0+ (0.108696,-5.217408) [-5.217408|105.9786] "percent"  GWM
+ SG_ FuelLvlWarn_D_ActlEng : 19|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ FuelRange_L_DsplyEng : 39|14@0+ (0.1,0) [0|1638.3] "kilometer"  GWM
+ SG_ SelDrvMdePt_D_Stat : 25|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+
+BO_ 1057 PowertrainData_1: 8 PCM_HEV
+ SG_ FohEng_D_Rq : 1|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ EngIdlShutDwnTxt_D_Rq : 17|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ EngIdlShutDown_D_Stat : 9|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ FUEL_ALCOHOL_PERCNT : 63|8@0+ (0.393700787,0) [0|99.999899898] "Percent"  GWM
+ SG_ TrnTotTq_Rt_Est : 39|16@0+ (0.001,0) [0|65.533] "Unitless"  GWM
+ SG_ TrnTotLss_Tq_Est : 31|8@0+ (0.5,0) [0|126.5] "Nm"  GWM
+ SG_ ECMMILRequest : 3|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AirCondFluidHi_P_Actl : 55|8@0+ (0.125,0) [0|31.625] "bar"  SOBDMC_HPCM_FD1,GWM
+ SG_ OilPressureWarning : 18|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ VehVLimStat_D_Actl : 6|3@0+ (1,0) [0|7] "SED"  GWM,TCM_DSL
+ SG_ VehVLimActv_B_Actl : 7|1@0+ (1,0) [0|1] "SED"  GWM,TCM_DSL
+ SG_ CoolantFanStepAct : 23|5@0+ (1,0) [0|31] "Steps"  GWM
+
+BO_ 1055 PowertrainData_7: 8 PCM_HEV
+ SG_ EcoCochInstNeg_B_Dsply : 53|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EcoCochShif_Pc_Dsply : 39|8@0+ (0.392157,0) [0|100.000035] "percent"  GWM
+ SG_ EcoCochInst_Pc_Dsply : 47|10@0+ (0.1,0) [0|102.3] "percent"  GWM
+ SG_ EcoCochIdlFuel_Pc_Dsply : 31|8@0+ (0.392157,0) [0|100.000035] "percent"  GWM
+ SG_ EcoCochDecel_Pc_Dsply : 23|8@0+ (0.392157,0) [0|100.000035] "percent"  GWM
+ SG_ EcoCochCrus_Pc_Dsply : 15|8@0+ (0.392157,0) [0|100.000035] "percent"  GWM
+ SG_ EcoCochA_Pc_Dsply : 7|8@0+ (0.392157,0) [0|100.000035] "percent"  GWM
+
+BO_ 562 PowertrainData_11: 8 ECM_Diesel
+ SG_ GearNtrl_No_Cs : 15|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ GearNtrl_No_Cnt : 5|4@0+ (1,0) [0|15] "unitless"  GWM
+ SG_ GearNtrl_D_Stat : 7|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+
+BO_ 523 Engine_Data_18: 8 ECM_Diesel
+ SG_ EngAirFiltMsgTxt_D_Rq : 2|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ WaterInFuel_B_Falt : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ UreaMnAdd_L2_Actl : 23|8@0+ (0.1,0) [0|25.4] "litre"  GWM
+ SG_ VehUreaRnge3_L_DsplyMx : 31|16@0+ (1,0) [0|65535] "unitless"  GWM
+ SG_ UreaMxAdd_L2_Actl : 47|9@0+ (0.1,0) [0|51] "litre"  GWM
+
+BO_ 517 PowertrainData_6: 8 PCM_HEV
+ SG_ FapLc_B_Err : 10|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ BrkTot_Tq_RqFapLc : 7|13@0+ (4,0) [0|32764] "Nm"  ABS_ESC,GWM
+ SG_ TrnAin_Pc_RqDrv : 9|10@0+ (0.1,0) [0|102.3] "percent"  TCCM,GWM
+
+BO_ 516 EngVehicleSpThrottle: 8 PCM_HEV
+ SG_ EngAoutNActl_D_QF : 31|2@0+ (1,0) [0|3] "SED"  TCM_DSL,GWM
+ SG_ EngAout3_N_Actl : 55|16@0+ (0.25,0) [0|16383.5] "RPM"  SOBDMC_HPCM_FD1,GWM
+ SG_ ApedPos_PcRate_ActlArb : 23|8@0+ (0.04,-5) [-5|5.12] "%/ms"  TCM_DSL,GWM
+ SG_ ApedPos_Pc_ActlArb : 1|10@0+ (0.1,0) [0|102.3] "%"  VDM,CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,TCCM,ABS_ESC,PSCM,TCM_DSL,GWM
+ SG_ ApedPosPcActl_D_Qf : 7|2@0+ (1,0) [0|3] "SED"  VDM,CMR_DSMC,IPMA_ADAS,SOBDMC_HPCM_FD1,ABS_ESC,PSCM,TCM_DSL,GWM
+ SG_ EngAout_N_Actl : 28|13@0+ (2,0) [0|16382] "rpm"  VDM,ABS_ESC,PSCM,TCCM,TCM_DSL,GWM
+ SG_ ApedPosPcActl_No_Cnt : 5|4@0+ (1,0) [0|15] "Unitless"  ABS_ESC,SOBDMC_HPCM_FD1,GWM
+ SG_ ApedPosPcActl_No_Cs : 47|8@0+ (1,0) [0|255] "Unitless"  ABS_ESC,SOBDMC_HPCM_FD1,GWM
+
+BO_ 514 EngVehicleSpThrottle2: 8 PCM_HEV
+ SG_ StrtrMtrDlyStrt_B_Stat : 39|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ VehVTrlrAid_B_Avail : 23|1@0+ (1,0) [0|1] "SED"  PSCM,GWM
+ SG_ StrtrMtrCtlMsgTxt_D_Rq : 7|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ VehVActlEng_No_Cs : 15|8@0+ (1,0) [0|255] "Unitless"  PSCM,GWM
+ SG_ VehVActlEng_No_Cnt : 22|4@0+ (1,0) [0|15] "Unitless"  PSCM,GWM
+ SG_ Veh_V_RqCcSet : 32|9@0+ (0.5,0) [0|255.5] "kph"  IPMA_ADAS,ABS_ESC,TCM_DSL,GWM
+ SG_ VehVActlEng_D_Qf : 38|2@0+ (1,0) [0|3] "SED"  VDM,IPMA_ADAS,ABS_ESC,PSCM,TCM_DSL,GWM
+ SG_ Veh_V_ActlEng : 55|16@0+ (0.01,0) [0|655.35] "kph"  VDM,SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,PSCM,TCM_DSL,GWM
+ SG_ GearRvrse_D_Actl : 4|3@0+ (1,0) [0|7] "SED"  CMR_DSMC,IPMA_ADAS,ABS_ESC,PSCM,GWM
+ SG_ StrtrMtrCtlMsgTxt_D2_Rq : 1|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 512 TorqueDataEngFlags: 8 PCM_HEV
+ SG_ PrplWhlTotTqRq_No_Cs : 63|8@0+ (1,0) [0|255] "Unitless"  ABS_ESC,GWM
+ SG_ PrplWhlTotTqRq_No_Cnt : 51|4@0+ (1,0) [0|15] "Unitless"  ABS_ESC,GWM
+ SG_ PrplWhlTot_Tq_Rq : 39|16@0+ (4,-131072) [-131072|131068] "Nm"  VDM,TCCM,ABS_ESC,GWM
+ SG_ PrplWhlTot_Tq_LimMn : 23|16@0+ (4,-131072) [-131072|131068] "Nm"  ABS_ESC,GWM
+ SG_ PtDrvMde_D_Stat : 55|4@0+ (1,0) [0|15] "SED"  IPMA_ADAS,GWM
+
+BO_ 381 EngineData_17: 8 ECM_Diesel
+ SG_ EngOilLife_T_Actl : 23|11@0+ (1,0) [0|2047] "days"  GWM
+ SG_ EngOilSrvcMsgTxt_D_Rq : 55|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ DistToNextOilChange : 7|16@0+ (1,0) [0|65535] "unitless"  GWM
+ SG_ RunDryPrevent_B_Stat : 28|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ WaterInFuel : 52|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ GlowIndication : 51|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 380 EngineData_16: 8 PCM
+ SG_ EngOilLvlWarn_D_Rq1 : 55|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ EngExhBrkOnLamp_B_Rq : 27|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EngExhBrkAutoLamp_B_Rq : 3|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EngAout_N_MxAllw : 52|13@0+ (2,0) [0|16382] "rpm"  SOBDMC_HPCM_FD1,GWM
+ SG_ EngExhBrkMde_D_Actl : 31|4@0+ (1,0) [0|15] "SED"  TCM_DSL,GWM
+
+BO_ 377 EngineData_7: 8 PCM_HEV
+ SG_ HvacAirFullOut_B_Rq : 23|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ FuelFlw_Vl_Dsply : 49|10@0+ (25,0) [0|25575] "Micro_Liter"  GWM
+ SG_ FuelFillInlet_B_Dsply : 32|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EngSrvcRqd_B_Rq : 19|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ OdoCount : 47|8@0+ (0.2,0) [0|50.8] "Meters"  GWM
+ SG_ EngOilLife_Pc_Actl : 39|7@0+ (1,0) [0|100] "Percent"  GWM
+ SG_ FuelFilterLamp_B_Dsply : 50|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AirCondRec_B_Rq : 55|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AirCondClutch_B_Stats : 51|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 376 EngineClimateData: 8 PCM_HEV
+ SG_ GasPrtc_D_RqDsply : 22|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ EngAout_Aa_Actl : 17|10@0+ (0.05,-25.6) [-25.6|25.55] "rpm/ms"  ABS_ESC,GWM
+ SG_ DynoMde_B_Cmd : 4|1@0+ (1,0) [0|1] "SED"  TCM_DSL,ABS_ESC,GWM
+ SG_ AslIconDsply_D_Rq : 3|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AslChime_B_Rq : 39|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HvacHtrCore2_Te_Actl : 1|10@0+ (0.25,-50) [-50|205.5] "degC"  SOBDMC_HPCM_FD1,GWM
+ SG_ EcssLamp_D_RqDsply : 19|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AirAmbTe_D_Qf : 35|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,TCCM,GWM
+ SG_ AirAmb_Te_ActlFilt : 49|10@0+ (0.25,-128) [-128|127.75] "deg C"  SOBDMC_HPCM_FD1,IPMA_ADAS,GWM
+ SG_ AirAmb_Te_Actl : 33|10@0+ (0.25,-128) [-128|127.75] "degC"  ABS_ESC,TCCM,GWM
+ SG_ AirAmb_P_Actl : 55|6@0+ (10,500) [500|1110] "mbar"  ABS_ESC,TCM_DSL,GWM
+
+BO_ 373 EngineData_11: 8 ECM_Diesel
+ SG_ DieslPrtc2_D_RqDsply : 47|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ DieslPrtcRgen_D_Actl : 38|2@0+ (1,0) [0|3] "SED"  TCM_DSL,GWM
+ SG_ EngTeColdPrtct_D_Stats : 4|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ EngExhOvrTe_B_RqDsply : 39|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 359 VehicleOperatingModes: 8 PCM_HEV
+ SG_ PrplWhlRgenMn_Tq_Actl : 25|13@0+ (4,-16380) [-16380|16380] "Nm"  ABS_ESC,GWM
+ SG_ ElPw_D_StatStrtStop : 31|4@0+ (1,0) [0|15] "SED"  ABS_ESC,PSCM,GWM
+ SG_ TrnAin_Tq_Actl : 42|11@0+ (1,-500) [-500|1547] "Nm"  ABS_ESC,GWM
+ SG_ PrplWhlTot2_Tq_Actl : 15|16@0+ (4,-131072) [-131072|131060] "Nm"  ABS_ESC,PSCM,TCCM,GWM
+ SG_ PwPckTq_D_Stat : 5|2@0+ (1,0) [0|3] "SED"  VDM,CMR_DSMC,IPMA_ADAS,ABS_ESC,PSCM,TCCM,TCM_DSL,GWM
+ SG_ Eng_D_Stat : 7|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+ SG_ PlgActvArb_B_Actl : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ElPw_D_Stat : 3|3@0+ (1,0) [0|7] "SED"  VDM,CMR_DSMC,IPMA_ADAS,ABS_ESC,PSCM,TCCM,TCM_DSL,GWM
+ SG_ TrnAinTq_D_Qf : 44|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+
+BO_ 358 Stop_Start: 8 PCM_HEV
+ SG_ StopStrtStdby_D_Indic : 55|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ StopStrtIODTxt_D_Rq : 52|5@0+ (1,0) [0|31] "SED"  GWM
+ SG_ StopStrtDrvMde_D_Indic : 13|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ StopStrtMsgTxt_D_Rq : 11|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ OdoTripVerify_L_Actl : 31|24@0+ (0.1,0) [0|1677721.4] "km"  GWM
+ SG_ HiElPwInhbt_B_Stat : 15|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AutoStopPtDelta_I_Est : 7|8@0+ (1,-127) [-127|127] "Amps"  GWM
+
+BO_ 357 EngBrakeData: 8 PCM_HEV
+ SG_ BPedDrvAppl_D_QF : 15|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,PSCM,TCM_DSL,GWM
+ SG_ CmbbDeny_B_ActlPrpl : 3|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ PrplTqMnSat_B_Actl : 41|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ BpedDrvAppl_D_Actl : 5|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,PSCM,TCCM,TCM_DSL,GWM
+ SG_ CmbbEngTqMn_B_Actl : 7|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,GWM
+ SG_ Veh_V_DsplyCcSet : 23|8@0+ (1,0) [0|253] "Unitless"  GWM,IPMA_ADAS
+ SG_ AccEngStat_D_Actl : 2|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS,GWM
+ SG_ CcMde_D_Actl : 13|3@0+ (1,0) [0|7] "SED"  VDM,TCM_DSL,ABS_ESC,GWM
+ SG_ CcStat_D_Actl : 10|3@0+ (1,0) [0|7] "SED"  CMR_DSMC,SOBDMC_HPCM_FD1,IPMA_ADAS,ABS_ESC,TCCM,TCM_DSL,GWM
+ SG_ EngAout_N_MnAllw : 52|13@0+ (2,0) [0|16382] "rpm"  SOBDMC_HPCM_FD1,GWM
+ SG_ CcOvrrdActv_B_Actl : 6|1@0+ (1,0) [0|1] "SED"  VDM,IPMA_ADAS,ABS_ESC,TCCM,TCM_DSL,GWM
+ SG_ AccStopMde_D_Rq : 39|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,ABS_ESC,GWM
+
+BO_ 355 EngineData_10: 8 ECM_Diesel
+ SG_ AutoRgenTxt_B_RqDsply : 48|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AccFllwMdeActv_B_Actl : 32|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ EngPtoMde_D_Actl : 60|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ManRgenTxt_D_RqDsply : 63|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ManRgenSoot_Pc_RqDsply : 39|7@0+ (1,0) [0|126] "%"  GWM
+ SG_ DieslMsgTxt_D_Rq : 57|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 342 EngineData_6: 8 PCM_HEV
+ SG_ EngOvrhtMitgActv_D_Ind : 36|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ EngClntTe_D_Qf : 33|2@0+ (1,0) [0|3] "SED"  VDM,SOBDMC_HPCM_FD1,TCM_DSL,GWM
+ SG_ EngGoutLss_Tq_Est : 31|8@0+ (1,0) [0|255] "Nm"  SOBDMC_HPCM_FD1,GWM
+ SG_ EngOil_Te_Actl : 15|8@0+ (1,-60) [-60|193] "degC"  GWM
+ SG_ EngClnt_Te_Actl : 7|8@0+ (1,-60) [-60|195] "degC"  VDM,SOBDMC_HPCM_FD1,TCM_DSL,GWM
+
+BO_ 71 Global_PATS_TargetInfo: 8 PCM_HEV
+ SG_ immoTarget1Status : 7|3@0+ (1,0) [0|7] "SED"  ABS_ESC,TCM_DSL,GWM
+ SG_ immoTarget1Data : 15|40@0+ (1,0) [0|1099511627775] "Encrypted"  ABS_ESC,GWM
+ SG_ immoTarget1Cmd : 4|3@0+ (1,0) [0|7] "SED"  ABS_ESC,GWM
+
+BO_ 1822 TesterPhysicalResGWM_FD1: 64 GWM
+ SG_ TesterPhysicalResGWM_F1 : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1438 GWM_AutoSar_NetMgmt_FD1: 8 GWM
+ SG_ GWM_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+ SG_ GWM_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,PCM,SOBDMC_HPCM_FD1,PSCM,ABS_ESC
+
+BO_ 954 Body_Info_10_FD1: 8 GWM
+ SG_ GenericSwtch3_No_Actl : 15|3@0+ (1,0) [0|7] "unitless" Vector__XXX
+ SG_ GenericSwtch2_No_Actl : 4|3@0+ (1,0) [0|7] "unitless" Vector__XXX
+ SG_ GenericSwtch1_No_Actl : 7|3@0+ (1,0) [0|7] "unitless" Vector__XXX
+
+BO_ 1006 Personality_IPMB_Data: 8 IPMA_ADAS
+ SG_ PersIndexIpmb_D_Actl : 39|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ FeatNoIpmbActl : 23|16@0+ (1,0) [0|65535] "Number"  GWM
+ SG_ FeatConfigIpmbActl : 7|16@0+ (1,0) [0|65535] "Undefined"  GWM
+
+BO_ 820 Adaptive_Headlamp_Stat: 8 GWM
+ SG_ AhbStatGfhbFdbk_D_Actl : 53|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ HeadLghtDrvSide_B_Stat : 33|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ HeadLghtHiOn_B_StatHcm : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Adaptive_Hdlmp_Fault : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 137 ActiveFrontStrg_Stat_FD1: 8 GWM
+ SG_ SteWhlOffstRq_D_Stat : 43|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ SteWhlOffst_An_TotActl : 23|15@0+ (0.1,-1600) [-1600|1676.5] "degrees"  ABS_ESC
+ SG_ SteWhlBrkOffst_An_Actl : 7|15@0+ (0.1,-1600) [-1600|1676.5] "degrees"  ABS_ESC
+ SG_ SteWhlBrkAnActl_No_Cs : 39|8@0+ (1,0) [0|255] "Unitless"  ABS_ESC
+ SG_ SteWhlBrkAnActl_No_Cnt : 47|4@0+ (1,0) [0|15] "Unitless"  ABS_ESC
+
+BO_ 129 Steering_Wheel_Data2_FD1: 8 GWM
+ SG_ SelDrvMdeSwtch_D_Stat4 : 21|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ SteWhlSwtchView_B_Stat : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchSet_B_Stat : 8|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchPhon_B_Stat : 9|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchNav_B_Stat : 10|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchMed_B_Stat : 11|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchIod_B_Stat : 12|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchHud_B_Stat : 13|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchBack_B_Stat : 14|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchMenu_B_Stat : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteEffortInc_B_RqDrv : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SelDrvMdeInc_B_RqDrv : 6|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SelDrvMdeDec_B_RqDrv : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SuspDampInc_B_RqDrv : 15|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchUp_B_Stat : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchRght_B_Stat : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchOk_B_Stat : 4|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchLeft_B_Stat : 1|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchDown_B_Stat : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchHome_B_Stat : 19|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ SteWhlSwtchInfo_B_Stat : 18|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 935 Side_Detect_R_Stat: 8 IPMA_ADAS
+ SG_ SodRight_D_Stat : 15|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ CtaAlrtRight2_D_Stat : 30|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ BttRight_D_Stat : 45|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ BttRight_D_RqDrv : 47|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ CtaBrkRightMsgTxt_B_Rq : 42|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CtaRightBrkEnbl_B_Rq : 31|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ CtaRightBrkDecel_B_Rq : 7|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ Side_Detect_R_Illum : 39|8@0+ (1,0) [0|255] "Percent"  GWM
+ SG_ CtaSnsRight_D_Stat : 25|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ CtaAlrtRight_D_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CtaRight_D_Stat : 18|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ SodSnsRight_D_Stat : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SodAlrtRight_D_Stat : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SodDetctRight_D_Stat : 23|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ SodWarnRight_Prd_Rq : 6|7@0+ (1,0) [0|127] "millisecond"  GWM
+
+BO_ 1108 RCMSerialNumber_FD1: 8 GWM
+ SG_ RCMSerialNoByte8 : 63|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte7 : 55|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte6 : 47|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte5 : 39|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte4 : 31|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte3 : 23|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte2 : 15|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+ SG_ RCMSerialNoByte1 : 7|8@0+ (1,0) [0|253] "Unitless"  ABS_ESC
+
+BO_ 261 APIM_Request_Signals_FD1: 8 GWM
+ SG_ ChrgStatDsply_D_Rq : 47|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ OffPeakTimeSetMin_Rq : 13|6@0+ (1,0) [0|63] "unitless" Vector__XXX
+ SG_ OffPeakTimeSetHR_Rq : 7|5@0+ (1,0) [0|31] "unitless" Vector__XXX
+ SG_ NextUsageTimeToggle_Rq : 15|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ LongTermParking_Rq : 17|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ CbnCmrtPrefLstNmItm_Rq : 31|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ CbnCmrtPrefListIndx_Rq : 39|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ ModemReset_D_Rq : 45|4@0+ (1,0) [0|15] "SED"  SOBDMC_HPCM_FD1
+ SG_ StopStrtDrvMde_B_RqBtn3 : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TCU_ESN_D_Rq : 22|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ FactoryReset_Rq : 18|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 1146 TrailerInfo_2_FD1: 8 GWM
+ SG_ TrlrAidSwtch_D_RqDrv : 35|2@0+ (1,0) [0|3] "SED"  PSCM,IPMA_ADAS
+ SG_ TrlrAidCtl_U_RqDrv : 31|12@0+ (0.00125,0) [0|5.11625] "volt"  PSCM
+
+BO_ 533 APIM_Send_Signals_2_FD1: 8 GWM
+ SG_ DcacGfciTestBttn_B_Stat : 9|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ TrlrBrkGain_No_Rq : 55|5@0+ (0.5,0) [0|15.5] "unitless" Vector__XXX
+ SG_ DcacPwResetButtn_B_Stat : 11|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacPwOffButtn_B_Stat : 12|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacPwLoButtn_B_Stat : 13|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacPwHiButtn_B_Stat : 14|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacPwButtn_B_Falt : 15|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ TrlrHitch_D_RqMnu : 23|4@0+ (1,0) [0|15] "SED"  IPMA_ADAS
+ SG_ AutoEpbZoomView_B_Stat : 32|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ AutoEpbButtn_B_Stat : 19|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ TrlrAidMde_D_Rq : 5|2@0+ (1,0) [0|3] "SED"  PSCM
+ SG_ TCU_Init_Actvtn_St : 1|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TCU_Final_Actvtn_St : 3|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ OtaTrg_D_Stat : 41|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ OnbChrgGoTTouch_D_Rq : 43|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTPrcond_D_Rq : 34|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTOn_D_Rq : 25|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTMnte_D_Rq : 47|4@0+ (1,0) [0|15] "minute"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTHr_T_Rq : 39|5@0+ (1,0) [0|29] "hour"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTExtHtr_D_Rq : 27|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTElement_D_Rq : 31|4@0+ (1,0) [0|15] "Unitless"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgGoTDelete_B_Rq : 17|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+ SG_ OnbChrgClearAll_B_Rq : 18|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+ SG_ PaakMyKey_D_Rq : 7|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ OnbChrgGoTUpdate_B_Rq : 16|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 1041 AC_Compressor_Data_FD1: 8 GWM
+ SG_ ElCmprUHi_U_Actl : 31|8@0+ (2,0) [0|510] "volt"  SOBDMC_HPCM_FD1
+ SG_ ElCmprUHi_D_Stat : 23|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprOverTe_D_Stat : 21|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmpr_N_Actl : 15|8@0+ (50,0) [0|12700] "RPM"  SOBDMC_HPCM_FD1
+ SG_ ElCmpr_Pw_Actl : 7|8@0+ (40,0) [0|10160] "watts"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ ElCmpr_D_Stat : 19|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprPerfErr_D_Falt : 43|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprInnrErr_D_Falt : 35|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprLostComm_D_Falt : 33|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprOverLoad_D_Falt : 47|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprOverTe_D_Falt : 45|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprBattURng_D_Falt : 37|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprBattSysU_D_Falt : 39|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ ElCmprSysU_D_Falt : 41|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 1067 Battery_Mgmt_4_FD1: 8 GWM
+ SG_ BattULoAuxIsol_D_Rq : 25|2@0+ (1,0) [0|3] "SED"  PCM_HEV
+ SG_ BattULoAux_U_Rq : 55|12@0+ (0.00390625,0) [0|15.9921875] "volt"  PCM_HEV
+ SG_ BattULoAuxSoc_Pc_Actl : 15|7@0+ (1,0) [0|127] "percent"  PCM_HEV
+ SG_ BattULoAux_I_Actl : 23|12@0+ (0.0625,-128) [-128|127.875] "ampere"  PCM_HEV
+ SG_ BattULoAux_D_Qlty : 27|2@0+ (1,0) [0|3] "SED"  PCM_HEV
+ SG_ BattULoCrnkStrt_U_Pred : 47|7@0+ (0.1,0) [0|12.7] "volt"  PCM_HEV
+ SG_ BattULoCrnkBelt_U_Pred : 39|7@0+ (0.1,0) [0|12.7] "volt"  PCM_HEV
+ SG_ BattULoAux_U_Actl : 7|8@0+ (0.0625,0) [0|15.875] "volt"  PCM_HEV
+ SG_ BattULoAux_B_Falt : 8|1@0+ (1,0) [0|1] "SED"  PCM_HEV
+
+BO_ 1112 Battery_Traction_6_FD1: 8 GWM
+ SG_ BattTracChrgSustn_B_Rq : 4|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracCnnct_D_Cmd : 18|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracHvilOpen_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracDcdcDis_B_Rq : 7|1@0+ (1,0) [0|1] "SED"  PCM_HEV
+ SG_ HtrnClntPump_D_Stat : 6|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ BattTracDelta_Te_Actl : 63|8@0+ (0.5,-60) [-60|67.5] "degC"  SOBDMC_HPCM_FD1
+ SG_ BattTracClntPmp_D_Stat : 33|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 139 CruiseCtrl_Strg_Data_FD1: 8 GWM
+ SG_ AfsPw_B_Rq : 24|1@0+ (1,0) [0|1] "SED"  PCM
+ SG_ AccButtnGpTogglePress2 : 25|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TjaButtnOnOffPress2 : 26|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ActvFrontSteMsgTxt_D_Rq : 31|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ ActvFrontSteLck_D_Stat : 17|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ SelDrvMdeAdptSte_D_Stat : 28|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ AslButtnOnOffPress2 : 4|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AslButtnOnOffCnclPres2 : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcButtnOnPress2 : 18|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcButtnOnOffPress2 : 19|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcButtnOnOffCnclPress2 : 20|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcButtnOffPress2 : 21|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAsllButtnResPress2 : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnSetPress2 : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnSetIncPress2 : 8|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnSetDecPress2 : 9|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnResIncPress2 : 10|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnResDecPress2 : 11|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnOnPress2 : 12|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnOnOffCncl2 : 13|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnOffCnclPres2 : 14|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnIndxIncPres2 : 15|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnIndxDecPres2 : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnDeny_B_Actl2 : 1|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnCnclResPres2 : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnCnclPress2 : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AccButtnGapIncPress2 : 6|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AccButtnGapDecPress2 : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 1121 AllTerrainControlData_FD1: 8 GWM
+ SG_ SelDrvMdeSwtch_No_Actl : 2|2@0+ (1,0) [0|3] "unitless"  ABS_ESC
+ SG_ SelDrvMdeSwtch_D_Stat : 4|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ SelDrvMdeCnt_D_Stat : 7|3@0+ (1,0) [0|7] "Counts"  ABS_ESC
+
+BO_ 1120 FourByFourSwitchData_FD1: 8 GWM
+ SG_ DrvSlipCtlMde_B_Rq3 : 14|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ HybMdeSwtch_B_Rq : 13|1@0+ (1,0) [0|1] "SED"  PCM_HEV
+ SG_ TrailCtlSwtch_B_Stat3 : 15|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ RearDiffLck_D_RqDrv : 4|2@0+ (1,0) [0|3] "SED"  PCM,TCCM
+ SG_ AwdMde_D_RqDrv : 7|3@0+ (1,0) [0|7] "SED"  TCCM
+ SG_ HdcSwtchPos_B_Actl : 0|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+
+BO_ 1050 Climate_Control_Data_FD1: 8 GWM
+ SG_ AutoHoldSwtch_D_Stat : 20|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ LpdbPtc3_B_Rq : 36|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ LpdbPtc2_B_Rq : 37|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ LpdbPtc1_B_Rq : 38|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ LpdbHeatWiprPrk_B_Rq : 39|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ LpdbDfrstRearOn_B_Rq : 24|1@0+ (1,0) [0|1] "SED"  ECM_Diesel
+ SG_ SteWhlHeat_D_Rq : 13|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ MirrorHeatOn_B_Rq : 14|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Remote_Start_QuietMode : 15|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Outside_Air_Temp_Stat : 7|8@0+ (0.5,-40) [-40|86.5] "Degrees C"  VDM,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,PSCM
+
+BO_ 1137 Cluster_HEV_Data10_FD1: 8 PCM_HEV
+ SG_ RngPerChrgAvg_L_Dsply : 7|12@0+ (0.1,0) [0|409.3] "km"  GWM
+
+BO_ 1255 BoundaryAlert_Right_4: 8 IPMA_ADAS
+ SG_ BalrRight4Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight4Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight4Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight4CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight4CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1254 BoundaryAlert_Right_3: 8 IPMA_ADAS
+ SG_ BalrRight3Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight3Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight3Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight3CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight3CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1253 BoundaryAlert_Right_2: 8 IPMA_ADAS
+ SG_ BalrRight2Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight2Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight2Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight2CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight2CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1252 BoundaryAlert_Right_1: 8 IPMA_ADAS
+ SG_ BalrRight1Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight1Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight1Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrRight1CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrRight1CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1251 BoundaryAlert_Left_4: 8 IPMA_ADAS
+ SG_ BalrLeft4Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft4Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft4Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft4CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft4CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1250 BoundaryAlert_Left_3: 8 IPMA_ADAS
+ SG_ BalrLeft3Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft3Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft3Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft3CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft3CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1249 BoundaryAlert_Left_2: 8 IPMA_ADAS
+ SG_ BalrLeft2Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft2Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft2Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft2CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft2CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1248 BoundaryAlert_Left_1: 8 IPMA_ADAS
+ SG_ BalrLeft1Threat_D_Stat : 16|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft1Prev3Y_L_Actl : 51|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1Prev3X_L_Actl : 42|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1Prev2Y_L_Actl : 33|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1Prev2X_L_Actl : 24|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1Prev1Y_L_Actl : 31|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1Prev1X_L_Actl : 23|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1Fast_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft1Dsply_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrLeft1CurntY_L_Actl : 15|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+ SG_ BalrLeft1CurntX_L_Actl : 7|7@0+ (0.5,-32) [-32|31.5] "meter"  GWM
+
+BO_ 1113 TrailerAid_Stat3: 8 IPMA_ADAS
+ SG_ TrlrTrgtAcquire_D_Stat : 51|3@0+ (1,0) [0|7] "SED"  PSCM,GWM
+ SG_ TrlrAnOffst_An_Calc : 48|9@0+ (0.1,0) [0|51.1] "degrees"  GWM
+ SG_ TrlrAnOffstDir_D_Calc : 33|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrlrAnCalib_B_Complt : 40|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TrlrRvrse_D_Stat : 42|2@0+ (1,0) [0|3] "SED"  GWM,PSCM
+ SG_ TrlrAid_D2_Stat : 55|4@0+ (1,0) [0|15] "SED"  GWM,PSCM
+ SG_ TrlrAidTrgtId_No_Actl : 47|5@0+ (1,0) [0|31] "unitless"  GWM,PSCM
+ SG_ TrlrAid_An3_Actl : 28|11@0+ (0.125,-90) [-90|165.75] "degrees"  PSCM,GWM
+ SG_ TrlrAid_AnRate2_Actl : 22|10@0+ (0.125,-50) [-50|77.75] "degrees/second"  PSCM,GWM
+ SG_ HitchToVehAxle_L_Calc : 7|8@0+ (0.0127,-0.508) [-0.508|2.7178] "meter"  PSCM,GWM
+ SG_ HitchToTrlrAxle_L_Calc2 : 15|9@0+ (0.0254,0) [0|12.9794] "meter"  GWM
+
+BO_ 1105 Image_Processing_Data: 8 IPMA_ADAS
+ SG_ TrlrAidSwtchLamp_B_Rq : 32|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TrlrHitchMsgTxt_D_Rq : 47|6@0+ (1,0) [0|63] "SED"  GWM
+ SG_ TrlrHitchIcon_D_Rq : 36|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ TrlrHitchChime_D_Rq : 39|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TrlrAidEnbl_D_RqAdas : 5|3@0+ (1,0) [0|7] "SED"  GWM,PSCM
+ SG_ TrlrRvrseMsgTxt_D2_Rq : 31|6@0+ (1,0) [0|63] "SED"  PSCM,GWM
+ SG_ TrlrRvrseEnbl_D2_Stat : 18|3@0+ (1,0) [0|7] "SED"  PSCM,GWM
+ SG_ RbaMsg_D_Rq : 22|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BrkDecel_B_RqRba : 8|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ BrkEnbl_B_RqRba : 23|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ Rba_D_Stat : 14|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ RbaAlrt_D_Dsply : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ RbaMnu_D_Rq : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ CamraFrntStat_D_Stat : 7|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TrlrHitchLamp_D_Rq2 : 15|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 938 ParkAid_Aud_Warn_Stat: 8 IPMA_ADAS
+ SG_ SidePrkSnsR2_D_Stat : 59|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ SidePrkSnsR1_D_Stat : 63|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ SidePrkSnsL2_D_Stat : 51|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ ApaMde_D_Stat : 23|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ApaActvSd_D_Actl : 14|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PrkAidSwtch_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ ApaMde_D_Avail : 12|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsFrCrnr_D_Stat : 47|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsFrCntr_D_Stat : 35|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsFlCrnr_D_Stat : 27|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsFlCntr_D_Stat : 31|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkBrkEl_B_RqFap : 20|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ RpaChime_D_Rq : 7|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ FpaChime_D_Rq : 3|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidMsgTxt_D_Rq : 19|4@0+ (1,0) [0|15] "SED"  GWM,PSCM
+ SG_ SidePrkSnsL1_D_Stat : 55|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidAudioMute_B_Rq : 15|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 939 ParkAid_Aud_Warn_Stat2: 8 IPMA_ADAS
+ SG_ ApaBrk_D_Rq : 51|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SidePrkSnsR4_D_Stat : 55|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ SidePrkSnsR3_D_Stat : 47|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ SidePrkSnsL4_D_Stat : 43|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ SidePrkSnsL3_D_Stat : 37|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidChime_D_Stat : 4|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PrkAidSnsRlCntr_D_Stat : 15|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsRrCrnr_D_Stat : 31|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsRrCntr_D_Stat : 19|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidSnsRlCrnr_D_Stat : 11|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ PrkAidRear_D_Stat : 39|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PrkAidFront_D_Stat : 2|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PrkAid_D_Falt : 7|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ApaLongCtrlEnbl_D_Rq : 0|1@0+ (1,0) [0|1] "SED"  ABS_ESC,ECM_Diesel,PCM,PCM_HEV,TCM_DSL,GWM
+ SG_ ApaBrk_A_Rq : 63|8@0+ (0.05,-12.75) [-12.75|0] "m/sec^2"  ABS_ESC,ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ PrkAidLamp_D_Rq : 33|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 937 ParkAid_Data_2: 8 IPMA_ADAS
+ SG_ Veh_V_RqFap : 31|8@0+ (0.1,0) [0|25.5] "km/h"  ECM_Diesel,PCM,PCM_HEV
+ SG_ TrnRngDRqFap_No_Cs : 23|8@0+ (1,0) [0|255] "unitless"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnRngDRqFap_No_Cnt : 15|4@0+ (1,0) [0|15] "unitless"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnRng_D_RqFap : 11|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,PCM,PCM_HEV,TCM_DSL,GWM
+ SG_ FapLcDistToObj_L_Actl : 7|8@0+ (0.01,0) [0|2.53] "meter"  ECM_Diesel,PCM,PCM_HEV
+
+BO_ 936 ParkAid_Data: 8 IPMA_ADAS
+ SG_ ApaButtnPrssd_B_Stat : 58|1@0+ (1,0) [0|1] "SED"  PSCM
+ SG_ SAPPStatusCoding : 7|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ ApaSys_D_Stat : 61|3@0+ (1,0) [0|7] "SED"  PSCM,GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ ApaSteWhl_D_RqDrv : 63|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaSteScanMde_D_Stat : 49|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaSelSapp_D_Stat : 51|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaSelPpa_D_Stat : 53|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaSelPoa_D_Stat : 55|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaScan_D_Stat : 41|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaLongCtl_D_RqDrv : 44|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ApaGearShif_D_RqDrv : 47|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ApaActvSide2_D_Stat : 33|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ ApaAcsy_D_RqDrv : 36|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ ApaTrgtDist_D_Stat : 11|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ ApaMsgTxt_D_Rq : 15|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ ApaChime_D_Rq : 39|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ EPASExtAngleStatReq : 23|1@0+ (1,0) [0|1] "SED"  PSCM,GWM,ABS_ESC
+ SG_ ExtSteeringAngleReq2 : 22|15@0+ (0.1,-1000) [-1000|2276.5] "Degrees"  GWM,PSCM
+
+BO_ 877 HEV_Powertrain_Data7_FD1: 8 PCM_HEV
+ SG_ RngImpctDrv_L_Dsply : 39|9@0+ (1,-255) [-255|256] "km"  GWM
+ SG_ RngImpctClim_L_Dsply : 16|9@0+ (1,-255) [-255|256] "km"  GWM
+ SG_ VehElEffAvg_No_Dsply : 23|7@0+ (10,-100) [-100|1150] "wattHr/km"  GWM
+ SG_ PwFlwFuelDrv_D_Dsply : 15|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ PwFlwFuelClimt_B_Dsply : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwFlwFuelBatt_B_Dsply : 1|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwFlwBattClimt_B_Dsply : 3|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ PwFlwBatt_D_Dsply : 7|4@0+ (1,0) [0|15] "SED"  GWM
+
+BO_ 589 Battery_Traction_5_FD1: 8 GWM
+ SG_ BattTrac2_Pw_LimChrg : 31|13@0+ (50,0) [0|409550] "watts"  PCM_HEV
+ SG_ BattTrac2_Pw_LimDchrg : 34|13@0+ (50,0) [0|409550] "watts"  PCM_HEV
+ SG_ BattTrac2_Pw_DchrgInst : 53|13@0+ (50,0) [0|409550] "watts"  PCM_HEV
+ SG_ BattTrac2_Pw_ChrgInst : 7|13@0+ (50,0) [0|409550] "watts"  PCM_HEV
+
+BO_ 588 Battery_Traction_4_FD1: 8 GWM
+ SG_ BattTracSoc2_Pc_Actl : 29|14@0+ (0.01,0) [0|163.81] "%"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTrac_Te_Actl : 9|10@0+ (0.5,-50) [-50|460.5] "degC"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracDiagClr_B_Rq : 30|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 587 Battery_Traction_3_FD1: 8 GWM
+ SG_ BattTracClnt_Te_Actl : 41|8@0+ (0.5,-60) [-60|67.5] "degC"  SOBDMC_HPCM_FD1
+ SG_ BattTracWarnLamp_B_Rq : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ BattTracSrvcRqd_B_Rq : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ BattTracSoc_Pc_MxPrtct : 35|10@0+ (0.1,0) [0|100] "%"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracSoc_Pc_MnPrtct : 29|10@0+ (0.1,0) [0|100] "%"  PCM_HEV
+ SG_ BattTracSoc_Pc_LimLo : 23|10@0+ (0.1,0) [0|100] "%"  PCM_HEV
+ SG_ BattTracSoc_Pc_LimHi : 1|10@0+ (0.1,0) [0|100] "%"  PCM_HEV
+
+BO_ 389 PreCond_Hev_Data2_FD1: 8 SOBDMC_HPCM_FD1
+ SG_ BattTracClntFlw_Pc_Rq : 63|7@0+ (1,0) [0|127] "percent"  GWM
+ SG_ HtrnOvrTeLamp_B_Dsply : 5|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HtrnMil_D_Rq : 7|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ HtrnAin_UHi_Actl : 39|10@0+ (0.5,0) [0|510.5] "volt"  GWM,PCM_HEV
+ SG_ HtrnSrvcRqd_B_Dsply : 3|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HtrnHvilOpen_B_Actl : 24|1@0+ (1,0) [0|1] "SED"  GWM,PCM_HEV
+ SG_ PtWakeupDeltaT_T_Rq : 2|11@0+ (1,0) [0|2045] "minute"  GWM
+ SG_ PreCondActv_B_Actl : 50|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ DrvCondTpRrDefrs_B_Rq : 49|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BattTrac_I_EstVsc : 23|15@0+ (0.05,-750) [-750|888.25] "Amps"  GWM
+
+BO_ 1009 APIM_Send_Signals1_FD1: 8 GWM
+ SG_ ChrgCordUnlock_B_Rq : 60|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AutoHoldSwtch_D_Stat3 : 50|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ TrlrTrgtAcquire_D_Rq : 63|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ TrlrAidCancl_B_Rq : 48|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,PSCM
+ SG_ CenterStackRing_D_Actl : 59|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ APIM_NumberofTracks_St : 39|16@0+ (1,0) [0|65535] "unitless" Vector__XXX
+ SG_ APIM_ActiveTrackNum_St : 7|32@0+ (1,0) [0|4294967295] "unitless" Vector__XXX
+ SG_ ValetMode_D_Stat : 57|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TrlrAidSetup_D_Stat : 55|3@0+ (1,0) [0|7] "SED" Vector__XXX
+
+BO_ 360 Gear_Shift_by_Wire_2_FD1: 8 GWM
+ SG_ GsmSrvcRqd_B_Rq : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TrnGearPwmFalt_B_Actl : 15|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ GearButtnStuck_B_Actl : 14|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+
+BO_ 122 Battery_Traction_1_FD1: 8 GWM
+ SG_ BattTrac_U_LimLo : 47|8@0+ (2,0) [0|510] "volt"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTrac_U_LimHi : 39|8@0+ (2,0) [0|510] "volt"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ VehStrtInhbt_B_RqBatt : 23|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracOffFst_D_Actl : 22|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracOff_B_Actl : 20|1@0+ (1,0) [0|1] "SED"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTracMil_D_Rq : 19|2@0+ (1,0) [0|3] "SED"  PCM_HEV
+ SG_ BattTrac_U_Actl : 17|10@0+ (0.5,0) [0|510.5] "Volts"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ BattTrac_I_Actl : 6|15@0+ (0.05,-750) [-750|888.25] "Amps"  SOBDMC_HPCM_FD1,PCM_HEV
+
+BO_ 90 Gear_Shift_by_Wire_FD1: 8 GWM
+ SG_ TrnGsmNtmState_D_Actl : 55|2@0+ (1,0) [0|3] "SED"  ABS_ESC,PCM,PCM_HEV,TCM_DSL
+ SG_ DrQltyDrv_D_StatGsm : 42|3@0+ (1,0) [0|7] "SED"  ABS_ESC,PCM,PCM_HEV,TCM_DSL,IPMA_ADAS
+ SG_ TrnBtsiOvrrd_B_Stat : 43|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ GsmGearMsgTxt_D_Rq : 63|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TrnRng_D_RqGsm : 51|4@0+ (1,0) [0|15] "SED"  PCM,TCM_DSL
+ SG_ PrkBrkActv_D_RqGsmGear : 53|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ TrnValidGearRq_D_Stat : 25|2@0+ (1,0) [0|3] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearRqCnt_B_Actl : 26|1@0+ (1,0) [0|1] "unitless"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_U_Actl : 23|8@0+ (0.05,0) [0|12.7] "VOLT"  TCM_DSL
+ SG_ TrnGearButtn_B_ActlR2 : 8|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlR1 : 9|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlR0 : 10|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlP2 : 11|1@0+ (1,0) [0|1] "SED"  TCM_DSL,PCM,PCM_HEV
+ SG_ TrnGearButtn_B_ActlP1 : 12|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlP0 : 13|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlN2 : 14|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlN1 : 15|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlN0 : 0|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlM2 : 1|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlM1 : 2|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlM0 : 3|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlD2 : 4|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlD1 : 5|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGearButtn_B_ActlD0 : 6|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGear_No_Cs : 39|8@0+ (1,0) [0|255] "Unitless"  SOBDMC_HPCM_FD1,PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGear_No_Cnt : 47|4@0+ (1,0) [0|15] "Unitless"  SOBDMC_HPCM_FD1,PCM,PCM_HEV,TCM_DSL
+ SG_ TrnGear_D_RqDrv : 31|5@0+ (1,0) [0|31] "SED"  SOBDMC_HPCM_FD1,PCM,PCM_HEV,TCM_DSL
+ SG_ BrkSwtchPos_B_ActlGsm : 7|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+
+BO_ 1091 TrailerInfo_FD1: 8 GWM
+ SG_ ParkLampTrlrOut_B_Stat : 15|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TrlrLampCtl_D_Stat : 4|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TrlrBattChrg_D_Stat : 2|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ StopLampTrlrOut_B_Stat : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TurnLampTrlrRr_B_Stat : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TurnLampTrlrRl_B_Stat : 6|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TrlrLampCnnct_B_Actl : 7|1@0+ (1,0) [0|1] "SED"  VDM,PCM_HEV,ECM_Diesel,PCM,TCM_DSL,ABS_ESC,IPMA_ADAS,PSCM
+
+BO_ 138 ActiveFrontStrg_Stat2_FD1: 8 GWM
+ SG_ SteWhlRelCalib_T_Actl : 7|8@0+ (1,0) [0|255] "ms"  ABS_ESC
+ SG_ SteWhlRelCalib_An_Sns : 15|15@0+ (0.1,-1600) [-1600|1676.5] "deg"  CMR_DSMC,PSCM,TCCM
+
+BO_ 131 Steering_Data_FD1: 8 GWM
+ SG_ HeadLghtHiFlash_D_Stat : 7|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TurnLghtSwtch_D_Stat : 5|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS,PSCM
+ SG_ WiprFront_D_Stat : 3|4@0+ (1,0) [0|15] "SED"  ABS_ESC,IPMA_ADAS,PCM,PCM_HEV
+ SG_ LghtAmb_D_Sns : 15|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS
+ SG_ AccButtnGapDecPress : 12|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ AccButtnGapIncPress : 11|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ AslButtnOnOffCnclPress : 10|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ AslButtnOnOffPress : 9|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ CcAslButtnCnclPress : 8|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ LaSwtchPos_D_Stat : 23|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ CcAslButtnCnclResPress : 21|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcAslButtnDeny_B_Actl : 20|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcAslButtnIndxDecPress : 19|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ CcAslButtnIndxIncPress : 18|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ CcAslButtnOffCnclPress : 17|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnOnOffCncl : 16|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnOnPress : 31|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcAslButtnResDecPress : 30|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAslButtnResIncPress : 29|1@0+ (1,0) [0|1] "SED"  ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcAslButtnSetDecPress : 28|1@0+ (1,0) [0|1] "SED"  ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcAslButtnSetIncPress : 27|1@0+ (1,0) [0|1] "SED"  ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcAslButtnSetPress : 26|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CcAsllButtnResPress : 25|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcButtnOffPress : 24|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcButtnOnOffCnclPress : 39|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcButtnOnOffPress : 38|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ CcButtnOnPress : 37|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ HeadLghtHiFlash_D_Actl : 36|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ HeadLghtHiOn_B_StatAhb : 34|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ AhbStat_B_Dsply : 33|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AccButtnGapTogglePress : 32|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ WiprFrontSwtch_D_Stat : 47|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ HeadLghtHiCtrl_D_RqAhb : 43|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ TjaButtnOnOffPress : 40|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+
+BO_ 787 Power_Liftgate_Stat_FD1: 8 GWM
+ SG_ DrLckCnt_No_ActlTgate : 12|4@0+ (1,0) [0|15] "unitless" Vector__XXX
+ SG_ DrTgateChime2_D_Rq : 15|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ DrTGate_D_Rq : 2|2@0+ (1,0) [0|3] "SED"  ECM_Diesel
+ SG_ PwLftgtIntSw_B_Stat : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Power_Liftgate_Mode_Stt : 4|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 953 Body_Info_8_FD1: 8 GWM
+ SG_ BattRgenLoDChrg_D_Rq : 27|2@0+ (1,0) [0|3] "SED"  PCM_HEV,PCM
+ SG_ BattRgenLoChrg_D_Rq : 25|2@0+ (1,0) [0|3] "SED"  PCM_HEV,PCM
+ SG_ ChrgCordLck_B_Stat : 31|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ChrgCordResp2_No_Actl : 23|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ ChrgCordResp1_No_Actl : 15|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ WakeAlarm3_D_Stat : 1|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ WakeAlarm2_D_Stat : 3|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ WakeAlarm1_D_Stat : 5|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM_HEV
+ SG_ WakeAlarm0_D_Stat : 7|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+
+BO_ 1093 TrailerBrakeInfo_FD1: 8 GWM
+ SG_ TrlBrkInitOut_D_Stat : 10|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TrlrBrkOut_No_Dsply : 23|4@0+ (1,0) [0|15] "unitless" Vector__XXX
+ SG_ TrlrBrkMde_D_Actl : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TrlrBrkGain_No_Actl : 15|5@0+ (0.5,0) [0|15.5] "unitless" Vector__XXX
+ SG_ TrlrBrkDsply_B_Rq : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TrlrBrkDcnnt_B_Actl : 5|1@0+ (1,0) [0|1] "SED"  VDM
+ SG_ TrlrBrkActCnnct_B_Actl : 6|1@0+ (1,0) [0|1] "SED"  VDM,ECM_Diesel,PCM,TCM_DSL,ABS_ESC,PSCM,TCCM,IPMA_ADAS
+ SG_ StopLamp_B_RqTrlrBrk : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TrlrBrkCtl_B_Falt : 4|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ TrlrBrkActCirct_B_Falt : 1|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+
+BO_ 792 IPC_Send_Signals_2_FD1: 8 GWM
+ SG_ FuelRange_L_Dsply : 45|14@0+ (0.1,0) [0|1638.3] "km"  ECM_Diesel
+ SG_ ElTrip_L_Dsply : 31|16@0+ (0.1,0) [0|6553.3] "unitless" Vector__XXX
+ SG_ ElLongTerm_L_Dsply : 7|24@0+ (0.1,0) [0|1677721.3] "unitless" Vector__XXX
+
+BO_ 968 Cluster_Lighting_Rq_FD1: 8 GWM
+ SG_ SlMde_D_Rq : 27|2@0+ (1,0) [0|3] "SED"  ECM_Diesel
+ SG_ IsaOffst_D_Rq : 31|4@0+ (1,0) [0|15] "SED"  ECM_Diesel
+
+BO_ 819 Pass_Dr_Stat_FD1: 8 GWM
+ SG_ RollCode_No_ActlPdm : 31|16@0+ (1,0) [0|65535] "Unitless" Vector__XXX
+ SG_ Memory_3_SwPsngr_Stat : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Memory_2_SwPsngr_Stat : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Memory_1_SwPsngr_Stat : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ BLISLEDStatPassSide : 2|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ WndwPsngrSide_D_Stat : 4|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM
+ SG_ Pasngr_Lock_Sw_Stat : 6|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Pasngr_Lock_Sw_Cnt : 15|8@0+ (1,0) [0|255] "Cnt" Vector__XXX
+ SG_ ChildLckFdbckRp_B_Stat : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 818 Driver_Dr_Stat_FD1: 8 GWM
+ SG_ BLISLEDStatDriverSide : 47|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ ChildLckPw_N_Cnt : 39|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ WndwDrvSide_D_Stat : 1|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM
+ SG_ RollCodeDrvDrKeyCyl : 23|16@0+ (1,0) [0|65535] "Unitless" Vector__XXX
+ SG_ KeyCylSwDrvDr_D_Stat : 3|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Driver_Lock_Sw_Stat : 5|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Driver_Lock_Sw_Cnt : 15|8@0+ (1,0) [0|255] "Cnt" Vector__XXX
+ SG_ ChildLckPw_D_Rq : 6|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ChildLckFdbckRd_B_Stat : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ RvrseMirrorChime_B_Rq : 45|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 806 Compressor_Req_FD1: 8 GWM
+ SG_ SnowPlowMde_B_Enbl : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ StopStrtDrvMde_B_RqBtn : 3|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM
+ SG_ HvacHtrCore_Te_Rq : 49|10@0+ (0.25,-50) [-50|205.75] "degC"  PCM_HEV,SOBDMC_HPCM_FD1,ECM_Diesel
+ SG_ ClimtHeat_D_Rq : 20|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1,ECM_Diesel,PCM,PCM_HEV
+ SG_ ClimtCool_D_Rq : 23|3@0+ (1,0) [0|7] "SED"  SOBDMC_HPCM_FD1,ECM_Diesel,PCM,PCM_HEV
+ SG_ HvacEvap_Te_Rq : 33|10@0+ (0.125,-50) [-50|77.875] "Degrees C"  SOBDMC_HPCM_FD1,ECM_Diesel,PCM,PCM_HEV
+ SG_ HvacEvap_Te_Actl : 17|10@0+ (0.125,-50) [-50|77.75] "Degrees C"  SOBDMC_HPCM_FD1,ECM_Diesel,PCM,PCM_HEV
+ SG_ HvacAirCond_B_Rq : 7|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ HvacEvap_Te_Offst : 1|10@0+ (0.125,-50) [-50|77.875] "Degrees C"  ECM_Diesel,PCM,PCM_HEV
+ SG_ ClimtPw_B_Rq : 5|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM
+
+BO_ 765 Mc_Send_Signals_2_FD1: 8 GWM
+ SG_ Mc_VehTimeFrmtUsrSel_St : 1|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Running_Board_Cmd : 21|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ EngExhMdeQuiet_D2_Rq : 55|3@0+ (1,0) [0|7] "SED"  PCM
+ SG_ EdmSailMde_B_RqDrv : 48|1@0+ (1,0) [0|1] "SED"  ECM_Diesel
+ SG_ DrvInputRequired_B_Rq : 32|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AwdRnge_D_ActlIpc : 29|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ BalrSwtch_D_Stat : 57|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ BalrMde_D_Rq : 59|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ WaitToStartLamp_D_Falt : 50|2@0+ (1,0) [0|3] "SED"  ECM_Diesel
+ SG_ EsaOn_B_Rq : 15|1@0+ (1,0) [0|1] "SED"  PSCM
+ SG_ BttOn_B_Rq : 26|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ Btt_L_Actl : 39|7@0+ (0.1,0) [0|12.5] "meter"  IPMA_ADAS
+ SG_ SelDrvMdeTxtReset_B_Rq : 40|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ SelDrvMdeDsply_B_Avail : 41|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ Mc_VehUntTrpCoUsrSel_St : 23|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Mc_VehUnitTempUsrSel_St : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Mc_VehLangUsrSel_St : 7|6@0+ (1,0) [0|63] "SED" Vector__XXX
+
+BO_ 559 ElecHorizon_Data2_FD1: 8 GWM
+ SG_ EhData2_No_Actl : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  IPMA_ADAS,ECM_Diesel
+
+BO_ 558 ElecHorizon_Data1_FD1: 8 GWM
+ SG_ EhData1_No_Actl : 7|64@0+ (1,0) [0|1.84467440737096E+019] "unitless"  IPMA_ADAS,ECM_Diesel
+
+BO_ 934 Side_Detect_L_Stat: 8 IPMA_ADAS
+ SG_ CtaAlrtLeft2_D_Stat : 30|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ CtaBrkLeftMsgTxt_B_Rq : 42|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CtaLeftBrkDecel_B_Rq : 7|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ CtaLeftBrkEnbl_B_Rq : 31|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ Side_Detect_L_Illum : 39|8@0+ (1,0) [0|255] "Percent"  GWM
+ SG_ BttLeft_D_Stat : 45|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ BttLeft_D_RqDrv : 47|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ CtaSnsLeft_D_Stat : 25|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SodDetctLeft_D_Stat : 23|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ CtaLeft_D_Stat : 18|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ CtaAlrtLeft_D_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SodLeft_D_Stat : 15|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ SodSnsLeft_D_Stat : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SodAlrtLeft_D_Stat : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SodWarnLeft_Prd_Rq : 6|7@0+ (1,0) [0|127] "millisecond"  GWM
+
+BO_ 1072 Cluster_Info1_FD1: 8 GWM
+ SG_ LscmbbStat_B_Actl : 2|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ HaDsplyCpblty_B_Stat : 42|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ AccDeny_B_RqIpc : 7|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ DrvSlipCtlMde_D_Rq : 33|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ EngIdlShutDown_B_RqDrv : 3|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ HsaMde_D_Rq : 54|2@0+ (1,0) [0|3] "SED"  ABS_ESC
+ SG_ NtrlTowMdeEnbl_B_RqDrv : 1|1@0+ (1,0) [0|1] "SED"  TCCM,TCM_DSL,PCM_HEV,PCM
+ SG_ BulbChkActv_B_Stat : 55|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ParkDetect_Stat : 52|1@0+ (1,0) [0|1] "SED"  PCM_HEV,PCM
+ SG_ ReducedGuard_D_Rq : 51|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TrlrBrkMde_D_Rq : 57|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TRLR_SWAY_CONFIG_CMD : 56|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ TRAILER_BRAKE_CONFIG : 37|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Power_Liftgate_Mode_Cmd : 39|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ AccEnbl_B_RqDrv : 35|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ OdometerMasterValue : 15|24@0+ (1,0) [0|16777214] "km"  VDM,SOBDMC_HPCM_FD1,TCCM,CMR_DSMC,ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,PSCM,TCM_DSL
+ SG_ EngOilLife_B_RqReset : 43|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ ePRNDL_MODE : 0|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ DrvSlipCtlMde_B_Rq2 : 34|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ MetricActv_B_Actl : 6|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ KeyTypeChngMykey_D_Rq : 41|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ManRgen_D_Rq : 5|2@0+ (1,0) [0|3] "SED"  ECM_Diesel
+
+BO_ 909 Body_Info_6_FD1: 8 GWM
+ SG_ IgnPsswrdDsply_B_Rq : 57|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ ElPwPoint_D_Rq : 59|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PoliceIdlMde_D_Stat : 55|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ DrLatchMsgTxt_D_Rq : 43|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ SecurityMsgTxt_D_Rq : 47|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PrmtrAlrmEvnt_D_Stat : 35|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ HeadLghtHiPrmsn_D_Stat : 51|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ SteWhlLckMsgTxt_D_Rq : 25|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ immoMsgTxt_D_Rq : 39|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ PrsnlDevcChrgEnbl_B_Rq : 40|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TracKeyMde_D_Stat : 45|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PEBackupSlot_Stats : 27|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ KeyMykeyTot_No_Cnt : 3|4@0+ (1,0) [0|15] "Counts" Vector__XXX
+ SG_ Keycode_Status : 15|20@0+ (1,0) [0|1048575] "unitless" Vector__XXX
+ SG_ KeyAdmnTot_No_Cnt : 7|4@0+ (1,0) [0|15] "Counts" Vector__XXX
+
+BO_ 963 BCM_Lamp_Stat_FD1: 8 GWM
+ SG_ Illuminated_Entry_Stat : 63|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Dr_Courtesy_Light_Stat : 49|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Courtesy_Delay_Status : 51|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ImpactEvntFdbck_D_Stat : 53|2@0+ (1,0) [0|3] "SED"  CMR_DSMC
+ SG_ WrlssAcsyChrgInhbt_B_Rq : 40|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PudLampPsngr_D_Rq : 57|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ HeadLampLoOut_B_Stat : 32|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CrnrLghtRight_Pc_Rq : 47|7@0+ (1,0) [0|100] "percent" Vector__XXX
+ SG_ CrnrLghtLeft_Pc_Rq : 39|7@0+ (1,0) [0|100] "percent" Vector__XXX
+ SG_ HeadLghtHiFdbck_D_Stat : 55|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PudLampDrv_D_Rq : 59|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ TrnNotInPrkChime_B_Rq : 24|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PrkLightChime_B_Rq : 25|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ KeyInIgnWarn_B_Cmd : 27|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ HomeSafeLtChime_B_Rq : 28|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ StopLghtOn_B_Stat : 8|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ RvrseLghtOn_B_Stat : 9|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PrkLght_D_Stat : 13|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ HeadLghtSwtch_D_Stat : 15|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ HeadLampLoFrOn_B_Stat : 2|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ HeadLampLoFlOn_B_Stat : 3|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ HeadLampLoActv_B_Stat : 4|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS,PCM,ECM_Diesel
+ SG_ Headlamp_On_Wrning_Cmd : 29|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Park_Brake_Chime_Rqst : 26|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ HeadLghtHiOn_B_Stat : 1|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,IPMA_ADAS,PCM
+ SG_ BrkWarnInd_B_Rq : 20|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Brk_Fluid_Lvl_Low : 31|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ ReducedGuard_D_Stat : 19|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Perimeter_Alarm_Status : 17|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ Courtesy_BSave_Stat : 7|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ DrTgateLck_D_Stat : 61|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ WndwGlbl_D_Cmd : 23|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ PudLamp_D_Rq : 11|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ DayRnngLampOn_B_Stat : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PerimeterAlarmChimeRq : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 145 Yaw_Data_FD1: 8 GWM
+ SG_ VehYawWActl_D_Qf : 53|2@0+ (1,0) [0|3] "SED"  VDM,IPMA_ADAS,ABS_ESC
+ SG_ VehRolWActl_D_Qf : 55|2@0+ (1,0) [0|3] "SED"  VDM,IPMA_ADAS,ABS_ESC
+ SG_ VehRollYawW_No_Cs : 39|8@0+ (1,0) [0|255] "Unitless"  IPMA_ADAS,ABS_ESC
+ SG_ VehRollYaw_No_Cnt : 47|8@0+ (1,0) [0|255] "Unitless"  VDM,IPMA_ADAS,ABS_ESC
+ SG_ VehYaw_W_Actl : 23|16@0+ (0.0002,-6.5) [-6.5|6.6066] "rad/s"  VDM,ABS_ESC,PSCM,IPMA_ADAS
+ SG_ VehRol_W_Actl : 7|16@0+ (0.0002,-6.5) [-6.5|6.6066] "rad/s"  VDM,ABS_ESC,IPMA_ADAS
+
+BO_ 76 RCMStatusMessage2_FD1: 8 GWM
+ SG_ FirstRowBuckleMid : 28|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ SecondRowBucklePsngr : 23|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ SecondRowBuckleMid : 9|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ SecondRowBuckleDriver : 11|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ FirstRowBuckleDriver : 15|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,ABS_ESC,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCM_DSL
+ SG_ RILReq : 7|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ FirstRowBucklePsngr : 13|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ RstrnImpactEvntStatus : 3|3@0+ (1,0) [0|7] "SED"  CMR_DSMC,SOBDMC_HPCM_FD1,ABS_ESC,IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV,TCM_DSL
+ SG_ PsngrFrntDetct_D_Actl : 5|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ EDRTriggerEvntSync : 29|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ PassRstrnInd_Req : 31|2@0+ (1,0) [0|3] "SED" Vector__XXX
+
+BO_ 65 Global_PATS_Cntrl_Info_FD1: 8 GWM
+ SG_ immoControlData_T1 : 15|40@0+ (1,0) [0|1099511627775] "Encrypted"  ECM_Diesel,PCM,PCM_HEV
+ SG_ immoControlCmd_T1 : 7|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,PCM,PCM_HEV
+
+BO_ 1076 Cluster_Info_3_FD1: 8 GWM
+ SG_ HILL_DESC_SW : 32|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ AutoRgen_D_Rq : 34|2@0+ (1,0) [0|3] "SED"  ECM_Diesel
+ SG_ W2S_LAMP_OK : 37|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ OdoTripRx_B_Actl : 2|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ Veh_V_CompLimMx : 47|12@0+ (0.1,0) [0|409.5] "km/h"  ECM_Diesel,PCM,PCM_HEV
+ SG_ DrvSlipCtlMde_B_RqMyKey : 38|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ FuelLvlWarn_D_Actl : 51|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ FuelSecndActv_B_Actl : 39|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ FuelLvlPssvSide_No_Raw : 17|10@0+ (1,0) [0|1023] "Unitless"  ECM_Diesel,PCM,PCM_HEV
+ SG_ FUEL_SENSOR_NUM : 35|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ FuelLvlActvSide_No_Raw : 49|10@0+ (1,0) [0|1023] "Unitless"  ECM_Diesel,PCM,PCM_HEV
+ SG_ FuelLvl_Pc_Dsply : 1|10@0+ (0.108696,-5.217408) [-5.217408|105.9786] "Percent"  VDM,ECM_Diesel
+ SG_ DISPLAY_SPEED_SCALING : 23|4@0+ (0.5,100) [100|107.5] "%"  IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV
+ SG_ DISPLAY_SPEED_OFFSET : 7|3@0+ (0.5,0) [0|3.5] "kph"  IPMA_ADAS,ECM_Diesel,PCM,PCM_HEV
+
+BO_ 862 Climate_Cntrl_Data_2_FD1: 8 GWM
+ SG_ AutoStpHvacDelta_I_Est : 15|8@0+ (1,-192) [-192|62] "ampere" Vector__XXX
+ SG_ HvacBlwrFront_D_Stat : 55|5@0+ (1,0) [0|31] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ CabnAmb_Te_Actl : 39|8@0+ (0.5,-57) [-57|70] "degreesC"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ HvacRemoteStrt_N_Rq : 7|4@0+ (100,450) [450|1950] "RPM"  ECM_Diesel,PCM,PCM_HEV
+ SG_ ClimtThrmlLoad_No_Actl : 47|8@0+ (1,0) [0|254] "unitless"  SOBDMC_HPCM_FD1,PCM_HEV
+ SG_ HvacRec_Pc_Est : 23|7@0+ (1,0) [0|127] "Percent"  PCM_HEV,SOBDMC_HPCM_FD1
+ SG_ HvacAir_Flw_Est : 16|9@0+ (0.5,0) [0|255.5] "liter/second"  SOBDMC_HPCM_FD1
+
+BO_ 931 Body_Info_9_FD1: 8 GWM
+ SG_ PtWakeReas_D_Stat : 38|4@0+ (1,0) [0|15] "SED"  PCM_HEV
+ SG_ VehOnSrc_D_Stat : 19|4@0+ (1,0) [0|15] "SED"  ABS_ESC,PCM_HEV,ECM_Diesel,PCM
+ SG_ StrtrMtrCtlDStat_No_Cs : 31|8@0+ (1,0) [0|255] "unitless"  PCM_HEV,ECM_Diesel,PCM
+ SG_ EngStrtActv_B_Stat : 39|1@0+ (1,0) [0|1] "SED"  PCM_HEV,ECM_Diesel,PCM
+ SG_ EngStrt_B_Rq : 0|1@0+ (1,0) [0|1] "SED"  PCM_HEV,ECM_Diesel,PCM
+ SG_ DrvInCtl_B_Stat : 1|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ AdvStrt_D_Stat : 23|4@0+ (1,0) [0|15] "SED"  PCM_HEV,ECM_Diesel,PCM
+ SG_ CrnkInhbt_No_Cs : 15|8@0+ (1,0) [0|255] "Unitless"  ECM_Diesel,PCM,PCM_HEV
+ SG_ CrnkInhbt_No_Cnt : 6|4@0+ (1,0) [0|15] "Unitless"  ECM_Diesel,PCM,PCM_HEV
+ SG_ CrnkInhbt_B_Stat : 7|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ IgnPreOffActv_B_Stat : 2|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+
+BO_ 578 Body_Info_4_FD1: 8 GWM
+ SG_ PtLatchActv_B_RqBcm : 56|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV,TCM_DSL
+ SG_ immoSecureIdleMode : 61|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ ReFuelSwtchStat_D_Actl : 63|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ FuelPumpPwr_D_Stat : 50|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BattULo_U_Actl : 39|8@0+ (0.0625,0) [0|15.875] "volt"  CMR_DSMC,SOBDMC_HPCM_FD1,ABS_ESC,IPMA_ADAS,PSCM,ECM_Diesel,PCM,PCM_HEV
+ SG_ PrkLckCtl_B_Enbl : 22|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PrkLckCtlMsgTxt_D_Rq : 55|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PrkLckCtlAvail_T_Stat : 47|8@0+ (1,0) [0|255] "second" Vector__XXX
+ SG_ BrkTrnShifLck_B_Stat : 23|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV,TCM_DSL
+ SG_ PrkLckCtlUnlck_D_Stat : 58|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ PrkLckCtlTow_B_Enbl : 59|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DriverCrankingReq : 51|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ EngOff_T_Actl : 7|16@0+ (1,0) [0|65534] "second^0.5"  ABS_ESC,IPMA_ADAS,TCCM,ECM_Diesel,PCM,PCM_HEV,TCM_DSL
+ SG_ DcacElPw_D_Rq : 53|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM
+ SG_ BattULo_I_Actl : 21|14@0+ (0.0625,-512) [-512|511.875] "ampere"  ECM_Diesel,PCM,PCM_HEV
+
+BO_ 947 BodyInfo_3_FD1: 8 GWM
+ SG_ ValetMode_D_Mem : 16|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DimmingLvlEvnt_No_Actl : 18|2@0+ (1,0) [0|3] "unitless" Vector__XXX
+ SG_ DrStatDrvErrCnt_B_Stat : 19|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ TurnLghtRight_D_Rq : 63|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,IPMA_ADAS
+ SG_ TurnLghtRightOn_B_Stat : 35|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ TurnLghtLeftOn_B_Stat : 54|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ FogLghtRearOn_B_Stat : 1|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ Backlit_LED_Status : 23|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ TurnLghtLeft_D_Rq : 9|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,IPMA_ADAS
+ SG_ FogLghtFrontOn_B_Stat : 56|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ IgnKeyType_D_Actl : 39|4@0+ (1,0) [0|15] "SED"  ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV
+ SG_ Parklamp_Status : 3|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ Litval : 47|8@0+ (1,0) [0|253] "SED"  IPMA_ADAS
+ SG_ Key_In_Ignition_Stat : 11|1@0+ (1,0) [0|1] "SED"  ABS_ESC
+ SG_ Ignition_Status : 7|4@0+ (1,0) [0|15] "SED"  VDM,CMR_DSMC,SOBDMC_HPCM_FD1,ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,PSCM,TCCM,TCM_DSL
+ SG_ Dimming_Lvl : 31|8@0+ (1,0) [0|253] "SED"  IPMA_ADAS
+ SG_ Day_Night_Status : 15|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,ECM_Diesel,IPMA_ADAS,PCM
+ SG_ Remote_Start_Status : 13|2@0+ (1,0) [0|3] "SED"  CMR_DSMC,IPMA_ADAS
+ SG_ DrStatTgate_B_Actl : 0|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ DrStatRr_B_Actl : 49|1@0+ (1,0) [0|1] "SED"  ABS_ESC,IPMA_ADAS
+ SG_ DrStatRl_B_Actl : 48|1@0+ (1,0) [0|1] "SED"  ABS_ESC,IPMA_ADAS
+ SG_ DrStatPsngr_B_Actl : 60|1@0+ (1,0) [0|1] "SED"  CMR_DSMC,ABS_ESC,IPMA_ADAS
+ SG_ DrStatInnrTgate_B_Actl : 58|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ DrStatHood_B_Actl : 59|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DrStatDrv_B_Actl : 61|1@0+ (1,0) [0|1] "SED"  CMR_DSMC,ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,TCCM
+ SG_ PrkBrkActv_B_Actl : 55|1@0+ (1,0) [0|1] "SED"  ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,TCCM,TCM_DSL
+ SG_ LifeCycMde_D_Actl : 53|4@0+ (1,0) [0|15] "SED"  VDM,SOBDMC_HPCM_FD1,ABS_ESC,ECM_Diesel,IPMA_ADAS,PCM,PCM_HEV,PSCM,TCM_DSL
+ SG_ Delay_Accy : 57|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CrashEvnt_D_Stat : 34|2@0+ (1,0) [0|3] "SED" Vector__XXX
+ SG_ FuelPmpInhbt_B_Stat : 32|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ BodySrvcRqd_B_Rq : 10|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 1084 Battery_Mgmt_3_FD1: 8 GWM
+ SG_ BattULoChrg_URate_RqMx : 63|6@0+ (0.1,0) [0|6.3] "volts/second"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BattULoChrg_U_RqMx : 55|6@0+ (0.1,10.6) [10.6|16.9] "volt"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BattULoChrg_U_RqMn : 45|6@0+ (0.1,10.6) [10.6|16.9] "volt"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BattULoState_D_Qlty : 47|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BSFault : 7|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BattULo2_Te_Actl : 30|7@0+ (1,-40) [-40|86] "degC"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BSBattSOC : 22|7@0+ (1,0) [0|127] "%"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BSBattQDeltaRideAh : 6|15@0+ (0.0078125,-100) [-100|155.9921875] "ampere*hour"  ECM_Diesel,PCM,PCM_HEV
+ SG_ BSBattQCapAh : 38|7@0+ (1,0) [0|127] "ampere*hour"  ECM_Diesel,PCM,PCM_HEV
+
+BO_ 1068 Battery_Mgmt_2_FD1: 8 GWM
+ SG_ EngStrtInhbt_B_RqBatt : 2|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM
+ SG_ BattULoChrg_D_Rq : 7|2@0+ (1,0) [0|3] "SED"  ECM_Diesel,PCM
+ SG_ PwSysULoFalt_D_Stat : 12|4@0+ (1,0) [0|15] "SED" Vector__XXX
+ SG_ Shed_T_Eng_Off_B : 8|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Shed_Feature_Group_ID : 20|5@0+ (1,0) [0|31] "SED"  ECM_Diesel,PCM,PCM_HEV,IPMA_ADAS
+ SG_ Shed_Drain_Eng_Off_B : 0|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Shed_Level_Req : 23|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,PCM,PCM_HEV,IPMA_ADAS
+ SG_ BattULoSrvc_T_Actl : 39|12@0+ (1,0) [0|4095] "days" Vector__XXX
+ SG_ ULoRgenTestMde_B_Rq : 31|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM
+ SG_ ChargeMode : 15|3@0+ (1,0) [0|7] "SED"  ECM_Diesel,PCM
+ SG_ IdleSpeedIncrease_El : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ Batt_Lo_SoC_B : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ PeriodicElLoad_B_Stat : 1|1@0+ (1,0) [0|1] "SED"  ECM_Diesel
+ SG_ Batt_Crit_SoC_B : 4|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 146 Accel_Data_FD1: 8 GWM
+ SG_ VehVert2_A_Actl : 36|13@0+ (0.01,-40) [-40|41.89] "m/s^2"  VDM,TCCM,IPMA_ADAS,ABS_ESC,ECM_Diesel
+ SG_ VehLatLongVertA_No_Cs : 55|8@0+ (1,0) [0|255] "Unitless"  TCCM,IPMA_ADAS,ABS_ESC
+ SG_ VehLatLongVert_No_Cnt : 63|8@0+ (1,0) [0|255] "Unitless"  VDM,TCCM,IPMA_ADAS,ABS_ESC
+ SG_ VehLong2_A_Actl : 20|13@0+ (0.01,-40) [-40|41.89] "m/s^2"  VDM,TCCM,ABS_ESC,ECM_Diesel,IPMA_ADAS
+ SG_ VehLat2_A_Actl : 4|13@0+ (0.01,-40) [-40|41.89] "m/s^2"  VDM,TCCM,ABS_ESC,ECM_Diesel,IPMA_ADAS
+ SG_ VehVertAActl_D_Qf : 38|2@0+ (1,0) [0|3] "SED"  VDM,TCCM,IPMA_ADAS,ABS_ESC
+ SG_ VehLongAActl_D_Qf : 22|2@0+ (1,0) [0|3] "SED"  VDM,TCCM,ABS_ESC,ECM_Diesel
+ SG_ VehLatAActl_D_Qf : 6|2@0+ (1,0) [0|3] "SED"  VDM,TCCM,ABS_ESC
+
+BO_ 1900 TesterPhysicalResCCM: 64 IPMA_ADAS
+ SG_ TesterPhysicalResCCM : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1806 TesterPhysicalResIPMA: 64 IPMA_ADAS
+ SG_ TesterPhysicalResIPMA : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 997 Personality_CCM_Data: 8 IPMA_ADAS
+ SG_ PersIndexCcm_D_Actl : 39|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ FeatNoCcmActl : 23|16@0+ (1,0) [0|65535] "Number"  GWM
+ SG_ FeatConfigCcmActl : 7|16@0+ (1,0) [0|65535] "Undefined"  GWM
+
+BO_ 983 Steer_Assist_Data: 8 IPMA_ADAS
+ SG_ CmbbObjRelLong_V_Actl : 39|10@0+ (0.1,-102.1) [-102.1|0] "meters/sec"  PSCM
+ SG_ CmbbObjRelLat_V_Actl : 23|9@0+ (0.1,-25.5) [-25.5|25.4] "meters/sec"  PSCM
+ SG_ CmbbObjDistLong_L_Actl : 7|10@0+ (0.1,0) [0|102.1] "meter"  PSCM
+ SG_ CmbbObjDistLat_L_Actl : 45|9@0+ (0.1,-25.5) [-25.5|25.4] "meter"  PSCM
+ SG_ CmbbObjConfdnc_D_Stat : 9|2@0+ (1,0) [0|3] "SED"  PSCM
+ SG_ CmbbObjColl_T_Actl : 30|7@0+ (0.05,0) [0|6.25] "second"  PSCM
+ SG_ CmbbObjClass_D_Stat : 13|4@0+ (1,0) [0|15] "SED"  PSCM
+ SG_ EsaEnbl_D2_Rq : 52|2@0+ (1,0) [0|3] "SED"  PSCM
+
+BO_ 982 LateralMotionControl2: 8 IPMA_ADAS
+ SG_ LatCtlCrv_NoRate2_Actl : 55|11@0+ (1E-006,-0.001024) [-0.001024|0.001023] "meter^2"  PSCM
+ SG_ LatCtlPath_No_Cnt : 60|4@0+ (1,0) [0|15] "Unitless"  PSCM
+ SG_ LatCtlPath_No_Cs : 15|8@0+ (1,0) [0|255] "Unitless"  PSCM
+ SG_ LatCtl_D2_Rq : 6|3@0+ (1,0) [0|7] "SED"  PSCM
+ SG_ HandsOffCnfm_B_Rq : 7|1@0+ (1,0) [0|1] "SED"  PSCM
+ SG_ LatCtlRampType_D_Rq : 1|2@0+ (1,0) [0|3] "SED"  PSCM
+ SG_ LatCtlPrecision_D_Rq : 3|2@0+ (1,0) [0|3] "SED"  PSCM
+ SG_ LatCtlPathOffst_L_Actl : 33|10@0+ (0.01,-5.12) [-5.12|5.11] "meter"  PSCM
+ SG_ LatCtlPath_An_Actl : 28|11@0+ (0.0005,-0.5) [-0.5|0.5235] "radians"  PSCM
+ SG_ LatCtlCurv_No_Actl : 23|11@0+ (2E-005,-0.02) [-0.02|0.02094] "1/meter"  PSCM
+
+BO_ 981 GlareFreeBeam: 8 IPMA_ADAS
+ SG_ AdbRamping_T_Rq : 44|4@0+ (200,0) [0|3000] "millisecond"  GWM
+ SG_ AdbBrdrTop_An_Rq : 7|8@0+ (0.04,-9.54) [-9.54|0.58] "degrees"  GWM
+ SG_ AdbBrdrRight_L_Stat : 37|9@0+ (2,0) [0|1018] "meter"  GWM
+ SG_ AdbBrdrRight_An_Rq : 31|10@0+ (0.04,-20.4) [-20.4|20.44] "degrees"  GWM
+ SG_ AdbBrdrLeft_L_Stat : 40|9@0+ (2,0) [0|1018] "meter"  GWM
+ SG_ AdbBrdrLeft_An_Rq : 9|10@0+ (0.04,-20.4) [-20.4|20.44] "degrees"  GWM
+ SG_ AdbBrdrBottom_An_Rq : 15|6@0+ (0.04,-1.86) [-1.86|0.58] "degrees"  GWM
+ SG_ AdbBeam_D_Rq : 63|3@0+ (1,0) [0|7] "SED"  GWM
+
+BO_ 980 AutoDriveBeam_Data1: 8 IPMA_ADAS
+ SG_ AdbBrdr1DistRigh_D_Stat : 59|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AdbBrdr1DistLeft_D_Stat : 63|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AdbMde1_D_Rq : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdbIntns1_D_Rq : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdbBrdr1Up_An_Rq : 36|9@0+ (0.02,-8) [-8|2.18] "degrees"  GWM
+ SG_ AdbBrdr1Right_An_Rq : 31|11@0+ (0.02,-20) [-20|20.9] "degrees"  GWM
+ SG_ AdbBrdr1Low_An_Rq : 8|9@0+ (0.02,-8) [-8|2.18] "degrees"  GWM
+ SG_ AdbBrdr1Left_An_Rq : 7|11@0+ (0.02,-20) [-20|20.9] "degrees"  GWM
+ SG_ AdbBrdr1CritRigh_T_Stat : 43|4@0+ (100,0) [0|1500] "millisecond"  GWM
+ SG_ AdbBrdr1CritLeft_T_Stat : 55|4@0+ (100,0) [0|1500] "millisecond"  GWM
+
+BO_ 979 LateralMotionControl: 8 IPMA_ADAS
+ SG_ LatCtlRng_L_Max : 63|6@0+ (2,0) [0|126] "meter"  GWM
+ SG_ HandsOffCnfm_B_Rq : 51|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ LatCtl_D_Rq : 36|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ LatCtlRampType_D_Rq : 53|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ LatCtlPrecision_D_Rq : 33|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ LatCtlPathOffst_L_Actl : 47|10@0+ (0.01,-5.12) [-5.12|5.11] "meter"  GWM
+ SG_ LatCtlPath_An_Actl : 31|11@0+ (0.0005,-0.5) [-0.5|0.5235] "radians"  GWM
+ SG_ LatCtlCurv_NoRate_Actl : 12|13@0+ (2.5E-007,-0.001024) [-0.001024|0.00102375] "1/meter"  GWM
+ SG_ LatCtlCurv_No_Actl : 7|11@0+ (2E-005,-0.02) [-0.02|0.02094] "1/meter"  GWM
+
+BO_ 976 SuspensionRoad_Data: 8 IPMA_ADAS
+ SG_ SuspClkSync_No_Actl : 55|8@0+ (1,0) [0|253] "unitless"  GWM
+ SG_ SrpSigValid_B_Stat : 47|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ SrpHghtRight_L_Actl : 24|9@0+ (0.000625,-0.16) [-0.16|0.158125] "meter"  GWM
+ SG_ SrpHghtLeft_L_Actl : 17|9@0+ (0.000625,-0.16) [-0.16|0.158125] "meter"  GWM
+ SG_ SrpEventRight_D_Stat : 19|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SrpEventLeft_D_Stat : 21|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ SrpDistRight_L_Actl : 14|9@0+ (0.02,0) [0|10.18] "meter"  GWM
+ SG_ SrpDistLeft_L_Actl : 7|9@0+ (0.02,0) [0|10.18] "meter"  GWM
+
+BO_ 973 Traffic_RecognitnData: 8 IPMA_ADAS
+ SG_ TsrVl2PrmntMsgTxt_D_Rq : 60|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrVl1PrmntMsgTxt_D_Rq : 41|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrVl2RstrcMsgTxt2_D_Rq : 63|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TsrVl1RstrcMsgTxt2_D_Rq : 51|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TsrOvtkMsgTxt2_D_Rq : 55|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ WwaWarn_B_Rq : 48|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TsrVlUnitMsgTxt_D_Rq : 43|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrVLim2MsgTxt_D_Rq : 39|8@0+ (1,0) [0|255] "SED"  GWM
+ SG_ TsrVLim1MsgTxt_D_Rq : 31|8@0+ (1,0) [0|255] "SED"  GWM
+ SG_ TsrVl2StatMsgTxt_D_Rq : 47|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrVl2RstrcMsgTxt_D_Rq : 17|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrVl1StatMsgTxt_D_Rq : 21|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrVl1RstrcMsgTxt_D_Rq : 23|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrStatMsgTxt_D_Rq : 10|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TsrOvtkStatMsgTxt_D_Rq : 1|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrOvtkMsgTxt_D_Rq : 15|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TsrOswWarnMsgTxt_D_Rq : 3|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ TsrMsgTxt_D_Rq : 7|4@0+ (1,0) [0|15] "SED"  GWM
+
+BO_ 970 Lane_Assist_Data1: 8 IPMA_ADAS
+ SG_ LkaDrvOvrrd_D_Rq : 38|2@0+ (1,0) [0|3] "SED"  PSCM
+ SG_ LkaActvStats_D2_Req : 7|3@0+ (1,0) [0|7] "SED"  PSCM
+ SG_ LaRefAng_No_Req : 19|12@0+ (0.05,-102.4) [-102.4|102.3] "mrad"  PSCM
+ SG_ LaRampType_B_Req : 39|1@0+ (1,0) [0|1] "SED"  PSCM
+ SG_ LaCurvature_No_Calc : 15|12@0+ (5E-006,-0.01024) [-0.01024|0.01023] "1/m"  PSCM
+ SG_ LdwActvStats_D_Req : 4|3@0+ (1,0) [0|7] "SED"  PSCM
+ SG_ LdwActvIntns_D_Req : 1|2@0+ (1,0) [0|3] "SED"  PSCM
+
+BO_ 962 AutoDriveBeam_Data3: 8 IPMA_ADAS
+ SG_ AdbBrdr3DistRigh_D_Stat : 59|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AdbBrdr3DistLeft_D_Stat : 63|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AdbMde3_D_Rq : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdbIntns3_D_Rq : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdbBrdr3Up_An_Rq : 36|9@0+ (0.02,-8) [-8|2.18] "degrees"  GWM
+ SG_ AdbBrdr3Right_An_Rq : 31|11@0+ (0.02,-20) [-20|20.9] "degrees"  GWM
+ SG_ AdbBrdr3Low_An_Rq : 8|9@0+ (0.02,-8) [-8|2.18] "degrees"  GWM
+ SG_ AdbBrdr3Left_An_Rq : 7|11@0+ (0.02,-20) [-20|20.9] "degrees"  GWM
+ SG_ AdbBrdr3CritRigh_T_Stat : 43|4@0+ (100,0) [0|1500] "millisecond"  GWM
+ SG_ AdbBrdr3CritLeft_T_Stat : 55|4@0+ (100,0) [0|1500] "millisecond"  GWM
+
+BO_ 961 AutoDriveBeam_Data2: 8 IPMA_ADAS
+ SG_ AdbBrdr2DistRigh_D_Stat : 59|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AdbBrdr2DistLeft_D_Stat : 63|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AdbMde2_D_Rq : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdbIntns2_D_Rq : 12|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AdbBrdr2Up_An_Rq : 36|9@0+ (0.02,-8) [-8|2.18] "degrees"  GWM
+ SG_ AdbBrdr2Right_An_Rq : 31|11@0+ (0.02,-20) [-20|20.9] "degrees"  GWM
+ SG_ AdbBrdr2Low_An_Rq : 8|9@0+ (0.02,-8) [-8|2.18] "degrees"  GWM
+ SG_ AdbBrdr2Left_An_Rq : 7|11@0+ (0.02,-20) [-20|20.9] "degrees"  GWM
+ SG_ AdbBrdr2CritRigh_T_Stat : 43|4@0+ (100,0) [0|1500] "millisecond"  GWM
+ SG_ AdbBrdr2CritLeft_T_Stat : 55|4@0+ (100,0) [0|1500] "millisecond"  GWM
+
+BO_ 394 ACCDATA_3: 8 IPMA_ADAS
+ SG_ HaDsply_No_Cs : 63|8@0+ (1,0) [0|255] "Unitless"  GWM
+ SG_ HaDsply_No_Cnt : 4|4@0+ (1,0) [0|15] "Unitless"  GWM
+ SG_ AccStopStat_D_Dsply : 41|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AccTrgDist2_D_Dsply : 27|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ AccStopRes_B_Dsply : 54|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ TjaWarn_D_Rq : 50|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ Tja_D_Stat : 44|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ TjaMsgTxt_D_Dsply : 53|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ IaccLamp_D_Rq : 46|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ AccMsgTxt_D2_Rq : 31|4@0+ (1,0) [0|15] "SED"  GWM
+ SG_ FcwDeny_B_Dsply : 10|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ FcwMemStat_B_Actl : 13|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AccTGap_B_Dsply : 35|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CadsAlignIncplt_B_Actl : 11|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AccFllwMde_B_Dsply : 17|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CadsRadrBlck_B_Actl : 22|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CmbbPostEvnt_B_Dsply : 15|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AccStopMde_B_Dsply : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ FcwMemSens_D_Actl : 20|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ FcwMsgTxt_D_Rq : 7|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ AccWarn_D_Dsply : 39|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ FcwVisblWarn_B_Rq : 47|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ FcwAudioWarn_B_Rq : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ AccTGap_D_Dsply : 34|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ AccMemEnbl_B_RqDrv : 36|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ FdaMem_B_Stat : 37|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 391 ACCDATA_2: 8 IPMA_ADAS
+ SG_ CmbbBrkDecel_No_Cnt : 47|4@0+ (1,0) [0|15] "Unitless"  GWM,ABS_ESC
+ SG_ HudDsplyIntns_No_Actl : 31|8@0+ (0.5,0) [0|100] "%"  GWM
+ SG_ HudBlk3_B_Rq : 37|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HudBlk2_B_Rq : 51|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HudBlk1_B_Rq : 50|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ HudFlashRate_D_Actl : 53|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ CmbbBrkDecel_No_Cs : 7|8@0+ (1,0) [0|255] "Unitless"  GWM,ABS_ESC
+ SG_ CmbbBrkDecel_A_Rq : 12|13@0+ (0.0039,-20) [-20|11.9449] "m/s^2"  ABS_ESC,GWM
+ SG_ CmbbBrkPrchg_D_Rq : 55|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+ SG_ CmbbBrkDecel_B_Rq : 15|1@0+ (1,0) [0|1] "SED"  ABS_ESC,GWM
+ SG_ CmbbBaSens_D_Rq : 14|2@0+ (1,0) [0|3] "SED"  ABS_ESC,GWM
+
+BO_ 390 ACCDATA: 8 IPMA_ADAS
+ SG_ AccBrkPulse_B_Rq : 36|1@0+ (1,0) [0|1] "SED"  ABS_ESC,GWM
+ SG_ AccAutoResum_D_Rq : 7|2@0+ (1,0) [0|3] "SED"  PCM_HEV,PCM,ECM_Diesel
+ SG_ AccBrkTot_A_Rq : 4|13@0+ (0.0039,-20) [-20|11.9449] "m/s^2"  GWM,ABS_ESC
+ SG_ AccPrpl_A_Pred : 17|10@0+ (0.01,-5) [-5|5.23] "m/s^2"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ AccVeh_V_Trg : 32|9@0+ (0.5,0) [0|255.5] "kph"  GWM,ECM_Diesel,PCM,PCM_HEV,TCM_DSL
+ SG_ AccBrkPrkEl_B_Rq : 38|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ Cmbb_B_Enbl : 50|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CmbbOvrrd_B_RqDrv : 51|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CmbbDeny_B_Actl : 37|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ CmbbEngTqMn_B_Rq : 52|1@0+ (1,0) [0|1] "SED"  ECM_Diesel,PCM,PCM_HEV,GWM
+ SG_ AccPrpl_A_Rq : 49|10@0+ (0.01,-5) [-5|5.23] "m/s^2"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ AccDeny_B_Rq : 53|1@0+ (1,0) [0|1] "SED"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ AccResumEnbl_B_Rq : 33|1@0+ (1,0) [0|1] "SED"  GWM,ECM_Diesel,PCM,PCM_HEV
+ SG_ AccCancl_B_Rq : 39|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC,ECM_Diesel,PCM,PCM_HEV
+ SG_ AccBrkPrchg_B_Rq : 54|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ AccBrkDecel_B_Rq : 55|1@0+ (1,0) [0|1] "SED"  GWM,ABS_ESC
+ SG_ AccStopStat_B_Rq : 34|1@0+ (1,0) [0|1] "SED"  GWM,ECM_Diesel,PCM,PCM_HEV,ABS_ESC
+
+BO_ 1441 TCCM_AutoSar_NetwkMgmt: 8 TCCM
+ SG_ TCCM_GWOnBoardTester : 39|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_GWNMProxy : 47|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_AutoSarNMReserved4 : 63|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_AutoSarNMReserved3 : 55|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_AutoSarNMReserved2 : 31|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_AutoSarNMReserved1 : 23|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_AutoSarNMNodeId : 7|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+ SG_ TCCM_AutoSarNMControl : 15|8@0+ (1,0) [0|255] "unitless" Vector__XXX
+
+BO_ 1787 TesterPhysicalResSODCMD: 64 IPMA_ADAS
+ SG_ TesterPhysicalResSODCMD : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1779 TesterPhysicalReqSODCMD: 64 TSTR
+ SG_ TesterPhysicalReqSODCMD : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  IPMA_ADAS
+
+BO_ 1786 TesterPhysicalResSODCMC: 64 IPMA_ADAS
+ SG_ TesterPhysicalResSODCMC : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1778 TesterPhysicalReqSODCMC: 64 TSTR
+ SG_ TesterPhysicalReqSODCMC : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  IPMA_ADAS
+
+BO_ 1153 All_Terrain_Data_FD1: 8 GWM
+ SG_ TerrMde_D_RqDrv : 3|3@0+ (1,0) [0|7] "SED" Vector__XXX
+
+BO_ 942 ParkAid_Data2: 8 IPMA_ADAS
+ SG_ PrkAidRdiusRight_L_Dsply : 15|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ PrkAidRdiusLeft_L_Dsply : 7|8@0+ (1,0) [0|255] "unitless"  GWM
+ SG_ PrkAidDrvDir_D_Stat : 23|3@0+ (1,0) [0|7] "SED"  GWM
+ SG_ PrkAidAcsyRear_D_Stat : 18|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ PrkAidAcsyFront_D_Stat : 20|2@0+ (1,0) [0|3] "SED"  GWM
+
+BO_ 930 Bndry_Alert_R_Data: 8 IPMA_ADAS
+ SG_ BalrWndwRight_B_Stat : 19|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrSnsRight_D_Falt : 21|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwPsngrRear_D_RqBalrr : 25|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwPsngr_D_RqBalrr : 27|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwDrvRear_D_RqBalrr : 29|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwDrv_D_RqBalrr : 31|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrRight_D_Stat : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrMdeSelRight_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrMdeRight_D_Stat : 23|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrLckRight_B_Stat : 11|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrChimeRight_D_Rq : 2|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ CamraRearOn_B_RqBalrr : 7|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ DrLckCnt_No_ActlBalrr : 5|3@0+ (1,0) [0|7] "unitless"  GWM
+ SG_ DrLckActv_B_RqBalrr : 6|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 929 Bndry_Alert_L_Data: 8 IPMA_ADAS
+ SG_ BalrChimeLeft_D_Rq : 2|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrLeft_D_Stat : 10|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrWndwLeft_B_Stat : 0|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ WndwPsngrRear_D_RqBalrl : 25|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwPsngr_D_RqBalrl : 27|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwDrvRear_D_RqBalrl : 29|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ WndwDrv_D_RqBalrl : 31|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrSnsLeft_D_Falt : 21|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrMdeSelLeft_B_Stat : 8|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ BalrMdeLeft_D_Stat : 23|2@0+ (1,0) [0|3] "SED"  GWM
+ SG_ BalrLckLeft_B_Stat : 11|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ CamraRearOn_B_RqBalrl : 7|1@0+ (1,0) [0|1] "SED"  GWM
+ SG_ DrLckCnt_No_ActlBalrl : 5|3@0+ (1,0) [0|7] "unitless"  GWM
+ SG_ DrLckActv_B_RqBalrl : 6|1@0+ (1,0) [0|1] "SED"  GWM
+
+BO_ 402 Dsp_Request_Signals11_FD1: 8 GWM
+ SG_ PrkAidSwtch_D_RqMnu : 11|1@0+ (1,0) [0|1] "SED"  IPMA_ADAS
+ SG_ ApaSwtch_D_RqMnu : 10|2@0+ (1,0) [0|3] "SED"  IPMA_ADAS
+ SG_ ApaMdeStat_D_RqDrv : 2|3@0+ (1,0) [0|7] "SED"  IPMA_ADAS
+ SG_ CamraViewSplit_B_Rq : 3|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CamraZoomMan_D_Rq : 15|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ CamraOvrlStat_D_Rq : 4|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CamraOvrlDyn_D_Rq : 7|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ CamAutoTowbarZoom : 6|1@0+ (1,0) [0|1] "SED" Vector__XXX
+ SG_ DistanceBarSetting : 5|1@0+ (1,0) [0|1] "SED" Vector__XXX
+
+BO_ 924 DCACA_Data3_FD1: 8 GWM
+ SG_ DcacOut_Pw_Mx : 34|11@0+ (5,0) [0|10225] "watts"  PCM,PCM_HEV
+ SG_ DcacOut2_Pw_Actl : 31|13@0+ (1,0) [0|8189] "watts"  PCM_HEV
+ SG_ DcacOut1_Pw_Actl : 12|13@0+ (1,0) [0|8189] "watts"  PCM,PCM_HEV
+ SG_ DcacIn_Pw_Mx : 7|11@0+ (5,0) [0|10225] "watts"  PCM,PCM_HEV
+
+BO_ 923 DCACA_Data2_FD1: 8 GWM
+ SG_ DcacIn_U2_Actl : 39|12@0+ (0.01,0) [0|40.93] "volt"  PCM
+ SG_ DcacIn_U_Actl : 19|12@0+ (0.1,0) [0|409.3] "volt"  PCM,PCM_HEV
+ SG_ DcacIn_I_Actl : 15|11@0+ (0.1,0) [0|204.5] "Amps"  PCM,PCM_HEV
+ SG_ Dcac_Te_Actl : 7|8@0+ (1,-60) [-60|193] "degC"  PCM
+
+BO_ 1998 TesterPhysicalResSODR: 64 IPMA_ADAS
+ SG_ TesterPhysicalResSODR : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1996 TesterPhysicalResSODL: 64 IPMA_ADAS
+ SG_ TesterPhysicalResSODL : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  TSTR
+
+BO_ 1988 TesterPhysicalReqSODL: 64 TSTR
+ SG_ TesterPhysicalReqSODL : 7|64@0+ (1,0) [0|1.84467E+019] "unitless"  IPMA_ADAS
+
+BO_ 922 DCACA_Data1_FD1: 8 GWM
+ SG_ DcacBp2BrkrOpn_B_Falt : 13|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacBp1BrkrOpn_B_Falt : 14|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacIpRcBrkrOpn_B_Falt : 10|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacRdy_D2_Stat : 23|2@0+ (1,0) [0|3] "SED"  PCM,PCM_HEV
+ SG_ DcacOvrld_B_Falt : 8|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacOverTe_B_Falt : 9|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacGfci_B_Falt : 11|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacErr_B_Stat : 12|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacAcUDetct_B_Falt : 15|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacRdy_D_Stat : 2|3@0+ (1,0) [0|7] "SED" Vector__XXX
+ SG_ DcacPlugPrsnt_B_Stat : 3|1@0+ (1,0) [0|1] "SED"  PCM,PCM_HEV
+ SG_ DcacClntFlw_D_Rq : 5|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+ SG_ CoolFanDcac_D_Rq : 7|2@0+ (1,0) [0|3] "SED"  SOBDMC_HPCM_FD1
+
+BO_TX_BU_ 2612224016 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 878 : PCM,PCM_HEV;
+BO_TX_BU_ 1085 : ECM_Diesel,PCM;
+BO_TX_BU_ 2611175440 : ECM_Diesel,PCM_HEV,PCM;
+BO_TX_BU_ 2610126864 : ECM_Diesel,PCM_HEV,PCM;
+BO_TX_BU_ 786 : PCM_HEV,SOBDMC_HPCM_FD1;
+BO_TX_BU_ 1090 : SOBDMC_HPCM_FD1,PCM_HEV;
+BO_TX_BU_ 374 : PCM_HEV,TCM_DSL,PCM;
+BO_TX_BU_ 872 : SOBDMC_HPCM_FD1,PCM_HEV;
+BO_TX_BU_ 560 : PCM,PCM_HEV,TCM_DSL;
+BO_TX_BU_ 369 : PCM_HEV,TCM_DSL,PCM;
+BO_TX_BU_ 92 : PCM,TCM_DSL,PCM_HEV;
+BO_TX_BU_ 2030 : SOBDMC_HPCM_FD1,ECM_Diesel;
+BO_TX_BU_ 1087 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 2024 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1697 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1696 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1429 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1100 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1086 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1071 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1069 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1060 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1057 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 1055 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 517 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 516 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 514 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 512 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 380 : ECM_Diesel,PCM;
+BO_TX_BU_ 377 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 376 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 359 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 358 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 357 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 342 : ECM_Diesel,PCM,PCM_HEV;
+BO_TX_BU_ 71 : ECM_Diesel,PCM,PCM_HEV;
+
+CM_ "New CAN FD network";
+CM_ BU_ CMR_DSMC "Driver Status Monitor Camera";
+CM_ BU_ IPMA_ADAS "Assist Driving Alert System";
+CM_ BU_ PSCM "Passenger Front Climate Control Seat Module";
+CM_ BU_ ABS_ESC "Anti-lock Brake / Traction Control Module";
+CM_ BU_ TCCM "Transfer Case Control Module, 4x4 Control Module";
+CM_ BU_ TCM_DSL "Transmission Control Module";
+CM_ BU_ PCM "Powertrain Control Module";
+CM_ BU_ ECM_Diesel "Diesel";
+CM_ BU_ GWM "Gateway Module CGEA1.3(Star Architecture)";
+CM_ BU_ TSTR "Diagnostic Tester";
+
+CM_ SG_ 524 PrplWhlTotTqRqMxAwd_No_Cs "Signal not transmitted on gas variants.";
+CM_ SG_ 524 PrplWhlTotTqRqMxAwd_No_Cnt "Signal not transmitted on gas variants.";
+CM_ SG_ 1150 LocationServices_1 "Tx by HS3 APIM";
+CM_ SG_ 542 LocationServices_3 "Tx by HS3 APIM";
+CM_ SG_ 810 NtfyDrvTrgtDist_L_Rq "Object.SetTripRangeAlert_Rq This signal is meant to provide the customer settings for the target distance remote notification";
+CM_ SG_ 810 NtfyDrvSocLvl1_Pc_Rq "Object.SetCustomerLevelAlert_Rq This signal is meant to provide the customer settings for the SOC remote notification.";
+CM_ SG_ 810 PtRmtRprt_D_Stat "Object.RemoteDataReport_St";
+CM_ SG_ 550 PtWakeupActv1_B_Rq "ECG Application signal";
+CM_ SG_ 982 LatCtlPath_No_Cnt "Signal not transmitted on gas variants.";
+CM_ SG_ 982 LatCtlPath_No_Cs "Signal not transmitted on gas variants.";
+CM_ SG_ 1104 DrvEngageLevel_No_Cs "Signal not transmitted on gas variants.";
+CM_ SG_ 1104 DrvEngageLevel_No_Cnt "Signal not transmitted on gas variants.";
+CM_ SG_ 1085 ULoRgenTestMde_B_Stat "Signal not transmitted on HEV variants.";
+CM_ SG_ 1085 PwSrcULoComm_B_Falt "Signal not transmitted on HEV variants.";
+CM_ SG_ 1445 SOBDMC_AutoSarNMReserved4 "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 1445 SOBDMC_AutoSarNMReserved3 "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 1445 SOBDMC_AutoSarNMReserved2 "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 1445 SOBDMC_AutoSarNMReserved1 "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 1445 SOBDMC_AutoSarNMNodeId "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 1445 SOBDMC_AutoSarNMControl "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 1088 HvacPrecondMode2_D_Rq "Signal not transmitted on vehicles that do not have the Fuel operated heater feature.";
+CM_ SG_ 1088 HvacPrecondBlwr2_D_Rq "Signal not transmitted on vehicles that do not have the Fuel operated heater feature.";
+CM_ SG_ 786 ChrgStat_D_Dsply "Signal not transmitted by PCM_HEV";
+CM_ SG_ 66 immoControlData_T2 "Not transmitted on all vehicle variants";
+CM_ SG_ 66 immoControlCmd_T2 "Not transmitted on all vehicle variants";
+CM_ SG_ 549 BeltminderAudioMute "Object.MyKey.BeltMinderAudioMute.St";
+CM_ SG_ 549 Power_Up_Chime_Modules "Object.AlertMethod.IPC _Infotainment";
+CM_ SG_ 549 Chime_Source "Object.AlertMethod.IPC_infotainment";
+CM_ SG_ 611 AwdStat_D_RqDsply "Signal not transmitted on programs that do not have AWD.";
+CM_ SG_ 611 AwdSrvcRqd_B_Rq "Signal not transmitted on programs that do not have AWD.";
+CM_ SG_ 611 AwdLck_Tq_Rq "Signal not transmitted on programs that do not have AWD.";
+CM_ SG_ 130 VehVTrlrAid_B_Rq "VR session start- req. limit blower speed no more than X volts.  CC restriction on time msg. will be honored.Double Event msg1st event to request limit, 2nd event to release limit, No msg. CC Grammar v7.xls";
+CM_ SG_ 130 SteMdule_U_Meas "DCR 1745  to update Tx from GWM to EP100ms. SteMdule_I_Est & SteMdule_U_Meas are used by BMS system & filtered. The filter uses standard periodic rate & changing to EP would adversely affect the filter.(jweinfur)";
+CM_ SG_ 130 SteMdule_I_Est "DCR 1745  to update Tx from GWM to EP100ms. SteMdule_I_Est & SteMdule_U_Meas are used by BMS system & filtered. The filter uses standard periodic rate & changing to EP would adversely affect the filter.(jweinfur)";
+CM_ SG_ 133 StePinRelInit_An_Sns "SASM will transmit these signals on vehicles with SASM and without PSCM.  SCCM will not Tx this signal when SASM is present.";
+CM_ SG_ 133 StePinAn_No_Cs "Signal not transmitted on gas variants.";
+CM_ SG_ 1200 BrkTot_Tq_RqDrv "DCR 1836 to update Tx from GWM to EP100ms rejected due MPS6 TCM requires BrkTot_Tq_RqDrv at 20ms (bshu1).";
+CM_ SG_ 1046 TCMode "Signal data set to 0x0 for ABS only vehicle option content";
+CM_ SG_ 1046 DrvAntiLckLamp_D_Rq "update value table v8.34, not align w/GSDB, need etracker.  ABS & IPC implemented as updated.";
+CM_ SG_ 1046 BpedMove_D_Actl "CCMGenSigTimeoutTime=1000";
+CM_ SG_ 1044 StePinOffst_An_Est "SASM will transmit these signals on vehicles with SASM and without PSCM.  SCCM will not Tx this signal when SASM is present.";
+CM_ SG_ 1044 StePinOffst_No_Cs "Signal not transmitted on gas variants.";
+CM_ SG_ 534 BrkObdData_No_Actl "Signal not transmitted on gas, diesel and HEV.  Only supported on PHEV.";
+CM_ SG_ 534 BrkObdIndex_No_Actl "Signal not transmitted on gas, diesel and HEV.  Only supported on PHEV.";
+CM_ SG_ 534 WhlRotatRr_No_Cnt "DCR 1833 to update Tx from GWM to EP100ms. Wheel Count signals are used by complex algorithm to determine Tire Pressure by Location & can't change from 20msec. (jweinfur)";
+CM_ SG_ 534 WhlRotatRl_No_Cnt "DCR 1833 to update Tx from GWM to EP100ms. Wheel Count signals are used by complex algorithm to determine Tire Pressure by Location & can't change from 20msec. (jweinfur)";
+CM_ SG_ 534 WhlRotatFr_No_Cnt "DCR 1833 to update Tx from GWM to EP100ms. Wheel Count signals are used by complex algorithm to determine Tire Pressure by Location & can't change from 20msec. (jweinfur)";
+CM_ SG_ 534 WhlRotatFl_No_Cnt "DCR 1833 to update Tx from GWM to EP100ms. Wheel Count signals are used by complex algorithm to determine Tire Pressure by Location & can't change from 20msec. (jweinfur)";
+CM_ SG_ 531 VehLongOvrGnd_A_Est "CCMGenSigTimeoutTime=1000";
+CM_ SG_ 1034 VehicleGGCCData "RCMGenSigTimeout=6000";
+CM_ SG_ 1090 Mtr2State_D_ActlMntr "Signal Not transmitted on PCM_HEV variant";
+CM_ SG_ 1090 Inv1Ain_I_ActlMntr "Signal Not transmitted on PCM_HEV variant";
+CM_ SG_ 1090 VehElRnge_L_Dsply "Signal Not transmitted on HPCM variant";
+CM_ SG_ 374 TrnRng_D_Rq "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 374 TrnPrkSys_D_Actl "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 374 GearLvr_D_ActlDrv "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 374 GearPos_No_Cs "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 374 GearPos_D_Trg "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 374 GearPos_No_Cnt "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 374 GearPos_D_Actl "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 603 WhlDirAvgDrv_D_Actl "48V mHEV: ECM_HEVDSL is Tx,  MHT HEV: PCM_HEV is Tx,  Powersplit HEV: SOBDMC_HPCM is Tx";
+CM_ SG_ 603 PrplTqMnRgen_B_Actl "48V mHEV: ECM_HEVDSL is Tx,  MHT HEV: PCM_HEV is Tx,  Powersplit HEV: SOBDMC_HPCM is Tx";
+CM_ SG_ 603 BattTracCnnct_D_Rq "48V mHEV: ECM_HEVDSL is Tx,  MHT HEV: PCM_HEV is Tx,  Powersplit HEV: SOBDMC_HPCM is Tx";
+CM_ SG_ 872 HybMdeStat_D_Dsply "Signal not transmitted by HPCM";
+CM_ SG_ 560 SelDrvMdeSwtch_D_Stat3 "ECM_HEV,  PCM & PCM_HEV do not support or Transmit signal.";
+CM_ SG_ 560 TrnSrvcRqd_B_Rq "Signal not transmitted on Diesel & HEV variants. MHT(U611/625) HPCM Rx 0x230 from PCM_HEV. Powersplit FWD HEVs(Cx482/3 430) HPCM Tx 0x230.";
+CM_ SG_ 560 TrnShifActv_B_Actl "Signal not transmitted on HEV variants. MHT(U611/625) HPCM Rx 0x230 from PCM_HEV. Powersplit FWD HEVs(Cx482/3 430) HPCM Tx 0x230.";
+CM_ SG_ 560 GboxOil_Te_Actl "Signal not transmitted on HEV variants. MHT(U611/625) HPCM Rx 0x230 from PCM_HEV. Powersplit FWD HEVs(Cx482/3 430) HPCM Tx 0x230.";
+CM_ SG_ 369 SeatWorkSrfc_B_Falt "Signal Not transmitted by TCM_DSL";
+CM_ SG_ 369 TrnIpcDsplyRng2_D_Actl "Signal not transmitted on HEV variants.";
+CM_ SG_ 369 TrnIpcDsplyRng_D_Stat "Signal not transmitted on HEV variants.";
+CM_ SG_ 92 TrnLvrV_D_Rq "Signal not transmitted on vehicles with PCM_HEV";
+CM_ SG_ 92 TrnSbwSysHlth_D_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnGearNtmAllow_B_Stat "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnDtpCmd_D_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnGearCmd_No_Cs "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnValidGear_D_Cnfm "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnNtrlTowCmd_D_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnGearCmd_Pc_ActlPt "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnGear_D_RqPt "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnCmdState_B_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnCmdCnt_B_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 PrkBrkActv_D_RqTrnGear "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnGearMsgTxt_D_Rq "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 92 TrnGearCmd_No_Cnt "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 1087 BattRgenLoChrg_D_RqEng "Signal not transmitted on diesel variant";
+CM_ SG_ 1087 BattRgenLoDChrg_D_RqEng "Signal not transmitted on diesel variant";
+CM_ SG_ 1087 FapLcInhbt_B_Rq "Signal not transmitted on diesel variant";
+CM_ SG_ 1100 EngExhMdeQuiet_D2_Stat "Signal not transmitted on HEV & Diesel programs";
+CM_ SG_ 1100 HvacCmprLim_D_Stat "Signal not transmitted on Diesel variants";
+CM_ SG_ 1100 WakeAlarm1_T_Rq "Signal not transmitted on Gas variants";
+CM_ SG_ 1100 WakeAlarm1_B_Typ "Signal not transmitted on Gas variants";
+CM_ SG_ 1100 Veh_V_DsplyTrailCtlSet "Signal not transmitted on HEV & Diesel programs";
+CM_ SG_ 1100 TrailCtlPt_B_Falt "Signal not transmitted on HEV & Diesel programs";
+CM_ SG_ 1100 AutoTowAllw_D_StatMnu "Signal not transmitted on Gas & Diesel variants";
+CM_ SG_ 1100 AutoTowActv_B_Stat "Signal not transmitted on Gas & Diesel variants";
+CM_ SG_ 1086 EngMnfld_P_Actl "Signal not transmitted on HEV & Diesel programs";
+CM_ SG_ 1086 ElLoadCtl_D_Rq "Signal not transmitted on HEV variants.";
+CM_ SG_ 1071 CluPdl_PcRate_Actl "Signal not transmitted on HEV and Gas variants.";
+CM_ SG_ 1071 CluPdlPosPcMeas_D_Qf "Signal not transmitted on HEV and Gas variants.";
+CM_ SG_ 1071 CluPdlPos_Pc_Meas "Signal not transmitted on HEV and Gas variants.";
+CM_ SG_ 1071 EngAoutIdl_N_Ntrl "Signal not transmitted on HEV variants and diesel.";
+CM_ SG_ 1069 SlMde_D_Stat "IPC and HUD_ADV Receve from HS3 FGW 0x42D, not HS3 0x38A, MSG DCR 506. Signal not transmitted on Gas & HEV variants";
+CM_ SG_ 1069 SlMde_D_RqDsply "IPC and HUD_ADV Receve from HS3 FGW 0x42D, not HS3 0x38A, MSG DCR 506. Signal not transmitted on Gas & HEV variants";
+CM_ SG_ 1069 IsaOffst_D_Stat "Signal not transmitted on Gas & HEV variants";
+CM_ SG_ 1069 ObdWarmUp_B_Complt "Signal not transmitted on diesel variants.";
+CM_ SG_ 1069 EngMsgTxt_D_Rq "Signal not transmitted on diesel variants.";
+CM_ SG_ 1069 EngClnt_Te_ActlDiag "Signal not transmitted on gas variants.";
+CM_ SG_ 1069 EngLoad_Pc_CalcDiag "Signal not transmitted on gas variants.";
+CM_ SG_ 1069 ApedPos_Pc_ActlDiag "Signal not transmitted on gas variants.";
+CM_ SG_ 1060 RearDiffOilTeWarn_B_Rq "Signal not transmitted on HEV & Diesel programs";
+CM_ SG_ 1060 RearDiffOil_Te_Actl "Signal not transmitted on HEV & Diesel programs";
+CM_ SG_ 1057 FohEng_D_Rq "Signal not transmitted on vehicles that do not have the fuel operated heater feature. Signal not transmitted on HEV programs";
+CM_ SG_ 1057 EngIdlShutDown_D_Stat "Signal not transmitted on diesel variants.";
+CM_ SG_ 1057 FUEL_ALCOHOL_PERCNT "signal not transmitted on diesel and HEV variants.";
+CM_ SG_ 1057 TrnTotTq_Rt_Est "Signal not transmitted on gas and HEV variants.";
+CM_ SG_ 1057 TrnTotLss_Tq_Est "Signal not transmitted on gas and HEV variants.";
+CM_ SG_ 1057 VehVLimStat_D_Actl "Signal not transmitted on gas and HEV variants.";
+CM_ SG_ 1057 VehVLimActv_B_Actl "Signal not transmitted on gas and HEV variants.";
+CM_ SG_ 562 GearNtrl_No_Cs "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 562 GearNtrl_No_Cnt "Powersplit HEVs with HF45, HPCM will Tx  this message.  For all other programs it will be Tx by PCM or TCM. ";
+CM_ SG_ 516 EngAoutNActl_D_QF "Signal not transmitted on Gas & HEV variants";
+CM_ SG_ 516 EngAout3_N_Actl "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 516 ApedPos_Pc_ActlArb "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 516 ApedPosPcActl_No_Cnt "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 516 ApedPosPcActl_No_Cs "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 514 VehVTrlrAid_B_Avail "Signal not transmitted on HEV variants.";
+CM_ SG_ 514 GearRvrse_D_Actl "Do not implement GearRvrse_D_Actl  until eTracker 8804151 is approved, 11/24/09";
+CM_ SG_ 512 PrplWhlTotTqRq_No_Cs "Signal not transmitted on gas & Diesel variants.";
+CM_ SG_ 512 PrplWhlTotTqRq_No_Cnt "Signal not transmitted on gas & Diesel variants.";
+CM_ SG_ 512 PtDrvMde_D_Stat "Signal not transmitted on Gas & HEV variants.";
+CM_ SG_ 380 EngExhBrkOnLamp_B_Rq "Signal not transmitted on Gas variants";
+CM_ SG_ 380 EngExhBrkAutoLamp_B_Rq "Signal not transmitted on Gas variants";
+CM_ SG_ 380 EngAout_N_MxAllw "Signal not transmitted on Gas variants";
+CM_ SG_ 380 EngExhBrkMde_D_Actl "Signal not transmitted on Gas variants";
+CM_ SG_ 377 HvacAirFullOut_B_Rq "Signal not transmitted on diesel variant";
+CM_ SG_ 377 FuelFlw_Vl_Dsply "Signal not transmitted on diesel variants.";
+CM_ SG_ 377 FuelFillInlet_B_Dsply "Signal not transmitted on diesel variants.";
+CM_ SG_ 377 OdoCount "Signal not transmitted on diesel variants.";
+CM_ SG_ 377 EngOilLife_Pc_Actl "Signal not transmitted on diesel variants.";
+CM_ SG_ 377 FuelFilterLamp_B_Dsply "Signal not transmitted on Gas & HEV variants";
+CM_ SG_ 377 AirCondRec_B_Rq "Signal not transmitted on diesel variants.";
+CM_ SG_ 377 AirCondClutch_B_Stats "Signal not transmitted on diesel variants.";
+CM_ SG_ 376 GasPrtc_D_RqDsply "Signal not transmitted on HEV & Diesel variants.";
+CM_ SG_ 376 EngAout_Aa_Actl "Signal not transmitted on HEV variants.";
+CM_ SG_ 376 AslIconDsply_D_Rq "Signal not transmitted on HEV variants.";
+CM_ SG_ 376 AslChime_B_Rq "Signal not transmitted on HEV variants.";
+CM_ SG_ 376 HvacHtrCore2_Te_Actl "Signal not transmitted on Gas & Diesel variants";
+CM_ SG_ 376 EcssLamp_D_RqDsply "Signal not transmitted on Gas & HEV variants";
+CM_ SG_ 376 AirAmb_Te_Actl "Signal not transmitted on Gas variants";
+CM_ SG_ 359 PrplWhlRgenMn_Tq_Actl "Signal not transmitted on Gas & Diesel variants";
+CM_ SG_ 359 ElPw_D_StatStrtStop "Signal not transmitted on HEV variants.";
+CM_ SG_ 359 TrnAin_Tq_Actl "Signal not transmitted on HEV variances.";
+CM_ SG_ 359 PlgActvArb_B_Actl "Only supported on PHEV programs.  PlgActvArb_B_Actl HPCM will Tx on Powersplit PHEVs,  On MHT PHEVs the PCM_HEV will Tx and HPCM will Rx.";
+CM_ SG_ 359 TrnAinTq_D_Qf "Signal not transmitted on HEV variances.";
+CM_ SG_ 358 StopStrtStdby_D_Indic "Signal not transmitted on HEV variants.";
+CM_ SG_ 358 StopStrtIODTxt_D_Rq "Signal not transmitted on HEV variants.";
+CM_ SG_ 358 StopStrtDrvMde_D_Indic "Signal not transmitted on HEV variants.";
+CM_ SG_ 358 StopStrtMsgTxt_D_Rq "Signal not transmitted on HEV variants.";
+CM_ SG_ 358 HiElPwInhbt_B_Stat "Signal not transmitted on HEV programs";
+CM_ SG_ 358 AutoStopPtDelta_I_Est "Signal not transmitted on HEV variants. ";
+CM_ SG_ 357 BpedDrvAppl_D_Actl "CCMGenSigTimeoutTime=1000";
+CM_ SG_ 357 CcStat_D_Actl "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 357 EngAout_N_MnAllw "Signal not transmitted on Gas & Diesel variants.";
+CM_ SG_ 357 AccStopMde_D_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 342 EngOvrhtMitgActv_D_Ind "Signal not transmitted on diesel.";
+CM_ SG_ 342 EngGoutLss_Tq_Est "Signal not transmitted on gas and diesel variants.";
+CM_ SG_ 342 EngOil_Te_Actl "Signal not transmitted on Gas & HEV variants. ";
+CM_ SG_ 954 GenericSwtch2_No_Actl "U625 Police Wig Wag feature";
+CM_ SG_ 935 SodRight_D_Stat "IPCGenSigTimeoutTime=1600";
+CM_ SG_ 935 Side_Detect_R_Illum "DDMGenSigTimeoutTime=2000";
+CM_ SG_ 935 SodSnsRight_D_Stat "IPCGenSigTimeoutTime=1600";
+CM_ SG_ 935 SodAlrtRight_D_Stat "DDMGenSigTimeoutTime=2000";
+CM_ SG_ 1112 BattTracClntPmp_D_Stat "48V mHEV: ECM_HEVDSL is Tx,  MHT HEV: PCM_HEV is Tx,  Powersplit HEV: SOBDMC_HPCM is Tx";
+CM_ SG_ 1050 Outside_Air_Temp_Stat "Filtered value, i.e. same as disply for customer";
+CM_ SG_ 1009 CenterStackRing_D_Actl "The Center Stack sends the CPLR a signal to turn On or Off the light Ring, This is a customer selectable preference switch";
+CM_ SG_ 1009 APIM_NumberofTracks_St "Object NumberofTracks";
+CM_ SG_ 1009 APIM_ActiveTrackNum_St "Object.ActiveTrackNum";
+CM_ SG_ 360 GsmSrvcRqd_B_Rq "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 360 TrnGearPwmFalt_B_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 360 GearButtnStuck_B_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGsmNtmState_D_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 DrQltyDrv_D_StatGsm "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnBtsiOvrrd_B_Stat "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnValidGearRq_D_Stat "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearRqCnt_B_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_U_Actl "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlR2 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlR1 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlR0 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlP2 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlP1 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlP0 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlN2 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlN1 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlN0 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlM2 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlM1 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlM0 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlD2 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlD1 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGearButtn_B_ActlD0 "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGear_No_Cs "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGear_No_Cnt "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 TrnGear_D_RqDrv "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 90 BrkSwtchPos_B_ActlGsm "Signal not transmitted on vehicles that do not have shift by wire.";
+CM_ SG_ 138 SteWhlRelCalib_An_Sns "Signal is not transmitted on vehicles where PSCM is transmitting the message that contains this signal. Signal data set to 0x0 for ABS only vehicle option content";
+CM_ SG_ 1093 StopLamp_B_RqTrlrBrk "Signal not transmitted on all variants.";
+CM_ SG_ 792 ElTrip_L_Dsply "Key cycle trip distance driven with the engine off (Trip EV Miles)";
+CM_ SG_ 792 ElLongTerm_L_Dsply "Long term distance distance driven with the engine off since the last long term reset (Long Term EV Miles).";
+CM_ SG_ 765 Mc_VehTimeFrmtUsrSel_St "Object.BodyInterface.Settings.VehicleTimeFormatUserSelection";
+CM_ SG_ 765 Mc_VehUntTrpCoUsrSel_St "Object.VehicleSettings.Disp_Miles_Kilometers.Rq";
+CM_ SG_ 765 Mc_VehUnitTempUsrSel_St "Object.VehicleSettings.Disp_Temperature.Rq";
+CM_ SG_ 765 Mc_VehLangUsrSel_St "Object.BodyInterface.Settings.VehicleLanguageUserSelection Object Vehicle Settings.Disp_LangSel";
+CM_ SG_ 934 Side_Detect_L_Illum "DDMGenSigTimeoutTime=2000";
+CM_ SG_ 934 SodLeft_D_Stat "IPCGenSigTimeoutTime=1600";
+CM_ SG_ 934 SodSnsLeft_D_Stat "IPCGenSigTimeoutTime=1600";
+CM_ SG_ 934 SodAlrtLeft_D_Stat "DDMGenSigTimeoutTime=2000";
+CM_ SG_ 1072 MetricActv_B_Actl "0 =Inactive(English), 1=Active(Metric)";
+CM_ SG_ 145 VehYaw_W_Actl "CCMGenSigTimeoutTime=1000";
+CM_ SG_ 931 CrnkInhbt_No_Cs "Signal not transmitted on gas and HEV variants.";
+CM_ SG_ 931 CrnkInhbt_No_Cnt "Signal not transmitted on gas and HEV variants.";
+CM_ SG_ 947 Dimming_Lvl "Refer to Vehicle Interior Illum Dimming Ctrl Sys Eng Spec, Table 2";
+CM_ SG_ 947 PrkBrkActv_B_Actl "Signal not transmitted on vehicles with electric park brake. ";
+CM_ SG_ 394 HaDsply_No_Cs "Signal not transmitted on gas variants.";
+CM_ SG_ 394 HaDsply_No_Cnt "Signal not transmitted on gas variants.";
+CM_ SG_ 391 CmbbBrkDecel_A_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 391 CmbbBrkPrchg_D_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 391 CmbbBrkDecel_B_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 391 CmbbBaSens_D_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 390 AccBrkTot_A_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 390 AccBrkPrkEl_B_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 390 AccPrpl_A_Rq "PCMGenSigTimeoutTime=1000";
+CM_ SG_ 390 AccBrkPrchg_B_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 390 AccBrkDecel_B_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 390 AccStopStat_B_Rq "ABSGenSigTimeoutTime=1000";
+CM_ SG_ 942 PrkAidRdiusRight_L_Dsply "MSGDCR 679, set all signals to OnChange";
+CM_ SG_ 942 PrkAidRdiusLeft_L_Dsply "MSGDCR 679, set all signals to OnChange";
+CM_ SG_ 942 PrkAidDrvDir_D_Stat "MSGDCR 679, set all signals to OnChange";
+
+BA_DEF_ BO_  "OvtpPushApplication" ENUM  "FALSE","TRUE";
+BA_DEF_ BU_  "OvtpOperationMode" ENUM  "SERVER","CLIENT";
+BA_DEF_ BU_  "OvtpEcuAddress" INT 0 1022;
+BA_DEF_ SG_  "ECGUsedRxSignal" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_S650_MY2022_Rx" ENUM  "No","Yes";
+BA_DEF_ SG_  "ECGUsedTxSignal" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_S650_MY2022_Tx" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigTimeoutTime_CHCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_SOBDMC_HPCM_F" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_CMR_DSMC" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_ECM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_TCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_ECM_HEVDSL" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_AWD_DLCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_ECM_HEV" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_GENERIC" INT 0 100000;
+BA_DEF_ BO_  "VFrameFormat" ENUM  "StandardCAN","ExtendedCAN","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","reserved","StandardCAN_FD","ExtendedCAN_FD";
+BA_DEF_ SG_  "GenSigTimeoutTime_PSCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_HCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_ABS_ESC" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_ECM_Diesel" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_TCCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime__delete" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_TCM_DSL" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_TSTR" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_IPMA_ADAS" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_GWM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_PCM" INT 0 100000;
+BA_DEF_ SG_  "GenSigTimeoutTime_PCM_HEV" INT 0 100000;
+BA_DEF_  "BusType" STRING;
+BA_DEF_ BO_  "FrameRouting" STRING;
+BA_DEF_ BO_  "FrameGatewayNetwork" STRING;
+BA_DEF_ BO_  "FrameGateway_LC1" HEX 0 1407;
+BA_DEF_ BO_  "FrameGatewayLC1_HS3" HEX 0 1407;
+BA_DEF_ BO_  "FrameGatewayMS1" HEX 0 1407;
+BA_DEF_ BO_  "FrameGatewayHS3" HEX 0 1407;
+BA_DEF_ BO_  "FrameGatewayHS2" HEX 0 1407;
+BA_DEF_ BO_  "FrameGatewayHS1" HEX 0 1407;
+BA_DEF_ BO_  "NetworkInitialization" ENUM  "No","Yes";
+BA_DEF_ BO_  "FrameGatewayId" HEX 0 1407;
+BA_DEF_ BO_  "EventRateOfChange" INT 10 10000;
+BA_DEF_ BO_  "ConfiguredTransmitter" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgStartDelayTime" INT 0 10000;
+BA_DEF_ BO_  "GenMsgNrOfRepetition" INT 0 100;
+BA_DEF_ BO_  "GenMsgDelayTime" INT 0 1000;
+BA_DEF_ BO_  "GenMsgCycleTimeFast" INT 0 100000;
+BA_DEF_ BO_  "GenMsgCycleTime" INT 0 100000;
+BA_DEF_ BO_  "GenMsgSendType" ENUM  "FixedPeriodic","Event","EnabledPeriodic","NotUsed","NotUsed","EventPeriodic","NotUsed","NotUsed","NoMsgSendType";
+BA_DEF_ SG_  "U_T6_MCA_MY2020_Tx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_P702_MY2021_Tx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_CX727_MY2021_Tx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_F5X_MY20_Tx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_Commodity_MYXX_Tx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_T6_MCA_MY2020_Rx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_P702_MY2021_Rx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_CX727_MY2021_Rx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_F5X_MY20_Rx" ENUM  "No","Yes";
+BA_DEF_ SG_  "U_Commodity_MYXX_Rx" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigStartValue" HEX 0 268435455;
+BA_DEF_ SG_  "MetaData" ENUM  "No","Yes";
+BA_DEF_ SG_  "ApprovedOrphan" ENUM  "No","Yes";
+BA_DEF_ SG_  "ContentDependant" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigStartValueInteger" INT 0 1000000000;
+BA_DEF_ SG_  "UsedOnPgmDBC" ENUM  "No","Yes";
+BA_DEF_ SG_  "CrossOver_InfoCAN" ENUM  "No","Yes";
+BA_DEF_ SG_  "WakeupSignal" ENUM  "No","Yes";
+BA_DEF_ SG_  "GenSigInactiveValue" INT 0 100000;
+BA_DEF_ SG_  "GenSigSendType" ENUM  "Cyclic","OnWrite","vector_leerstring","OnChange","vector_leerstring","IfActive","vector_leerstring","NoSigSendType";
+BA_DEF_ BO_  "SCP_FreshnessValueLength" INT 0 512;
+BA_DEF_ BO_  "AuthFreshnessCounterSyncAttempt" INT 0 512;
+BA_DEF_ BO_  "SCP_DataID" INT 0 65535;
+BA_DEF_ BO_  "SCP_FreshnessValueTxLength" INT 0 512;
+BA_DEF_ BO_  "SCP_AuthInfoTxLength" INT 0 512;
+BA_DEF_ BO_  "SC_Message" ENUM  "No","Yes";
+BA_DEF_ BO_  "ProgBWConditional" STRING;
+BA_DEF_ BO_  "GenMsgRoutingTimeoutTime" INT 0 5000;
+BA_DEF_ BO_  "MessageGateway" ENUM  "No","Yes";
+BA_DEF_ BO_  "NmAsrMessage" ENUM  "No","Yes";
+BA_DEF_ BO_  "TpApplType" STRING;
+BA_DEF_ BO_  "DiagState" ENUM  "No","Yes";
+BA_DEF_ BO_  "TpTxIndex" INT 0 536870911;
+BA_DEF_ BO_  "NetworkInitializationCommand" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagRequest" ENUM  "No","Yes";
+BA_DEF_ BO_  "DiagResponse" ENUM  "No","Yes";
+BA_DEF_ BO_  "NmMessage" ENUM  "No","Yes";
+BA_DEF_ BO_  "GenMsgILSupport" ENUM  "No","Yes";
+BA_DEF_ BU_  "Terminator" ENUM  "No","Yes";
+BA_DEF_ BU_  "NodeWakeUpTime" INT 0 10000;
+BA_DEF_ BU_  "NodeStartUpTime" INT 0 10000;
+BA_DEF_ BU_  "NmAsrNodeIdentifier" HEX 128 255;
+BA_DEF_ BU_  "NmAsrNode" ENUM  "No","Yes";
+BA_DEF_ BU_  "PowerType" ENUM  "Switched","Latched","Sleep","vector_leerstring","vector_leerstring";
+BA_DEF_ BU_  "DiagNode" ENUM  "GGDS","GDS","NONE";
+BA_DEF_ BU_  "EOL_SB_Flash" ENUM  "GGDS","GDS","NONE","vector_leerstring";
+BA_DEF_ BU_  "NetworkInitializationUsed" ENUM  "No","Yes";
+BA_DEF_ BU_  "NmNode" ENUM  "No","Yes";
+BA_DEF_ BU_  "NmStationAddress" INT 0 255;
+BA_DEF_ BU_  "ILUsed" ENUM  "No","Yes";
+BA_DEF_ BU_  "NosPackage" ENUM  "None","I3_1","I3_2","1.0.1","RP","EuCD","Volcano","I3_3","FNOS_Autosar";
+BA_DEF_ BU_  "LIN_Master" ENUM  "No","Yes";
+BA_DEF_ BU_  "PackageID" STRING;
+BA_DEF_ BU_  "GatewayECU" ENUM  "No","Yes";
+BA_DEF_  "NetworkSpeed" ENUM  "500kBits/s","125kBit/s";
+BA_DEF_  "VersionNumber" INT 0 10000;
+BA_DEF_  "StarNetworkGwType" ENUM  "0=NotDefined","1=HS1","2=HS2","3=HS3","4=HS4","5=HS5","6=MS1","7=HS6","8=HS7","9=MS2","10=FD1","11=FD2","12=FD3","13=FD4","14=FD5","15=FD6","16=FD7","17=FD8";
+BA_DEF_  "CMDB_Version" STRING;
+BA_DEF_  "NmType" STRING;
+BA_DEF_  "NmAsrMessageCount" INT 128 128;
+BA_DEF_  "NmAsrBaseAddress" HEX 1408 1408;
+BA_DEF_  "DBName" STRING;
+BA_DEF_  "VersionDay" INT 1 31;
+BA_DEF_  "Manufacturer" STRING;
+BA_DEF_  "VersionMonth" INT 1 12;
+BA_DEF_  "VersionYear" INT 2000 3000;
+BA_DEF_  "NmBaseAddress" HEX 1280 1280;
+BA_DEF_  "NmMessageCount" INT 0 128;
+BA_DEF_DEF_  "OvtpPushApplication" "FALSE";
+BA_DEF_DEF_  "OvtpOperationMode" "SERVER";
+BA_DEF_DEF_  "OvtpEcuAddress" 0;
+BA_DEF_DEF_  "ECGUsedRxSignal" "No";
+BA_DEF_DEF_  "U_S650_MY2022_Rx" "No";
+BA_DEF_DEF_  "ECGUsedTxSignal" "No";
+BA_DEF_DEF_  "U_S650_MY2022_Tx" "No";
+BA_DEF_DEF_  "GenSigTimeoutTime_CHCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_SOBDMC_HPCM_F" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_CMR_DSMC" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_ECM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_TCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_ECM_HEVDSL" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_AWD_DLCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_ECM_HEV" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_GENERIC" 0;
+BA_DEF_DEF_  "VFrameFormat" "ExtendedCAN_FD";
+BA_DEF_DEF_  "GenSigTimeoutTime_PSCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_HCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_ABS_ESC" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_ECM_Diesel" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_TCCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime__delete" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_TCM_DSL" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_TSTR" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_IPMA_ADAS" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_GWM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_PCM" 0;
+BA_DEF_DEF_  "GenSigTimeoutTime_PCM_HEV" 0;
+BA_DEF_DEF_  "BusType" "";
+BA_DEF_DEF_  "FrameRouting" "NONE";
+BA_DEF_DEF_  "FrameGatewayNetwork" "NONE";
+BA_DEF_DEF_  "FrameGateway_LC1" 0;
+BA_DEF_DEF_  "FrameGatewayLC1_HS3" 0;
+BA_DEF_DEF_  "FrameGatewayMS1" 0;
+BA_DEF_DEF_  "FrameGatewayHS3" 0;
+BA_DEF_DEF_  "FrameGatewayHS2" 0;
+BA_DEF_DEF_  "FrameGatewayHS1" 0;
+BA_DEF_DEF_  "NetworkInitialization" "Yes";
+BA_DEF_DEF_  "FrameGatewayId" 0;
+BA_DEF_DEF_  "EventRateOfChange" 10000;
+BA_DEF_DEF_  "ConfiguredTransmitter" "No";
+BA_DEF_DEF_  "GenMsgStartDelayTime" 0;
+BA_DEF_DEF_  "GenMsgNrOfRepetition" 1;
+BA_DEF_DEF_  "GenMsgDelayTime" 20;
+BA_DEF_DEF_  "GenMsgCycleTimeFast" 0;
+BA_DEF_DEF_  "GenMsgCycleTime" 0;
+BA_DEF_DEF_  "GenMsgSendType" "NoMsgSendType";
+BA_DEF_DEF_  "U_T6_MCA_MY2020_Tx" "No";
+BA_DEF_DEF_  "U_P702_MY2021_Tx" "No";
+BA_DEF_DEF_  "U_CX727_MY2021_Tx" "No";
+BA_DEF_DEF_  "U_F5X_MY20_Tx" "No";
+BA_DEF_DEF_  "U_Commodity_MYXX_Tx" "No";
+BA_DEF_DEF_  "U_T6_MCA_MY2020_Rx" "No";
+BA_DEF_DEF_  "U_P702_MY2021_Rx" "No";
+BA_DEF_DEF_  "U_CX727_MY2021_Rx" "No";
+BA_DEF_DEF_  "U_F5X_MY20_Rx" "No";
+BA_DEF_DEF_  "U_Commodity_MYXX_Rx" "No";
+BA_DEF_DEF_  "GenSigStartValue" 0;
+BA_DEF_DEF_  "MetaData" "No";
+BA_DEF_DEF_  "ApprovedOrphan" "No";
+BA_DEF_DEF_  "ContentDependant" "No";
+BA_DEF_DEF_  "GenSigStartValueInteger" 0;
+BA_DEF_DEF_  "UsedOnPgmDBC" "Yes";
+BA_DEF_DEF_  "CrossOver_InfoCAN" "No";
+BA_DEF_DEF_  "WakeupSignal" "No";
+BA_DEF_DEF_  "GenSigInactiveValue" 0;
+BA_DEF_DEF_  "GenSigSendType" "NoSigSendType";
+BA_DEF_DEF_  "SCP_FreshnessValueLength" 64;
+BA_DEF_DEF_  "AuthFreshnessCounterSyncAttempt" 2;
+BA_DEF_DEF_  "SCP_DataID" 0;
+BA_DEF_DEF_  "SCP_FreshnessValueTxLength" 8;
+BA_DEF_DEF_  "SCP_AuthInfoTxLength" 56;
+BA_DEF_DEF_  "SC_Message" "No";
+BA_DEF_DEF_  "ProgBWConditional" "NONE";
+BA_DEF_DEF_  "GenMsgRoutingTimeoutTime" 0;
+BA_DEF_DEF_  "MessageGateway" "No";
+BA_DEF_DEF_  "NmAsrMessage" "No";
+BA_DEF_DEF_  "TpApplType" "";
+BA_DEF_DEF_  "DiagState" "No";
+BA_DEF_DEF_  "TpTxIndex" 0;
+BA_DEF_DEF_  "NetworkInitializationCommand" "No";
+BA_DEF_DEF_  "DiagRequest" "No";
+BA_DEF_DEF_  "DiagResponse" "No";
+BA_DEF_DEF_  "NmMessage" "No";
+BA_DEF_DEF_  "GenMsgILSupport" "Yes";
+BA_DEF_DEF_  "Terminator" "No";
+BA_DEF_DEF_  "NodeWakeUpTime" 10;
+BA_DEF_DEF_  "NodeStartUpTime" 250;
+BA_DEF_DEF_  "NmAsrNodeIdentifier" 128;
+BA_DEF_DEF_  "NmAsrNode" "No";
+BA_DEF_DEF_  "PowerType" "Switched";
+BA_DEF_DEF_  "DiagNode" "GGDS";
+BA_DEF_DEF_  "EOL_SB_Flash" "GGDS";
+BA_DEF_DEF_  "NetworkInitializationUsed" "No";
+BA_DEF_DEF_  "NmNode" "No";
+BA_DEF_DEF_  "NmStationAddress" 0;
+BA_DEF_DEF_  "ILUsed" "Yes";
+BA_DEF_DEF_  "NosPackage" "I3_3";
+BA_DEF_DEF_  "LIN_Master" "No";
+BA_DEF_DEF_  "PackageID" "08.05.00.00.71.xx.xx.rr.00.00";
+BA_DEF_DEF_  "GatewayECU" "No";
+BA_DEF_DEF_  "NetworkSpeed" "500kBits/s";
+BA_DEF_DEF_  "VersionNumber" 1;
+BA_DEF_DEF_  "StarNetworkGwType" "0=NotDefined";
+BA_DEF_DEF_  "CMDB_Version" "v11.01";
+BA_DEF_DEF_  "NmType" "Ford-OSEK";
+BA_DEF_DEF_  "NmAsrMessageCount" 128;
+BA_DEF_DEF_  "NmAsrBaseAddress" 1408;
+BA_DEF_DEF_  "DBName" "";
+BA_DEF_DEF_  "VersionDay" 1;
+BA_DEF_DEF_  "Manufacturer" "Ford";
+BA_DEF_DEF_  "VersionMonth" 1;
+BA_DEF_DEF_  "VersionYear" 2011;
+BA_DEF_DEF_  "NmBaseAddress" 1280;
+BA_DEF_DEF_  "NmMessageCount" 128;
+BA_ "BusType" "CAN FD";
+BA_ "VersionYear" 2019;
+BA_ "VersionMonth" 4;
+BA_ "Manufacturer" "Ford";
+BA_ "VersionDay" 11;
+BA_ "CMDB_Version" "FNV2_v18.07";
+BA_ "StarNetworkGwType" 10;
+BA_ "VersionNumber" 6;
+BA_ "NmType" "Ford-OSEK";
+BA_ "DBName" "FD1_CAN";
+BA_ "NmStationAddress" BU_ VDM 48;
+BA_ "OvtpEcuAddress" BU_ VDM 32;
+BA_ "OvtpEcuAddress" BU_ CMR_DSMC 187;
+BA_ "NmStationAddress" BU_ CMR_DSMC 95;
+BA_ "PowerType" BU_ CMR_DSMC 2;
+BA_ "NmAsrNode" BU_ CMR_DSMC 1;
+BA_ "NmAsrNodeIdentifier" BU_ CMR_DSMC 223;
+BA_ "OvtpEcuAddress" BU_ SOBDMC_HPCM_FD1 17;
+BA_ "NmStationAddress" BU_ SOBDMC_HPCM_FD1 37;
+BA_ "OvtpEcuAddress" BU_ IPMA_ADAS 33;
+BA_ "NmStationAddress" BU_ IPMA_ADAS 28;
+BA_ "NodeStartUpTime" BU_ IPMA_ADAS 300;
+BA_ "OvtpEcuAddress" BU_ PSCM 48;
+BA_ "NmStationAddress" BU_ PSCM 53;
+BA_ "PowerType" BU_ PSCM 1;
+BA_ "NmAsrNode" BU_ PSCM 1;
+BA_ "NmAsrNodeIdentifier" BU_ PSCM 181;
+BA_ "Terminator" BU_ PSCM 1;
+BA_ "OvtpEcuAddress" BU_ ABS_ESC 40;
+BA_ "NmStationAddress" BU_ ABS_ESC 22;
+BA_ "PowerType" BU_ ABS_ESC 2;
+BA_ "NmAsrNode" BU_ ABS_ESC 1;
+BA_ "NmAsrNodeIdentifier" BU_ ABS_ESC 150;
+BA_ "NodeStartUpTime" BU_ ABS_ESC 1000;
+BA_ "NodeWakeUpTime" BU_ ABS_ESC 300;
+BA_ "OvtpEcuAddress" BU_ TCCM 25;
+BA_ "NmStationAddress" BU_ TCCM 33;
+BA_ "NmAsrNode" BU_ TCCM 1;
+BA_ "NmAsrNodeIdentifier" BU_ TCCM 161;
+BA_ "NodeStartUpTime" BU_ TCCM 1000;
+BA_ "NodeWakeUpTime" BU_ TCCM 25;
+BA_ "OvtpEcuAddress" BU_ TCM_DSL 24;
+BA_ "NmStationAddress" BU_ TCM_DSL 32;
+BA_ "PowerType" BU_ TCM_DSL 1;
+BA_ "NmAsrNode" BU_ TCM_DSL 1;
+BA_ "NmAsrNodeIdentifier" BU_ TCM_DSL 160;
+BA_ "NodeWakeUpTime" BU_ TCM_DSL 200;
+BA_ "NosPackage" BU_ TCM_DSL 4;
+BA_ "OvtpEcuAddress" BU_ PCM_HEV 16;
+BA_ "NmStationAddress" BU_ PCM_HEV 21;
+BA_ "PowerType" BU_ PCM_HEV 1;
+BA_ "NmAsrNode" BU_ PCM_HEV 1;
+BA_ "NmAsrNodeIdentifier" BU_ PCM_HEV 149;
+BA_ "NodeStartUpTime" BU_ PCM_HEV 350;
+BA_ "OvtpEcuAddress" BU_ PCM 16;
+BA_ "NmStationAddress" BU_ PCM 21;
+BA_ "PowerType" BU_ PCM 1;
+BA_ "NmAsrNode" BU_ PCM 1;
+BA_ "NmAsrNodeIdentifier" BU_ PCM 149;
+BA_ "NodeStartUpTime" BU_ PCM 350;
+BA_ "OvtpEcuAddress" BU_ ECM_Diesel 16;
+BA_ "NmStationAddress" BU_ ECM_Diesel 21;
+BA_ "PowerType" BU_ ECM_Diesel 1;
+BA_ "NmAsrNode" BU_ ECM_Diesel 1;
+BA_ "NmAsrNodeIdentifier" BU_ ECM_Diesel 149;
+BA_ "OvtpEcuAddress" BU_ GWM 216;
+BA_ "OvtpOperationMode" BU_ GWM 1;
+BA_ "NmStationAddress" BU_ GWM 30;
+BA_ "PowerType" BU_ GWM 2;
+BA_ "NmAsrNode" BU_ GWM 1;
+BA_ "NmAsrNodeIdentifier" BU_ GWM 158;
+BA_ "NodeStartUpTime" BU_ GWM 100;
+BA_ "Terminator" BU_ GWM 1;
+BA_ "GatewayECU" BU_ GWM 1;
+BA_ "NosPackage" BU_ GWM 4;
+BA_ "GenMsgSendType" BO_ 823 5;
+BA_ "GenMsgCycleTime" BO_ 823 1000;
+BA_ "VFrameFormat" BO_ 823 14;
+BA_ "GenMsgSendType" BO_ 824 5;
+BA_ "GenMsgCycleTime" BO_ 824 1000;
+BA_ "VFrameFormat" BO_ 824 14;
+BA_ "FrameGatewayId" BO_ 949 949;
+BA_ "FrameGatewayNetwork" BO_ 949 "HS1_CAN";
+BA_ "FrameRouting" BO_ 949 "";
+BA_ "VFrameFormat" BO_ 949 14;
+BA_ "GenMsgILSupport" BO_ 1825 0;
+BA_ "DiagRequest" BO_ 1825 1;
+BA_ "GenMsgSendType" BO_ 1825 1;
+BA_ "GenMsgDelayTime" BO_ 1825 0;
+BA_ "NetworkInitialization" BO_ 1825 0;
+BA_ "VFrameFormat" BO_ 1825 14;
+BA_ "GenMsgDelayTime" BO_ 524 0;
+BA_ "GenMsgCycleTime" BO_ 524 10;
+BA_ "GenMsgSendType" BO_ 524 0;
+BA_ "ProgBWConditional" BO_ 524 "MSGDCR1008_CX48X_V03_HS1D_56.84_mHEV_54.89";
+BA_ "VFrameFormat" BO_ 524 14;
+BA_ "FrameRouting" BO_ 740 "";
+BA_ "FrameGatewayNetwork" BO_ 740 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 740 740;
+BA_ "VFrameFormat" BO_ 740 14;
+BA_ "GenMsgCycleTime" BO_ 1160 1000;
+BA_ "GenMsgSendType" BO_ 1160 5;
+BA_ "VFrameFormat" BO_ 1160 14;
+BA_ "GenMsgCycleTime" BO_ 776 1000;
+BA_ "GenMsgSendType" BO_ 776 5;
+BA_ "VFrameFormat" BO_ 776 14;
+BA_ "GenMsgCycleTime" BO_ 775 1000;
+BA_ "GenMsgSendType" BO_ 775 5;
+BA_ "VFrameFormat" BO_ 775 14;
+BA_ "GenMsgCycleTime" BO_ 774 1000;
+BA_ "GenMsgSendType" BO_ 774 5;
+BA_ "VFrameFormat" BO_ 774 14;
+BA_ "FrameGatewayId" BO_ 811 811;
+BA_ "FrameGatewayNetwork" BO_ 811 "HS3_CAN";
+BA_ "FrameRouting" BO_ 811 "";
+BA_ "VFrameFormat" BO_ 811 14;
+BA_ "GenMsgSendType" BO_ 850 0;
+BA_ "GenMsgCycleTime" BO_ 850 150;
+BA_ "VFrameFormat" BO_ 850 14;
+BA_ "GenMsgCycleTime" BO_ 563 1000;
+BA_ "GenMsgSendType" BO_ 563 5;
+BA_ "VFrameFormat" BO_ 563 14;
+BA_ "GenMsgILSupport" BO_ 1833 0;
+BA_ "DiagResponse" BO_ 1833 1;
+BA_ "GenMsgSendType" BO_ 1833 1;
+BA_ "GenMsgDelayTime" BO_ 1833 0;
+BA_ "NetworkInitialization" BO_ 1833 0;
+BA_ "VFrameFormat" BO_ 1833 14;
+BA_ "FrameRouting" BO_ 570 "";
+BA_ "GenMsgSendType" BO_ 570 0;
+BA_ "GenMsgCycleTime" BO_ 570 20;
+BA_ "GenMsgDelayTime" BO_ 570 10;
+BA_ "VFrameFormat" BO_ 570 14;
+BA_ "FrameRouting" BO_ 837 "";
+BA_ "GenMsgSendType" BO_ 837 5;
+BA_ "GenMsgCycleTime" BO_ 837 1000;
+BA_ "VFrameFormat" BO_ 837 14;
+BA_ "FrameRouting" BO_ 885 "";
+BA_ "GenMsgSendType" BO_ 885 0;
+BA_ "GenMsgCycleTime" BO_ 885 200;
+BA_ "VFrameFormat" BO_ 885 14;
+BA_ "FrameRouting" BO_ 1150 "";
+BA_ "FrameGatewayNetwork" BO_ 1150 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 1150 1118;
+BA_ "VFrameFormat" BO_ 1150 14;
+BA_ "FrameRouting" BO_ 542 "";
+BA_ "FrameGatewayNetwork" BO_ 542 "HS4_CAN";
+BA_ "FrameGatewayId" BO_ 542 542;
+BA_ "VFrameFormat" BO_ 542 14;
+BA_ "FrameRouting" BO_ 2612224016 "";
+BA_ "TpTxIndex" BO_ 2612224016 464535768;
+BA_ "GenMsgSendType" BO_ 2612224016 1;
+BA_ "GenMsgCycleTime" BO_ 2612224016 0;
+BA_ "GenMsgDelayTime" BO_ 2612224016 0;
+BA_ "NetworkInitialization" BO_ 2612224016 0;
+BA_ "OvtpPushApplication" BO_ 2612224016 1;
+BA_ "VFrameFormat" BO_ 2612224016 15;
+BA_ "FrameRouting" BO_ 810 "";
+BA_ "GenMsgCycleTime" BO_ 810 1000;
+BA_ "GenMsgSendType" BO_ 810 5;
+BA_ "VFrameFormat" BO_ 810 14;
+BA_ "FrameRouting" BO_ 550 "";
+BA_ "GenMsgCycleTime" BO_ 550 1000;
+BA_ "GenMsgSendType" BO_ 550 5;
+BA_ "VFrameFormat" BO_ 550 14;
+BA_ "FrameRouting" BO_ 639 "";
+BA_ "GenMsgCycleTime" BO_ 639 1000;
+BA_ "GenMsgSendType" BO_ 639 5;
+BA_ "VFrameFormat" BO_ 639 14;
+BA_ "FrameRouting" BO_ 530 "";
+BA_ "GenMsgCycleTime" BO_ 530 1000;
+BA_ "GenMsgSendType" BO_ 530 5;
+BA_ "VFrameFormat" BO_ 530 14;
+BA_ "FrameRouting" BO_ 1142 "";
+BA_ "GenMsgSendType" BO_ 1142 0;
+BA_ "GenMsgCycleTime" BO_ 1142 500;
+BA_ "VFrameFormat" BO_ 1142 14;
+BA_ "FrameRouting" BO_ 817 "";
+BA_ "FrameGatewayId" BO_ 817 817;
+BA_ "FrameGatewayNetwork" BO_ 817 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 817 14;
+BA_ "FrameRouting" BO_ 879 "";
+BA_ "FrameGatewayNetwork" BO_ 879 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 879 879;
+BA_ "VFrameFormat" BO_ 879 14;
+BA_ "FrameRouting" BO_ 878 "";
+BA_ "GenMsgSendType" BO_ 878 5;
+BA_ "GenMsgCycleTime" BO_ 878 1000;
+BA_ "VFrameFormat" BO_ 878 14;
+BA_ "FrameRouting" BO_ 395 "";
+BA_ "FrameGatewayNetwork" BO_ 395 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 395 395;
+BA_ "VFrameFormat" BO_ 395 14;
+BA_ "TpTxIndex" BO_ 2611055832 463572184;
+BA_ "FrameRouting" BO_ 2611055832 "";
+BA_ "NetworkInitialization" BO_ 2611055832 0;
+BA_ "GenMsgDelayTime" BO_ 2611055832 0;
+BA_ "GenMsgSendType" BO_ 2611055832 1;
+BA_ "VFrameFormat" BO_ 2611055832 15;
+BA_ "TpTxIndex" BO_ 2611054808 463571160;
+BA_ "FrameRouting" BO_ 2611054808 "";
+BA_ "NetworkInitialization" BO_ 2611054808 0;
+BA_ "GenMsgDelayTime" BO_ 2611054808 0;
+BA_ "GenMsgSendType" BO_ 2611054808 1;
+BA_ "VFrameFormat" BO_ 2611054808 15;
+BA_ "TpTxIndex" BO_ 2611026136 463542488;
+BA_ "FrameRouting" BO_ 2611026136 "";
+BA_ "NetworkInitialization" BO_ 2611026136 0;
+BA_ "GenMsgDelayTime" BO_ 2611026136 0;
+BA_ "GenMsgSendType" BO_ 2611026136 1;
+BA_ "VFrameFormat" BO_ 2611026136 15;
+BA_ "TpTxIndex" BO_ 2611025112 463541464;
+BA_ "FrameRouting" BO_ 2611025112 "";
+BA_ "NetworkInitialization" BO_ 2611025112 0;
+BA_ "GenMsgDelayTime" BO_ 2611025112 0;
+BA_ "GenMsgSendType" BO_ 2611025112 1;
+BA_ "VFrameFormat" BO_ 2611025112 15;
+BA_ "TpTxIndex" BO_ 2610975960 463492312;
+BA_ "FrameRouting" BO_ 2610975960 "";
+BA_ "NetworkInitialization" BO_ 2610975960 0;
+BA_ "GenMsgDelayTime" BO_ 2610975960 0;
+BA_ "GenMsgSendType" BO_ 2610975960 1;
+BA_ "VFrameFormat" BO_ 2610975960 15;
+BA_ "FrameRouting" BO_ 2610007256 "";
+BA_ "NetworkInitialization" BO_ 2610007256 0;
+BA_ "GenMsgDelayTime" BO_ 2610007256 0;
+BA_ "GenMsgSendType" BO_ 2610007256 1;
+BA_ "TpTxIndex" BO_ 2610007256 462523608;
+BA_ "VFrameFormat" BO_ 2610007256 15;
+BA_ "FrameRouting" BO_ 2610006232 "";
+BA_ "NetworkInitialization" BO_ 2610006232 0;
+BA_ "GenMsgDelayTime" BO_ 2610006232 0;
+BA_ "GenMsgSendType" BO_ 2610006232 1;
+BA_ "TpTxIndex" BO_ 2610006232 462522584;
+BA_ "VFrameFormat" BO_ 2610006232 15;
+BA_ "FrameRouting" BO_ 2609977560 "";
+BA_ "NetworkInitialization" BO_ 2609977560 0;
+BA_ "GenMsgDelayTime" BO_ 2609977560 0;
+BA_ "GenMsgSendType" BO_ 2609977560 1;
+BA_ "TpTxIndex" BO_ 2609977560 462493912;
+BA_ "VFrameFormat" BO_ 2609977560 15;
+BA_ "FrameRouting" BO_ 2609976536 "";
+BA_ "NetworkInitialization" BO_ 2609976536 0;
+BA_ "GenMsgDelayTime" BO_ 2609976536 0;
+BA_ "GenMsgSendType" BO_ 2609976536 1;
+BA_ "TpTxIndex" BO_ 2609976536 462492888;
+BA_ "VFrameFormat" BO_ 2609976536 15;
+BA_ "FrameRouting" BO_ 2609927384 "";
+BA_ "NetworkInitialization" BO_ 2609927384 0;
+BA_ "GenMsgDelayTime" BO_ 2609927384 0;
+BA_ "GenMsgSendType" BO_ 2609927384 1;
+BA_ "TpTxIndex" BO_ 2609927384 462443736;
+BA_ "VFrameFormat" BO_ 2609927384 15;
+BA_ "TpTxIndex" BO_ 2611175523 463572184;
+BA_ "FrameRouting" BO_ 2611175523 "";
+BA_ "NetworkInitialization" BO_ 2611175523 0;
+BA_ "GenMsgDelayTime" BO_ 2611175523 0;
+BA_ "GenMsgSendType" BO_ 2611175523 1;
+BA_ "VFrameFormat" BO_ 2611175523 15;
+BA_ "TpTxIndex" BO_ 2612224099 464620760;
+BA_ "OvtpPushApplication" BO_ 2612224099 1;
+BA_ "FrameRouting" BO_ 2612224099 "";
+BA_ "NetworkInitialization" BO_ 2612224099 0;
+BA_ "GenMsgDelayTime" BO_ 2612224099 0;
+BA_ "GenMsgSendType" BO_ 2612224099 1;
+BA_ "VFrameFormat" BO_ 2612224099 15;
+BA_ "TpTxIndex" BO_ 2611175522 463571160;
+BA_ "FrameRouting" BO_ 2611175522 "";
+BA_ "NetworkInitialization" BO_ 2611175522 0;
+BA_ "GenMsgDelayTime" BO_ 2611175522 0;
+BA_ "GenMsgSendType" BO_ 2611175522 1;
+BA_ "VFrameFormat" BO_ 2611175522 15;
+BA_ "TpTxIndex" BO_ 2612224098 464619736;
+BA_ "OvtpPushApplication" BO_ 2612224098 1;
+BA_ "FrameRouting" BO_ 2612224098 "";
+BA_ "NetworkInitialization" BO_ 2612224098 0;
+BA_ "GenMsgDelayTime" BO_ 2612224098 0;
+BA_ "GenMsgSendType" BO_ 2612224098 1;
+BA_ "VFrameFormat" BO_ 2612224098 15;
+BA_ "TpTxIndex" BO_ 2611175494 463542488;
+BA_ "FrameRouting" BO_ 2611175494 "";
+BA_ "NetworkInitialization" BO_ 2611175494 0;
+BA_ "GenMsgDelayTime" BO_ 2611175494 0;
+BA_ "GenMsgSendType" BO_ 2611175494 1;
+BA_ "VFrameFormat" BO_ 2611175494 15;
+BA_ "TpTxIndex" BO_ 2612224070 464591064;
+BA_ "OvtpPushApplication" BO_ 2612224070 1;
+BA_ "FrameRouting" BO_ 2612224070 "";
+BA_ "NetworkInitialization" BO_ 2612224070 0;
+BA_ "GenMsgDelayTime" BO_ 2612224070 0;
+BA_ "GenMsgSendType" BO_ 2612224070 1;
+BA_ "VFrameFormat" BO_ 2612224070 15;
+BA_ "TpTxIndex" BO_ 2611175493 463541464;
+BA_ "FrameRouting" BO_ 2611175493 "";
+BA_ "NetworkInitialization" BO_ 2611175493 0;
+BA_ "GenMsgDelayTime" BO_ 2611175493 0;
+BA_ "GenMsgSendType" BO_ 2611175493 1;
+BA_ "VFrameFormat" BO_ 2611175493 15;
+BA_ "TpTxIndex" BO_ 2612224069 464590040;
+BA_ "OvtpPushApplication" BO_ 2612224069 1;
+BA_ "FrameRouting" BO_ 2612224069 "";
+BA_ "NetworkInitialization" BO_ 2612224069 0;
+BA_ "GenMsgDelayTime" BO_ 2612224069 0;
+BA_ "GenMsgSendType" BO_ 2612224069 1;
+BA_ "VFrameFormat" BO_ 2612224069 15;
+BA_ "TpTxIndex" BO_ 2611175445 463492312;
+BA_ "FrameRouting" BO_ 2611175445 "";
+BA_ "NetworkInitialization" BO_ 2611175445 0;
+BA_ "GenMsgDelayTime" BO_ 2611175445 0;
+BA_ "GenMsgSendType" BO_ 2611175445 1;
+BA_ "VFrameFormat" BO_ 2611175445 15;
+BA_ "TpTxIndex" BO_ 2612224021 464540888;
+BA_ "OvtpPushApplication" BO_ 2612224021 1;
+BA_ "FrameRouting" BO_ 2612224021 "";
+BA_ "NetworkInitialization" BO_ 2612224021 0;
+BA_ "GenMsgDelayTime" BO_ 2612224021 0;
+BA_ "GenMsgSendType" BO_ 2612224021 1;
+BA_ "VFrameFormat" BO_ 2612224021 15;
+BA_ "TpTxIndex" BO_ 2610126947 462523608;
+BA_ "FrameRouting" BO_ 2610126947 "";
+BA_ "NetworkInitialization" BO_ 2610126947 0;
+BA_ "GenMsgDelayTime" BO_ 2610126947 0;
+BA_ "GenMsgSendType" BO_ 2610126947 1;
+BA_ "VFrameFormat" BO_ 2610126947 15;
+BA_ "TpTxIndex" BO_ 2610126946 462522584;
+BA_ "FrameRouting" BO_ 2610126946 "";
+BA_ "NetworkInitialization" BO_ 2610126946 0;
+BA_ "GenMsgDelayTime" BO_ 2610126946 0;
+BA_ "GenMsgSendType" BO_ 2610126946 1;
+BA_ "VFrameFormat" BO_ 2610126946 15;
+BA_ "TpTxIndex" BO_ 2610126918 462493912;
+BA_ "FrameRouting" BO_ 2610126918 "";
+BA_ "NetworkInitialization" BO_ 2610126918 0;
+BA_ "GenMsgDelayTime" BO_ 2610126918 0;
+BA_ "GenMsgSendType" BO_ 2610126918 1;
+BA_ "VFrameFormat" BO_ 2610126918 15;
+BA_ "TpTxIndex" BO_ 2610126917 462492888;
+BA_ "FrameRouting" BO_ 2610126917 "";
+BA_ "NetworkInitialization" BO_ 2610126917 0;
+BA_ "GenMsgDelayTime" BO_ 2610126917 0;
+BA_ "GenMsgSendType" BO_ 2610126917 1;
+BA_ "VFrameFormat" BO_ 2610126917 15;
+BA_ "FrameRouting" BO_ 2610126869 "";
+BA_ "NetworkInitialization" BO_ 2610126869 0;
+BA_ "GenMsgDelayTime" BO_ 2610126869 0;
+BA_ "GenMsgSendType" BO_ 2610126869 1;
+BA_ "TpTxIndex" BO_ 2610126869 462443736;
+BA_ "VFrameFormat" BO_ 2610126869 15;
+BA_ "FrameRouting" BO_ 984 "";
+BA_ "GenMsgCycleTime" BO_ 984 1000;
+BA_ "GenMsgSendType" BO_ 984 5;
+BA_ "VFrameFormat" BO_ 984 14;
+BA_ "FrameRouting" BO_ 985 "";
+BA_ "GenMsgSendType" BO_ 985 5;
+BA_ "GenMsgCycleTime" BO_ 985 1000;
+BA_ "VFrameFormat" BO_ 985 14;
+BA_ "FrameRouting" BO_ 992 "";
+BA_ "FrameGatewayNetwork" BO_ 992 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 992 992;
+BA_ "VFrameFormat" BO_ 992 14;
+BA_ "OvtpPushApplication" BO_ 2612019416 1;
+BA_ "FrameRouting" BO_ 2612019416 "";
+BA_ "TpTxIndex" BO_ 2612019416 464535768;
+BA_ "NetworkInitialization" BO_ 2612019416 0;
+BA_ "GenMsgDelayTime" BO_ 2612019416 0;
+BA_ "GenMsgSendType" BO_ 2612019416 1;
+BA_ "VFrameFormat" BO_ 2612019416 15;
+BA_ "FrameRouting" BO_ 943 "";
+BA_ "GenMsgSendType" BO_ 943 0;
+BA_ "GenMsgCycleTime" BO_ 943 20;
+BA_ "GenMsgDelayTime" BO_ 943 10;
+BA_ "VFrameFormat" BO_ 943 14;
+BA_ "FrameRouting" BO_ 515 "";
+BA_ "GenMsgSendType" BO_ 515 5;
+BA_ "GenMsgCycleTime" BO_ 515 100;
+BA_ "VFrameFormat" BO_ 515 14;
+BA_ "FrameRouting" BO_ 1111 "";
+BA_ "FrameGatewayId" BO_ 1111 1111;
+BA_ "FrameGatewayNetwork" BO_ 1111 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 1111 14;
+BA_ "FrameRouting" BO_ 1106 "";
+BA_ "FrameGatewayId" BO_ 1106 1106;
+BA_ "FrameGatewayNetwork" BO_ 1106 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 1106 14;
+BA_ "FrameRouting" BO_ 982 "";
+BA_ "GenMsgSendType" BO_ 982 0;
+BA_ "GenMsgCycleTime" BO_ 982 50;
+BA_ "VFrameFormat" BO_ 982 14;
+BA_ "FrameRouting" BO_ 1985 "";
+BA_ "NetworkInitialization" BO_ 1985 0;
+BA_ "GenMsgDelayTime" BO_ 1985 0;
+BA_ "GenMsgSendType" BO_ 1985 1;
+BA_ "DiagRequest" BO_ 1985 1;
+BA_ "GenMsgILSupport" BO_ 1985 0;
+BA_ "VFrameFormat" BO_ 1985 14;
+BA_ "FrameRouting" BO_ 1993 "";
+BA_ "NetworkInitialization" BO_ 1993 0;
+BA_ "GenMsgDelayTime" BO_ 1993 0;
+BA_ "GenMsgSendType" BO_ 1993 1;
+BA_ "DiagResponse" BO_ 1993 1;
+BA_ "GenMsgILSupport" BO_ 1993 0;
+BA_ "VFrameFormat" BO_ 1993 14;
+BA_ "FrameRouting" BO_ 1104 "";
+BA_ "GenMsgCycleTime" BO_ 1104 200;
+BA_ "GenMsgSendType" BO_ 1104 0;
+BA_ "VFrameFormat" BO_ 1104 14;
+BA_ "FrameRouting" BO_ 1503 "";
+BA_ "NetworkInitialization" BO_ 1503 0;
+BA_ "GenMsgCycleTime" BO_ 1503 1000;
+BA_ "GenMsgSendType" BO_ 1503 0;
+BA_ "NmAsrMessage" BO_ 1503 1;
+BA_ "GenMsgILSupport" BO_ 1503 0;
+BA_ "VFrameFormat" BO_ 1503 14;
+BA_ "TpTxIndex" BO_ 2610995416 463511768;
+BA_ "FrameRouting" BO_ 2610995416 "";
+BA_ "NetworkInitialization" BO_ 2610995416 0;
+BA_ "GenMsgDelayTime" BO_ 2610995416 0;
+BA_ "GenMsgSendType" BO_ 2610995416 1;
+BA_ "VFrameFormat" BO_ 2610995416 15;
+BA_ "TpTxIndex" BO_ 2612043992 464560344;
+BA_ "OvtpPushApplication" BO_ 2612043992 1;
+BA_ "FrameRouting" BO_ 2612043992 "";
+BA_ "NetworkInitialization" BO_ 2612043992 0;
+BA_ "GenMsgDelayTime" BO_ 2612043992 0;
+BA_ "GenMsgSendType" BO_ 2612043992 1;
+BA_ "VFrameFormat" BO_ 2612043992 15;
+BA_ "FrameRouting" BO_ 2609946840 "";
+BA_ "NetworkInitialization" BO_ 2609946840 0;
+BA_ "GenMsgDelayTime" BO_ 2609946840 0;
+BA_ "GenMsgSendType" BO_ 2609946840 1;
+BA_ "TpTxIndex" BO_ 2609946840 462463192;
+BA_ "VFrameFormat" BO_ 2609946840 15;
+BA_ "TpTxIndex" BO_ 2611175464 463511768;
+BA_ "FrameRouting" BO_ 2611175464 "";
+BA_ "NetworkInitialization" BO_ 2611175464 0;
+BA_ "GenMsgDelayTime" BO_ 2611175464 0;
+BA_ "GenMsgSendType" BO_ 2611175464 1;
+BA_ "VFrameFormat" BO_ 2611175464 15;
+BA_ "TpTxIndex" BO_ 2612224040 464560344;
+BA_ "OvtpPushApplication" BO_ 2612224040 1;
+BA_ "FrameRouting" BO_ 2612224040 "";
+BA_ "NetworkInitialization" BO_ 2612224040 0;
+BA_ "GenMsgDelayTime" BO_ 2612224040 0;
+BA_ "GenMsgSendType" BO_ 2612224040 1;
+BA_ "VFrameFormat" BO_ 2612224040 15;
+BA_ "TpTxIndex" BO_ 2610126888 462463192;
+BA_ "FrameRouting" BO_ 2610126888 "";
+BA_ "NetworkInitialization" BO_ 2610126888 0;
+BA_ "GenMsgDelayTime" BO_ 2610126888 0;
+BA_ "GenMsgSendType" BO_ 2610126888 1;
+BA_ "VFrameFormat" BO_ 2610126888 15;
+BA_ "TpTxIndex" BO_ 2610988248 463504600;
+BA_ "FrameRouting" BO_ 2610988248 "";
+BA_ "NetworkInitialization" BO_ 2610988248 0;
+BA_ "GenMsgDelayTime" BO_ 2610988248 0;
+BA_ "GenMsgSendType" BO_ 2610988248 1;
+BA_ "VFrameFormat" BO_ 2610988248 15;
+BA_ "FrameRouting" BO_ 2609939672 "";
+BA_ "NetworkInitialization" BO_ 2609939672 0;
+BA_ "GenMsgDelayTime" BO_ 2609939672 0;
+BA_ "GenMsgSendType" BO_ 2609939672 1;
+BA_ "TpTxIndex" BO_ 2609939672 462456024;
+BA_ "VFrameFormat" BO_ 2609939672 15;
+BA_ "FrameRouting" BO_ 1114 "";
+BA_ "FrameGatewayNetwork" BO_ 1114 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 1114 1114;
+BA_ "VFrameFormat" BO_ 1114 14;
+BA_ "FrameRouting" BO_ 1116 "";
+BA_ "FrameGatewayNetwork" BO_ 1116 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 1116 1116;
+BA_ "VFrameFormat" BO_ 1116 14;
+BA_ "TpTxIndex" BO_ 2611175457 463504600;
+BA_ "FrameRouting" BO_ 2611175457 "";
+BA_ "NetworkInitialization" BO_ 2611175457 0;
+BA_ "GenMsgDelayTime" BO_ 2611175457 0;
+BA_ "GenMsgSendType" BO_ 2611175457 1;
+BA_ "VFrameFormat" BO_ 2611175457 15;
+BA_ "TpTxIndex" BO_ 2612224033 464553176;
+BA_ "OvtpPushApplication" BO_ 2612224033 1;
+BA_ "FrameRouting" BO_ 2612224033 "";
+BA_ "NetworkInitialization" BO_ 2612224033 0;
+BA_ "GenMsgDelayTime" BO_ 2612224033 0;
+BA_ "GenMsgSendType" BO_ 2612224033 1;
+BA_ "VFrameFormat" BO_ 2612224033 15;
+BA_ "TpTxIndex" BO_ 2610126881 462456024;
+BA_ "FrameRouting" BO_ 2610126881 "";
+BA_ "NetworkInitialization" BO_ 2610126881 0;
+BA_ "GenMsgDelayTime" BO_ 2610126881 0;
+BA_ "GenMsgSendType" BO_ 2610126881 1;
+BA_ "VFrameFormat" BO_ 2610126881 15;
+BA_ "FrameRouting" BO_ 1085 "";
+BA_ "GenMsgSendType" BO_ 1085 0;
+BA_ "GenMsgCycleTime" BO_ 1085 50;
+BA_ "VFrameFormat" BO_ 1085 14;
+BA_ "FrameRouting" BO_ 981 "";
+BA_ "GenMsgSendType" BO_ 981 0;
+BA_ "GenMsgCycleTime" BO_ 981 30;
+BA_ "VFrameFormat" BO_ 981 14;
+BA_ "FrameRouting" BO_ 791 "";
+BA_ "FrameGatewayId" BO_ 791 791;
+BA_ "FrameGatewayNetwork" BO_ 791 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 791 14;
+BA_ "TpTxIndex" BO_ 2610970840 463487192;
+BA_ "FrameRouting" BO_ 2610970840 "";
+BA_ "NetworkInitialization" BO_ 2610970840 0;
+BA_ "GenMsgDelayTime" BO_ 2610970840 0;
+BA_ "GenMsgSendType" BO_ 2610970840 1;
+BA_ "VFrameFormat" BO_ 2610970840 15;
+BA_ "TpTxIndex" BO_ 2609922264 462438616;
+BA_ "FrameRouting" BO_ 2609922264 "";
+BA_ "NetworkInitialization" BO_ 2609922264 0;
+BA_ "GenMsgDelayTime" BO_ 2609922264 0;
+BA_ "GenMsgSendType" BO_ 2609922264 1;
+BA_ "VFrameFormat" BO_ 2609922264 15;
+BA_ "FrameRouting" BO_ 868 "";
+BA_ "FrameGatewayNetwork" BO_ 868 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 868 868;
+BA_ "VFrameFormat" BO_ 868 14;
+BA_ "FrameRouting" BO_ 867 "";
+BA_ "FrameGatewayNetwork" BO_ 867 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 867 867;
+BA_ "VFrameFormat" BO_ 867 14;
+BA_ "FrameRouting" BO_ 866 "";
+BA_ "FrameGatewayNetwork" BO_ 866 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 866 866;
+BA_ "VFrameFormat" BO_ 866 14;
+BA_ "FrameRouting" BO_ 865 "";
+BA_ "FrameGatewayNetwork" BO_ 865 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 865 865;
+BA_ "VFrameFormat" BO_ 865 14;
+BA_ "TpTxIndex" BO_ 2611175440 463487192;
+BA_ "FrameRouting" BO_ 2611175440 "";
+BA_ "NetworkInitialization" BO_ 2611175440 0;
+BA_ "GenMsgDelayTime" BO_ 2611175440 0;
+BA_ "GenMsgCycleTime" BO_ 2611175440 0;
+BA_ "GenMsgSendType" BO_ 2611175440 1;
+BA_ "VFrameFormat" BO_ 2611175440 15;
+BA_ "TpTxIndex" BO_ 2610126864 462438616;
+BA_ "FrameRouting" BO_ 2610126864 "";
+BA_ "NetworkInitialization" BO_ 2610126864 0;
+BA_ "GenMsgDelayTime" BO_ 2610126864 0;
+BA_ "GenMsgSendType" BO_ 2610126864 1;
+BA_ "VFrameFormat" BO_ 2610126864 15;
+BA_ "TpTxIndex" BO_ 2611175441 463488216;
+BA_ "FrameRouting" BO_ 2611175441 "";
+BA_ "NetworkInitialization" BO_ 2611175441 0;
+BA_ "GenMsgDelayTime" BO_ 2611175441 0;
+BA_ "GenMsgSendType" BO_ 2611175441 1;
+BA_ "VFrameFormat" BO_ 2611175441 15;
+BA_ "TpTxIndex" BO_ 2612224017 463488216;
+BA_ "OvtpPushApplication" BO_ 2612224017 1;
+BA_ "FrameRouting" BO_ 2612224017 "";
+BA_ "NetworkInitialization" BO_ 2612224017 0;
+BA_ "GenMsgDelayTime" BO_ 2612224017 0;
+BA_ "GenMsgSendType" BO_ 2612224017 1;
+BA_ "VFrameFormat" BO_ 2612224017 15;
+BA_ "FrameRouting" BO_ 2610126865 "";
+BA_ "NetworkInitialization" BO_ 2610126865 0;
+BA_ "GenMsgDelayTime" BO_ 2610126865 0;
+BA_ "GenMsgSendType" BO_ 2610126865 1;
+BA_ "TpTxIndex" BO_ 2610126865 462439640;
+BA_ "VFrameFormat" BO_ 2610126865 15;
+BA_ "FrameRouting" BO_ 1679 "";
+BA_ "GenMsgCycleTime" BO_ 1679 0;
+BA_ "GenMsgSendType" BO_ 1679 1;
+BA_ "TpApplType" BO_ 1679 "DiagUUDTResponse";
+BA_ "GenMsgILSupport" BO_ 1679 0;
+BA_ "VFrameFormat" BO_ 1679 14;
+BA_ "FrameRouting" BO_ 1678 "";
+BA_ "GenMsgCycleTime" BO_ 1678 0;
+BA_ "GenMsgSendType" BO_ 1678 1;
+BA_ "TpApplType" BO_ 1678 "DiagUUDTResponse";
+BA_ "GenMsgILSupport" BO_ 1678 0;
+BA_ "VFrameFormat" BO_ 1678 14;
+BA_ "FrameRouting" BO_ 1677 "";
+BA_ "GenMsgCycleTime" BO_ 1677 0;
+BA_ "GenMsgSendType" BO_ 1677 1;
+BA_ "TpApplType" BO_ 1677 "DiagUUDTResponse";
+BA_ "GenMsgILSupport" BO_ 1677 0;
+BA_ "VFrameFormat" BO_ 1677 14;
+BA_ "FrameRouting" BO_ 1676 "";
+BA_ "GenMsgCycleTime" BO_ 1676 0;
+BA_ "GenMsgSendType" BO_ 1676 1;
+BA_ "TpApplType" BO_ 1676 "DiagUUDTResponse";
+BA_ "GenMsgILSupport" BO_ 1676 0;
+BA_ "VFrameFormat" BO_ 1676 14;
+BA_ "FrameRouting" BO_ 1445 "";
+BA_ "GenMsgILSupport" BO_ 1445 0;
+BA_ "NmAsrMessage" BO_ 1445 1;
+BA_ "GenMsgSendType" BO_ 1445 0;
+BA_ "GenMsgCycleTime" BO_ 1445 1000;
+BA_ "NetworkInitialization" BO_ 1445 0;
+BA_ "VFrameFormat" BO_ 1445 14;
+BA_ "FrameRouting" BO_ 1144 "";
+BA_ "GenMsgSendType" BO_ 1144 5;
+BA_ "GenMsgCycleTime" BO_ 1144 1000;
+BA_ "VFrameFormat" BO_ 1144 14;
+BA_ "FrameRouting" BO_ 1141 "";
+BA_ "GenMsgSendType" BO_ 1141 0;
+BA_ "GenMsgCycleTime" BO_ 1141 500;
+BA_ "VFrameFormat" BO_ 1141 14;
+BA_ "FrameRouting" BO_ 1140 "";
+BA_ "GenMsgSendType" BO_ 1140 0;
+BA_ "GenMsgCycleTime" BO_ 1140 1000;
+BA_ "VFrameFormat" BO_ 1140 14;
+BA_ "FrameRouting" BO_ 1139 "";
+BA_ "GenMsgCycleTime" BO_ 1139 1500;
+BA_ "GenMsgSendType" BO_ 1139 0;
+BA_ "VFrameFormat" BO_ 1139 14;
+BA_ "FrameRouting" BO_ 1138 "";
+BA_ "GenMsgCycleTime" BO_ 1138 1500;
+BA_ "GenMsgSendType" BO_ 1138 0;
+BA_ "VFrameFormat" BO_ 1138 14;
+BA_ "FrameRouting" BO_ 1089 "";
+BA_ "GenMsgCycleTime" BO_ 1089 1000;
+BA_ "GenMsgSendType" BO_ 1089 0;
+BA_ "VFrameFormat" BO_ 1089 14;
+BA_ "FrameRouting" BO_ 1088 "";
+BA_ "GenMsgCycleTime" BO_ 1088 1000;
+BA_ "GenMsgSendType" BO_ 1088 0;
+BA_ "VFrameFormat" BO_ 1088 14;
+BA_ "FrameRouting" BO_ 1040 "";
+BA_ "GenMsgCycleTime" BO_ 1040 100;
+BA_ "GenMsgSendType" BO_ 1040 0;
+BA_ "VFrameFormat" BO_ 1040 14;
+BA_ "FrameRouting" BO_ 1016 "";
+BA_ "GenMsgCycleTime" BO_ 1016 1000;
+BA_ "GenMsgSendType" BO_ 1016 5;
+BA_ "VFrameFormat" BO_ 1016 14;
+BA_ "FrameRouting" BO_ 1013 "";
+BA_ "GenMsgCycleTime" BO_ 1013 1000;
+BA_ "GenMsgSendType" BO_ 1013 5;
+BA_ "VFrameFormat" BO_ 1013 14;
+BA_ "FrameRouting" BO_ 1012 "";
+BA_ "GenMsgCycleTime" BO_ 1012 1000;
+BA_ "GenMsgSendType" BO_ 1012 5;
+BA_ "VFrameFormat" BO_ 1012 14;
+BA_ "FrameRouting" BO_ 1011 "";
+BA_ "GenMsgCycleTime" BO_ 1011 1000;
+BA_ "GenMsgSendType" BO_ 1011 5;
+BA_ "VFrameFormat" BO_ 1011 14;
+BA_ "FrameRouting" BO_ 871 "";
+BA_ "GenMsgCycleTime" BO_ 871 100;
+BA_ "GenMsgSendType" BO_ 871 0;
+BA_ "VFrameFormat" BO_ 871 14;
+BA_ "FrameRouting" BO_ 786 "";
+BA_ "GenMsgCycleTime" BO_ 786 100;
+BA_ "GenMsgSendType" BO_ 786 0;
+BA_ "VFrameFormat" BO_ 786 14;
+BA_ "FrameRouting" BO_ 72 "";
+BA_ "GenMsgDelayTime" BO_ 72 10;
+BA_ "GenMsgCycleTime" BO_ 72 20;
+BA_ "GenMsgSendType" BO_ 72 0;
+BA_ "VFrameFormat" BO_ 72 14;
+BA_ "FrameRouting" BO_ 912 "";
+BA_ "FrameGatewayNetwork" BO_ 912 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 912 912;
+BA_ "VFrameFormat" BO_ 912 14;
+BA_ "FrameRouting" BO_ 874 "";
+BA_ "FrameGatewayNetwork" BO_ 874 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 874 874;
+BA_ "VFrameFormat" BO_ 874 14;
+BA_ "FrameRouting" BO_ 651 "";
+BA_ "FrameGatewayNetwork" BO_ 651 "HS4_CAN";
+BA_ "FrameGatewayId" BO_ 651 651;
+BA_ "VFrameFormat" BO_ 651 14;
+BA_ "FrameRouting" BO_ 529 "";
+BA_ "FrameGatewayNetwork" BO_ 529 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 529 529;
+BA_ "VFrameFormat" BO_ 529 14;
+BA_ "FrameRouting" BO_ 66 "";
+BA_ "FrameGatewayNetwork" BO_ 66 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 66 66;
+BA_ "DiagResponse" BO_ 66 0;
+BA_ "VFrameFormat" BO_ 66 14;
+BA_ "TpTxIndex" BO_ 2610971864 463488216;
+BA_ "FrameRouting" BO_ 2610971864 "";
+BA_ "NetworkInitialization" BO_ 2610971864 0;
+BA_ "GenMsgDelayTime" BO_ 2610971864 0;
+BA_ "GenMsgSendType" BO_ 2610971864 1;
+BA_ "VFrameFormat" BO_ 2610971864 15;
+BA_ "TpTxIndex" BO_ 2612002008 464518360;
+BA_ "FrameRouting" BO_ 2612002008 "";
+BA_ "NetworkInitialization" BO_ 2612002008 0;
+BA_ "GenMsgDelayTime" BO_ 2612002008 0;
+BA_ "GenMsgSendType" BO_ 2612002008 1;
+BA_ "VFrameFormat" BO_ 2612002008 15;
+BA_ "FrameRouting" BO_ 2609923288 "";
+BA_ "NetworkInitialization" BO_ 2609923288 0;
+BA_ "GenMsgDelayTime" BO_ 2609923288 0;
+BA_ "GenMsgSendType" BO_ 2609923288 1;
+BA_ "TpTxIndex" BO_ 2609923288 462439640;
+BA_ "VFrameFormat" BO_ 2609923288 15;
+BA_ "TpTxIndex" BO_ 2610953432 463469784;
+BA_ "FrameRouting" BO_ 2610953432 "";
+BA_ "NetworkInitialization" BO_ 2610953432 0;
+BA_ "GenMsgDelayTime" BO_ 2610953432 0;
+BA_ "GenMsgSendType" BO_ 2610953432 1;
+BA_ "VFrameFormat" BO_ 2610953432 15;
+BA_ "FrameRouting" BO_ 2022 "";
+BA_ "GenMsgILSupport" BO_ 2022 0;
+BA_ "DiagRequest" BO_ 2022 1;
+BA_ "GenMsgSendType" BO_ 2022 1;
+BA_ "GenMsgDelayTime" BO_ 2022 0;
+BA_ "VFrameFormat" BO_ 2022 14;
+BA_ "FrameRouting" BO_ 1124 "";
+BA_ "FrameGatewayId" BO_ 1124 1124;
+BA_ "FrameGatewayNetwork" BO_ 1124 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1124 14;
+BA_ "FrameRouting" BO_ 1119 "";
+BA_ "FrameGatewayId" BO_ 1119 1119;
+BA_ "FrameGatewayNetwork" BO_ 1119 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1119 14;
+BA_ "FrameRouting" BO_ 132 "";
+BA_ "FrameGatewayNetwork" BO_ 132 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 132 132;
+BA_ "VFrameFormat" BO_ 132 14;
+BA_ "FrameRouting" BO_ 1990 "";
+BA_ "NetworkInitialization" BO_ 1990 0;
+BA_ "GenMsgDelayTime" BO_ 1990 0;
+BA_ "GenMsgSendType" BO_ 1990 1;
+BA_ "DiagRequest" BO_ 1990 1;
+BA_ "GenMsgILSupport" BO_ 1990 0;
+BA_ "VFrameFormat" BO_ 1990 14;
+BA_ "FrameRouting" BO_ 1892 "";
+BA_ "NetworkInitialization" BO_ 1892 0;
+BA_ "GenMsgDelayTime" BO_ 1892 0;
+BA_ "GenMsgSendType" BO_ 1892 1;
+BA_ "DiagRequest" BO_ 1892 1;
+BA_ "GenMsgILSupport" BO_ 1892 0;
+BA_ "VFrameFormat" BO_ 1892 14;
+BA_ "FrameRouting" BO_ 1798 "";
+BA_ "NetworkInitialization" BO_ 1798 0;
+BA_ "GenMsgDelayTime" BO_ 1798 0;
+BA_ "GenMsgSendType" BO_ 1798 1;
+BA_ "DiagRequest" BO_ 1798 1;
+BA_ "GenMsgILSupport" BO_ 1798 0;
+BA_ "VFrameFormat" BO_ 1798 14;
+BA_ "FrameRouting" BO_ 1123 "";
+BA_ "FrameGatewayNetwork" BO_ 1123 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 1123 1123;
+BA_ "VFrameFormat" BO_ 1123 14;
+BA_ "FrameRouting" BO_ 1122 "";
+BA_ "FrameGatewayNetwork" BO_ 1122 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 1122 1122;
+BA_ "VFrameFormat" BO_ 1122 14;
+BA_ "FrameRouting" BO_ 1003 "";
+BA_ "FrameGatewayNetwork" BO_ 1003 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 1003 1003;
+BA_ "VFrameFormat" BO_ 1003 14;
+BA_ "FrameRouting" BO_ 994 "";
+BA_ "FrameGatewayNetwork" BO_ 994 "HS3_CAN";
+BA_ "FrameGatewayId" BO_ 994 994;
+BA_ "VFrameFormat" BO_ 994 14;
+BA_ "FrameRouting" BO_ 778 "";
+BA_ "FrameGatewayId" BO_ 778 778;
+BA_ "FrameGatewayNetwork" BO_ 778 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 778 14;
+BA_ "FrameRouting" BO_ 549 "";
+BA_ "FrameGatewayId" BO_ 549 549;
+BA_ "FrameGatewayNetwork" BO_ 549 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 549 14;
+BA_ "FrameRouting" BO_ 551 "";
+BA_ "FrameGatewayId" BO_ 551 551;
+BA_ "FrameGatewayNetwork" BO_ 551 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 551 14;
+BA_ "FrameRouting" BO_ 1010 "";
+BA_ "GenMsgCycleTime" BO_ 1010 50;
+BA_ "GenMsgSendType" BO_ 1010 0;
+BA_ "VFrameFormat" BO_ 1010 14;
+BA_ "FrameRouting" BO_ 1070 "";
+BA_ "FrameGatewayNetwork" BO_ 1070 "HS1_CAN";
+BA_ "FrameGatewayId" BO_ 1070 1070;
+BA_ "VFrameFormat" BO_ 1070 14;
+BA_ "FrameRouting" BO_ 1186 "";
+BA_ "GenMsgSendType" BO_ 1186 0;
+BA_ "GenMsgCycleTime" BO_ 1186 100;
+BA_ "VFrameFormat" BO_ 1186 14;
+BA_ "FrameRouting" BO_ 611 "";
+BA_ "GenMsgSendType" BO_ 611 0;
+BA_ "GenMsgCycleTime" BO_ 611 100;
+BA_ "VFrameFormat" BO_ 611 14;
+BA_ "FrameRouting" BO_ 1461 "";
+BA_ "GenMsgILSupport" BO_ 1461 0;
+BA_ "NmAsrMessage" BO_ 1461 1;
+BA_ "GenMsgSendType" BO_ 1461 0;
+BA_ "GenMsgCycleTime" BO_ 1461 1000;
+BA_ "NetworkInitialization" BO_ 1461 0;
+BA_ "VFrameFormat" BO_ 1461 14;
+BA_ "FrameRouting" BO_ 1047 "";
+BA_ "GenMsgSendType" BO_ 1047 5;
+BA_ "GenMsgCycleTime" BO_ 1047 1000;
+BA_ "VFrameFormat" BO_ 1047 14;
+BA_ "FrameRouting" BO_ 972 "";
+BA_ "GenMsgSendType" BO_ 972 0;
+BA_ "GenMsgCycleTime" BO_ 972 30;
+BA_ "GenMsgDelayTime" BO_ 972 10;
+BA_ "VFrameFormat" BO_ 972 14;
+BA_ "FrameRouting" BO_ 130 "";
+BA_ "GenMsgSendType" BO_ 130 0;
+BA_ "GenMsgCycleTime" BO_ 130 20;
+BA_ "GenMsgDelayTime" BO_ 130 10;
+BA_ "VFrameFormat" BO_ 130 14;
+BA_ "FrameRouting" BO_ 133 "";
+BA_ "GenMsgSendType" BO_ 133 0;
+BA_ "GenMsgCycleTime" BO_ 133 10;
+BA_ "GenMsgDelayTime" BO_ 133 0;
+BA_ "VFrameFormat" BO_ 133 14;
+BA_ "FrameRouting" BO_ 1430 "";
+BA_ "GenMsgILSupport" BO_ 1430 0;
+BA_ "NmAsrMessage" BO_ 1430 1;
+BA_ "GenMsgSendType" BO_ 1430 0;
+BA_ "GenMsgCycleTime" BO_ 1430 1000;
+BA_ "NetworkInitialization" BO_ 1430 0;
+BA_ "VFrameFormat" BO_ 1430 14;
+BA_ "FrameRouting" BO_ 1200 "";
+BA_ "GenMsgSendType" BO_ 1200 0;
+BA_ "GenMsgCycleTime" BO_ 1200 20;
+BA_ "GenMsgDelayTime" BO_ 1200 10;
+BA_ "VFrameFormat" BO_ 1200 14;
+BA_ "FrameRouting" BO_ 1102 "";
+BA_ "GenMsgSendType" BO_ 1102 5;
+BA_ "GenMsgCycleTime" BO_ 1102 100000;
+BA_ "GenMsgStartDelayTime" BO_ 1102 1130;
+BA_ "VFrameFormat" BO_ 1102 14;
+BA_ "FrameRouting" BO_ 1056 "";
+BA_ "GenMsgSendType" BO_ 1056 5;
+BA_ "GenMsgCycleTime" BO_ 1056 1000;
+BA_ "VFrameFormat" BO_ 1056 14;
+BA_ "FrameRouting" BO_ 1054 "";
+BA_ "GenMsgSendType" BO_ 1054 5;
+BA_ "GenMsgCycleTime" BO_ 1054 1000;
+BA_ "VFrameFormat" BO_ 1054 14;
+BA_ "FrameRouting" BO_ 1046 "";
+BA_ "GenMsgSendType" BO_ 1046 0;
+BA_ "GenMsgCycleTime" BO_ 1046 100;
+BA_ "VFrameFormat" BO_ 1046 14;
+BA_ "FrameRouting" BO_ 1045 "";
+BA_ "GenMsgSendType" BO_ 1045 0;
+BA_ "GenMsgCycleTime" BO_ 1045 20;
+BA_ "GenMsgDelayTime" BO_ 1045 10;
+BA_ "VFrameFormat" BO_ 1045 14;
+BA_ "FrameRouting" BO_ 1044 "";
+BA_ "GenMsgSendType" BO_ 1044 0;
+BA_ "GenMsgCycleTime" BO_ 1044 100;
+BA_ "VFrameFormat" BO_ 1044 14;
+BA_ "FrameRouting" BO_ 1042 "";
+BA_ "GenMsgSendType" BO_ 1042 0;
+BA_ "GenMsgCycleTime" BO_ 1042 50;
+BA_ "VFrameFormat" BO_ 1042 14;
+BA_ "FrameRouting" BO_ 535 "";
+BA_ "GenMsgSendType" BO_ 535 0;
+BA_ "GenMsgCycleTime" BO_ 535 10;
+BA_ "GenMsgDelayTime" BO_ 535 0;
+BA_ "VFrameFormat" BO_ 535 14;
+BA_ "FrameRouting" BO_ 534 "";
+BA_ "GenMsgSendType" BO_ 534 0;
+BA_ "GenMsgCycleTime" BO_ 534 20;
+BA_ "GenMsgDelayTime" BO_ 534 10;
+BA_ "VFrameFormat" BO_ 534 14;
+BA_ "FrameRouting" BO_ 532 "";
+BA_ "GenMsgSendType" BO_ 532 0;
+BA_ "GenMsgCycleTime" BO_ 532 20;
+BA_ "GenMsgDelayTime" BO_ 532 10;
+BA_ "VFrameFormat" BO_ 532 14;
+BA_ "FrameRouting" BO_ 531 "";
+BA_ "GenMsgSendType" BO_ 531 0;
+BA_ "GenMsgCycleTime" BO_ 531 20;
+BA_ "GenMsgDelayTime" BO_ 531 10;
+BA_ "VFrameFormat" BO_ 531 14;
+BA_ "FrameRouting" BO_ 136 "";
+BA_ "GenMsgSendType" BO_ 136 0;
+BA_ "GenMsgCycleTime" BO_ 136 10;
+BA_ "GenMsgDelayTime" BO_ 136 0;
+BA_ "VFrameFormat" BO_ 136 14;
+BA_ "FrameRouting" BO_ 125 "";
+BA_ "GenMsgSendType" BO_ 125 0;
+BA_ "GenMsgCycleTime" BO_ 125 20;
+BA_ "GenMsgDelayTime" BO_ 125 10;
+BA_ "VFrameFormat" BO_ 125 14;
+BA_ "FrameRouting" BO_ 119 "";
+BA_ "GenMsgSendType" BO_ 119 0;
+BA_ "GenMsgCycleTime" BO_ 119 20;
+BA_ "GenMsgDelayTime" BO_ 119 10;
+BA_ "VFrameFormat" BO_ 119 14;
+BA_ "FrameRouting" BO_ 118 "";
+BA_ "GenMsgSendType" BO_ 118 5;
+BA_ "GenMsgCycleTime" BO_ 118 500;
+BA_ "VFrameFormat" BO_ 118 14;
+BA_ "FrameRouting" BO_ 73 "";
+BA_ "GenMsgSendType" BO_ 73 0;
+BA_ "GenMsgCycleTime" BO_ 73 20;
+BA_ "GenMsgDelayTime" BO_ 73 10;
+BA_ "VFrameFormat" BO_ 73 14;
+BA_ "FrameRouting" BO_ 1034 "";
+BA_ "FrameGatewayId" BO_ 1034 1034;
+BA_ "FrameGatewayNetwork" BO_ 1034 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1034 14;
+BA_ "FrameRouting" BO_ 1440 "";
+BA_ "GenMsgILSupport" BO_ 1440 0;
+BA_ "NmAsrMessage" BO_ 1440 1;
+BA_ "GenMsgSendType" BO_ 1440 0;
+BA_ "GenMsgCycleTime" BO_ 1440 1000;
+BA_ "NetworkInitialization" BO_ 1440 0;
+BA_ "VFrameFormat" BO_ 1440 14;
+BA_ "FrameRouting" BO_ 561 "";
+BA_ "GenMsgSendType" BO_ 561 0;
+BA_ "GenMsgCycleTime" BO_ 561 100;
+BA_ "VFrameFormat" BO_ 561 14;
+BA_ "FrameRouting" BO_ 330 "";
+BA_ "GenMsgSendType" BO_ 330 0;
+BA_ "GenMsgCycleTime" BO_ 330 10;
+BA_ "GenMsgDelayTime" BO_ 330 0;
+BA_ "VFrameFormat" BO_ 330 14;
+BA_ "FrameRouting" BO_ 1090 "";
+BA_ "GenMsgSendType" BO_ 1090 0;
+BA_ "GenMsgCycleTime" BO_ 1090 1000;
+BA_ "VFrameFormat" BO_ 1090 14;
+BA_ "FrameRouting" BO_ 870 "";
+BA_ "GenMsgSendType" BO_ 870 0;
+BA_ "GenMsgCycleTime" BO_ 870 100;
+BA_ "VFrameFormat" BO_ 870 14;
+BA_ "FrameRouting" BO_ 869 "";
+BA_ "GenMsgSendType" BO_ 869 0;
+BA_ "GenMsgCycleTime" BO_ 869 100;
+BA_ "VFrameFormat" BO_ 869 14;
+BA_ "FrameRouting" BO_ 606 "";
+BA_ "GenMsgSendType" BO_ 606 5;
+BA_ "GenMsgCycleTime" BO_ 606 1000;
+BA_ "VFrameFormat" BO_ 606 14;
+BA_ "FrameRouting" BO_ 374 "";
+BA_ "GenMsgSendType" BO_ 374 5;
+BA_ "GenMsgCycleTime" BO_ 374 100;
+BA_ "VFrameFormat" BO_ 374 14;
+BA_ "FrameRouting" BO_ 603 "";
+BA_ "GenMsgSendType" BO_ 603 0;
+BA_ "GenMsgCycleTime" BO_ 603 20;
+BA_ "GenMsgDelayTime" BO_ 603 10;
+BA_ "VFrameFormat" BO_ 603 14;
+BA_ "FrameRouting" BO_ 602 "";
+BA_ "GenMsgSendType" BO_ 602 0;
+BA_ "GenMsgCycleTime" BO_ 602 100;
+BA_ "VFrameFormat" BO_ 602 14;
+BA_ "FrameRouting" BO_ 1152 "";
+BA_ "GenMsgSendType" BO_ 1152 5;
+BA_ "GenMsgCycleTime" BO_ 1152 1000;
+BA_ "VFrameFormat" BO_ 1152 14;
+BA_ "FrameRouting" BO_ 872 "";
+BA_ "GenMsgSendType" BO_ 872 0;
+BA_ "GenMsgCycleTime" BO_ 872 100;
+BA_ "VFrameFormat" BO_ 872 14;
+BA_ "FrameRouting" BO_ 560 "";
+BA_ "GenMsgSendType" BO_ 560 0;
+BA_ "GenMsgCycleTime" BO_ 560 20;
+BA_ "GenMsgDelayTime" BO_ 560 10;
+BA_ "VFrameFormat" BO_ 560 14;
+BA_ "FrameRouting" BO_ 369 "";
+BA_ "GenMsgSendType" BO_ 369 0;
+BA_ "GenMsgCycleTime" BO_ 369 30;
+BA_ "GenMsgDelayTime" BO_ 369 10;
+BA_ "VFrameFormat" BO_ 369 14;
+BA_ "FrameRouting" BO_ 92 "";
+BA_ "GenMsgSendType" BO_ 92 5;
+BA_ "GenMsgCycleTime" BO_ 92 100;
+BA_ "VFrameFormat" BO_ 92 14;
+BA_ "FrameRouting" BO_ 2030 "";
+BA_ "GenMsgILSupport" BO_ 2030 0;
+BA_ "DiagResponse" BO_ 2030 1;
+BA_ "GenMsgSendType" BO_ 2030 1;
+BA_ "GenMsgDelayTime" BO_ 2030 0;
+BA_ "NetworkInitialization" BO_ 2030 0;
+BA_ "VFrameFormat" BO_ 2030 14;
+BA_ "FrameRouting" BO_ 1087 "";
+BA_ "GenMsgSendType" BO_ 1087 0;
+BA_ "GenMsgCycleTime" BO_ 1087 100;
+BA_ "VFrameFormat" BO_ 1087 14;
+BA_ "FrameRouting" BO_ 332 "";
+BA_ "GenMsgSendType" BO_ 332 0;
+BA_ "GenMsgCycleTime" BO_ 332 200;
+BA_ "VFrameFormat" BO_ 332 14;
+BA_ "FrameRouting" BO_ 1896 "";
+BA_ "GenMsgILSupport" BO_ 1896 0;
+BA_ "DiagResponse" BO_ 1896 1;
+BA_ "GenMsgSendType" BO_ 1896 1;
+BA_ "GenMsgDelayTime" BO_ 1896 0;
+BA_ "NetworkInitialization" BO_ 1896 0;
+BA_ "VFrameFormat" BO_ 1896 14;
+BA_ "FrameRouting" BO_ 1889 "";
+BA_ "GenMsgILSupport" BO_ 1889 0;
+BA_ "DiagRequest" BO_ 1889 1;
+BA_ "GenMsgSendType" BO_ 1889 1;
+BA_ "GenMsgDelayTime" BO_ 1889 0;
+BA_ "NetworkInitialization" BO_ 1889 0;
+BA_ "VFrameFormat" BO_ 1889 14;
+BA_ "FrameRouting" BO_ 1888 "";
+BA_ "GenMsgILSupport" BO_ 1888 0;
+BA_ "DiagRequest" BO_ 1888 1;
+BA_ "GenMsgSendType" BO_ 1888 1;
+BA_ "GenMsgDelayTime" BO_ 1888 0;
+BA_ "NetworkInitialization" BO_ 1888 0;
+BA_ "VFrameFormat" BO_ 1888 14;
+BA_ "FrameRouting" BO_ 1848 "";
+BA_ "GenMsgILSupport" BO_ 1848 0;
+BA_ "DiagResponse" BO_ 1848 1;
+BA_ "GenMsgSendType" BO_ 1848 1;
+BA_ "GenMsgDelayTime" BO_ 1848 0;
+BA_ "NetworkInitialization" BO_ 1848 0;
+BA_ "VFrameFormat" BO_ 1848 14;
+BA_ "FrameRouting" BO_ 1840 "";
+BA_ "GenMsgILSupport" BO_ 1840 0;
+BA_ "DiagRequest" BO_ 1840 1;
+BA_ "GenMsgSendType" BO_ 1840 1;
+BA_ "GenMsgDelayTime" BO_ 1840 0;
+BA_ "NetworkInitialization" BO_ 1840 0;
+BA_ "VFrameFormat" BO_ 1840 14;
+BA_ "FrameRouting" BO_ 1713 "";
+BA_ "GenMsgILSupport" BO_ 1713 0;
+BA_ "TpApplType" BO_ 1713 "DiagUUDTResponse";
+BA_ "GenMsgSendType" BO_ 1713 1;
+BA_ "NetworkInitialization" BO_ 1713 0;
+BA_ "VFrameFormat" BO_ 1713 14;
+BA_ "FrameRouting" BO_ 1712 "";
+BA_ "GenMsgILSupport" BO_ 1712 0;
+BA_ "TpApplType" BO_ 1712 "DiagUUDTResponse";
+BA_ "GenMsgSendType" BO_ 1712 1;
+BA_ "NetworkInitialization" BO_ 1712 0;
+BA_ "VFrameFormat" BO_ 1712 14;
+BA_ "FrameRouting" BO_ 2025 "";
+BA_ "GenMsgILSupport" BO_ 2025 0;
+BA_ "DiagResponse" BO_ 2025 1;
+BA_ "GenMsgSendType" BO_ 2025 1;
+BA_ "GenMsgDelayTime" BO_ 2025 0;
+BA_ "NetworkInitialization" BO_ 2025 0;
+BA_ "VFrameFormat" BO_ 2025 14;
+BA_ "FrameRouting" BO_ 2024 "";
+BA_ "GenMsgILSupport" BO_ 2024 0;
+BA_ "DiagResponse" BO_ 2024 1;
+BA_ "GenMsgSendType" BO_ 2024 1;
+BA_ "GenMsgDelayTime" BO_ 2024 0;
+BA_ "NetworkInitialization" BO_ 2024 0;
+BA_ "VFrameFormat" BO_ 2024 14;
+BA_ "FrameRouting" BO_ 2017 "";
+BA_ "GenMsgILSupport" BO_ 2017 0;
+BA_ "DiagRequest" BO_ 2017 1;
+BA_ "GenMsgSendType" BO_ 2017 1;
+BA_ "GenMsgDelayTime" BO_ 2017 0;
+BA_ "NetworkInitialization" BO_ 2017 0;
+BA_ "VFrameFormat" BO_ 2017 14;
+BA_ "FrameRouting" BO_ 2016 "";
+BA_ "GenMsgILSupport" BO_ 2016 0;
+BA_ "DiagRequest" BO_ 2016 1;
+BA_ "GenMsgSendType" BO_ 2016 1;
+BA_ "GenMsgDelayTime" BO_ 2016 0;
+BA_ "NetworkInitialization" BO_ 2016 0;
+BA_ "VFrameFormat" BO_ 2016 14;
+BA_ "FrameRouting" BO_ 2015 "";
+BA_ "GenMsgILSupport" BO_ 2015 0;
+BA_ "DiagState" BO_ 2015 1;
+BA_ "GenMsgSendType" BO_ 2015 1;
+BA_ "GenMsgDelayTime" BO_ 2015 0;
+BA_ "NetworkInitialization" BO_ 2015 0;
+BA_ "VFrameFormat" BO_ 2015 14;
+BA_ "FrameRouting" BO_ 1897 "";
+BA_ "GenMsgILSupport" BO_ 1897 0;
+BA_ "DiagResponse" BO_ 1897 1;
+BA_ "GenMsgSendType" BO_ 1897 1;
+BA_ "GenMsgDelayTime" BO_ 1897 0;
+BA_ "NetworkInitialization" BO_ 1897 0;
+BA_ "VFrameFormat" BO_ 1897 14;
+BA_ "FrameRouting" BO_ 1814 "";
+BA_ "GenMsgILSupport" BO_ 1814 0;
+BA_ "DiagRequest" BO_ 1814 1;
+BA_ "GenMsgSendType" BO_ 1814 1;
+BA_ "GenMsgDelayTime" BO_ 1814 0;
+BA_ "NetworkInitialization" BO_ 1814 0;
+BA_ "VFrameFormat" BO_ 1814 14;
+BA_ "FrameRouting" BO_ 1701 "";
+BA_ "GenMsgILSupport" BO_ 1701 0;
+BA_ "TpApplType" BO_ 1701 "DiagUUDTResponse";
+BA_ "GenMsgSendType" BO_ 1701 1;
+BA_ "NetworkInitialization" BO_ 1701 0;
+BA_ "VFrameFormat" BO_ 1701 14;
+BA_ "FrameRouting" BO_ 1700 "";
+BA_ "GenMsgILSupport" BO_ 1700 0;
+BA_ "TpApplType" BO_ 1700 "DiagUUDTResponse";
+BA_ "GenMsgSendType" BO_ 1700 1;
+BA_ "NetworkInitialization" BO_ 1700 0;
+BA_ "VFrameFormat" BO_ 1700 14;
+BA_ "FrameRouting" BO_ 1697 "";
+BA_ "GenMsgILSupport" BO_ 1697 0;
+BA_ "TpApplType" BO_ 1697 "DiagUUDTResponse";
+BA_ "GenMsgSendType" BO_ 1697 1;
+BA_ "NetworkInitialization" BO_ 1697 0;
+BA_ "VFrameFormat" BO_ 1697 14;
+BA_ "FrameRouting" BO_ 1696 "";
+BA_ "GenMsgILSupport" BO_ 1696 0;
+BA_ "TpApplType" BO_ 1696 "DiagUUDTResponse";
+BA_ "GenMsgSendType" BO_ 1696 1;
+BA_ "NetworkInitialization" BO_ 1696 0;
+BA_ "VFrameFormat" BO_ 1696 14;
+BA_ "FrameRouting" BO_ 1429 "";
+BA_ "GenMsgILSupport" BO_ 1429 0;
+BA_ "NmAsrMessage" BO_ 1429 1;
+BA_ "GenMsgSendType" BO_ 1429 0;
+BA_ "GenMsgCycleTime" BO_ 1429 1000;
+BA_ "NetworkInitialization" BO_ 1429 0;
+BA_ "VFrameFormat" BO_ 1429 14;
+BA_ "FrameRouting" BO_ 1100 "";
+BA_ "GenMsgSendType" BO_ 1100 0;
+BA_ "GenMsgCycleTime" BO_ 1100 100;
+BA_ "VFrameFormat" BO_ 1100 14;
+BA_ "FrameRouting" BO_ 1098 "";
+BA_ "GenMsgSendType" BO_ 1098 5;
+BA_ "GenMsgCycleTime" BO_ 1098 500;
+BA_ "VFrameFormat" BO_ 1098 14;
+BA_ "FrameRouting" BO_ 1086 "";
+BA_ "GenMsgSendType" BO_ 1086 0;
+BA_ "GenMsgCycleTime" BO_ 1086 100;
+BA_ "VFrameFormat" BO_ 1086 14;
+BA_ "FrameRouting" BO_ 1071 "";
+BA_ "GenMsgSendType" BO_ 1071 0;
+BA_ "GenMsgCycleTime" BO_ 1071 100;
+BA_ "VFrameFormat" BO_ 1071 14;
+BA_ "FrameRouting" BO_ 1069 "";
+BA_ "GenMsgSendType" BO_ 1069 0;
+BA_ "GenMsgCycleTime" BO_ 1069 100;
+BA_ "VFrameFormat" BO_ 1069 14;
+BA_ "FrameRouting" BO_ 1060 "";
+BA_ "GenMsgSendType" BO_ 1060 0;
+BA_ "GenMsgCycleTime" BO_ 1060 100;
+BA_ "VFrameFormat" BO_ 1060 14;
+BA_ "FrameRouting" BO_ 1057 "";
+BA_ "GenMsgSendType" BO_ 1057 0;
+BA_ "GenMsgCycleTime" BO_ 1057 100;
+BA_ "VFrameFormat" BO_ 1057 14;
+BA_ "FrameRouting" BO_ 1055 "";
+BA_ "GenMsgSendType" BO_ 1055 0;
+BA_ "GenMsgCycleTime" BO_ 1055 100;
+BA_ "VFrameFormat" BO_ 1055 14;
+BA_ "FrameRouting" BO_ 562 "";
+BA_ "GenMsgSendType" BO_ 562 0;
+BA_ "GenMsgCycleTime" BO_ 562 100;
+BA_ "VFrameFormat" BO_ 562 14;
+BA_ "FrameRouting" BO_ 523 "";
+BA_ "GenMsgSendType" BO_ 523 0;
+BA_ "GenMsgCycleTime" BO_ 523 1000;
+BA_ "VFrameFormat" BO_ 523 14;
+BA_ "FrameRouting" BO_ 517 "";
+BA_ "GenMsgSendType" BO_ 517 0;
+BA_ "GenMsgCycleTime" BO_ 517 20;
+BA_ "GenMsgDelayTime" BO_ 517 10;
+BA_ "VFrameFormat" BO_ 517 14;
+BA_ "FrameRouting" BO_ 516 "";
+BA_ "GenMsgSendType" BO_ 516 0;
+BA_ "GenMsgCycleTime" BO_ 516 10;
+BA_ "GenMsgDelayTime" BO_ 516 0;
+BA_ "VFrameFormat" BO_ 516 14;
+BA_ "FrameRouting" BO_ 514 "";
+BA_ "GenMsgSendType" BO_ 514 0;
+BA_ "GenMsgCycleTime" BO_ 514 20;
+BA_ "GenMsgDelayTime" BO_ 514 10;
+BA_ "VFrameFormat" BO_ 514 14;
+BA_ "FrameRouting" BO_ 512 "";
+BA_ "GenMsgSendType" BO_ 512 0;
+BA_ "GenMsgCycleTime" BO_ 512 20;
+BA_ "GenMsgDelayTime" BO_ 512 10;
+BA_ "VFrameFormat" BO_ 512 14;
+BA_ "FrameRouting" BO_ 381 "";
+BA_ "GenMsgSendType" BO_ 381 0;
+BA_ "GenMsgCycleTime" BO_ 381 100;
+BA_ "VFrameFormat" BO_ 381 14;
+BA_ "FrameRouting" BO_ 380 "";
+BA_ "GenMsgSendType" BO_ 380 0;
+BA_ "GenMsgCycleTime" BO_ 380 100;
+BA_ "VFrameFormat" BO_ 380 14;
+BA_ "FrameRouting" BO_ 377 "";
+BA_ "GenMsgSendType" BO_ 377 0;
+BA_ "GenMsgCycleTime" BO_ 377 100;
+BA_ "VFrameFormat" BO_ 377 14;
+BA_ "FrameRouting" BO_ 376 "";
+BA_ "GenMsgSendType" BO_ 376 0;
+BA_ "GenMsgCycleTime" BO_ 376 100;
+BA_ "VFrameFormat" BO_ 376 14;
+BA_ "FrameRouting" BO_ 373 "";
+BA_ "GenMsgSendType" BO_ 373 0;
+BA_ "GenMsgCycleTime" BO_ 373 20;
+BA_ "GenMsgDelayTime" BO_ 373 10;
+BA_ "VFrameFormat" BO_ 373 14;
+BA_ "FrameRouting" BO_ 359 "";
+BA_ "GenMsgSendType" BO_ 359 0;
+BA_ "GenMsgCycleTime" BO_ 359 10;
+BA_ "GenMsgDelayTime" BO_ 359 0;
+BA_ "VFrameFormat" BO_ 359 14;
+BA_ "FrameRouting" BO_ 358 "";
+BA_ "GenMsgSendType" BO_ 358 0;
+BA_ "GenMsgCycleTime" BO_ 358 100;
+BA_ "VFrameFormat" BO_ 358 14;
+BA_ "FrameRouting" BO_ 357 "";
+BA_ "GenMsgSendType" BO_ 357 0;
+BA_ "GenMsgCycleTime" BO_ 357 20;
+BA_ "GenMsgDelayTime" BO_ 357 10;
+BA_ "VFrameFormat" BO_ 357 14;
+BA_ "FrameRouting" BO_ 355 "";
+BA_ "GenMsgSendType" BO_ 355 0;
+BA_ "GenMsgCycleTime" BO_ 355 100;
+BA_ "VFrameFormat" BO_ 355 14;
+BA_ "FrameRouting" BO_ 342 "";
+BA_ "GenMsgSendType" BO_ 342 0;
+BA_ "GenMsgCycleTime" BO_ 342 100;
+BA_ "VFrameFormat" BO_ 342 14;
+BA_ "FrameRouting" BO_ 71 "";
+BA_ "GenMsgSendType" BO_ 71 0;
+BA_ "GenMsgCycleTime" BO_ 71 20;
+BA_ "GenMsgDelayTime" BO_ 71 10;
+BA_ "VFrameFormat" BO_ 71 14;
+BA_ "FrameRouting" BO_ 1822 "";
+BA_ "GenMsgILSupport" BO_ 1822 0;
+BA_ "DiagResponse" BO_ 1822 1;
+BA_ "GenMsgSendType" BO_ 1822 1;
+BA_ "GenMsgDelayTime" BO_ 1822 0;
+BA_ "NetworkInitialization" BO_ 1822 0;
+BA_ "VFrameFormat" BO_ 1822 14;
+BA_ "FrameRouting" BO_ 1438 "";
+BA_ "GenMsgILSupport" BO_ 1438 0;
+BA_ "NmAsrMessage" BO_ 1438 1;
+BA_ "GenMsgSendType" BO_ 1438 0;
+BA_ "GenMsgCycleTime" BO_ 1438 1000;
+BA_ "NetworkInitialization" BO_ 1438 0;
+BA_ "VFrameFormat" BO_ 1438 14;
+BA_ "FrameRouting" BO_ 954 "";
+BA_ "FrameGatewayId" BO_ 954 954;
+BA_ "FrameGatewayNetwork" BO_ 954 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 954 14;
+BA_ "FrameRouting" BO_ 1006 "";
+BA_ "GenMsgSendType" BO_ 1006 5;
+BA_ "GenMsgCycleTime" BO_ 1006 1000;
+BA_ "VFrameFormat" BO_ 1006 14;
+BA_ "FrameRouting" BO_ 820 "";
+BA_ "FrameGatewayNetwork" BO_ 820 "HS2_CAN";
+BA_ "FrameGatewayId" BO_ 820 820;
+BA_ "VFrameFormat" BO_ 820 14;
+BA_ "FrameRouting" BO_ 137 "";
+BA_ "FrameGatewayId" BO_ 137 137;
+BA_ "FrameGatewayNetwork" BO_ 137 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 137 14;
+BA_ "FrameRouting" BO_ 129 "";
+BA_ "FrameGatewayId" BO_ 129 129;
+BA_ "FrameGatewayNetwork" BO_ 129 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 129 14;
+BA_ "FrameRouting" BO_ 935 "";
+BA_ "GenMsgSendType" BO_ 935 5;
+BA_ "GenMsgCycleTime" BO_ 935 200;
+BA_ "VFrameFormat" BO_ 935 14;
+BA_ "FrameRouting" BO_ 1108 "";
+BA_ "FrameGatewayId" BO_ 1108 1108;
+BA_ "FrameGatewayNetwork" BO_ 1108 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 1108 14;
+BA_ "FrameRouting" BO_ 261 "";
+BA_ "FrameGatewayId" BO_ 261 261;
+BA_ "FrameGatewayNetwork" BO_ 261 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 261 14;
+BA_ "FrameRouting" BO_ 1146 "";
+BA_ "FrameGatewayId" BO_ 1146 1146;
+BA_ "FrameGatewayNetwork" BO_ 1146 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1146 14;
+BA_ "FrameRouting" BO_ 533 "";
+BA_ "FrameGatewayId" BO_ 533 533;
+BA_ "FrameGatewayNetwork" BO_ 533 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 533 14;
+BA_ "FrameRouting" BO_ 1041 "";
+BA_ "FrameGatewayId" BO_ 1041 1041;
+BA_ "FrameGatewayNetwork" BO_ 1041 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1041 14;
+BA_ "FrameRouting" BO_ 1067 "";
+BA_ "FrameGatewayId" BO_ 1067 1067;
+BA_ "FrameGatewayNetwork" BO_ 1067 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1067 14;
+BA_ "FrameRouting" BO_ 1112 "";
+BA_ "FrameGatewayId" BO_ 1112 1112;
+BA_ "FrameGatewayNetwork" BO_ 1112 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1112 14;
+BA_ "FrameRouting" BO_ 139 "";
+BA_ "FrameGatewayId" BO_ 139 139;
+BA_ "FrameGatewayNetwork" BO_ 139 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 139 14;
+BA_ "FrameRouting" BO_ 1121 "";
+BA_ "FrameGatewayId" BO_ 1121 1121;
+BA_ "FrameGatewayNetwork" BO_ 1121 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 1121 14;
+BA_ "FrameRouting" BO_ 1120 "";
+BA_ "FrameGatewayId" BO_ 1120 1120;
+BA_ "FrameGatewayNetwork" BO_ 1120 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 1120 14;
+BA_ "FrameRouting" BO_ 1050 "";
+BA_ "FrameGatewayId" BO_ 1050 1050;
+BA_ "FrameGatewayNetwork" BO_ 1050 "MS1_CAN";
+BA_ "VFrameFormat" BO_ 1050 14;
+BA_ "FrameRouting" BO_ 1137 "";
+BA_ "GenMsgSendType" BO_ 1137 0;
+BA_ "GenMsgCycleTime" BO_ 1137 1000;
+BA_ "VFrameFormat" BO_ 1137 14;
+BA_ "FrameRouting" BO_ 1255 "";
+BA_ "GenMsgSendType" BO_ 1255 0;
+BA_ "GenMsgCycleTime" BO_ 1255 1000;
+BA_ "VFrameFormat" BO_ 1255 14;
+BA_ "FrameRouting" BO_ 1254 "";
+BA_ "GenMsgSendType" BO_ 1254 0;
+BA_ "GenMsgCycleTime" BO_ 1254 1000;
+BA_ "VFrameFormat" BO_ 1254 14;
+BA_ "FrameRouting" BO_ 1253 "";
+BA_ "GenMsgSendType" BO_ 1253 0;
+BA_ "GenMsgCycleTime" BO_ 1253 1000;
+BA_ "VFrameFormat" BO_ 1253 14;
+BA_ "FrameRouting" BO_ 1252 "";
+BA_ "GenMsgSendType" BO_ 1252 0;
+BA_ "GenMsgCycleTime" BO_ 1252 1000;
+BA_ "VFrameFormat" BO_ 1252 14;
+BA_ "FrameRouting" BO_ 1251 "";
+BA_ "GenMsgSendType" BO_ 1251 0;
+BA_ "GenMsgCycleTime" BO_ 1251 1000;
+BA_ "VFrameFormat" BO_ 1251 14;
+BA_ "FrameRouting" BO_ 1250 "";
+BA_ "GenMsgSendType" BO_ 1250 0;
+BA_ "GenMsgCycleTime" BO_ 1250 1000;
+BA_ "VFrameFormat" BO_ 1250 14;
+BA_ "FrameRouting" BO_ 1249 "";
+BA_ "GenMsgSendType" BO_ 1249 0;
+BA_ "GenMsgCycleTime" BO_ 1249 1000;
+BA_ "VFrameFormat" BO_ 1249 14;
+BA_ "FrameRouting" BO_ 1248 "";
+BA_ "GenMsgSendType" BO_ 1248 0;
+BA_ "GenMsgCycleTime" BO_ 1248 1000;
+BA_ "VFrameFormat" BO_ 1248 14;
+BA_ "FrameRouting" BO_ 1113 "";
+BA_ "GenMsgSendType" BO_ 1113 0;
+BA_ "GenMsgCycleTime" BO_ 1113 50;
+BA_ "VFrameFormat" BO_ 1113 14;
+BA_ "FrameRouting" BO_ 1105 "";
+BA_ "GenMsgSendType" BO_ 1105 5;
+BA_ "GenMsgCycleTime" BO_ 1105 1000;
+BA_ "VFrameFormat" BO_ 1105 14;
+BA_ "FrameRouting" BO_ 938 "";
+BA_ "GenMsgSendType" BO_ 938 5;
+BA_ "GenMsgCycleTime" BO_ 938 200;
+BA_ "VFrameFormat" BO_ 938 14;
+BA_ "FrameRouting" BO_ 939 "";
+BA_ "GenMsgSendType" BO_ 939 5;
+BA_ "GenMsgCycleTime" BO_ 939 200;
+BA_ "VFrameFormat" BO_ 939 14;
+BA_ "FrameRouting" BO_ 937 "";
+BA_ "GenMsgSendType" BO_ 937 0;
+BA_ "GenMsgCycleTime" BO_ 937 20;
+BA_ "GenMsgDelayTime" BO_ 937 10;
+BA_ "VFrameFormat" BO_ 937 14;
+BA_ "FrameRouting" BO_ 936 "";
+BA_ "GenMsgSendType" BO_ 936 0;
+BA_ "GenMsgCycleTime" BO_ 936 20;
+BA_ "GenMsgDelayTime" BO_ 936 10;
+BA_ "VFrameFormat" BO_ 936 14;
+BA_ "FrameRouting" BO_ 877 "";
+BA_ "GenMsgSendType" BO_ 877 5;
+BA_ "GenMsgCycleTime" BO_ 877 1000;
+BA_ "VFrameFormat" BO_ 877 14;
+BA_ "FrameRouting" BO_ 589 "";
+BA_ "FrameGatewayId" BO_ 589 589;
+BA_ "FrameGatewayNetwork" BO_ 589 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 589 14;
+BA_ "FrameRouting" BO_ 588 "";
+BA_ "FrameGatewayId" BO_ 588 588;
+BA_ "FrameGatewayNetwork" BO_ 588 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 588 14;
+BA_ "FrameRouting" BO_ 587 "";
+BA_ "FrameGatewayId" BO_ 587 587;
+BA_ "FrameGatewayNetwork" BO_ 587 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 587 14;
+BA_ "FrameRouting" BO_ 389 "";
+BA_ "GenMsgSendType" BO_ 389 0;
+BA_ "GenMsgCycleTime" BO_ 389 100;
+BA_ "VFrameFormat" BO_ 389 14;
+BA_ "FrameRouting" BO_ 1009 "";
+BA_ "FrameGatewayId" BO_ 1009 1009;
+BA_ "FrameGatewayNetwork" BO_ 1009 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1009 14;
+BA_ "FrameRouting" BO_ 360 "";
+BA_ "FrameGatewayId" BO_ 360 360;
+BA_ "FrameGatewayNetwork" BO_ 360 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 360 14;
+BA_ "FrameRouting" BO_ 122 "";
+BA_ "FrameGatewayId" BO_ 122 122;
+BA_ "FrameGatewayNetwork" BO_ 122 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 122 14;
+BA_ "FrameRouting" BO_ 90 "";
+BA_ "FrameGatewayId" BO_ 90 90;
+BA_ "FrameGatewayNetwork" BO_ 90 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 90 14;
+BA_ "FrameRouting" BO_ 1091 "";
+BA_ "FrameGatewayId" BO_ 1091 1091;
+BA_ "FrameGatewayNetwork" BO_ 1091 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1091 14;
+BA_ "FrameRouting" BO_ 138 "";
+BA_ "FrameGatewayId" BO_ 138 138;
+BA_ "FrameGatewayNetwork" BO_ 138 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 138 14;
+BA_ "FrameRouting" BO_ 131 "";
+BA_ "FrameGatewayId" BO_ 131 131;
+BA_ "FrameGatewayNetwork" BO_ 131 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 131 14;
+BA_ "FrameRouting" BO_ 787 "";
+BA_ "FrameGatewayId" BO_ 787 787;
+BA_ "FrameGatewayNetwork" BO_ 787 "MS2_CAN";
+BA_ "VFrameFormat" BO_ 787 14;
+BA_ "FrameRouting" BO_ 953 "";
+BA_ "FrameGatewayId" BO_ 953 953;
+BA_ "FrameGatewayNetwork" BO_ 953 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 953 14;
+BA_ "FrameRouting" BO_ 1093 "";
+BA_ "FrameGatewayId" BO_ 1093 1093;
+BA_ "FrameGatewayNetwork" BO_ 1093 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1093 14;
+BA_ "FrameRouting" BO_ 792 "";
+BA_ "FrameGatewayId" BO_ 792 792;
+BA_ "FrameGatewayNetwork" BO_ 792 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 792 14;
+BA_ "FrameRouting" BO_ 968 "";
+BA_ "FrameGatewayId" BO_ 968 968;
+BA_ "FrameGatewayNetwork" BO_ 968 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 968 14;
+BA_ "FrameRouting" BO_ 819 "";
+BA_ "FrameGatewayId" BO_ 819 819;
+BA_ "FrameGatewayNetwork" BO_ 819 "MS1_CAN";
+BA_ "VFrameFormat" BO_ 819 14;
+BA_ "FrameRouting" BO_ 818 "";
+BA_ "FrameGatewayId" BO_ 818 818;
+BA_ "FrameGatewayNetwork" BO_ 818 "MS1_CAN";
+BA_ "VFrameFormat" BO_ 818 14;
+BA_ "FrameRouting" BO_ 806 "";
+BA_ "FrameGatewayId" BO_ 806 806;
+BA_ "FrameGatewayNetwork" BO_ 806 "MS1_CAN";
+BA_ "VFrameFormat" BO_ 806 14;
+BA_ "FrameRouting" BO_ 765 "";
+BA_ "FrameGatewayId" BO_ 765 765;
+BA_ "FrameGatewayNetwork" BO_ 765 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 765 14;
+BA_ "FrameRouting" BO_ 559 "";
+BA_ "FrameGatewayId" BO_ 559 559;
+BA_ "FrameGatewayNetwork" BO_ 559 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 559 14;
+BA_ "FrameRouting" BO_ 558 "";
+BA_ "FrameGatewayId" BO_ 558 558;
+BA_ "FrameGatewayNetwork" BO_ 558 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 558 14;
+BA_ "FrameRouting" BO_ 934 "";
+BA_ "GenMsgSendType" BO_ 934 5;
+BA_ "GenMsgCycleTime" BO_ 934 200;
+BA_ "VFrameFormat" BO_ 934 14;
+BA_ "FrameRouting" BO_ 1072 "";
+BA_ "FrameGatewayId" BO_ 1072 1072;
+BA_ "FrameGatewayNetwork" BO_ 1072 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1072 14;
+BA_ "FrameRouting" BO_ 909 "";
+BA_ "FrameGatewayId" BO_ 909 909;
+BA_ "FrameGatewayNetwork" BO_ 909 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 909 14;
+BA_ "FrameRouting" BO_ 963 "";
+BA_ "FrameGatewayId" BO_ 963 963;
+BA_ "FrameGatewayNetwork" BO_ 963 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 963 14;
+BA_ "FrameRouting" BO_ 145 "";
+BA_ "FrameGatewayId" BO_ 145 145;
+BA_ "FrameGatewayNetwork" BO_ 145 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 145 14;
+BA_ "FrameRouting" BO_ 76 "";
+BA_ "FrameGatewayId" BO_ 76 76;
+BA_ "FrameGatewayNetwork" BO_ 76 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 76 14;
+BA_ "FrameRouting" BO_ 65 "";
+BA_ "DiagResponse" BO_ 65 0;
+BA_ "FrameGatewayId" BO_ 65 65;
+BA_ "FrameGatewayNetwork" BO_ 65 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 65 14;
+BA_ "FrameRouting" BO_ 1076 "";
+BA_ "FrameGatewayId" BO_ 1076 1076;
+BA_ "FrameGatewayNetwork" BO_ 1076 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 1076 14;
+BA_ "FrameRouting" BO_ 862 "";
+BA_ "FrameGatewayId" BO_ 862 862;
+BA_ "FrameGatewayNetwork" BO_ 862 "MS1_CAN";
+BA_ "VFrameFormat" BO_ 862 14;
+BA_ "FrameRouting" BO_ 931 "";
+BA_ "FrameGatewayId" BO_ 931 931;
+BA_ "FrameGatewayNetwork" BO_ 931 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 931 14;
+BA_ "FrameRouting" BO_ 578 "";
+BA_ "FrameGatewayId" BO_ 578 578;
+BA_ "FrameGatewayNetwork" BO_ 578 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 578 14;
+BA_ "FrameRouting" BO_ 947 "";
+BA_ "FrameGatewayId" BO_ 947 947;
+BA_ "FrameGatewayNetwork" BO_ 947 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 947 14;
+BA_ "FrameRouting" BO_ 1084 "";
+BA_ "FrameGatewayId" BO_ 1084 1084;
+BA_ "FrameGatewayNetwork" BO_ 1084 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1084 14;
+BA_ "FrameRouting" BO_ 1068 "";
+BA_ "FrameGatewayId" BO_ 1068 1068;
+BA_ "FrameGatewayNetwork" BO_ 1068 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 1068 14;
+BA_ "FrameRouting" BO_ 146 "";
+BA_ "FrameGatewayId" BO_ 146 146;
+BA_ "FrameGatewayNetwork" BO_ 146 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 146 14;
+BA_ "FrameRouting" BO_ 1900 "";
+BA_ "GenMsgILSupport" BO_ 1900 0;
+BA_ "DiagResponse" BO_ 1900 1;
+BA_ "GenMsgSendType" BO_ 1900 1;
+BA_ "GenMsgDelayTime" BO_ 1900 0;
+BA_ "NetworkInitialization" BO_ 1900 0;
+BA_ "VFrameFormat" BO_ 1900 14;
+BA_ "FrameRouting" BO_ 1806 "";
+BA_ "GenMsgILSupport" BO_ 1806 0;
+BA_ "DiagResponse" BO_ 1806 1;
+BA_ "GenMsgSendType" BO_ 1806 1;
+BA_ "GenMsgDelayTime" BO_ 1806 0;
+BA_ "NetworkInitialization" BO_ 1806 0;
+BA_ "VFrameFormat" BO_ 1806 14;
+BA_ "FrameRouting" BO_ 997 "";
+BA_ "GenMsgSendType" BO_ 997 5;
+BA_ "GenMsgCycleTime" BO_ 997 1000;
+BA_ "VFrameFormat" BO_ 997 14;
+BA_ "FrameRouting" BO_ 983 "";
+BA_ "GenMsgSendType" BO_ 983 0;
+BA_ "GenMsgCycleTime" BO_ 983 50;
+BA_ "VFrameFormat" BO_ 983 14;
+BA_ "FrameRouting" BO_ 980 "";
+BA_ "GenMsgSendType" BO_ 980 0;
+BA_ "GenMsgCycleTime" BO_ 980 30;
+BA_ "GenMsgDelayTime" BO_ 980 10;
+BA_ "VFrameFormat" BO_ 980 14;
+BA_ "FrameRouting" BO_ 979 "";
+BA_ "GenMsgSendType" BO_ 979 0;
+BA_ "GenMsgCycleTime" BO_ 979 50;
+BA_ "VFrameFormat" BO_ 979 14;
+BA_ "FrameRouting" BO_ 976 "";
+BA_ "GenMsgSendType" BO_ 976 0;
+BA_ "GenMsgCycleTime" BO_ 976 100;
+BA_ "VFrameFormat" BO_ 976 14;
+BA_ "FrameRouting" BO_ 973 "";
+BA_ "GenMsgSendType" BO_ 973 5;
+BA_ "GenMsgCycleTime" BO_ 973 1000;
+BA_ "VFrameFormat" BO_ 973 14;
+BA_ "FrameRouting" BO_ 970 "";
+BA_ "GenMsgSendType" BO_ 970 0;
+BA_ "GenMsgCycleTime" BO_ 970 30;
+BA_ "GenMsgDelayTime" BO_ 970 10;
+BA_ "VFrameFormat" BO_ 970 14;
+BA_ "FrameRouting" BO_ 962 "";
+BA_ "GenMsgSendType" BO_ 962 5;
+BA_ "GenMsgCycleTime" BO_ 962 1000;
+BA_ "VFrameFormat" BO_ 962 14;
+BA_ "FrameRouting" BO_ 961 "";
+BA_ "GenMsgSendType" BO_ 961 5;
+BA_ "GenMsgCycleTime" BO_ 961 1000;
+BA_ "VFrameFormat" BO_ 961 14;
+BA_ "FrameRouting" BO_ 394 "";
+BA_ "GenMsgSendType" BO_ 394 5;
+BA_ "GenMsgCycleTime" BO_ 394 200;
+BA_ "VFrameFormat" BO_ 394 14;
+BA_ "FrameRouting" BO_ 391 "";
+BA_ "GenMsgSendType" BO_ 391 0;
+BA_ "GenMsgCycleTime" BO_ 391 20;
+BA_ "GenMsgDelayTime" BO_ 391 10;
+BA_ "VFrameFormat" BO_ 391 14;
+BA_ "FrameRouting" BO_ 390 "";
+BA_ "GenMsgSendType" BO_ 390 0;
+BA_ "GenMsgCycleTime" BO_ 390 20;
+BA_ "GenMsgDelayTime" BO_ 390 10;
+BA_ "VFrameFormat" BO_ 390 14;
+BA_ "FrameRouting" BO_ 1441 "";
+BA_ "GenMsgILSupport" BO_ 1441 0;
+BA_ "NmAsrMessage" BO_ 1441 1;
+BA_ "GenMsgSendType" BO_ 1441 0;
+BA_ "GenMsgCycleTime" BO_ 1441 1000;
+BA_ "NetworkInitialization" BO_ 1441 0;
+BA_ "VFrameFormat" BO_ 1441 14;
+BA_ "FrameRouting" BO_ 1787 "";
+BA_ "GenMsgILSupport" BO_ 1787 0;
+BA_ "DiagResponse" BO_ 1787 1;
+BA_ "GenMsgSendType" BO_ 1787 1;
+BA_ "GenMsgDelayTime" BO_ 1787 0;
+BA_ "VFrameFormat" BO_ 1787 14;
+BA_ "FrameRouting" BO_ 1779 "";
+BA_ "GenMsgILSupport" BO_ 1779 0;
+BA_ "DiagRequest" BO_ 1779 1;
+BA_ "GenMsgSendType" BO_ 1779 1;
+BA_ "GenMsgDelayTime" BO_ 1779 0;
+BA_ "VFrameFormat" BO_ 1779 14;
+BA_ "FrameRouting" BO_ 1786 "";
+BA_ "GenMsgILSupport" BO_ 1786 0;
+BA_ "DiagResponse" BO_ 1786 1;
+BA_ "GenMsgSendType" BO_ 1786 1;
+BA_ "GenMsgDelayTime" BO_ 1786 0;
+BA_ "VFrameFormat" BO_ 1786 14;
+BA_ "FrameRouting" BO_ 1778 "";
+BA_ "GenMsgILSupport" BO_ 1778 0;
+BA_ "DiagRequest" BO_ 1778 1;
+BA_ "GenMsgSendType" BO_ 1778 1;
+BA_ "GenMsgDelayTime" BO_ 1778 0;
+BA_ "VFrameFormat" BO_ 1778 14;
+BA_ "FrameRouting" BO_ 1153 "";
+BA_ "FrameGatewayId" BO_ 1153 1152;
+BA_ "FrameGatewayNetwork" BO_ 1153 "HS2_CAN";
+BA_ "VFrameFormat" BO_ 1153 14;
+BA_ "FrameRouting" BO_ 942 "";
+BA_ "GenMsgSendType" BO_ 942 5;
+BA_ "GenMsgCycleTime" BO_ 942 1000;
+BA_ "VFrameFormat" BO_ 942 14;
+BA_ "FrameRouting" BO_ 930 "";
+BA_ "GenMsgSendType" BO_ 930 5;
+BA_ "GenMsgCycleTime" BO_ 930 1000;
+BA_ "VFrameFormat" BO_ 930 14;
+BA_ "FrameRouting" BO_ 929 "";
+BA_ "GenMsgSendType" BO_ 929 5;
+BA_ "GenMsgCycleTime" BO_ 929 1000;
+BA_ "VFrameFormat" BO_ 929 14;
+BA_ "FrameRouting" BO_ 402 "";
+BA_ "FrameGatewayId" BO_ 402 402;
+BA_ "FrameGatewayNetwork" BO_ 402 "HS3_CAN";
+BA_ "VFrameFormat" BO_ 402 14;
+BA_ "FrameRouting" BO_ 924 "";
+BA_ "FrameGatewayId" BO_ 924 924;
+BA_ "FrameGatewayNetwork" BO_ 924 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 924 14;
+BA_ "FrameRouting" BO_ 923 "";
+BA_ "FrameGatewayId" BO_ 923 923;
+BA_ "FrameGatewayNetwork" BO_ 923 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 923 14;
+BA_ "FrameRouting" BO_ 1998 "";
+BA_ "GenMsgILSupport" BO_ 1998 0;
+BA_ "DiagResponse" BO_ 1998 1;
+BA_ "GenMsgSendType" BO_ 1998 1;
+BA_ "GenMsgDelayTime" BO_ 1998 0;
+BA_ "NetworkInitialization" BO_ 1998 0;
+BA_ "VFrameFormat" BO_ 1998 14;
+BA_ "FrameRouting" BO_ 1996 "";
+BA_ "GenMsgILSupport" BO_ 1996 0;
+BA_ "DiagResponse" BO_ 1996 1;
+BA_ "GenMsgSendType" BO_ 1996 1;
+BA_ "GenMsgDelayTime" BO_ 1996 0;
+BA_ "NetworkInitialization" BO_ 1996 0;
+BA_ "VFrameFormat" BO_ 1996 14;
+BA_ "FrameRouting" BO_ 1988 "";
+BA_ "GenMsgILSupport" BO_ 1988 0;
+BA_ "DiagRequest" BO_ 1988 1;
+BA_ "GenMsgSendType" BO_ 1988 1;
+BA_ "GenMsgDelayTime" BO_ 1988 0;
+BA_ "NetworkInitialization" BO_ 1988 0;
+BA_ "VFrameFormat" BO_ 1988 14;
+BA_ "FrameRouting" BO_ 922 "";
+BA_ "FrameGatewayId" BO_ 922 922;
+BA_ "FrameGatewayNetwork" BO_ 922 "HS1_CAN";
+BA_ "VFrameFormat" BO_ 922 14;
+BA_ "GenSigSendType" SG_ 823 DteVehPwId_No_Actl 3;
+BA_ "ECGUsedRxSignal" SG_ 823 DteVehPwId_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 823 DteVehEId_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 823 DteVehEffId_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 823 DteVeh_Pw_Actl 1;
+BA_ "GenSigStartValue" SG_ 823 DteVeh_Eff_Actl 100;
+BA_ "ECGUsedRxSignal" SG_ 823 DteVeh_Eff_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 823 DteVeh_E_Actl 1;
+BA_ "GenSigSendType" SG_ 823 DteAcceptNew_B_Rq 3;
+BA_ "ECGUsedRxSignal" SG_ 823 DteAcceptNew_B_Rq 1;
+BA_ "GenSigSendType" SG_ 824 DteCldTrlrOn_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldTrlrOn_B_Stat 1;
+BA_ "GenSigSendType" SG_ 824 DteCldTrlrOff_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldTrlrOff_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 824 DteCldTrip_L_Actl 100;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldTrip_L_Actl 1;
+BA_ "GenSigSendType" SG_ 824 DteCldTraffic_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldTraffic_B_Stat 1;
+BA_ "GenSigSendType" SG_ 824 DteCldTerrain_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldTerrain_B_Stat 1;
+BA_ "GenSigSendType" SG_ 824 DteCldRoute_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldRoute_B_Stat 1;
+BA_ "GenSigSendType" SG_ 824 DteCldPayload_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldPayload_B_Stat 1;
+BA_ "GenSigSendType" SG_ 824 DteCldId_No_Actl 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldId_No_Actl 1;
+BA_ "GenSigSendType" SG_ 824 DteCldExtTe_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldExtTe_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 824 DteCldExt_Eff_Actl 100;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldExt_Eff_Actl 1;
+BA_ "GenSigStartValue" SG_ 824 DteCldDrv_Eff_Actl 100;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldDrv_Eff_Actl 1;
+BA_ "GenSigSendType" SG_ 824 DteCldDcac_B_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldDcac_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 824 DteCldClimt_Eff_Actl 100;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldClimt_Eff_Actl 1;
+BA_ "GenSigStartValue" SG_ 824 DteCldBattULo_Eff_Actl 100;
+BA_ "ECGUsedTxSignal" SG_ 824 DteCldBattULo_Eff_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 949 Tire_Press_RR_ORR_Data 65533;
+BA_ "GenSigStartValue" SG_ 949 Tire_Press_RR_ORR_Data 65533;
+BA_ "GenSigStartValueInteger" SG_ 949 Tire_Press_LR_OLR_Data 65533;
+BA_ "GenSigStartValue" SG_ 949 Tire_Press_LR_OLR_Data 65533;
+BA_ "GenSigStartValueInteger" SG_ 949 Tire_Press_LF_Data 65533;
+BA_ "GenSigStartValue" SG_ 949 Tire_Press_LF_Data 65533;
+BA_ "GenSigStartValueInteger" SG_ 949 Tire_Press_RF_Data 65533;
+BA_ "GenSigStartValue" SG_ 949 Tire_Press_RF_Data 65533;
+BA_ "GenSigSendType" SG_ 1825 TesterPhysicalReqVDM 3;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cs 1;
+BA_ "MetaData" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cs 1;
+BA_ "ContentDependant" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 524 PrplWhlTot_Tq_RqMxAwd 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 524 PrplWhlTot_Tq_RqMxAwd 1;
+BA_ "GenSigStartValue" SG_ 524 PrplWhlTot_Tq_RqMxAwd 65535;
+BA_ "GenSigStartValueInteger" SG_ 524 PrplWhlTot_Tq_RqMxAwd 65535;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cnt 1;
+BA_ "MetaData" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cnt 1;
+BA_ "ContentDependant" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 524 PrplWhlTotTqRqMxAwd_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 740 BattAuxCnnct_B_Cmd 1;
+BA_ "GenSigSendType" SG_ 1160 DgtlCommPncReset_B_Req 3;
+BA_ "ECGUsedTxSignal" SG_ 1160 DgtlCommPncReset_B_Req 1;
+BA_ "ECGUsedTxSignal" SG_ 1160 DataMntrSustn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1160 DataMntrSustn_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 1160 PwSustnRdata_B_RqTelem 1;
+BA_ "GenSigSendType" SG_ 1160 PwSustnRdata_B_RqTelem 3;
+BA_ "ECGUsedTxSignal" SG_ 776 ScMnSoc_Pc_RqCld 1;
+BA_ "GenSigStartValue" SG_ 776 ScMnSoc_Pc_RqCld 100;
+BA_ "GenSigSendType" SG_ 776 ScMnSoc_Pc_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 ScChrgrPwMax_Pw_RqCld 1;
+BA_ "GenSigSendType" SG_ 776 ScChrgrPwMax_Pw_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 ScLocPwId_No_RqCld 1;
+BA_ "GenSigSendType" SG_ 776 ScLocPwId_No_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 PrcondEdit_D_RqCld 1;
+BA_ "GenSigSendType" SG_ 776 PrcondEdit_D_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 GoTEditMnte_T_RqCld 1;
+BA_ "GenSigStartValue" SG_ 776 GoTEditMnte_T_RqCld 14;
+BA_ "GenSigSendType" SG_ 776 GoTEditMnte_T_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 GoTEditHr_T_RqCld 1;
+BA_ "GenSigStartValue" SG_ 776 GoTEditHr_T_RqCld 30;
+BA_ "GenSigSendType" SG_ 776 GoTEditHr_T_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 ChrgToPcEdit_Pc_RqCld 1;
+BA_ "GenSigStartValue" SG_ 776 ChrgToPcEdit_Pc_RqCld 126;
+BA_ "GenSigSendType" SG_ 776 ChrgToPcEdit_Pc_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 AirAmb_Te_ActlCld 1;
+BA_ "GenSigStartValueInteger" SG_ 776 AirAmb_Te_ActlCld 512;
+BA_ "UsedOnPgmDBC" SG_ 776 AirAmb_Te_ActlCld 1;
+BA_ "GenSigSendType" SG_ 776 AirAmb_Te_ActlCld 3;
+BA_ "ECGUsedTxSignal" SG_ 776 ScFreshDataEnbl_B_Rq 1;
+BA_ "GenSigSendType" SG_ 776 ScFreshDataEnbl_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 776 ScEnbl_D_RqCld 1;
+BA_ "GenSigStartValue" SG_ 776 ScEnbl_D_RqCld 1;
+BA_ "GenSigSendType" SG_ 776 ScEnbl_D_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScDayOfWeekId_D_RqCld 1;
+BA_ "GenSigStartValue" SG_ 775 ScDayOfWeekId_D_RqCld 1;
+BA_ "GenSigSendType" SG_ 775 ScDayOfWeekId_D_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScLocSetId_No_RqCld 1;
+BA_ "GenSigSendType" SG_ 775 ScLocSetId_No_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScLocRdius_L_RqCld 1;
+BA_ "GenSigStartValue" SG_ 775 ScLocRdius_L_RqCld 1;
+BA_ "GenSigSendType" SG_ 775 ScLocRdius_L_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScChrgToPc_Pc_RqCld 1;
+BA_ "GenSigStartValue" SG_ 775 ScChrgToPc_Pc_RqCld 100;
+BA_ "GenSigSendType" SG_ 775 ScChrgToPc_Pc_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScChrgPrfl_No_RqCld 1;
+BA_ "GenSigSendType" SG_ 775 ScChrgPrfl_No_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScChrgDurSet_D_RqCld 1;
+BA_ "GenSigStartValue" SG_ 775 ScChrgDurSet_D_RqCld 1;
+BA_ "GenSigSendType" SG_ 775 ScChrgDurSet_D_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 775 ScChrgDur_T_RqCld 1;
+BA_ "GenSigSendType" SG_ 775 ScChrgDur_T_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocLongPostv_B_RqCld 1;
+BA_ "GenSigSendType" SG_ 774 ScLocLongPostv_B_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocLongFrct_An_RqCld 1;
+BA_ "GenSigStartValue" SG_ 774 ScLocLongFrct_An_RqCld 1048575;
+BA_ "GenSigSendType" SG_ 774 ScLocLongFrct_An_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocLongDeg_An_RqCld 1;
+BA_ "GenSigSendType" SG_ 774 ScLocLongDeg_An_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocLattPostv_B_RqCld 1;
+BA_ "GenSigSendType" SG_ 774 ScLocLattPostv_B_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocLattFrct_An_RqCld 1;
+BA_ "GenSigStartValue" SG_ 774 ScLocLattFrct_An_RqCld 1048575;
+BA_ "GenSigSendType" SG_ 774 ScLocLattFrct_An_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocLattDeg_An_RqCld 1;
+BA_ "GenSigSendType" SG_ 774 ScLocLattDeg_An_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocId_No_RqCld 1;
+BA_ "GenSigSendType" SG_ 774 ScLocId_No_RqCld 3;
+BA_ "ECGUsedTxSignal" SG_ 774 ScLocDelete_B_RqCld 1;
+BA_ "GenSigSendType" SG_ 774 ScLocDelete_B_RqCld 3;
+BA_ "GenSigStartValue" SG_ 811 DistToStopover_L_Actl 65535;
+BA_ "WakeupSignal" SG_ 811 ExtLghtRight_D_RqMnu 1;
+BA_ "WakeupSignal" SG_ 811 AutoLghtOvrrd_B_RqDrv 1;
+BA_ "WakeupSignal" SG_ 811 ExtLghtRear_D_RqMnu 1;
+BA_ "WakeupSignal" SG_ 811 ExtLghtLeft_D_RqMnu 1;
+BA_ "WakeupSignal" SG_ 811 ExtLghtFront_D_RqMnu 1;
+BA_ "GenSigStartValue" SG_ 811 GoTEditMnte_T_RqMnu 14;
+BA_ "GenSigStartValue" SG_ 811 GoTEditHr_T_RqMnu 30;
+BA_ "U_CX727_MY2021_Tx" SG_ 850 VehElRngeNut_L_Dsply 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 850 NxtUsgSocEst_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 850 EstmChrgTimeLP_St 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 850 EstmChrgTimeLP_St 1;
+BA_ "ECGUsedRxSignal" SG_ 850 EstmChrgTimeHP_St 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 850 EstmChrgTimeHP_St 1;
+BA_ "ECGUsedRxSignal" SG_ 850 ChargeNowDuration_St 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 850 ChargeNowDuration_St 1;
+BA_ "ECGUsedTxSignal" SG_ 563 DrvBhavWarn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 563 DrvBhavWarn_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 563 OfbChrgSetSync_D_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 563 KeyOffPwMde_D_Stat 1;
+BA_ "GenSigSendType" SG_ 563 KeyOffPwMde_D_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 563 ModemReset_D_Stat 1;
+BA_ "GenSigSendType" SG_ 563 ModemReset_D_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 563 FactoryReset_St 1;
+BA_ "GenSigSendType" SG_ 563 FactoryReset_St 3;
+BA_ "GenSigSendType" SG_ 1833 TesterPhysicalResVDM 3;
+BA_ "GenSigStartValueInteger" SG_ 570 SuspRearRight_L_Actl 511;
+BA_ "GenSigStartValue" SG_ 570 SuspRearRight_L_Actl 511;
+BA_ "U_CX727_MY2021_Rx" SG_ 570 SuspRearRight_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 570 SuspFrntRight_L_Actl 511;
+BA_ "GenSigStartValue" SG_ 570 SuspFrntRight_L_Actl 511;
+BA_ "U_CX727_MY2021_Rx" SG_ 570 SuspFrntRight_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 570 SuspRear_L_Prev 511;
+BA_ "GenSigStartValue" SG_ 570 SuspRear_L_Prev 511;
+BA_ "U_CX727_MY2021_Rx" SG_ 570 SuspRear_L_Prev 1;
+BA_ "U_P702_MY2021_Rx" SG_ 570 SuspRear_L_Prev 1;
+BA_ "GenSigStartValueInteger" SG_ 570 SuspRear_L_Actl 511;
+BA_ "GenSigStartValue" SG_ 570 SuspRear_L_Actl 511;
+BA_ "U_CX727_MY2021_Rx" SG_ 570 SuspRear_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 570 SuspRear_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 570 SuspFrnt_L_Prev 511;
+BA_ "GenSigStartValue" SG_ 570 SuspFrnt_L_Prev 511;
+BA_ "U_CX727_MY2021_Rx" SG_ 570 SuspFrnt_L_Prev 1;
+BA_ "U_P702_MY2021_Rx" SG_ 570 SuspFrnt_L_Prev 1;
+BA_ "GenSigStartValueInteger" SG_ 570 SuspFrnt_L_Actl 511;
+BA_ "GenSigStartValue" SG_ 570 SuspFrnt_L_Actl 511;
+BA_ "U_CX727_MY2021_Rx" SG_ 570 SuspFrnt_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 570 SuspFrnt_L_Actl 1;
+BA_ "GenSigSendType" SG_ 837 Ccd_B_Falt 3;
+BA_ "GenSigInactiveValue" SG_ 837 Ccd_B_Falt 0;
+BA_ "GenSigSendType" SG_ 837 SelDrvMdeSusp_D_Stat 3;
+BA_ "GenSigInactiveValue" SG_ 837 SelDrvMdeSusp_D_Stat 0;
+BA_ "U_CX727_MY2021_Rx" SG_ 837 SelDrvMdeSusp_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 837 SelDrvMdeSusp_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 837 SelDrvMdeSusp_D_Stat 1;
+BA_ "GenSigSendType" SG_ 837 AdptDrvMdePt_D_Rq 3;
+BA_ "GenSigInactiveValue" SG_ 837 AdptDrvMdePt_D_Rq 0;
+BA_ "U_CX727_MY2021_Rx" SG_ 837 AdptDrvMdePt_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 837 AdptDrvMdePt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 837 AdptDrvMdePt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 837 AdptDrvMdeChassis_D_Rq 3;
+BA_ "GenSigInactiveValue" SG_ 837 AdptDrvMdeChassis_D_Rq 0;
+BA_ "U_CX727_MY2021_Rx" SG_ 837 AdptDrvMdeChassis_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 837 AdptDrvMdeChassis_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 837 AdptDrvMdeChassis_D_Rq 1;
+BA_ "GenSigSendType" SG_ 837 CcdMsgTxt_D_RqDsply 3;
+BA_ "GenSigInactiveValue" SG_ 837 CcdMsgTxt_D_RqDsply 0;
+BA_ "UsedOnPgmDBC" SG_ 837 CcdMsgTxt_D_RqDsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 837 CcdMsgTxt_D_RqDsply 1;
+BA_ "ECGUsedTxSignal" SG_ 885 BattULoChrg_D_RqOta 1;
+BA_ "ECGUsedTxSignal" SG_ 885 VehStrtInhbt_T_Dsply 1;
+BA_ "ECGUsedTxSignal" SG_ 885 VehStrtInhbt_D_Dsply 1;
+BA_ "ECGUsedTxSignal" SG_ 885 VehOnRqstr_D_Stat 1;
+BA_ "ECGUsedTxSignal" SG_ 885 VehStrtInhbt_D_RqCld 1;
+BA_ "ECGUsedTxSignal" SG_ 885 VehOn_D_RqCld 1;
+BA_ "ECGUsedTxSignal" SG_ 885 CanMsg375_No_Cnt 1;
+BA_ "ECGUsedTxSignal" SG_ 885 CanMsg375_No_Crc 1;
+BA_ "ECGUsedTxSignal" SG_ 885 OtaActv_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1150 LocationServices_1 1;
+BA_ "GenSigSendType" SG_ 2612224016 PARSEDPushPCMtoGWM_ECG 3;
+BA_ "U_P702_MY2021_Tx" SG_ 2612224016 PARSEDPushPCMtoGWM_ECG 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 2612224016 PARSEDPushPCMtoGWM_ECG 1;
+BA_ "ECGUsedRxSignal" SG_ 2612224016 PARSEDPushPCMtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 810 OBCCSerial_D_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 810 OBCCSerial_D_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 810 TlghtTest_D_RqArb 1;
+BA_ "GenSigSendType" SG_ 810 TlghtTest_D_RqArb 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ChrgrPncSustn_B_Rq 1;
+BA_ "GenSigStartValue" SG_ 810 ChrgrPncSustn_B_Rq 0;
+BA_ "GenSigStartValueInteger" SG_ 810 ChrgrPncSustn_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 810 NtfyDrvTrgtDist_L_Rq 1;
+BA_ "GenSigStartValue" SG_ 810 NtfyDrvTrgtDist_L_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 810 NtfyDrvTrgtDist_L_Rq 1;
+BA_ "WakeupSignal" SG_ 810 NtfyDrvTrgtDist_L_Rq 1;
+BA_ "GenSigSendType" SG_ 810 NtfyDrvTrgtDist_L_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 810 NtfyDrvSocLvl1_Pc_Rq 1;
+BA_ "GenSigStartValue" SG_ 810 NtfyDrvSocLvl1_Pc_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 810 NtfyDrvSocLvl1_Pc_Rq 1;
+BA_ "WakeupSignal" SG_ 810 NtfyDrvSocLvl1_Pc_Rq 1;
+BA_ "GenSigSendType" SG_ 810 NtfyDrvSocLvl1_Pc_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 810 PtRmtRprt_D_Stat 1;
+BA_ "WakeupSignal" SG_ 810 PtRmtRprt_D_Stat 1;
+BA_ "GenSigSendType" SG_ 810 PtRmtRprt_D_Stat 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ChrgrPncEnbl_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 810 ChrgrPncEnbl_D_Rq 3;
+BA_ "GenSigStartValueInteger" SG_ 810 ChrgrPncEnbl_D_Rq 3;
+BA_ "GenSigSendType" SG_ 810 ChrgrPncEnbl_D_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ExtLghtDsply_B_StatArb 1;
+BA_ "WakeupSignal" SG_ 810 ExtLghtDsply_B_StatArb 1;
+BA_ "GenSigSendType" SG_ 810 ExtLghtDsply_B_StatArb 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ExtLghtRight_D_RqOta 1;
+BA_ "WakeupSignal" SG_ 810 ExtLghtRight_D_RqOta 1;
+BA_ "GenSigSendType" SG_ 810 ExtLghtRight_D_RqOta 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ExtLghtRear_D_RqOta 1;
+BA_ "WakeupSignal" SG_ 810 ExtLghtRear_D_RqOta 1;
+BA_ "GenSigSendType" SG_ 810 ExtLghtRear_D_RqOta 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ExtLghtLeft_D_RqOta 1;
+BA_ "WakeupSignal" SG_ 810 ExtLghtLeft_D_RqOta 1;
+BA_ "GenSigSendType" SG_ 810 ExtLghtLeft_D_RqOta 3;
+BA_ "ECGUsedTxSignal" SG_ 810 ExtLghtFront_D_RqOta 1;
+BA_ "WakeupSignal" SG_ 810 ExtLghtFront_D_RqOta 1;
+BA_ "GenSigSendType" SG_ 810 ExtLghtFront_D_RqOta 3;
+BA_ "ECGUsedTxSignal" SG_ 550 PtWakeupActv1_B_Rq 1;
+BA_ "WakeupSignal" SG_ 550 PtWakeupActv1_B_Rq 1;
+BA_ "GenSigSendType" SG_ 550 PtWakeupActv1_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgPrflUpdate_B_Rq 1;
+BA_ "GenSigSendType" SG_ 639 OfbChrgPrflUpdate_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgClearAll_B_Rq 1;
+BA_ "GenSigSendType" SG_ 639 OfbChrgClearAll_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTTouch_D_Rq 1;
+BA_ "GenSigSendType" SG_ 639 OfbChrgGoTTouch_D_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTPrcond_D_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTOn_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 639 OfbChrgGoTOn_D_Rq 2;
+BA_ "GenSigStartValueInteger" SG_ 639 OfbChrgGoTOn_D_Rq 2;
+BA_ "GenSigSendType" SG_ 639 OfbChrgGoTOn_D_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTMnte_D_Rq 1;
+BA_ "MetaData" SG_ 639 OfbChrgGoTMnte_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 639 OfbChrgGoTMnte_D_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTHr_T_Rq 1;
+BA_ "GenSigStartValue" SG_ 639 OfbChrgGoTHr_T_Rq 30;
+BA_ "GenSigStartValueInteger" SG_ 639 OfbChrgGoTHr_T_Rq 30;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTExtHtr_D_Rq 1;
+BA_ "GenSigSendType" SG_ 639 OfbChrgGoTExtHtr_D_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTElement_D_Rq 1;
+BA_ "MetaData" SG_ 639 OfbChrgGoTElement_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 639 OfbChrgGoTElement_D_Rq 1;
+BA_ "GenSigSendType" SG_ 639 OfbChrgGoTElement_D_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTDelete_B_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 639 OfbChrgGoTUpdate_B_Rq 1;
+BA_ "GenSigSendType" SG_ 639 OfbChrgGoTUpdate_B_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgLocIdTrgt_No_Rq 1;
+BA_ "MetaData" SG_ 530 OfbChrgLocIdTrgt_No_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 530 OfbChrgLocIdTrgt_No_Rq 1;
+BA_ "GenSigSendType" SG_ 530 OfbChrgLocIdTrgt_No_Rq 3;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgToPcWknd_D_Actl 1;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgToPcWkdy_D_Actl 1;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgSetNow_D_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgSetDelete_B_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgPrflWknd_No_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgPrflWkdy_No_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 530 OfbChrgLocIdUns_B_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 1142 ConsTipV_No_Dsply 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1142 ConsTipV_No_Dsply 1;
+BA_ "WakeupSignal" SG_ 817 DrTgateOpen_B_Rq 1;
+BA_ "WakeupSignal" SG_ 817 DrTgateExtSwMde_B_Stat 1;
+BA_ "WakeupSignal" SG_ 817 Remote_Device_Feedback 1;
+BA_ "WakeupSignal" SG_ 817 Veh_Lock_Requestor 1;
+BA_ "WakeupSignal" SG_ 817 R_Pwr_Sliding_Dr_Rqst 1;
+BA_ "WakeupSignal" SG_ 817 Power_Liftgate_Rqst 1;
+BA_ "WakeupSignal" SG_ 817 Veh_Lock_EvNum 1;
+BA_ "WakeupSignal" SG_ 817 Power_Decklid_Rqst 1;
+BA_ "WakeupSignal" SG_ 817 L_Pwr_Sliding_Dr_Rqst 1;
+BA_ "WakeupSignal" SG_ 817 Keyfob_Pad_Msg_Count 1;
+BA_ "WakeupSignal" SG_ 817 Veh_Lock_Status 1;
+BA_ "GenSigStartValueInteger" SG_ 817 Veh_Lock_Status 1;
+BA_ "GenSigStartValue" SG_ 817 Veh_Lock_Status 1;
+BA_ "WakeupSignal" SG_ 817 ChildLck_D_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 817 ChildLck_D_Dsply 1;
+BA_ "GenSigStartValue" SG_ 817 ChildLck_D_Dsply 1;
+BA_ "WakeupSignal" SG_ 817 Lockmsgtxt_D_Rq 1;
+BA_ "WakeupSignal" SG_ 817 LockInhibit 1;
+BA_ "GenSigSendType" SG_ 878 DcacGfciTest_B_Rq 3;
+BA_ "GenSigStartValue" SG_ 878 DcacOut_Pw_DsplyMx 0;
+BA_ "GenSigStartValue" SG_ 878 DcacOut1_Pw_Dsply 0;
+BA_ "GenSigStartValue" SG_ 878 DcacOut2_Pw_Dsply 0;
+BA_ "GenSigSendType" SG_ 878 DcacHw_D_Confg 3;
+BA_ "UsedOnPgmDBC" SG_ 878 DcacHw_D_Confg 1;
+BA_ "GenSigStartValueInteger" SG_ 878 DcacHw_D_Confg 1;
+BA_ "GenSigStartValue" SG_ 878 DcacHw_D_Confg 1;
+BA_ "GenSigSendType" SG_ 878 DcacFaltMsgTxt_D_Rq 3;
+BA_ "UsedOnPgmDBC" SG_ 878 DcacFaltMsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 878 DcacFaltMsgTxt_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 878 DcacFaltMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 878 DcacLoFuelMsgTxt_D_Rq 3;
+BA_ "GenSigSendType" SG_ 878 DcacEngOnMsgTxt_D_Rq 3;
+BA_ "GenSigSendType" SG_ 878 DcacElPw_D_Stat 3;
+BA_ "UsedOnPgmDBC" SG_ 878 DcacElPw_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 878 DcacElPw_D_Stat 1;
+BA_ "GenSigStartValue" SG_ 878 DcacElPw_D_Stat 1;
+BA_ "GenSigSendType" SG_ 878 PwBedPnlEnbl_B_Rq 3;
+BA_ "GenSigSendType" SG_ 878 DcacOn_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 878 DcacOn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 878 DcacSys_B_Falt 3;
+BA_ "U_P702_MY2021_Tx" SG_ 878 DcacSys_B_Falt 1;
+BA_ "GenSigSendType" SG_ 878 DcacLedCtl_D_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 878 DcacLedCtl_D_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 2611055832 PARSEDPhysGWM_ECGtoSODR 1;
+BA_ "GenSigSendType" SG_ 2611055832 PARSEDPhysGWM_ECGtoSODR 3;
+BA_ "ECGUsedTxSignal" SG_ 2611054808 PARSEDPhysGWM_ECGtoSODL 1;
+BA_ "GenSigSendType" SG_ 2611054808 PARSEDPhysGWM_ECGtoSODL 3;
+BA_ "ECGUsedTxSignal" SG_ 2611026136 PARSEDPhysGWM_ECGtoSODCMD 1;
+BA_ "GenSigSendType" SG_ 2611026136 PARSEDPhysGWM_ECGtoSODCMD 3;
+BA_ "ECGUsedTxSignal" SG_ 2611025112 PARSEDPhysGWM_ECGtoSODCMC 1;
+BA_ "GenSigSendType" SG_ 2611025112 PARSEDPhysGWM_ECGtoSODCMC 3;
+BA_ "ECGUsedTxSignal" SG_ 2610975960 PARSEDPhysGWM_ECGtoCCM 1;
+BA_ "GenSigSendType" SG_ 2610975960 PARSEDPhysGWM_ECGtoCCM 3;
+BA_ "ECGUsedTxSignal" SG_ 2610007256 OTAPhysGWM_ECGtoSODR 1;
+BA_ "GenSigSendType" SG_ 2610007256 OTAPhysGWM_ECGtoSODR 3;
+BA_ "ECGUsedTxSignal" SG_ 2610006232 OTAPhysGWM_ECGtoSODL 1;
+BA_ "GenSigSendType" SG_ 2610006232 OTAPhysGWM_ECGtoSODL 3;
+BA_ "ECGUsedTxSignal" SG_ 2609977560 OTAPhysGWM_ECGtoSODCMD 1;
+BA_ "GenSigSendType" SG_ 2609977560 OTAPhysGWM_ECGtoSODCMD 3;
+BA_ "ECGUsedTxSignal" SG_ 2609976536 OTAPhysGWM_ECGtoSODCMC 1;
+BA_ "GenSigSendType" SG_ 2609976536 OTAPhysGWM_ECGtoSODCMC 3;
+BA_ "ECGUsedTxSignal" SG_ 2609927384 OTAPhysGWM_ECGtoCCM 1;
+BA_ "GenSigSendType" SG_ 2609927384 OTAPhysGWM_ECGtoCCM 3;
+BA_ "ECGUsedRxSignal" SG_ 2611175523 PARSEDPhysSODRtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175523 PARSEDPhysSODRtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224099 PARSEDPhysSODR2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224099 PARSEDPhysSODR2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2611175522 PARSEDPhysSODLtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175522 PARSEDPhysSODLtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224098 PARSEDPhysSODL2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224098 PARSEDPhysSODL2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2611175494 PARSEDPhysSODCMDtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175494 PARSEDPhysSODCMDtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224070 PARSEDPhysSODCMD2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224070 PARSEDPhysSODCMD2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2611175493 PARSEDPhysSODCMCtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175493 PARSEDPhysSODCMCtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224069 PARSEDPhysSODCMC2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224069 PARSEDPhysSODCMC2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2611175445 PARSEDPhysCCMtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175445 PARSEDPhysCCMtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224021 PARSEDPhysCCM2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224021 PARSEDPhysCCM2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126947 OTAPhysSODRtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126947 OTAPhysSODRtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126946 OTAPhysSODLtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126946 OTAPhysSODLtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126918 OTAPhysSODCMDtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126918 OTAPhysSODCMDtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126917 OTAPhysSODCMCtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126917 OTAPhysSODCMCtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126869 OTAPhysCCMtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126869 OTAPhysCCMtoGWM_ECG 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 FeatConfigIpmaActl 1;
+BA_ "CrossOver_InfoCAN" SG_ 984 FeatNoIpmaActl 1;
+BA_ "GenSigStartValue" SG_ 984 PersIndexIpma_D_Actl 4;
+BA_ "GenSigStartValueInteger" SG_ 984 PersIndexIpma_D_Actl 4;
+BA_ "CrossOver_InfoCAN" SG_ 984 PersIndexIpma_D_Actl 1;
+BA_ "GenSigSendType" SG_ 984 PersIndexIpma_D_Actl 3;
+BA_ "U_P702_MY2021_Rx" SG_ 984 AhbcRampingV_D_Rq 1;
+BA_ "GenSigSendType" SG_ 984 AhbcRampingV_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 LaActvStats_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 LaActvStats_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 LaDenyStats_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 LaDenyStats_B_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 LaHandsOff_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 LaHandsOff_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 CamraDefog_B_Req 1;
+BA_ "GenSigSendType" SG_ 984 CamraDefog_B_Req 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 CamraStats_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 CamraStats_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 DasAlrtLvl_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 DasAlrtLvl_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 DasStats_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 DasStats_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 984 DasWarn_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 984 DasWarn_D_Dsply 3;
+BA_ "GenSigSendType" SG_ 984 AhbHiBeam_D_Rq 3;
+BA_ "GenSigSendType" SG_ 985 LdwChime_B_Rq 3;
+BA_ "GenSigSendType" SG_ 985 TsrRegionTxt_D_Stat 3;
+BA_ "GenSigSendType" SG_ 985 SblmPedCrossScnr_B_Stat 3;
+BA_ "GenSigSendType" SG_ 985 LongCtrlEnbl_D_Rq 3;
+BA_ "GenSigSendType" SG_ 985 SblmRndAbtScnr_B_Stat 3;
+BA_ "GenSigSendType" SG_ 985 DasAlrtInfo_D_Dsply 3;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 985 IaccVLim_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 985 IaccVLim_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 985 IaccVLim_D_Rq 254;
+BA_ "GenSigStartValueInteger" SG_ 985 IaccVLim_D_Rq 254;
+BA_ "GenSigSendType" SG_ 985 IaccVLim_D_Rq 3;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 985 IaccVLimUnit_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 985 IaccVLimUnit_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 985 IaccVLimUnit_D_Rq 3;
+BA_ "GenSigStartValueInteger" SG_ 985 IaccVLimUnit_D_Rq 3;
+BA_ "GenSigSendType" SG_ 985 IaccVLimUnit_D_Rq 3;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 985 IsaVLim_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 985 IsaVLim_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 985 IsaVLim_D_Rq 254;
+BA_ "GenSigStartValueInteger" SG_ 985 IsaVLim_D_Rq 254;
+BA_ "GenSigSendType" SG_ 985 IsaVLim_D_Rq 3;
+BA_ "GenSigSendType" SG_ 985 SblmStopScnr_B_Stat 3;
+BA_ "GenSigSendType" SG_ 985 SblmYieldScnr_B_Stat 3;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 985 IsaVLimUnit_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 985 IsaVLimUnit_D_Rq 1;
+BA_ "GenSigSendType" SG_ 985 IsaVLimUnit_D_Rq 3;
+BA_ "GenSigSendType" SG_ 985 AdbDividedRoad_B_Stat 3;
+BA_ "GenSigSendType" SG_ 985 LcwaMsgTxt_D_Stat 3;
+BA_ "GenSigSendType" SG_ 985 AdbDrvSide_B_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 992 MsgCntrDsplyOp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 992 MsgCntrDsplyOp_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 992 MsgCntrFeatNoRq 1;
+BA_ "CrossOver_InfoCAN" SG_ 992 MsgCntrFeatNoRq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 992 MsgCntrFeatConfigRq 1;
+BA_ "CrossOver_InfoCAN" SG_ 992 MsgCntrFeatConfigRq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 992 MsgCntrPersIndex_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 992 MsgCntrPersIndex_D_Rq 4;
+BA_ "GenSigStartValueInteger" SG_ 992 MsgCntrPersIndex_D_Rq 4;
+BA_ "CrossOver_InfoCAN" SG_ 992 MsgCntrPersIndex_D_Rq 1;
+BA_ "GenSigSendType" SG_ 2612019416 PARSEDPhysGWM_ECG2toPCM 3;
+BA_ "ECGUsedTxSignal" SG_ 2612019416 PARSEDPhysGWM_ECG2toPCM 1;
+BA_ "UsedOnPgmDBC" SG_ 943 VehVActlAdas_D_Qf 1;
+BA_ "MetaData" SG_ 943 VehVActlAdas_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 943 VehVActlAdas_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 943 Veh_V_RqLsc 1;
+BA_ "UsedOnPgmDBC" SG_ 943 Veh_V_ActlAdas 1;
+BA_ "GenSigStartValue" SG_ 943 AdasLcDistToObj_L_Actl 4094;
+BA_ "UsedOnPgmDBC" SG_ 515 PtIgnSwtch_No_Cs 1;
+BA_ "MetaData" SG_ 515 PtIgnSwtch_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 515 PtIgnSwtch_No_Cnt 1;
+BA_ "MetaData" SG_ 515 PtIgnSwtch_No_Cnt 1;
+BA_ "GenSigSendType" SG_ 515 PtIgnSwtch_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 515 PtIgnSwtch_D_Stat 2;
+BA_ "GenSigStartValueInteger" SG_ 1111 TrlrYawWActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 1111 TrlrYawWActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1111 TrlrYawWActl_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1111 TrlrYawWActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 1111 TrlrYaw_W_Actl 65534;
+BA_ "GenSigStartValue" SG_ 1111 TrlrYaw_W_Actl 65534;
+BA_ "U_P702_MY2021_Rx" SG_ 1111 TrlrYaw_W_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1111 TrlrYaw_W_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1111 TrlrHitYaw_AnRate_Actl 4094;
+BA_ "GenSigStartValue" SG_ 1111 TrlrHitYaw_AnRate_Actl 4093;
+BA_ "U_P702_MY2021_Rx" SG_ 1111 TrlrHitYaw_AnRate_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1111 TrlrHitYaw_AnRate_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1111 TrlrHitchYaw_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1111 TrlrHitchYaw_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1111 TrlrHitchYaw_An_Actl 4094;
+BA_ "GenSigStartValue" SG_ 1111 TrlrHitchYaw_An_Actl 4093;
+BA_ "U_P702_MY2021_Rx" SG_ 1111 TrlrHitchYaw_An_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1111 TrlrHitchYaw_An_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1106 TrlrSnsId_No_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1106 TrlrSnsId_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 982 LatCtlCrv_NoRate2_Actl 1024;
+BA_ "UsedOnPgmDBC" SG_ 982 LatCtlPath_No_Cnt 1;
+BA_ "ContentDependant" SG_ 982 LatCtlPath_No_Cnt 1;
+BA_ "MetaData" SG_ 982 LatCtlPath_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 982 LatCtlPath_No_Cs 1;
+BA_ "ContentDependant" SG_ 982 LatCtlPath_No_Cs 1;
+BA_ "MetaData" SG_ 982 LatCtlPath_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 982 HandsOffCnfm_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 982 HandsOffCnfm_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 982 LatCtlRampType_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 982 LatCtlRampType_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 982 LatCtlPrecision_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 982 LatCtlPrecision_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 982 LatCtlPathOffst_L_Actl 512;
+BA_ "U_CX727_MY2021_Rx" SG_ 982 LatCtlPathOffst_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 982 LatCtlPathOffst_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 982 LatCtlPath_An_Actl 1000;
+BA_ "U_CX727_MY2021_Rx" SG_ 982 LatCtlPath_An_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 982 LatCtlPath_An_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 982 LatCtlCurv_No_Actl 1000;
+BA_ "U_CX727_MY2021_Rx" SG_ 982 LatCtlCurv_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 982 LatCtlCurv_No_Actl 1;
+BA_ "GenSigSendType" SG_ 1985 TesterPhysicalReqCMR_DSMC 3;
+BA_ "GenSigSendType" SG_ 1993 TesterPhysicalResCMR_DSMC 3;
+BA_ "MetaData" SG_ 1104 DrvEngageLevel_No_Cs 1;
+BA_ "ContentDependant" SG_ 1104 DrvEngageLevel_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 1104 DrvEngageLevel_No_Cs 1;
+BA_ "MetaData" SG_ 1104 DrvEngageLevel_No_Cnt 1;
+BA_ "ContentDependant" SG_ 1104 DrvEngageLevel_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 1104 DrvEngageLevel_No_Cnt 1;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_GWOnBoardTester 255;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_GWNMProxY 255;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_GWNMProxY 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_GWNMProxY 255;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_AutoSarNMReserved 255;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_AutoSarNMReserved 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_AutoSarNMReserved 255;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_AutoSarNMReserve4 255;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_AutoSarNMReserve4 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_AutoSarNMReserve4 255;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_AutoSarNMReserve3 255;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_AutoSarNMReserve3 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_AutoSarNMReserve3 255;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_AutoSarNMReserve2 255;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_AutoSarNMReserve2 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_AutoSarNMReserve2 255;
+BA_ "GenSigStartValue" SG_ 1503 CMR_DSMC_AutoSarNMNodeId 223;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_AutoSarNMNodeId 1;
+BA_ "GenSigStartValueInteger" SG_ 1503 CMR_DSMC_AutoSarNMNodeId 222;
+BA_ "ContentDependant" SG_ 1503 CMR_DSMC_AutoSarNMControl 1;
+BA_ "ECGUsedTxSignal" SG_ 2610995416 PARSEDPhysGWM_ECGtoABS 1;
+BA_ "GenSigSendType" SG_ 2610995416 PARSEDPhysGWM_ECGtoABS 3;
+BA_ "ECGUsedTxSignal" SG_ 2612043992 PARSEDPhysGWM_ECG2toABS 1;
+BA_ "GenSigSendType" SG_ 2612043992 PARSEDPhysGWM_ECG2toABS 3;
+BA_ "ECGUsedTxSignal" SG_ 2609946840 OTAPhysGWM_ECGtoABS 1;
+BA_ "GenSigSendType" SG_ 2609946840 OTAPhysGWM_ECGtoABS 3;
+BA_ "ECGUsedRxSignal" SG_ 2611175464 PARSEDPhysABStoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175464 PARSEDPhysABStoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224040 PARSEDPhysABS2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224040 PARSEDPhysABS2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126888 OTAPhysABStoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126888 OTAPhysABStoGWM_ECG 3;
+BA_ "ECGUsedTxSignal" SG_ 2610988248 PARSEDPhysGWM_ECGtoIPMA 1;
+BA_ "ECGUsedTxSignal" SG_ 2609939672 OTAPhysGWM_ECGtoIPMA 1;
+BA_ "GenSigSendType" SG_ 2609939672 OTAPhysGWM_ECGtoIPMA 3;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1114 TrailCtlSwtch_B_Stat2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1114 TrailCtlSwtch_B_Stat2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1116 TrlrAidSetup_D2_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1116 TrlrAidSetup_D2_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1116 TrlrAidEnbl_D2_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1116 TrlrAidEnbl_D2_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1116 TrlrTrgtToBmpr_L_Actl 0;
+BA_ "U_P702_MY2021_Rx" SG_ 1116 TrlrIdType_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1116 TrlrIdType_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1116 TrlrBallToBmpr_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1116 TrlrAxleToBmpr_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1116 TrlrAnOffst_An_Mem 0;
+BA_ "GenSigStartValueInteger" SG_ 1116 TrlrTrgtOffst_L_Actl 0;
+BA_ "ECGUsedRxSignal" SG_ 2611175457 PARSEDPhysIPMAtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175457 PARSEDPhysIPMAtoGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2612224033 PARSEDPhysIPMA2toGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612224033 PARSEDPhysIPMA2toGWM_ECG 3;
+BA_ "ECGUsedRxSignal" SG_ 2610126881 OTAPhysIPMAtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126881 OTAPhysIPMAtoGWM_ECG 3;
+BA_ "UsedOnPgmDBC" SG_ 1085 ULoRgenTestMde_B_Stat 1;
+BA_ "ContentDependant" SG_ 1085 ULoRgenTestMde_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 ULoRgenTestMde_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 ULoRgenTestMde_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1085 PwSrcULoOvrTe_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULoOvrTe_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULoOvrTe_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1085 PwSrcULoFalt_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULoFalt_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULoFalt_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1085 PwSrcULoDcnnt_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULoDcnnt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULoDcnnt_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULo_Pc_Mx 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULo_Pc_Mx 1;
+BA_ "UsedOnPgmDBC" SG_ 1085 PwSrcULoComm_B_Falt 1;
+BA_ "ContentDependant" SG_ 1085 PwSrcULoComm_B_Falt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULoComm_B_Falt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULoComm_B_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1085 PwSrcULo_I_Mx 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULo_I_Mx 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULo_I_Mx 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1085 PwSrcULo_I_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1085 PwSrcULo_I_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1085 PwSrcULo_I_Actl 1;
+BA_ "GenSigStartValue" SG_ 981 AdbBrdrTop_An_Rq 254;
+BA_ "GenSigStartValue" SG_ 981 AdbBrdrRight_L_Stat 510;
+BA_ "GenSigStartValue" SG_ 981 AdbBrdrRight_An_Rq 1022;
+BA_ "GenSigStartValue" SG_ 981 AdbBrdrLeft_L_Stat 510;
+BA_ "GenSigStartValue" SG_ 981 AdbBrdrLeft_An_Rq 1022;
+BA_ "GenSigStartValue" SG_ 981 AdbBrdrBottom_An_Rq 62;
+BA_ "U_P702_MY2021_Rx" SG_ 791 EngAirFilt_B_RqReset 1;
+BA_ "CrossOver_InfoCAN" SG_ 791 GpsElMdeSel_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 791 LongTermReset_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 791 DrvEffLvl_No_Stat 1;
+BA_ "ECGUsedTxSignal" SG_ 2610970840 PARSEDPhysGWM_ECGtoPCM 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2610970840 PARSEDPhysGWM_ECGtoPCM 1;
+BA_ "U_P702_MY2021_Rx" SG_ 2610970840 PARSEDPhysGWM_ECGtoPCM 1;
+BA_ "GenSigSendType" SG_ 2610970840 PARSEDPhysGWM_ECGtoPCM 3;
+BA_ "ECGUsedTxSignal" SG_ 2609922264 OTAPhysGWM_ECGtoPCM 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2609922264 OTAPhysGWM_ECGtoPCM 1;
+BA_ "U_P702_MY2021_Rx" SG_ 2609922264 OTAPhysGWM_ECGtoPCM 1;
+BA_ "GenSigSendType" SG_ 2609922264 OTAPhysGWM_ECGtoPCM 3;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoStat_D_Qlty 1;
+BA_ "GenSigStartValue" SG_ 868 BattRgenLoStat_D_Qlty 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoSoc_Pc_Actl 1;
+BA_ "GenSigStartValue" SG_ 868 BattRgenLoSoc_Pc_Actl 50;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoPulse_U_Pred 1;
+BA_ "GenSigStartValue" SG_ 868 BattRgenLoPulse_U_Pred 216;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoPrtct_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoDChrg_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoDchrg_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoChrg_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLoChrg_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLo_T_Est 1;
+BA_ "U_P702_MY2021_Rx" SG_ 868 BattRgenLo_B_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 867 BattRgenLoBalnc_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 867 BattRgenLo_Te_Hi 1;
+BA_ "GenSigStartValue" SG_ 867 BattRgenLo_Te_Hi 45;
+BA_ "U_P702_MY2021_Rx" SG_ 867 BattRgenLo_Te_Actl 1;
+BA_ "GenSigStartValue" SG_ 867 BattRgenLo_Te_Actl 85;
+BA_ "U_P702_MY2021_Rx" SG_ 867 BattRgenLo_R_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 867 BattRgenLo_AhRide_Actl 1;
+BA_ "GenSigStartValue" SG_ 867 BattRgenLo_AhRide_Actl 12800;
+BA_ "U_P702_MY2021_Rx" SG_ 867 BattRgenLo_Ah_Actl 1;
+BA_ "GenSigStartValue" SG_ 867 BattRgenLo_Ah_Actl 50;
+BA_ "U_P702_MY2021_Rx" SG_ 866 BattRgenLoOpen_U_Actl 1;
+BA_ "GenSigStartValue" SG_ 866 BattRgenLoOpen_U_Actl 180;
+BA_ "U_P702_MY2021_Rx" SG_ 866 BattRgenLoDchrg_U_Mn 1;
+BA_ "GenSigStartValue" SG_ 866 BattRgenLoDchrg_U_Mn 280;
+BA_ "U_P702_MY2021_Rx" SG_ 866 BattRgenLoDchrg_I_Mx 1;
+BA_ "U_P702_MY2021_Rx" SG_ 866 BattRgenLoChrg_U_Mx 1;
+BA_ "GenSigStartValue" SG_ 866 BattRgenLoChrg_U_Mx 96;
+BA_ "U_P702_MY2021_Rx" SG_ 866 BattRgenLoChrg_I_Mx 1;
+BA_ "U_P702_MY2021_Rx" SG_ 865 BattRgenLo_U_Actl 1;
+BA_ "GenSigStartValue" SG_ 865 BattRgenLo_U_Actl 768;
+BA_ "U_P702_MY2021_Rx" SG_ 865 BattRgenLo_I_Actl 1;
+BA_ "GenSigStartValue" SG_ 865 BattRgenLo_I_Actl 32768;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 2611175440 PARSEDPhysPCMtoGWM_ECG 1;
+BA_ "U_P702_MY2021_Tx" SG_ 2611175440 PARSEDPhysPCMtoGWM_ECG 1;
+BA_ "ECGUsedRxSignal" SG_ 2611175440 PARSEDPhysPCMtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2611175440 PARSEDPhysPCMtoGWM_ECG 3;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 2610126864 OTAPhysPCMtoGWM_ECG 1;
+BA_ "U_P702_MY2021_Tx" SG_ 2610126864 OTAPhysPCMtoGWM_ECG 1;
+BA_ "ECGUsedRxSignal" SG_ 2610126864 OTAPhysPCMtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126864 OTAPhysPCMtoGWM_ECG 3;
+BA_ "GenSigSendType" SG_ 2611175441 PARSEDPhysHPCMtoGWM_ECG 3;
+BA_ "GenSigSendType" SG_ 2612224017 PARSEDPhysHPCM2toGWM_ECG 3;
+BA_ "U_P702_MY2021_Tx" SG_ 2610126865 OTAPhysHPCMtoGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610126865 OTAPhysHPCMtoGWM_ECG 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1679 UUDTSOBDMCResponse4 1;
+BA_ "UsedOnPgmDBC" SG_ 1679 UUDTSOBDMCResponse4 1;
+BA_ "GenSigSendType" SG_ 1679 UUDTSOBDMCResponse4 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1678 UUDTSOBDMCResponse3 1;
+BA_ "UsedOnPgmDBC" SG_ 1678 UUDTSOBDMCResponse3 1;
+BA_ "GenSigSendType" SG_ 1678 UUDTSOBDMCResponse3 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1677 UUDTSOBDMCResponse2 1;
+BA_ "UsedOnPgmDBC" SG_ 1677 UUDTSOBDMCResponse2 1;
+BA_ "GenSigSendType" SG_ 1677 UUDTSOBDMCResponse2 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1676 UUDTSOBDMCResponse1 1;
+BA_ "UsedOnPgmDBC" SG_ 1676 UUDTSOBDMCResponse1 1;
+BA_ "GenSigSendType" SG_ 1676 UUDTSOBDMCResponse1 3;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_AutoSarNMReserved4 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_AutoSarNMReserved3 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_AutoSarNMReserved2 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_AutoSarNMReserved1 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_AutoSarNMNodeId 165;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_AutoSarNMNodeId 165;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_AutoSarNMControl 1;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_GWOnBoardTester 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1445 SOBDMC_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1445 SOBDMC_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1445 SOBDMC_GWNMProxy 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1445 SOBDMC_GWNMProxy 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1144 WakeAlarm0_T_Rq 1;
+BA_ "GenSigStartValue" SG_ 1144 WakeAlarm0_T_Rq 32767;
+BA_ "GenSigStartValueInteger" SG_ 1144 WakeAlarm0_T_Rq 32767;
+BA_ "U_CX727_MY2021_Tx" SG_ 1144 WakeAlarm0_B_Typ 1;
+BA_ "GenSigSendType" SG_ 1144 WakeAlarm0_B_Typ 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1144 PreCondBatt_B_Actl 1;
+BA_ "GenSigSendType" SG_ 1144 PreCondBatt_B_Actl 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1144 HtrnDcdcDis_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1144 HtrnDcdcDis_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 HtrnDcdcDis_B_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1144 ChrgNowEvnt_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1144 ChrgNowEvnt_B_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1144 CabinDrvSustn_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1144 CabinDrvSustn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 CabinDrvSustn_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 BattChrgTrgtSoC_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 CabnEvapSovFront_B_Rq 3;
+BA_ "WakeupSignal" SG_ 1144 CabnEvapSovFront_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 CabnEvapSovFront_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 HeatCoreSovRear_B_Rq 3;
+BA_ "WakeupSignal" SG_ 1144 HeatCoreSovRear_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 HeatCoreSovRear_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 BattChlrSov_B_Rq 3;
+BA_ "WakeupSignal" SG_ 1144 BattChlrSov_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 BattChlrSov_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 CabnEvapSovRear_B_Rq 3;
+BA_ "WakeupSignal" SG_ 1144 CabnEvapSovRear_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 CabnEvapSovRear_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 BrkAppl_D_RqPt 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1144 BrkAppl_D_RqPt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1144 BrkAppl_D_RqPt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 BrkAppl_D_RqPt 1;
+BA_ "GenSigSendType" SG_ 1144 HtrnCnnctPwr_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 HtrnCnnctPwr_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1144 PtcHtr_D_Stat 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1144 PtcHtr_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1144 PtcHtr_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 PtcHtr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1144 HtrnClntFlw_D_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 HtrnClntFlw_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 BattTracDrvSustn_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1144 BattTracDrvSustn_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 BattTracDrvSustn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1144 BattTracClntVlv_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1144 BattTracClntVlv_B_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1141 OfbChrgSetSync_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1141 OfbChrgSetSync_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1141 PtRmtRprt_D_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 1141 PtRmtRprt_D_Rq 1;
+BA_ "WakeupSignal" SG_ 1141 PtRmtRprt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1141 MtrTrac2_Tq_Actl 4095;
+BA_ "GenSigStartValue" SG_ 1141 MtrTrac2_Tq_Actl 4095;
+BA_ "U_P702_MY2021_Tx" SG_ 1141 MtrTrac2_Tq_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1141 MtrTrac2_Tq_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1141 NtfctnConflict1_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1141 NtfctnConflict1_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1140 RgenEvntLvl_Pc_Dsply 1;
+BA_ "GenSigStartValue" SG_ 1140 RgenEvntLvl_Pc_Dsply 1022;
+BA_ "GenSigStartValueInteger" SG_ 1140 RgenEvntLvl_Pc_Dsply 1023;
+BA_ "U_CX727_MY2021_Tx" SG_ 1140 BrkEvntComplt_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1140 PreCondStat_D_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1140 PreCondStat_D_Dsply 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1139 ActChrgStrtYr_No2_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1139 ActChrgStrtYr_No2_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1139 ActChrgStrtYr_No2_Actl 0;
+BA_ "U_P702_MY2021_Tx" SG_ 1139 BattChrgTrgtLMax_T_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1139 ActChrgStrtYr_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1139 ActChrgStrtYr_No_Actl 0;
+BA_ "ECGUsedRxSignal" SG_ 1139 ActChrgStrtYr_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1139 ActChrgStrtMin_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1139 ActChrgStrtMin_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1139 ActChrgStrtHr_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1139 ActChrgStrtHr_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1139 ActChrgStrtDay_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1139 ActChrgStrtDay_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1139 ActChrgStrtDay_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1139 ActChrgStrtDay_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1139 ActChrgStrMnth_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1139 ActChrgStrMnth_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1139 ActChrgStrMnth_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1139 ActChrgStrMnth_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1138 ActChrgEndYr_No2_Actl 0;
+BA_ "ECGUsedRxSignal" SG_ 1138 ActChrgEndYr_No2_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1138 ActChrgEndYr_No2_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1138 BattChrgTrgtLMin_T_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1138 ActChrgEndYr_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1138 ActChrgEndYr_No_Actl 0;
+BA_ "ECGUsedRxSignal" SG_ 1138 ActChrgEndYr_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1138 ActChrgEndMnth_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1138 ActChrgEndMnth_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1138 ActChrgEndMnth_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1138 ActChrgEndMnth_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1138 ActChrgEndMin_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1138 ActChrgEndMin_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1138 ActChrgEndHr_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1138 ActChrgEndHr_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1138 ActChrgEndDay_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1138 ActChrgEndDay_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1138 ActChrgEndDay_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1138 ActChrgEndDay_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 Mtr2Aout_W_ActlMntr 1;
+BA_ "GenSigStartValue" SG_ 1089 Mtr2Aout_W_ActlMntr 1023;
+BA_ "GenSigStartValueInteger" SG_ 1089 Mtr2Aout_W_ActlMntr 1023;
+BA_ "ECGUsedRxSignal" SG_ 1089 Mtr2Aout_W_ActlMntr 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 Inv1_Te_Actl 1;
+BA_ "GenSigStartValue" SG_ 1089 Inv1_Te_Actl 254;
+BA_ "GenSigStartValueInteger" SG_ 1089 Inv1_Te_Actl 254;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 MtrTrac2Coil_Te_Actl 1;
+BA_ "GenSigStartValue" SG_ 1089 MtrTrac2Coil_Te_Actl 254;
+BA_ "GenSigStartValueInteger" SG_ 1089 MtrTrac2Coil_Te_Actl 254;
+BA_ "ECGUsedRxSignal" SG_ 1089 MtrTrac2Coil_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 MtrTrac2_U_Actl 1;
+BA_ "GenSigStartValue" SG_ 1089 MtrTrac2_U_Actl 1023;
+BA_ "GenSigStartValueInteger" SG_ 1089 MtrTrac2_U_Actl 1023;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 MtrTrac2Falt_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 MtrTrac2TeAlrm_B_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1089 MtrTrac2TeAlrm_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 Mtr2CntlTeAlrm_B_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1089 Mtr2CntlTeAlrm_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 MtrTrac2Inv_Te_Actl 1;
+BA_ "GenSigStartValue" SG_ 1089 MtrTrac2Inv_Te_Actl 214;
+BA_ "GenSigStartValueInteger" SG_ 1089 MtrTrac2Inv_Te_Actl 214;
+BA_ "ECGUsedRxSignal" SG_ 1089 MtrTrac2Inv_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1089 MtrTrac2_I_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1089 MtrTrac2_I_Actl 10000;
+BA_ "U_CX727_MY2021_Tx" SG_ 1088 ChrgTMatch_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 ChrgStat_D2_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1088 ChrgStat_D2_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 HvacPrecondRecirc_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 HvacPrecondMode2_D_Rq 1;
+BA_ "ContentDependant" SG_ 1088 HvacPrecondMode2_D_Rq 1;
+BA_ "WakeupSignal" SG_ 1088 HvacPrecondMode2_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 HvacPrecondBlwr2_D_Rq 1;
+BA_ "ContentDependant" SG_ 1088 HvacPrecondBlwr2_D_Rq 1;
+BA_ "WakeupSignal" SG_ 1088 HvacPrecondBlwr2_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 HvacPrecondAC_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 HvacPrecond_Te_Rq 1;
+BA_ "GenSigStartValue" SG_ 1088 HvacPrecond_Te_Rq 2;
+BA_ "GenSigStartValueInteger" SG_ 1088 HvacPrecond_Te_Rq 2;
+BA_ "U_P702_MY2021_Tx" SG_ 1088 BattChrgInhbt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1040 ElCmprEnbl_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1040 ElCmprEnbl_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1040 ElCmprEnbl_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1040 ElCmpr_N_Rq 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTElement_B_Dsply 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTElement_B_Dsply 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1016 ChrgGoTElement_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgLocIdCurnt_D_Uns 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgLocIdCurnt_D_Uns 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgLocIdCurnt_D_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTTouchEnbl_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTTouchEnbl_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTTouch_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTTouch_B_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTTouch_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTPrcond_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTPrcond_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTNext_D_Stat 1;
+BA_ "MetaData" SG_ 1016 ChrgGoTNext_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1016 ChrgGoTNext_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1016 ChrgGoTNext_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTNext_D_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTNext_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTMnte_D_Stat 1;
+BA_ "MetaData" SG_ 1016 ChrgGoTMnte_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1016 ChrgGoTMnte_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1016 ChrgGoTMnte_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTMnte_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTHr_T_Stat 1;
+BA_ "GenSigStartValue" SG_ 1016 ChrgGoTHr_T_Stat 30;
+BA_ "GenSigStartValueInteger" SG_ 1016 ChrgGoTHr_T_Stat 30;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTHr_T_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTExtHtrEnbl_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTExtHtrEnbl_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTExtHtr_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTExtHtr_B_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTExtHtr_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTElement_D_Stat 1;
+BA_ "MetaData" SG_ 1016 ChrgGoTElement_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1016 ChrgGoTElement_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1016 ChrgGoTElement_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTElement_D_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTElement_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1016 ChrgGoTAllOn_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1016 ChrgGoTAllOn_B_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1016 ChrgGoTAllOn_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgToPcWkndSav_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1013 ChrgToPcWkndSav_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgToPcWkndSav_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgToPcWkdySav_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1013 ChrgToPcWkdySav_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgToPcWkdySav_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgProgIdSaved_D_Stat 1;
+BA_ "MetaData" SG_ 1013 ChrgProgIdSaved_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1013 ChrgProgIdSaved_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1013 ChrgProgIdSaved_D_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgProgIdSaved_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgNowEnbl_B_Saved 1;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgNowEnbl_B_Saved 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgLocIdUnsAck_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1013 ChrgLocIdUnsAck_B_Stat 3;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgLocIdUnsAck_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgLocIdCurnt_D_Sav 1;
+BA_ "MetaData" SG_ 1013 ChrgLocIdCurnt_D_Sav 1;
+BA_ "GenSigSendType" SG_ 1013 ChrgLocIdCurnt_D_Sav 3;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgLocIdCurnt_D_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgPrflWknd_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgPrflWknd_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1013 ChrgPrflWkdy_No_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 1013 ChrgPrflWkdy_No_Actl 1;
+BA_ "GenSigSendType" SG_ 1012 ChrgNowCurnt_B_Dsply 3;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgNowCurnt_B_Dsply 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1012 ChrgNowCurnt_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgNowCurnt_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 1012 ChrgLocSaved_B_Dsply 3;
+BA_ "UsedOnPgmDBC" SG_ 1012 ChrgLocSaved_B_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocSaved_B_Dsply 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1012 ChrgLocSaved_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocSaved_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocLongPostv_B_Sav 1;
+BA_ "UsedOnPgmDBC" SG_ 1012 ChrgLocLongPostv_B_Sav 1;
+BA_ "CrossOver_InfoCAN" SG_ 1012 ChrgLocLongPostv_B_Sav 1;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocLongPostv_B_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocLongFrct_An_Sav 1;
+BA_ "GenSigStartValue" SG_ 1012 ChrgLocLongFrct_An_Sav 1048575;
+BA_ "GenSigStartValueInteger" SG_ 1012 ChrgLocLongFrct_An_Sav 1048575;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocLongFrct_An_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocLongDeg_An_Sav 1;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocLongDeg_An_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocLattPostv_B_Sav 1;
+BA_ "UsedOnPgmDBC" SG_ 1012 ChrgLocLattPostv_B_Sav 1;
+BA_ "CrossOver_InfoCAN" SG_ 1012 ChrgLocLattPostv_B_Sav 1;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocLattPostv_B_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocLattFrct_An_Sav 1;
+BA_ "GenSigStartValue" SG_ 1012 ChrgLocLattFrct_An_Sav 1048575;
+BA_ "GenSigStartValueInteger" SG_ 1012 ChrgLocLattFrct_An_Sav 1048575;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocLattFrct_An_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocLattDeg_An_Sav 1;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocLattDeg_An_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1012 ChrgLocId_D_Sav 1;
+BA_ "GenSigSendType" SG_ 1012 ChrgLocId_D_Sav 3;
+BA_ "ECGUsedRxSignal" SG_ 1012 ChrgLocId_D_Sav 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocLongPostv_B_Uns 1;
+BA_ "UsedOnPgmDBC" SG_ 1011 ChrgLocLongPostv_B_Uns 1;
+BA_ "CrossOver_InfoCAN" SG_ 1011 ChrgLocLongPostv_B_Uns 1;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocLongPostv_B_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocLongFrct_An_Uns 1;
+BA_ "GenSigStartValue" SG_ 1011 ChrgLocLongFrct_An_Uns 1048575;
+BA_ "GenSigStartValueInteger" SG_ 1011 ChrgLocLongFrct_An_Uns 1048575;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocLongFrct_An_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocLongDeg_An_Uns 1;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocLongDeg_An_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocLattPostv_B_Uns 1;
+BA_ "UsedOnPgmDBC" SG_ 1011 ChrgLocLattPostv_B_Uns 1;
+BA_ "CrossOver_InfoCAN" SG_ 1011 ChrgLocLattPostv_B_Uns 1;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocLattPostv_B_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocLattFrct_An_Uns 1;
+BA_ "GenSigStartValue" SG_ 1011 ChrgLocLattFrct_An_Uns 1048575;
+BA_ "GenSigStartValueInteger" SG_ 1011 ChrgLocLattFrct_An_Uns 1048575;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocLattFrct_An_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocLattDeg_An_Uns 1;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocLattDeg_An_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1011 ChrgLocId_D_Uns 1;
+BA_ "GenSigSendType" SG_ 1011 ChrgLocId_D_Uns 3;
+BA_ "ECGUsedRxSignal" SG_ 1011 ChrgLocId_D_Uns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 871 BattElecPerf_D_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 871 BattElecPerf_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 871 BattChrgTrgtLPt_T_Est 1;
+BA_ "ECGUsedRxSignal" SG_ 871 BattChrgTrgtLPt_T_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 871 BattChrgTrgSocPt_T_Est 1;
+BA_ "ECGUsedRxSignal" SG_ 871 BattChrgTrgSocPt_T_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 871 BattChrgCmpltPt_T_Est 1;
+BA_ "ECGUsedRxSignal" SG_ 871 BattChrgCmpltPt_T_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 786 RgenTrip_Pc_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 786 RgenTrip_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 786 RgenTrip_Pc_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 786 RgenTrip_L_Dsply 1;
+BA_ "GenSigStartValue" SG_ 786 RgenTrip_L_Dsply 65535;
+BA_ "GenSigStartValueInteger" SG_ 786 RgenTrip_L_Dsply 65535;
+BA_ "CrossOver_InfoCAN" SG_ 786 RgenTrip_L_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 786 RgenTrip_L_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 786 ChrgStat_D_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 786 ChrgStat_D_Dsply 1;
+BA_ "UsedOnPgmDBC" SG_ 72 immoTarget2Status 1;
+BA_ "UsedOnPgmDBC" SG_ 72 immoTarget2Data 1;
+BA_ "UsedOnPgmDBC" SG_ 72 immoTarget2Cmd 1;
+BA_ "U_P702_MY2021_Rx" SG_ 912 CabnEvapSovFront_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 912 BattChlrSov_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 912 BattTracClntVlv_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 874 BattTracShrtGrnd_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 874 BattTracShrtBatt_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 874 BattTracOpnCirct_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 874 BattChlrShrtGrnd_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 874 BattChlrShrtBatt_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 874 BattChlrOpnCirct_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 651 TelematicsSrvc_D_St 1;
+BA_ "ECGUsedTxSignal" SG_ 651 OfbChrgSetSync_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgToPcWknd_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 529 OnbChrgToPcWknd_D_Actl 1;
+BA_ "ECGUsedTxSignal" SG_ 529 OnbChrgToPcWknd_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgToPcWkdy_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 529 OnbChrgToPcWkdy_D_Actl 1;
+BA_ "ECGUsedTxSignal" SG_ 529 OnbChrgToPcWkdy_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgSetNow_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgSetDelete_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 529 OnbChrgSetDelete_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgPrflWknd_No_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgPrflWkdy_No_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgPrflUpdate_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 529 OnbChrgPrflUpdate_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgLocIdUns_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 529 OnbChrgLocIdUns_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 529 OnbChrgLocIdTrgt_No_Rq 1;
+BA_ "MetaData" SG_ 529 OnbChrgLocIdTrgt_No_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 529 OnbChrgLocIdTrgt_No_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 529 OnbChrgLocIdTrgt_No_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 66 immoControlData_T2 1;
+BA_ "ContentDependant" SG_ 66 immoControlData_T2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 66 immoControlCmd_T2 1;
+BA_ "ContentDependant" SG_ 66 immoControlCmd_T2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 2610971864 PARSEDPhysGWM_ECGtoHPCM 1;
+BA_ "GenSigSendType" SG_ 2610971864 PARSEDPhysGWM_ECGtoHPCM 3;
+BA_ "ECGUsedTxSignal" SG_ 2610971864 PARSEDPhysGWM_ECGtoHPCM 1;
+BA_ "ECGUsedTxSignal" SG_ 2612002008 PARSEDFuncGWM_ECG 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2612002008 PARSEDFuncGWM_ECG 1;
+BA_ "U_P702_MY2021_Rx" SG_ 2612002008 PARSEDFuncGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2612002008 PARSEDFuncGWM_ECG 3;
+BA_ "U_P702_MY2021_Rx" SG_ 2609923288 OTAPhysGWM_ECGtoHPCM 1;
+BA_ "GenSigSendType" SG_ 2609923288 OTAPhysGWM_ECGtoHPCM 3;
+BA_ "ECGUsedTxSignal" SG_ 2609923288 OTAPhysGWM_ECGtoHPCM 1;
+BA_ "ECGUsedTxSignal" SG_ 2610953432 OTAFuncGWM_ECG 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2610953432 OTAFuncGWM_ECG 1;
+BA_ "U_P702_MY2021_Rx" SG_ 2610953432 OTAFuncGWM_ECG 1;
+BA_ "GenSigSendType" SG_ 2610953432 OTAFuncGWM_ECG 3;
+BA_ "GenSigSendType" SG_ 2022 TesterPhysicalReqSOBDMC 3;
+BA_ "U_P702_MY2021_Rx" SG_ 2022 TesterPhysicalReqSOBDMC 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_Vdop 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_Speed 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_Sat_num_in_view 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1124 GPS_Sat_num_in_view 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_MSL_altitude 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_Heading 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_Hdop 1;
+BA_ "CrossOver_InfoCAN" SG_ 1124 GPS_dimension 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1124 GPS_dimension 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1119 CoolFanDcdc_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1119 DcdcClntFlw_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 132 GlblClkYr_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 132 GlblClkScnd_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 132 GlblClkMnte_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 132 GlblClkHr_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 132 GlblClkDay_No_Actl 1;
+BA_ "GenSigSendType" SG_ 1990 TesterPhysicalReqSODR 3;
+BA_ "GenSigSendType" SG_ 1892 TesterPhysicalReqCCM 3;
+BA_ "GenSigSendType" SG_ 1798 TesterPhysicalReqIPMA 3;
+BA_ "GenSigStartValueInteger" SG_ 1123 GpsUtcYr_No_Actl 0;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GpsUtcYr_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1123 GpsUtcMnth_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1123 GpsUtcMnth_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GpsUtcMnth_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1123 GpsUtcDay_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1123 GpsUtcDay_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GpsUtcDay_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GPS_UTC_seconds 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GPS_UTC_minutes 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GPS_UTC_hours 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GPS_Pdop 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GPS_Compass_direction 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 GPS_Actual_vs_Infer_pos 1;
+BA_ "CrossOver_InfoCAN" SG_ 1123 Gps_B_Falt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GpsHsphLongEast_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GpsHsphLattSth_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GPS_Longitude_Minutes 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GPS_Longitude_Min_dec 1;
+BA_ "GenSigStartValueInteger" SG_ 1122 GPS_Longitude_Degrees 179;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GPS_Longitude_Degrees 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GPS_Latitude_Minutes 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GPS_Latitude_Min_dec 1;
+BA_ "CrossOver_InfoCAN" SG_ 1122 GPS_Latitude_Degrees 1;
+BA_ "GenSigStartValue" SG_ 1003 PersNoPos_D_Actl 4;
+BA_ "GenSigStartValueInteger" SG_ 1003 PersNoPos_D_Actl 4;
+BA_ "CrossOver_InfoCAN" SG_ 1003 PersNoPos_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1003 PersSetupRestr_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1003 PersSetupAccessCtrl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1003 PersSetup_No_Actl 1;
+BA_ "GenSigStartValue" SG_ 1003 PersConflict_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1003 PersConflict_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1003 PersConflict_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1003 AssocConfirm_D_Actl 1;
+BA_ "MetaData" SG_ 1003 RecallEvent_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1003 RecallEvent_No_Cnt 1;
+BA_ "GenSigStartValue" SG_ 1003 PersNo_D_Actl 4;
+BA_ "GenSigStartValueInteger" SG_ 1003 PersNo_D_Actl 4;
+BA_ "CrossOver_InfoCAN" SG_ 1003 PersNo_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 PersStore_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 Pers4OptIn_B_Stats 1;
+BA_ "WakeupSignal" SG_ 994 Pers4OptIn_B_Stats 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 Pers3OptIn_B_Stats 1;
+BA_ "WakeupSignal" SG_ 994 Pers3OptIn_B_Stats 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 Pers2OptIn_B_Stats 1;
+BA_ "WakeupSignal" SG_ 994 Pers2OptIn_B_Stats 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 Pers1OptIn_B_Stats 1;
+BA_ "WakeupSignal" SG_ 994 Pers1OptIn_B_Stats 1;
+BA_ "GenSigStartValue" SG_ 994 CtrStkPersIndex_D_Actl 4;
+BA_ "GenSigStartValueInteger" SG_ 994 CtrStkPersIndex_D_Actl 4;
+BA_ "CrossOver_InfoCAN" SG_ 994 CtrStkPersIndex_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 CtrStkFeatNoActl 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 CtrStkFeatConfigActl 1;
+BA_ "CrossOver_InfoCAN" SG_ 994 CtrStkDsplyOp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 778 PrkAidFront_D_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 778 Cta_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 778 Cta_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 778 Cta_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 778 PrkAidRear_D_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 778 Sod_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 778 Sod_D_Rq 2;
+BA_ "GenSigStartValue" SG_ 778 Sod_D_Rq 2;
+BA_ "WakeupSignal" SG_ 549 Power_Up_Chime_Modules 1;
+BA_ "WakeupSignal" SG_ 551 Cntr_Plg_Mode_Cmd 1;
+BA_ "GenSigStartValue" SG_ 551 Btt_L_Actl2 30;
+BA_ "GenSigStartValueInteger" SG_ 551 Btt_L_Actl2 126;
+BA_ "WakeupSignal" SG_ 551 Em_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1010 CbdblActv_B_RqAdas 1;
+BA_ "UsedOnPgmDBC" SG_ 1010 CbdblActv_B_RqAdas 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1010 LightRng_L_Max 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1010 LightPathOffst_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1010 LightPathOffst_L_Actl 512;
+BA_ "U_P702_MY2021_Rx" SG_ 1010 LightPath_An_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1010 LightPath_An_Actl 1000;
+BA_ "U_P702_MY2021_Rx" SG_ 1010 LightCurv_NoRate_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1010 LightCurv_NoRate_Actl 4096;
+BA_ "U_P702_MY2021_Rx" SG_ 1010 LightCurv_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1010 LightCurv_No_Actl 1000;
+BA_ "GenSigStartValue" SG_ 1070 BattULo24_Te_Actl 127;
+BA_ "GenSigStartValueInteger" SG_ 1070 BattULo24_Te_Actl 127;
+BA_ "UsedOnPgmDBC" SG_ 1070 BattULo24_Te_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1070 BattULo24State_D_Qlty 1;
+BA_ "GenSigStartValue" SG_ 1070 BattULo24State_D_Qlty 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1070 BattULo24Soc_Pc_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1070 BattULo24Soc_Pc_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1070 BattULo24_I_Actl 1;
+BA_ "GenSigStartValue" SG_ 1070 BattULo24_I_Actl 8192;
+BA_ "U_P702_MY2021_Rx" SG_ 1070 BattULo24_B_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1070 BattULo24_Ah_DeltaRide 1;
+BA_ "GenSigStartValue" SG_ 1070 BattULo24_Ah_DeltaRide 12800;
+BA_ "GenSigStartValueInteger" SG_ 1186 SelDrvMdeAwd2_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1186 SelDrvMdeAwd2_D_Stat 31;
+BA_ "U_CX727_MY2021_Rx" SG_ 1186 SelDrvMdeAwd2_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1186 SelDrvMdeAwd2_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1186 SelDrvMdeAwd2_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1186 RearDiffLckMsg_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1186 RearDiffLckLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1186 RearDiffLckLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1186 RearDiffLck_Tq_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1186 RearDiffLck_Tq_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1186 RearDiffLck_Tq_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1186 RearDiffFalt_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1186 RearDiffFalt_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1186 LsdSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1186 LsdSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdSys_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 611 AwdSys_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdSys_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdStat_D_RqDsply 1;
+BA_ "ContentDependant" SG_ 611 AwdStat_D_RqDsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdStat_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 611 AwdStat_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdStat_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdLck_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 611 AwdLck_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdLck_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 611 AwdLck_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdLck_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdSrvcRqd_B_Rq 1;
+BA_ "ContentDependant" SG_ 611 AwdSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdSrvcRqd_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 611 AwdSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 NtrlTowAvail_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdLck_Tq_Rq 1;
+BA_ "ContentDependant" SG_ 611 AwdLck_Tq_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdLck_Tq_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdLck_Tq_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 TrnAout_Tq_RqMx 1;
+BA_ "GenSigStartValueInteger" SG_ 611 TrnAout_Tq_RqMx 8191;
+BA_ "GenSigStartValue" SG_ 611 TrnAout_Tq_RqMx 8191;
+BA_ "U_P702_MY2021_Rx" SG_ 611 TrnAout_Tq_RqMx 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 611 TrnAout_Tq_RqMx 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 TrnAout_Tq_RqMx 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdOffRoadMode_D_Stats 1;
+BA_ "UsedOnPgmDBC" SG_ 611 AwdOffRoadMode_D_Stats 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdOffRoadMode_D_Stats 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdLoLamp_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdLoLamp_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdHiLamp_D_RqDsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdHiLamp_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdHiLamp_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdAutoLamp_D_RqDsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdAutoLamp_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdAutoLamp_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 Awd2wdLamp_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 Awd2wdLamp_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 611 AwdRnge_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 611 AwdRnge_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 611 AwdRnge_D_Actl 7;
+BA_ "GenSigStartValue" SG_ 611 AwdRnge_D_Actl 7;
+BA_ "U_P702_MY2021_Rx" SG_ 611 AwdRnge_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 611 AwdRnge_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 611 AwdRnge_D_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 611 AwdRnge_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1461 PSCM_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_GWOnBoardTester 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1461 PSCM_GWOnBoardTester 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_GWOnBoardTester 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1461 PSCM_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_GWNMProxy 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1461 PSCM_GWNMProxy 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_GWNMProxy 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_GWNMProxy 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1461 PSCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_AutoSarNMReserved4 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1461 PSCM_AutoSarNMReserved4 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved4 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1461 PSCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_AutoSarNMReserved3 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1461 PSCM_AutoSarNMReserved3 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved3 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1461 PSCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_AutoSarNMReserved2 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1461 PSCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_AutoSarNMReserved1 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1461 PSCM_AutoSarNMNodeId 181;
+BA_ "ContentDependant" SG_ 1461 PSCM_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1461 PSCM_AutoSarNMNodeId 181;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMNodeId 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1461 PSCM_AutoSarNMControl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1461 PSCM_AutoSarNMControl 1;
+BA_ "GenSigStartValueInteger" SG_ 1047 TrlrAnOffst_An2_Calc 128;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAnOffst_An2_Calc 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAn_An_WarnCalc 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAn_An_MxCalc 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAidTrlrId_No_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAidTrgtId_No_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAidSetup_D2_Stat 1;
+BA_ "GenSigSendType" SG_ 1047 TrlrAidEnbl_D2_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1047 TrlrAidEnbl_D2_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1047 TrlrAidEnbl_D2_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAidEnbl_D2_Stat 1;
+BA_ "GenSigSendType" SG_ 1047 TrlrAidMsgTxt_D2_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1047 TrlrAidMsgTxt_D2_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 TrlrAidMsgTxt_D2_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1047 EsaOn_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 1047 EsaOn_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1047 EsaOn_B_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1047 EsaOn_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 EsaOn_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 HitchToTrlrAxle_L_Calc 1;
+BA_ "GenSigSendType" SG_ 1047 SelDrvMdeSte_D_Stat 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1047 SelDrvMdeSte_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1047 SelDrvMdeSte_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1047 SelDrvMdeSte_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1047 SelDrvMdeSte_D_Stat 1;
+BA_ "GenSigSendType" SG_ 972 LatCtlSte_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 972 LatCtlSte_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LatCtlSte_D_Stat 1;
+BA_ "GenSigSendType" SG_ 972 LatCtlLim_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 972 LatCtlLim_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LatCtlLim_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 972 LatCtlCpbltyDStat_No_Cnt 1;
+BA_ "MetaData" SG_ 972 LatCtlCpbltyDStat_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 972 LatCtlCpbltyDStat_No_Cs 1;
+BA_ "MetaData" SG_ 972 LatCtlCpbltyDStat_No_Cs 1;
+BA_ "GenSigStartValueInteger" SG_ 972 TrlrAn_An_TrgtCalc 128;
+BA_ "U_P702_MY2021_Tx" SG_ 972 TrlrAn_An_TrgtCalc 1;
+BA_ "U_P702_MY2021_Rx" SG_ 972 LsmcBrkDecelEnbl_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LsmcBrkDecelEnbl_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 972 TjaHandsOnCnfdnc_B_Est 1;
+BA_ "GenSigStartValue" SG_ 972 TjaHandsOnCnfdnc_B_Est 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 972 TjaHandsOnCnfdnc_B_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 TjaHandsOnCnfdnc_B_Est 1;
+BA_ "CrossOver_InfoCAN" SG_ 972 LaHandsOff_B_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 972 LaHandsOff_B_Actl 1;
+BA_ "GenSigStartValue" SG_ 972 LaHandsOff_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 972 LaHandsOff_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LaHandsOff_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 972 LaActDeny_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 972 LaActDeny_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LaActDeny_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 972 LaActAvail_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 972 LaActAvail_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LaActAvail_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 972 LsmcBrk_Tq_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 972 LsmcBrk_Tq_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 130 TrlrHitchLamp_D_Rqst 1;
+BA_ "UsedOnPgmDBC" SG_ 130 TrlrHitchLamp_D_Rqst 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 TrlrHitchLamp_D_Rqst 1;
+BA_ "CrossOver_InfoCAN" SG_ 130 VehVTrlrAid_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 130 VehVTrlrAid_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 130 VehVTrlrAid_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 VehVTrlrAid_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 130 Veh_V_RqMxTrlrAid 255;
+BA_ "GenSigStartValue" SG_ 130 Veh_V_RqMxTrlrAid 255;
+BA_ "U_P702_MY2021_Rx" SG_ 130 Veh_V_RqMxTrlrAid 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 130 Veh_V_RqMxTrlrAid 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 Veh_V_RqMxTrlrAid 1;
+BA_ "UsedOnPgmDBC" SG_ 130 DrvSteActv_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 130 DrvSteActv_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 DrvSteActv_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 130 DrvSte_Tq_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 130 DrvSte_Tq_Actl 128;
+BA_ "U_P702_MY2021_Rx" SG_ 130 DrvSte_Tq_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 DrvSte_Tq_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SteMdule_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SteMdule_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SteMdule_U_Meas 1;
+BA_ "GenSigStartValueInteger" SG_ 130 SteMdule_U_Meas 255;
+BA_ "GenSigStartValue" SG_ 130 SteMdule_U_Meas 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SteMdule_U_Meas 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SteMdule_U_Meas 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SteMdule_I_Est 1;
+BA_ "GenSigStartValueInteger" SG_ 130 SteMdule_I_Est 4095;
+BA_ "GenSigStartValue" SG_ 130 SteMdule_I_Est 4095;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SteMdule_I_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SteMdule_I_Est 1;
+BA_ "CrossOver_InfoCAN" SG_ 130 EPAS_Failure 1;
+BA_ "UsedOnPgmDBC" SG_ 130 EPAS_Failure 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 EPAS_Failure 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 EPAS_Failure 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SteeringColumnTorque 1;
+BA_ "GenSigStartValueInteger" SG_ 130 SteeringColumnTorque 254;
+BA_ "GenSigStartValue" SG_ 130 SteeringColumnTorque 254;
+BA_ "U_CX727_MY2021_Rx" SG_ 130 SteeringColumnTorque 1;
+BA_ "U_P702_MY2021_Rx" SG_ 130 SteeringColumnTorque 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SteeringColumnTorque 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SteeringColumnTorque 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SAPPAngleControlStat6 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SAPPAngleControlStat6 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SAPPAngleControlStat6 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SAPPAngleControlStat5 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SAPPAngleControlStat5 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SAPPAngleControlStat5 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SAPPAngleControlStat4 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SAPPAngleControlStat4 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SAPPAngleControlStat4 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SAPPAngleControlStat3 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SAPPAngleControlStat3 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SAPPAngleControlStat3 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SAPPAngleControlStat2 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SAPPAngleControlStat2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SAPPAngleControlStat2 1;
+BA_ "UsedOnPgmDBC" SG_ 130 SAPPAngleControlStat1 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 130 SAPPAngleControlStat1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 130 SAPPAngleControlStat1 1;
+BA_ "UsedOnPgmDBC" SG_ 133 StePw_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 133 StePw_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 133 StePw_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 133 StePw_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "GenSigStartValueInteger" SG_ 133 StePinRelInit_An_Sns 65535;
+BA_ "ContentDependant" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "GenSigStartValue" SG_ 133 StePinRelInit_An_Sns 65535;
+BA_ "U_P702_MY2021_Rx" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "U_P702_MY2021_Tx" SG_ 133 StePinRelInit_An_Sns 1;
+BA_ "CrossOver_InfoCAN" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "ECGUsedRxSignal" SG_ 133 StePinCompAnEst_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 133 StePinComp_An_Est 16000;
+BA_ "U_P702_MY2021_Rx" SG_ 133 StePinComp_An_Est 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 133 StePinComp_An_Est 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 133 StePinComp_An_Est 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 133 StePinComp_An_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 133 StePinComp_An_Est 1;
+BA_ "ECGUsedRxSignal" SG_ 133 StePinComp_An_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 133 StePinAn_No_Cs 1;
+BA_ "ContentDependant" SG_ 133 StePinAn_No_Cs 1;
+BA_ "MetaData" SG_ 133 StePinAn_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 133 StePinAn_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 133 StePinAn_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 133 StePinAn_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 133 StePinAn_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 133 StePinAn_No_Cnt 1;
+BA_ "MetaData" SG_ 133 StePinAn_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 133 StePinAn_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 133 StePinAn_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 133 StePinAn_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 133 StePinAn_No_Cnt 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1430 ABS_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_GWOnBoardTester 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_GWOnBoardTester 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1430 ABS_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_GWNMProxy 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_GWNMProxy 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_GWNMProxy 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1430 ABS_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_AutoSarNMReserved4 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved4 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1430 ABS_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_AutoSarNMReserved3 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved3 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1430 ABS_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_AutoSarNMReserved2 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1430 ABS_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_AutoSarNMReserved1 255;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1430 ABS_AutoSarNMNodeId 150;
+BA_ "ContentDependant" SG_ 1430 ABS_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1430 ABS_AutoSarNMNodeId 150;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_AutoSarNMNodeId 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1430 ABS_AutoSarNMControl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1430 ABS_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1430 ABS_AutoSarNMControl 1;
+BA_ "GenSigStartValueInteger" SG_ 1200 HsaTrnAout_Tq_Rq 32768;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 HsaTrnAout_Tq_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 HsaTrnAout_Tq_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1200 BrkBstrVac_P_Actl 127;
+BA_ "GenSigStartValue" SG_ 1200 BrkBstrVac_P_Actl 127;
+BA_ "U_P702_MY2021_Rx" SG_ 1200 BrkBstrVac_P_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1200 BrkBstrVac_P_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 BrkBstrVac_P_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 BrkBstrVac_P_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1200 YawStabilityIndex 256;
+BA_ "U_CX727_MY2021_Rx" SG_ 1200 YawStabilityIndex 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1200 YawStabilityIndex 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 YawStabilityIndex 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 YawStabilityIndex 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1200 BrkTot_Tq_RqDrv 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1200 BrkTot_Tq_RqDrv 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 BrkTot_Tq_RqDrv 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 BrkTot_Tq_RqDrv 1;
+BA_ "MetaData" SG_ 1200 BrkTotTqRqDrv_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1200 BrkTotTqRqDrv_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1200 BrkTotTqRqDrv_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 BrkTotTqRqDrv_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 BrkTotTqRqDrv_No_Cnt 1;
+BA_ "MetaData" SG_ 1200 BrkTotTqRqDrv_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1200 BrkTotTqRqDrv_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1200 BrkTotTqRqDrv_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 BrkTotTqRqDrv_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 BrkTotTqRqDrv_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1200 HsaStat_D_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1200 HsaStat_D_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos12_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos12_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos12_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos12_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos12_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos11_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos11_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos11_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos11_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos11_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos10_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos10_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos10_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos10_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos10_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos09_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos09_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos09_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos09_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos09_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos08_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos08_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos08_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos08_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos08_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos07_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos07_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos07_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos07_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos07_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos06_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos06_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos06_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos06_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos06_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos05_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos05_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos05_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos05_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos05_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos04_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos04_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos04_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos04_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos04_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos03_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos03_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos03_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos03_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos03_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos02_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos02_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos02_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos02_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos02_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1102 SelDrvMdePos01_D_Stat 31;
+BA_ "GenSigStartValue" SG_ 1102 SelDrvMdePos01_D_Stat 31;
+BA_ "GenSigSendType" SG_ 1102 SelDrvMdePos01_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1102 SelDrvMdePos01_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1102 SelDrvMdePos01_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1056 AutoEpbMsgTxt_D_Rq 3;
+BA_ "GenSigSendType" SG_ 1056 AutoEpbDsply_D_Stat 3;
+BA_ "GenSigSendType" SG_ 1056 AutoEpbButtnOn_B_Stat 3;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos12_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos12_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos12_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos11_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos11_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos11_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos10_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos10_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos10_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos09_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos09_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos09_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos08_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos08_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos08_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos07_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos07_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos07_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos06_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos06_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos06_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos05_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos05_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos05_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos04_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos04_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos04_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos03_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos03_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos03_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos02_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos02_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos02_B_Avail 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePos01_B_Avail 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePos01_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePos01_B_Avail 1;
+BA_ "GenSigStartValueInteger" SG_ 1056 ActvDrvMde_D2_Stat 31;
+BA_ "GenSigStartValue" SG_ 1056 ActvDrvMde_D2_Stat 31;
+BA_ "GenSigSendType" SG_ 1056 ActvDrvMde_D2_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 ActvDrvMde_D2_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 ActvDrvMde_D2_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1056 SelDrvMde_D2_Rq 31;
+BA_ "GenSigStartValue" SG_ 1056 SelDrvMde_D2_Rq 31;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMde_D2_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMde_D2_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMde_D2_Rq 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdePt_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1056 SelDrvMdePt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1056 SelDrvMdePt_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdePt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdePt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMdeMsgTxt_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMdeMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMdeMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1056 SelDrvMde_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 SelDrvMde_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 SelDrvMde_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1056 AwdMde_D_RqBrk 5;
+BA_ "GenSigStartValue" SG_ 1056 AwdMde_D_RqBrk 5;
+BA_ "GenSigSendType" SG_ 1056 AwdMde_D_RqBrk 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1056 AwdMde_D_RqBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1056 AwdMde_D_RqBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 AirDamUp_B_RqBrk 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1054 AirDamUp_B_RqBrk 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1054 AirDamUp_B_RqBrk 1;
+BA_ "GenSigSendType" SG_ 1054 AirDamUp_B_RqBrk 3;
+BA_ "GenSigSendType" SG_ 1054 RbaBrk_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 RbaBrk_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 RbaBrk_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1054 SelDrvMdeChassis2_D_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1054 SelDrvMdeChassis2_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1054 SelDrvMdeChassis2_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 SelDrvMdeChassis2_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1054 TrailCtl_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1054 TrailCtl_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1054 TrailCtl_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 TrailCtl_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 TrailCtl_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1054 TrailCtlMsgTxt_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 TrailCtlMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 TrailCtlMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1054 BrkBstrVac_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1054 BrkBstrVac_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1054 BrkBstrVac_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 BrkBstrVac_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 BrkBstrVac_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1054 DrvSlipCtlOffLamp_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 DrvSlipCtlOffLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 DrvSlipCtlOffLamp_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1054 DrvSlipCtlMdeMsg_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 DrvSlipCtlMdeMsg_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 DrvSlipCtlMdeMsg_D_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 1054 DrvSlipCtlMdeMsg_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1054 AutoHoldMsgTxt_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 AutoHoldMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 AutoHoldMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1054 CtaBrk_D_Stat 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 CtaBrk_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 CtaBrk_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1054 SelDrvMdeAwd_D_Rq 31;
+BA_ "GenSigStartValue" SG_ 1054 SelDrvMdeAwd_D_Rq 31;
+BA_ "GenSigSendType" SG_ 1054 SelDrvMdeAwd_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1054 SelDrvMdeAwd_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 SelDrvMdeAwd_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1054 AutoHoldSwMde_B_Ind 1;
+BA_ "ContentDependant" SG_ 1054 AutoHoldSwMde_B_Ind 1;
+BA_ "GenSigSendType" SG_ 1054 AutoHoldSwMde_B_Ind 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 AutoHoldSwMde_B_Ind 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 AutoHoldSwMde_B_Ind 1;
+BA_ "GenSigSendType" SG_ 1054 AutoHoldMde_D_Ind 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 AutoHoldMde_D_Ind 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 AutoHoldMde_D_Ind 1;
+BA_ "GenSigSendType" SG_ 1054 SelDrvMdeChassis_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 SelDrvMdeChassis_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 SelDrvMdeChassis_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1054 ApaBrk_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1054 ApaBrk_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1054 ApaBrk_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1054 ApaBrk_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1054 ApaBrk_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 HsaMde_D_Mem 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 HsaMde_D_Mem 1;
+BA_ "GenSigStartValueInteger" SG_ 1046 HsaMde_D_Mem 1;
+BA_ "GenSigStartValue" SG_ 1046 HsaMde_D_Mem 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 HsaMde_D_Mem 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 HsaMde_D_Mem 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 BrkBstrVac_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 BrkBstrVac_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 BrkBstrVac_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1046 BrkBstrVac_B_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 BrkBstrVac_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 BrkBstrVac_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 HdcMde_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 HdcMde_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 HdcMde_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 HdcMde_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1046 RearDiffLck_Tq2_RqMx 4094;
+BA_ "GenSigStartValue" SG_ 1046 RearDiffLck_Tq2_RqMx 4094;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 RearDiffLck_Tq2_RqMx 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 RearDiffLck_Tq2_RqMx 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 TRLR_SWAY_EVNT_IN_PROG 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 TRLR_SWAY_EVNT_IN_PROG 1;
+BA_ "ECGUsedRxSignal" SG_ 1046 TRLR_SWAY_EVNT_IN_PROG 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 TRLR_SWAY_CONFIG_STAT 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 TRLR_SWAY_CONFIG_STAT 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 TCMode 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 TCMode 1;
+BA_ "ContentDependant" SG_ 1046 TCMode 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 TCMode 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1046 TCMode 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 TCMode 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 TCMode 1;
+BA_ "ECGUsedRxSignal" SG_ 1046 TCMode 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 DrvSlipCtlLamp_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 DrvSlipCtlLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 DrvSlipCtlLamp_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1046 DrvSlipCtlLamp_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 DrvSlipCtlLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 DrvSlipCtlLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 Abs_B_Falt 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 Abs_B_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 Abs_B_Falt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1046 Abs_B_Falt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 Abs_B_Falt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 Abs_B_Falt 1;
+BA_ "ECGUsedRxSignal" SG_ 1046 Abs_B_Falt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "ECGUsedRxSignal" SG_ 1046 DrvSlipCtlMde_D_Ind 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 DrvAntiLckLamp_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 DrvAntiLckLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 DrvAntiLckLamp_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1046 DrvAntiLckLamp_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 DrvAntiLckLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 DrvAntiLckLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 BpedMove_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 BpedMove_No_Cnt 1;
+BA_ "MetaData" SG_ 1046 BpedMove_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 BpedMove_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 BpedMove_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 BpedMove_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 StabCtlBrk_B_Avail 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 StabCtlBrk_B_Avail 1;
+BA_ "GenSigStartValueInteger" SG_ 1046 StabCtlBrk_B_Avail 1;
+BA_ "GenSigStartValue" SG_ 1046 StabCtlBrk_B_Avail 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 StabCtlBrk_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 StabCtlBrk_B_Avail 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 DrvHdcWarnInfo_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 DrvHdcWarnInfo_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 DrvHdcWarnInfo_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 DrvHdcWarnInfo_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 DrvHdcMsg_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 DrvHdcMsg_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 DrvHdcMsg_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 DrvHdcMsg_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 DrvHdcLampInfo_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 DrvHdcLampInfo_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 DrvHdcLampInfo_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 DrvHdcLampInfo_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 BpedMove_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 BpedMove_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1046 BpedMove_D_Actl 3;
+BA_ "GenSigStartValue" SG_ 1046 BpedMove_D_Actl 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1046 BpedMove_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 BpedMove_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 BpedMove_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 ChimeBrk_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 ChimeBrk_B_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 ChimeBrk_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 ChimeBrk_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 BrkLamp_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 BrkLamp_B_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 BrkLamp_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 BrkLamp_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1046 HILL_DESC_MC 1;
+BA_ "UsedOnPgmDBC" SG_ 1046 HILL_DESC_MC 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1046 HILL_DESC_MC 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 HILL_DESC_MC 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1046 RearDiffElckrOpen_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1045 VehStab_D_Stat 14;
+BA_ "GenSigStartValue" SG_ 1045 VehStab_D_Stat 14;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 VehStab_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 VehStab_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 VehStab_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 VehStab_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 BrkFluidLvl_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 BrkFluidLvl_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 LsmcBrkDecel_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 LsmcBrkDecel_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1045 VehYawNonLin_W_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1045 VehYawNonLin_W_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1045 VehYawNonLin_W_Rq 4094;
+BA_ "GenSigStartValue" SG_ 1045 VehYawNonLin_W_Rq 4094;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 VehYawNonLin_W_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 VehYawNonLin_W_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 VehYawNonLin_W_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 VehYawNonLin_W_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1045 VehYawLin_W_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1045 VehYawLin_W_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1045 VehYawLin_W_Rq 4094;
+BA_ "GenSigStartValue" SG_ 1045 VehYawLin_W_Rq 4094;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 VehYawLin_W_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 VehYawLin_W_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 VehYawLin_W_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 VehYawLin_W_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "MetaData" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 VehVActlBrk_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "UsedOnPgmDBC" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 Veh_V_ActlBrk 1;
+BA_ "CrossOver_InfoCAN" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "MetaData" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 VehVActlBrk_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "MetaData" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1045 VehVActlBrk_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 1044 StePinOffst_An_Est 1;
+BA_ "GenSigStartValueInteger" SG_ 1044 StePinOffst_An_Est 65534;
+BA_ "ContentDependant" SG_ 1044 StePinOffst_An_Est 1;
+BA_ "GenSigStartValue" SG_ 1044 StePinOffst_An_Est 65533;
+BA_ "U_CX727_MY2021_Rx" SG_ 1044 StePinOffst_An_Est 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1044 StePinOffst_An_Est 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1044 StePinOffst_An_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1044 StePinOffst_An_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "ContentDependant" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "MetaData" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1044 StePinOffst_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 1044 StePinOffst_No_Cnt 1;
+BA_ "MetaData" SG_ 1044 StePinOffst_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1044 StePinOffst_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1044 StePinOffst_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1044 StePinOffst_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1044 StePinOffst_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1044 StePinOffst_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1044 StePinOffst_D_Stat 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1044 StePinOffst_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1044 StePinOffst_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1042 VehRol_An_Dsply 64;
+BA_ "GenSigStartValue" SG_ 1042 VehRol_An_Dsply 0;
+BA_ "U_P702_MY2021_Tx" SG_ 1042 VehRol_An_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1042 VehPtch_An_Dsply 64;
+BA_ "GenSigStartValue" SG_ 1042 VehPtch_An_Dsply 0;
+BA_ "U_P702_MY2021_Rx" SG_ 1042 VehPtch_An_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1042 VehPtch_An_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1042 TrlrBrk_Pc_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 535 WhlRr_W_Meas 1;
+BA_ "U_P702_MY2021_Rx" SG_ 535 WhlRr_W_Meas 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 535 WhlRr_W_Meas 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 535 WhlRr_W_Meas 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 535 WhlRr_W_Meas 1;
+BA_ "U_P702_MY2021_Tx" SG_ 535 WhlRr_W_Meas 1;
+BA_ "UsedOnPgmDBC" SG_ 535 WhlRl_W_Meas 1;
+BA_ "U_P702_MY2021_Rx" SG_ 535 WhlRl_W_Meas 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 535 WhlRl_W_Meas 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 535 WhlRl_W_Meas 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 535 WhlRl_W_Meas 1;
+BA_ "U_P702_MY2021_Tx" SG_ 535 WhlRl_W_Meas 1;
+BA_ "UsedOnPgmDBC" SG_ 535 WhlFr_W_Meas 1;
+BA_ "U_P702_MY2021_Rx" SG_ 535 WhlFr_W_Meas 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 535 WhlFr_W_Meas 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 535 WhlFr_W_Meas 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 535 WhlFr_W_Meas 1;
+BA_ "U_P702_MY2021_Tx" SG_ 535 WhlFr_W_Meas 1;
+BA_ "UsedOnPgmDBC" SG_ 535 WhlFl_W_Meas 1;
+BA_ "U_P702_MY2021_Rx" SG_ 535 WhlFl_W_Meas 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 535 WhlFl_W_Meas 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 535 WhlFl_W_Meas 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 535 WhlFl_W_Meas 1;
+BA_ "U_P702_MY2021_Tx" SG_ 535 WhlFl_W_Meas 1;
+BA_ "ContentDependant" SG_ 534 BrkObdData_No_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 BrkObdData_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 BrkObdData_No_Actl 1;
+BA_ "ContentDependant" SG_ 534 BrkObdIndex_No_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 BrkObdIndex_No_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 BrkObdIndex_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlRotatRr_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlRotatRr_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlRotatRr_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlRotatRr_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlRotatRr_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlDirRr_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlDirRl_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlDirFr_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlDirFl_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlRotatRl_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlRotatRl_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlRotatRl_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlRotatRl_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlRotatRl_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlRotatFr_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlRotatFr_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlRotatFr_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlRotatFr_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlRotatFr_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 534 WhlRotatFl_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 534 WhlRotatFl_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 534 WhlRotatFl_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 534 WhlRotatFl_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 534 WhlRotatFl_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 532 RgenTqFalt_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 532 RgenTqFalt_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 532 RgenTqFalt_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 532 RgenTqFalt_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 532 RgenBrkDynoMde_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 532 RgenBrkDynoMde_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 532 RgenBrkDynoMde_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 532 RgenBrkDynoMde_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 532 PrplWhlTqRqMn_No_Cs 1;
+BA_ "MetaData" SG_ 532 PrplWhlTqRqMn_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 532 PrplWhlTqRqMn_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 532 PrplWhlTqRqMn_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 532 PrplWhlTqRqMn_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 532 PrplWhlTqRqMn_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 532 PrplWhlTot_Tq_RqMn 1;
+BA_ "U_P702_MY2021_Rx" SG_ 532 PrplWhlTot_Tq_RqMn 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 532 PrplWhlTot_Tq_RqMn 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 532 PrplWhlTot_Tq_RqMn 1;
+BA_ "U_P702_MY2021_Tx" SG_ 532 PrplWhlTot_Tq_RqMn 1;
+BA_ "UsedOnPgmDBC" SG_ 532 PrplWhlTqRqMn_No_Cnt 1;
+BA_ "MetaData" SG_ 532 PrplWhlTqRqMn_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 532 PrplWhlTqRqMn_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 532 PrplWhlTqRqMn_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 532 PrplWhlTqRqMn_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 532 PrplWhlTqRqMn_No_Cnt 1;
+BA_ "GenSigStartValueInteger" SG_ 531 VehStop_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 531 VehStop_D_Stat 2;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 VehStop_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 VehStop_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 TracCtlPtActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 TracCtlPtActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 TracCtlPtActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 TracCtlPtActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 TracCtlPtActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 TracCtlPtActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 LscmbbMntr_B_Err 1;
+BA_ "UsedOnPgmDBC" SG_ 531 LscmbbMntr_B_Err 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 LscmbbMntr_B_Err 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 LscmbbBrkDis_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 LscmbbBrkDis_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 LscmbbBrkDis_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 LscmbbDeny_B_ActlBrk 1;
+BA_ "UsedOnPgmDBC" SG_ 531 LscmbbDeny_B_ActlBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 LscmbbDeny_B_ActlBrk 1;
+BA_ "WakeupSignal" SG_ 531 PrkBrkYwLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 PrkBrkYwLamp_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 531 PrkBrkYwLamp_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 PrkBrkYwLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 PrkBrkYwLamp_D_Rq 1;
+BA_ "WakeupSignal" SG_ 531 PrkBrkRedLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 PrkBrkRedLamp_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 531 PrkBrkRedLamp_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 PrkBrkRedLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 PrkBrkRedLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 LscmbbBrkDecel_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 LscmbbBrkDecel_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 LscmbbBrkDecel_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AbsActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AbsActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 531 AbsActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 AbsActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 AbsActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AbsActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AbsActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 531 StabCtlBrkActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 CmbbBrkPrchg_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 CmbbBrkPrchg_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 CmbbBrkPrchg_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 CmbbBrkPrchg_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 CmbbBrkDecel_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 CmbbBrkDecel_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 CmbbBrkDecel_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 CmbbBrkDecel_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 CmbbBaSensInc_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 CmbbBaSensInc_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 CmbbBaSensInc_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 CmbbBaSensInc_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccBrkWarm_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccBrkWarm_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccBrkWarm_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccBrkWarm_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccBrkTotTqMn_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccBrkTotTqMn_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccBrkTotTqMn_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccBrkTotTqMn_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccBrkPrchgActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccBrkPrchgActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccBrkPrchgActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccBrkPrchgActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccBrkDis_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccBrkDis_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccBrkDis_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccBrkDis_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccBrkDeny_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccBrkDeny_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 AccBrkDeny_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 AccBrkDeny_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccBrkDeny_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccBrkDeny_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccBrkActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccBrkActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 AccBrkActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 AccBrkActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccBrkActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccBrkActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 PrplDrgCtlActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 PrplDrgCtlActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 PrplDrgCtlActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 PrplDrgCtlActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 PrplDrgCtlActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 PrplDrgCtlActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 PrplWhlTot_Tq_RqMx 1;
+BA_ "UsedOnPgmDBC" SG_ 531 PrplWhlTot_Tq_RqMx 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 PrplWhlTot_Tq_RqMx 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 PrplWhlTot_Tq_RqMx 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 PrplWhlTot_Tq_RqMx 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 PrplWhlTot_Tq_RqMx 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 LscmbbBaSensInc_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 LscmbbBaSensInc_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 LscmbbBaSensInc_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 CmbbBrkDis_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 CmbbBrkDis_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 531 CmbbBrkDis_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 CmbbBrkDis_B_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 CmbbBrkDis_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 CmbbBrkDis_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "UsedOnPgmDBC" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 CmbbDeny_B_ActlBrk 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 CcDis_B_Cmd 1;
+BA_ "UsedOnPgmDBC" SG_ 531 CcDis_B_Cmd 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 CcDis_B_Cmd 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 CcDis_B_Cmd 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 CcDis_B_Cmd 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 CcDis_B_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 VehLongOvrGnd_A_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 531 VehLongOvrGnd_A_Est 1;
+BA_ "GenSigStartValueInteger" SG_ 531 VehLongOvrGnd_A_Est 511;
+BA_ "U_P702_MY2021_Rx" SG_ 531 VehLongOvrGnd_A_Est 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 VehLongOvrGnd_A_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 VehLongOvrGnd_A_Est 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 LscmbBrkPrchg_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 531 LscmbBrkPrchg_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 LscmbBrkPrchg_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccStopActv_B_ActlBrk 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccStopActv_B_ActlBrk 1;
+BA_ "U_P702_MY2021_Rx" SG_ 531 AccStopActv_B_ActlBrk 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 AccStopActv_B_ActlBrk 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccStopActv_B_ActlBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccStopActv_B_ActlBrk 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 AccDis_B_ActlEpb 1;
+BA_ "UsedOnPgmDBC" SG_ 531 AccDis_B_ActlEpb 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 AccDis_B_ActlEpb 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 AccDis_B_ActlEpb 1;
+BA_ "WakeupSignal" SG_ 531 PrkBrkMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 PrkBrkMsgTxt_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 531 PrkBrkMsgTxt_D_Rq 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 PrkBrkMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 PrkBrkMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 531 PrkBrkStatus 1;
+BA_ "UsedOnPgmDBC" SG_ 531 PrkBrkStatus 1;
+BA_ "GenSigStartValueInteger" SG_ 531 PrkBrkStatus 7;
+BA_ "GenSigStartValue" SG_ 531 PrkBrkStatus 7;
+BA_ "U_P702_MY2021_Rx" SG_ 531 PrkBrkStatus 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 531 PrkBrkStatus 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 531 PrkBrkStatus 1;
+BA_ "U_P702_MY2021_Tx" SG_ 531 PrkBrkStatus 1;
+BA_ "ECGUsedRxSignal" SG_ 531 PrkBrkStatus 1;
+BA_ "GenSigStartValueInteger" SG_ 136 SteWhlBrkOffst_An_Rq 32766;
+BA_ "GenSigStartValue" SG_ 136 SteWhlBrkOffst_An_Rq 32765;
+BA_ "U_P702_MY2021_Tx" SG_ 136 SteWhlBrkOffst_An_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 136 SteWhlBrkAnRq_No_Cs 1;
+BA_ "MetaData" SG_ 136 SteWhlBrkAnRq_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 136 SteWhlBrkAnRq_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 136 SteWhlBrkAnRq_No_Cnt 1;
+BA_ "MetaData" SG_ 136 SteWhlBrkAnRq_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 136 SteWhlBrkAnRq_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 125 VehRolComp_W_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 125 VehRolComp_W_Actl 4094;
+BA_ "GenSigStartValue" SG_ 125 VehRolComp_W_Actl 4094;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 VehRolComp_W_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 VehRolComp_W_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 125 VehVertComp_A_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 125 VehVertComp_A_Actl 1022;
+BA_ "GenSigStartValue" SG_ 125 VehVertComp_A_Actl 1022;
+BA_ "U_P702_MY2021_Rx" SG_ 125 VehVertComp_A_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 VehVertComp_A_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 VehVertComp_A_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 125 BrkTotTqRqArb_No_Cs 1;
+BA_ "MetaData" SG_ 125 BrkTotTqRqArb_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 125 BrkTotTqRqArb_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 125 BrkTotTqRqArb_No_Cs 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 BrkTotTqRqArb_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 BrkTotTqRqArb_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 125 BrkTotTqRqArb_No_Cnt 1;
+BA_ "MetaData" SG_ 125 BrkTotTqRqArb_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 125 BrkTotTqRqArb_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 125 BrkTotTqRqArb_No_Cnt 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 BrkTotTqRqArb_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 BrkTotTqRqArb_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 125 BrkTot_Tq_RqArb 1;
+BA_ "U_P702_MY2021_Rx" SG_ 125 BrkTot_Tq_RqArb 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 125 BrkTot_Tq_RqArb 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 BrkTot_Tq_RqArb 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 BrkTot_Tq_RqArb 1;
+BA_ "ECGUsedRxSignal" SG_ 125 BrkTot_Tq_RqArb 1;
+BA_ "UsedOnPgmDBC" SG_ 125 BrkTot_Tq_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 125 BrkTot_Tq_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 125 BrkTot_Tq_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 125 BrkTot_Tq_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 BrkTot_Tq_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 BrkTot_Tq_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 125 HsaStat_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 125 HsaStat_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 125 HsaStat_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 125 HsaStat_D_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 125 HsaStat_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 125 HsaStat_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 119 VehTrvlDir_D_Stat 6;
+BA_ "GenSigStartValue" SG_ 119 VehTrvlDir_D_Stat 6;
+BA_ "U_P702_MY2021_Tx" SG_ 119 VehTrvlDir_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 119 VehOverGnd_V_Est 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 119 VehOverGnd_V_Est 1;
+BA_ "U_P702_MY2021_Rx" SG_ 119 VehOverGnd_V_Est 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 119 VehOverGnd_V_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 119 VehOverGnd_V_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 119 VehLongComp_A_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 119 VehLongComp_A_Actl 1022;
+BA_ "GenSigStartValue" SG_ 119 VehLongComp_A_Actl 1022;
+BA_ "U_P702_MY2021_Rx" SG_ 119 VehLongComp_A_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 119 VehLongComp_A_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 119 VehLongComp_A_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 119 VehLongComp_A_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 119 VehLongComp_A_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 119 VehLatComp_A_Actl 1022;
+BA_ "GenSigStartValue" SG_ 119 VehLatComp_A_Actl 1022;
+BA_ "U_P702_MY2021_Rx" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 119 VehLatComp_A_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 119 VehYawComp_W_Actl 4094;
+BA_ "GenSigStartValue" SG_ 119 VehYawComp_W_Actl 4094;
+BA_ "U_CX727_MY2021_Rx" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 119 VehYawComp_W_Actl 1;
+BA_ "GenSigSendType" SG_ 118 BrkCtrFnd_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 118 BrkCtrFnd_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 118 AwdLck_Tq_RqMx 1;
+BA_ "U_P702_MY2021_Rx" SG_ 118 AwdLck_Tq_RqMx 1;
+BA_ "U_P702_MY2021_Tx" SG_ 118 AwdLck_Tq_RqMx 1;
+BA_ "UsedOnPgmDBC" SG_ 118 AwdLck_Tq_RqMn 1;
+BA_ "U_P702_MY2021_Rx" SG_ 118 AwdLck_Tq_RqMn 1;
+BA_ "U_P702_MY2021_Tx" SG_ 118 AwdLck_Tq_RqMn 1;
+BA_ "UsedOnPgmDBC" SG_ 118 DrvSte_D_Stat 1;
+BA_ "GenSigSendType" SG_ 118 DrvSte_D_Stat 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 118 DrvSte_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 118 DrvSte_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 118 DrvSte_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 118 DrvSte_Tq_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 118 DrvSte_Tq_Rq 128;
+BA_ "U_CX727_MY2021_Rx" SG_ 118 DrvSte_Tq_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 118 DrvSte_Tq_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 118 DrvSte_Tq_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 118 EmgcyBrkLamp_D_Rq 1;
+BA_ "GenSigSendType" SG_ 118 EmgcyBrkLamp_D_Rq 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 118 EmgcyBrkLamp_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 118 EmgcyBrkLamp_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 118 StopLamp_B_RqBrk 1;
+BA_ "GenSigSendType" SG_ 118 StopLamp_B_RqBrk 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 118 StopLamp_B_RqBrk 1;
+BA_ "U_P702_MY2021_Tx" SG_ 118 StopLamp_B_RqBrk 1;
+BA_ "UsedOnPgmDBC" SG_ 73 immoSubTarget1Data_T1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 73 immoSubTarget1Data_T1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 73 immoSubTarget1Data_T1 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 73 immoSubTarget1Data_T1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 73 immoSubTarget1Data_T1 1;
+BA_ "UsedOnPgmDBC" SG_ 73 immoSubTarget1Cmd_T1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 73 immoSubTarget1Cmd_T1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 73 immoSubTarget1Cmd_T1 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 73 immoSubTarget1Cmd_T1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 73 immoSubTarget1Cmd_T1 1;
+BA_ "CrossOver_InfoCAN" SG_ 1034 VehicleGGCCData 1;
+BA_ "UsedOnPgmDBC" SG_ 1034 VehicleGGCCData 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1034 VehicleGGCCData 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1034 VehicleGGCCData 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1034 VehicleGGCCData 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1440 TCM_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_GWOnBoardTester 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_GWOnBoardTester 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1440 TCM_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_GWNMProxy 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_GWNMProxy 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_GWNMProxy 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1440 TCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_AutoSarNMReserved4 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_AutoSarNMReserved4 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1440 TCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_AutoSarNMReserved3 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_AutoSarNMReserved3 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1440 TCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_AutoSarNMReserved2 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_AutoSarNMReserved2 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1440 TCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_AutoSarNMReserved1 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_AutoSarNMReserved1 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1440 TCM_AutoSarNMNodeId 160;
+BA_ "ContentDependant" SG_ 1440 TCM_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1440 TCM_AutoSarNMNodeId 160;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_AutoSarNMNodeId 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1440 TCM_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1440 TCM_AutoSarNMControl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1440 TCM_AutoSarNMControl 1;
+BA_ "CrossOver_InfoCAN" SG_ 561 TrnMsgTxt2_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 561 TrnMsgTxt2_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 561 TrnMsgTxt2_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 561 TrnMsgTxt_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 561 TrnMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 561 TrnMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 561 TrnMsgTxt_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 330 TrnAout_W_ActlUnfilt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 330 TrnAout_W_ActlUnfilt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 330 TrnAout_W_ActlUnfilt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 330 TrnAout_W_ActlUnfilt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 330 TrnAout_W_ActlUnfilt 1;
+BA_ "ECGUsedRxSignal" SG_ 1090 Mtr2State_D_ActlMntr 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1090 Mtr2State_D_ActlMntr 1;
+BA_ "GenSigStartValueInteger" SG_ 1090 Inv1Ain_I_ActlMntr 32766;
+BA_ "GenSigStartValue" SG_ 1090 Inv1Ain_I_ActlMntr 32765;
+BA_ "ECGUsedRxSignal" SG_ 1090 Inv1Ain_I_ActlMntr 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1090 Inv1Ain_I_ActlMntr 1;
+BA_ "ECGUsedRxSignal" SG_ 1090 HybVehMde_D_ActlMntr 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1090 HybVehMde_D_ActlMntr 1;
+BA_ "ECGUsedRxSignal" SG_ 1090 ChrgStat_D_ActlMntr 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1090 ChrgStat_D_ActlMntr 1;
+BA_ "CrossOver_InfoCAN" SG_ 1090 VehElRnge_L_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1090 VehElRnge_L_Dsply 4095;
+BA_ "GenSigStartValue" SG_ 1090 VehElRnge_L_Dsply 4093;
+BA_ "U_P702_MY2021_Tx" SG_ 1090 VehElRnge_L_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1090 VehElRnge_L_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 870 EngMdeMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 870 EffRgenThres_Pc_Dsply 1;
+BA_ "GenSigStartValue" SG_ 870 EffRgenThres_Pc_Dsply 1023;
+BA_ "CrossOver_InfoCAN" SG_ 870 EffRgenThres_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 870 RngPerChrgInst_L_Dsply 4094;
+BA_ "GenSigStartValue" SG_ 870 RngPerChrgInst_L_Dsply 4093;
+BA_ "U_P702_MY2021_Tx" SG_ 870 RngPerChrgInst_L_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 PwrFlowTxt_D_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EngOnMsg2_D_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EngOnMsg1_D_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 FuelMaintMde_D_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 869 EffWhlLvl2_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 869 EffWhlLvl2_Pc_Dsply 511;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EffWhlLvl2_Pc_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 869 EffWhlThres_Pc_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EffWhlThres_Pc_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 869 EngPwLvl_Pc_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EngPwLvl_Pc_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 869 EngActv_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EngActv_B_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 869 EffWhlThresOn_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 869 EffWhlThresOn_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 606 ElVehLaterMde_D_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 606 ElVehLaterMde_D_Stat 1;
+BA_ "GenSigSendType" SG_ 606 ElVehNowMde_D_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 606 ElVehNowMde_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 374 GearEngag_D_Actl 1;
+BA_ "GenSigSendType" SG_ 374 GearEngag_D_Actl 3;
+BA_ "U_P702_MY2021_Tx" SG_ 374 GearEngag_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 374 TrnRng_D_Rq 14;
+BA_ "ContentDependant" SG_ 374 TrnRng_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 374 TrnRng_D_Rq 14;
+BA_ "GenSigSendType" SG_ 374 TrnRng_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 374 TrnRng_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 TrnRng_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 TrnRng_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 TrnRng_D_Rq 1;
+BA_ "ContentDependant" SG_ 374 TrnPrkSys_D_Actl 1;
+BA_ "GenSigSendType" SG_ 374 TrnPrkSys_D_Actl 3;
+BA_ "U_P702_MY2021_Rx" SG_ 374 TrnPrkSys_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 TrnPrkSys_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 TrnPrkSys_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 TrnPrkSys_D_Actl 1;
+BA_ "ContentDependant" SG_ 374 GearLvr_D_ActlDrv 1;
+BA_ "GenSigSendType" SG_ 374 GearLvr_D_ActlDrv 3;
+BA_ "U_P702_MY2021_Rx" SG_ 374 GearLvr_D_ActlDrv 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 GearLvr_D_ActlDrv 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 GearLvr_D_ActlDrv 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 GearLvr_D_ActlDrv 1;
+BA_ "ContentDependant" SG_ 374 GearPos_No_Cs 1;
+BA_ "MetaData" SG_ 374 GearPos_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 374 GearPos_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 GearPos_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 374 GearPos_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 GearPos_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 GearPos_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 374 GearPos_D_Trg 1;
+BA_ "UsedOnPgmDBC" SG_ 374 GearPos_D_Trg 1;
+BA_ "GenSigStartValueInteger" SG_ 374 GearPos_D_Trg 15;
+BA_ "ContentDependant" SG_ 374 GearPos_D_Trg 1;
+BA_ "GenSigStartValue" SG_ 374 GearPos_D_Trg 15;
+BA_ "GenSigSendType" SG_ 374 GearPos_D_Trg 3;
+BA_ "U_P702_MY2021_Rx" SG_ 374 GearPos_D_Trg 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 GearPos_D_Trg 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 374 GearPos_D_Trg 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 GearPos_D_Trg 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 GearPos_D_Trg 1;
+BA_ "ContentDependant" SG_ 374 GearPos_No_Cnt 1;
+BA_ "MetaData" SG_ 374 GearPos_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 374 GearPos_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 GearPos_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 374 GearPos_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 GearPos_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 GearPos_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 TrnIgnOffDly_T_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 TrnIgnOffDly_T_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 374 GearPos_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 374 GearPos_D_Actl 15;
+BA_ "ContentDependant" SG_ 374 GearPos_D_Actl 1;
+BA_ "GenSigStartValue" SG_ 374 GearPos_D_Actl 15;
+BA_ "GenSigSendType" SG_ 374 GearPos_D_Actl 3;
+BA_ "U_P702_MY2021_Rx" SG_ 374 GearPos_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 374 GearPos_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 374 GearPos_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 374 GearPos_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 374 GearPos_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 603 WhlDirAvgDrv_D_Actl 1;
+BA_ "ContentDependant" SG_ 603 WhlDirAvgDrv_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 603 WhlDirAvgDrv_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 603 PrplTqMnRgen_B_Actl 1;
+BA_ "ContentDependant" SG_ 603 PrplTqMnRgen_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 603 PrplTqMnRgen_B_Actl 1;
+BA_ "ContentDependant" SG_ 603 BattTracCnnct_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 603 BattTracCnnct_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 602 HtrnWarnLamp_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 602 HtrnWarnLamp_B_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 602 HtrnWarnLamp_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 602 HybPwLimOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 602 PwPckTqRdy_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 602 PwPckTqRdy_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 1152 BattTracDiagClr_B_Stat 3;
+BA_ "GenSigSendType" SG_ 1152 EngTeHi_B_Actl 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1152 EngTeHi_B_Actl 1;
+BA_ "GenSigSendType" SG_ 1152 DcdcOn_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1152 DcdcOn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1152 ULoBattSpprtSustn_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1152 ULoBattSpprtSustn_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1152 VehElEff_No_Avg 126;
+BA_ "GenSigStartValue" SG_ 1152 VehElEff_No_Avg 126;
+BA_ "U_P702_MY2021_Tx" SG_ 1152 VehElEff_No_Avg 1;
+BA_ "CrossOver_InfoCAN" SG_ 872 PlgActvArb_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 872 PlgActvArb_B_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 872 PlgActvArb_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 872 HybMdeStat_D_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 872 HybMdeStat_D_Dsply 1;
+BA_ "ContentDependant" SG_ 560 SelDrvMdeSwtch_D_Stat3 1;
+BA_ "U_P702_MY2021_Rx" SG_ 560 SelDrvMdeSwtch_D_Stat3 1;
+BA_ "U_P702_MY2021_Tx" SG_ 560 SelDrvMdeSwtch_D_Stat3 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 560 SelDrvMdeSwtch_D_Stat3 1;
+BA_ "CrossOver_InfoCAN" SG_ 560 TrnSrvcRqd_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 560 TrnSrvcRqd_B_Rq 1;
+BA_ "ContentDependant" SG_ 560 TrnSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 560 TrnSrvcRqd_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 560 TrnSrvcRqd_B_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 560 TrnSrvcRqd_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "ContentDependant" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 560 TrnShifActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 560 GearLvrPos_D_Actl 14;
+BA_ "GenSigStartValue" SG_ 560 GearLvrPos_D_Actl 14;
+BA_ "U_P702_MY2021_Rx" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 560 GearLvrPos_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 560 GboxOil_Te_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 560 GboxOil_Te_Actl 254;
+BA_ "ContentDependant" SG_ 560 GboxOil_Te_Actl 1;
+BA_ "GenSigStartValue" SG_ 560 GboxOil_Te_Actl 254;
+BA_ "U_P702_MY2021_Rx" SG_ 560 GboxOil_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 560 GboxOil_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 560 GboxOil_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 560 GboxOil_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 369 TrnIpcDsplyRng2_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 369 TrnIpcDsplyRng2_D_Actl 15;
+BA_ "GenSigStartValue" SG_ 369 TrnIpcDsplyRng2_D_Actl 15;
+BA_ "U_P702_MY2021_Tx" SG_ 369 TrnIpcDsplyRng2_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 369 TrnIpcDsplyRng2_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 369 TrnIpcDsplyRng_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 369 TrnIpcDsplyRng_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 369 TrnIpcDsplyGear_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 369 TrnIpcDsplyGear_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 369 TrnIpcDsplyGear_D_Actl 15;
+BA_ "GenSigStartValue" SG_ 369 TrnIpcDsplyGear_D_Actl 15;
+BA_ "U_P702_MY2021_Tx" SG_ 369 TrnIpcDsplyGear_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 369 TrnIpcDsplyGear_D_Actl 1;
+BA_ "WakeupSignal" SG_ 369 TrnIpcDsplyMde_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 369 TrnIpcDsplyMde_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 369 TrnIpcDsplyMde_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 369 TrnIpcDsplyMde_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 369 TrnIpcDsplyMde_D_Stat 1;
+BA_ "WakeupSignal" SG_ 369 TrnIpcDsplyMde_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 369 TrnIpcDsplyMde_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 369 TrnIpcDsplyMde_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 369 TrnIpcDsplyMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 369 TrnIpcDsplyMde_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 369 TrnIpcDsplyGear_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 369 TrnIpcDsplyGear_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 369 TrnIpcDsplyGear_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 369 TrnIpcDsplyGear_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 92 TrnLvrV_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 92 TrnLvrV_D_Rq 1;
+BA_ "GenSigSendType" SG_ 92 TrnLvrV_D_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnLvrV_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnLvrV_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 92 TrnSbwSysHlth_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 92 TrnSbwSysHlth_D_Actl 1;
+BA_ "ContentDependant" SG_ 92 TrnSbwSysHlth_D_Actl 1;
+BA_ "GenSigStartValue" SG_ 92 TrnSbwSysHlth_D_Actl 1;
+BA_ "GenSigSendType" SG_ 92 TrnSbwSysHlth_D_Actl 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnSbwSysHlth_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnSbwSysHlth_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 92 TrnGearNtmAllow_B_Stat 1;
+BA_ "ContentDependant" SG_ 92 TrnGearNtmAllow_B_Stat 1;
+BA_ "GenSigSendType" SG_ 92 TrnGearNtmAllow_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnGearNtmAllow_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnGearNtmAllow_B_Stat 1;
+BA_ "WakeupSignal" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "ContentDependant" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "GenSigStartValue" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "GenSigSendType" SG_ 92 TrnDtpCmd_D_Actl 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnDtpCmd_D_Actl 1;
+BA_ "GenSigSendType" SG_ 92 GearSelLck_D_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 GearSelLck_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 GearSelLck_D_Rq 1;
+BA_ "ContentDependant" SG_ 92 TrnGearCmd_No_Cs 1;
+BA_ "MetaData" SG_ 92 TrnGearCmd_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnGearCmd_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnGearCmd_No_Cs 1;
+BA_ "ContentDependant" SG_ 92 TrnValidGear_D_Cnfm 1;
+BA_ "GenSigSendType" SG_ 92 TrnValidGear_D_Cnfm 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnValidGear_D_Cnfm 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnValidGear_D_Cnfm 1;
+BA_ "ContentDependant" SG_ 92 TrnNtrlTowCmd_D_Actl 1;
+BA_ "GenSigSendType" SG_ 92 TrnNtrlTowCmd_D_Actl 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 92 TrnNtrlTowCmd_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 92 TrnNtrlTowCmd_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnNtrlTowCmd_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnNtrlTowCmd_D_Actl 1;
+BA_ "ContentDependant" SG_ 92 TrnGearCmd_Pc_ActlPt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnGearCmd_Pc_ActlPt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnGearCmd_Pc_ActlPt 1;
+BA_ "ContentDependant" SG_ 92 TrnGear_D_RqPt 1;
+BA_ "GenSigSendType" SG_ 92 TrnGear_D_RqPt 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnGear_D_RqPt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnGear_D_RqPt 1;
+BA_ "ContentDependant" SG_ 92 TrnCmdState_B_Actl 1;
+BA_ "GenSigSendType" SG_ 92 TrnCmdState_B_Actl 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnCmdState_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnCmdState_B_Actl 1;
+BA_ "ContentDependant" SG_ 92 TrnCmdCnt_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnCmdCnt_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnCmdCnt_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "GenSigStartValueInteger" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "ContentDependant" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "GenSigStartValue" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "GenSigSendType" SG_ 92 PrkBrkActv_D_RqTrnGear 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "U_P702_MY2021_Rx" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "U_P702_MY2021_Tx" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 PrkBrkActv_D_RqTrnGear 1;
+BA_ "CrossOver_InfoCAN" SG_ 92 TrnGearMsgTxt_D_Rq 1;
+BA_ "ContentDependant" SG_ 92 TrnGearMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 92 TrnGearMsgTxt_D_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnGearMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnGearMsgTxt_D_Rq 1;
+BA_ "ContentDependant" SG_ 92 TrnGearCmd_No_Cnt 1;
+BA_ "MetaData" SG_ 92 TrnGearCmd_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 92 TrnGearCmd_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 92 TrnGearCmd_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 2030 TesterPhysicalResSOBDMC 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 2030 TesterPhysicalResSOBDMC 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 BattRgenLoChrg_D_RqEng 1;
+BA_ "GenSigSendType" SG_ 1087 BattRgenLoChrg_D_RqEng 3;
+BA_ "GenSigSendType" SG_ 1087 AdasLcObtclAbrt_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 BattRgenLoDChrg_D_RqEng 1;
+BA_ "GenSigSendType" SG_ 1087 BattRgenLoDChrg_D_RqEng 3;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 AirDamPos_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 AirDamPos_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1087 AirDamPos_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcInhbt_B_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcInhbt_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcInhbt_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcStopHold_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1087 FapLcStopHold_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1087 FapLcStopHold_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcStopHold_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcStopHold_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcPrchgBrk_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1087 FapLcPrchgBrk_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1087 FapLcPrchgBrk_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcPrchgBrk_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcPrchgBrk_B_Rq 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcObstcl_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcObstcl_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcObstcl_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcMaxGrdInhbt_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcMaxGrdInhbt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcMaxGrdInhbt_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcMaxGrdAbrt_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcMaxGrdAbrt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcMaxGrdAbrt_B_Stat 1;
+BA_ "GenSigSendType" SG_ 1087 FapLcActv_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1087 FapLcActv_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1087 FapLcActv_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 332 UreaLvlQlty_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaLvlQlty_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaLvlQlty_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 332 UreaLvlTxtWarn_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaLvlTxtWarn_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaLvlTxtWarn_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 332 UreaQltySysWarn_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaQltySysWarn_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaQltySysWarn_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 DieslPrtcWarn_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 DieslPrtcWarn_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaQltyFlg_B_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaQltyFlg_B_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 332 UreaQltyFlg_B_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaLvl_Pc_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaLvl_Pc_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 332 UreaLvl_Pc_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 VehUreaRnge2_L_DsplyMx 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 VehUreaRnge2_L_DsplyMx 1;
+BA_ "ECGUsedRxSignal" SG_ 332 VehUreaRnge2_L_DsplyMx 1;
+BA_ "CrossOver_InfoCAN" SG_ 332 UreaQltySys_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaQltySys_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaQltySys_D_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 332 UreaQltySys_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 332 UreaLvlTxt_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 UreaLvlTxt_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 UreaLvlTxt_D_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 332 UreaLvlTxt_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 332 VehUreaWarn_V_DsplyMx 1;
+BA_ "U_P702_MY2021_Tx" SG_ 332 VehUreaWarn_V_DsplyMx 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 332 VehUreaWarn_V_DsplyMx 1;
+BA_ "ECGUsedRxSignal" SG_ 332 VehUreaWarn_V_DsplyMx 1;
+BA_ "UsedOnPgmDBC" SG_ 1896 TesterPhysicalResABS 1;
+BA_ "GenSigSendType" SG_ 1896 TesterPhysicalResABS 3;
+BA_ "U_CX727_MY2021_Tx" SG_ 1896 TesterPhysicalResABS 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1896 TesterPhysicalResABS 1;
+BA_ "GenSigSendType" SG_ 1889 TesterPhysicalReqTCCM 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1889 TesterPhysicalReqTCCM 1;
+BA_ "UsedOnPgmDBC" SG_ 1888 TesterPhysicalReqABS 1;
+BA_ "GenSigSendType" SG_ 1888 TesterPhysicalReqABS 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1888 TesterPhysicalReqABS 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1888 TesterPhysicalReqABS 1;
+BA_ "UsedOnPgmDBC" SG_ 1848 TesterPhysicalResPSCM 1;
+BA_ "U_CX727_MY2021_Tx" SG_ 1848 TesterPhysicalResPSCM 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1848 TesterPhysicalResPSCM 1;
+BA_ "UsedOnPgmDBC" SG_ 1840 TesterPhysicalReqPSCM 1;
+BA_ "GenSigSendType" SG_ 1840 TesterPhysicalReqPSCM 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 1840 TesterPhysicalReqPSCM 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1840 TesterPhysicalReqPSCM 1;
+BA_ "UsedOnPgmDBC" SG_ 1713 UUDTABSResponse2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1713 UUDTABSResponse2 1;
+BA_ "UsedOnPgmDBC" SG_ 1712 UUDTABSResponse1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1712 UUDTABSResponse1 1;
+BA_ "UsedOnPgmDBC" SG_ 2025 TesterPhysicalResTCM 1;
+BA_ "U_P702_MY2021_Tx" SG_ 2025 TesterPhysicalResTCM 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 2025 TesterPhysicalResTCM 1;
+BA_ "UsedOnPgmDBC" SG_ 2024 TesterPhysicalResPCM 1;
+BA_ "U_P702_MY2021_Tx" SG_ 2024 TesterPhysicalResPCM 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 2024 TesterPhysicalResPCM 1;
+BA_ "UsedOnPgmDBC" SG_ 2017 TesterPhysicalReqTCM 1;
+BA_ "GenSigSendType" SG_ 2017 TesterPhysicalReqTCM 3;
+BA_ "U_P702_MY2021_Rx" SG_ 2017 TesterPhysicalReqTCM 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2017 TesterPhysicalReqTCM 1;
+BA_ "UsedOnPgmDBC" SG_ 2016 TesterPhysicalReqPCM 1;
+BA_ "GenSigSendType" SG_ 2016 TesterPhysicalReqPCM 3;
+BA_ "U_P702_MY2021_Rx" SG_ 2016 TesterPhysicalReqPCM 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2016 TesterPhysicalReqPCM 1;
+BA_ "CrossOver_InfoCAN" SG_ 2015 TesterFunctionalReq 1;
+BA_ "UsedOnPgmDBC" SG_ 2015 TesterFunctionalReq 1;
+BA_ "GenSigSendType" SG_ 2015 TesterFunctionalReq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 2015 TesterFunctionalReq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 2015 TesterFunctionalReq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 2015 TesterFunctionalReq 1;
+BA_ "ECGUsedRxSignal" SG_ 2015 TesterFunctionalReq 1;
+BA_ "GenSigSendType" SG_ 1897 TesterPhysicalResTCCM 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1897 TesterPhysicalResTCCM 1;
+BA_ "GenSigSendType" SG_ 1814 TesterPhysicalReqGWM_F1 3;
+BA_ "ECGUsedRxSignal" SG_ 1814 TesterPhysicalReqGWM_F1 1;
+BA_ "UsedOnPgmDBC" SG_ 1701 UUDTTCMResponse2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1701 UUDTTCMResponse2 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1701 UUDTTCMResponse2 1;
+BA_ "UsedOnPgmDBC" SG_ 1700 UUDTTCMResponse1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1700 UUDTTCMResponse1 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1700 UUDTTCMResponse1 1;
+BA_ "UsedOnPgmDBC" SG_ 1697 UUDTPCMResponse2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1697 UUDTPCMResponse2 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1697 UUDTPCMResponse2 1;
+BA_ "UsedOnPgmDBC" SG_ 1696 UUDTPCMResponse1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1696 UUDTPCMResponse1 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1696 UUDTPCMResponse1 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1429 PCM_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_GWOnBoardTester 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_GWOnBoardTester 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_GWOnBoardTester 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_GWOnBoardTester 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1429 PCM_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_GWNMProxy 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_GWNMProxy 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_GWNMProxy 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_GWNMProxy 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_GWNMProxy 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1429 PCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_AutoSarNMReserved4 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_AutoSarNMReserved4 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_AutoSarNMReserved4 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_AutoSarNMReserved4 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1429 PCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_AutoSarNMReserved3 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_AutoSarNMReserved3 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_AutoSarNMReserved3 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_AutoSarNMReserved3 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1429 PCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_AutoSarNMReserved2 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_AutoSarNMReserved2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_AutoSarNMReserved2 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_AutoSarNMReserved2 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1429 PCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_AutoSarNMReserved1 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_AutoSarNMReserved1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_AutoSarNMReserved1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_AutoSarNMReserved1 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1429 PCM_AutoSarNMNodeId 149;
+BA_ "ContentDependant" SG_ 1429 PCM_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1429 PCM_AutoSarNMNodeId 149;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_AutoSarNMNodeId 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_AutoSarNMNodeId 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_AutoSarNMNodeId 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1429 PCM_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1429 PCM_AutoSarNMControl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1429 PCM_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1429 PCM_AutoSarNMControl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1429 PCM_AutoSarNMControl 1;
+BA_ "GenSigStartValueInteger" SG_ 1100 EngExhMdeQuiet_D2_Stat 0;
+BA_ "GenSigSendType" SG_ 1100 EngExhMdeQuiet_D2_Stat 3;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1100 HvacCmprLim_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 HvacCmprLim_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1100 WakeAlarm1_T_Rq 32767;
+BA_ "GenSigStartValue" SG_ 1100 WakeAlarm1_T_Rq 32767;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 WakeAlarm1_T_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1100 WakeAlarm1_T_Rq 1;
+BA_ "WakeupSignal" SG_ 1100 WakeAlarm1_B_Typ 1;
+BA_ "GenSigSendType" SG_ 1100 WakeAlarm1_B_Typ 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 WakeAlarm1_B_Typ 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1100 WakeAlarm1_B_Typ 1;
+BA_ "GenSigSendType" SG_ 1100 Veh_V_DsplyTrailCtlSet 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 Veh_V_DsplyTrailCtlSet 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1100 Veh_V_DsplyTrailCtlSet 1;
+BA_ "GenSigSendType" SG_ 1100 TrailCtlPt_B_Falt 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1100 TrailCtlPt_B_Falt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 TrailCtlPt_B_Falt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1100 TrailCtlPt_B_Falt 1;
+BA_ "GenSigSendType" SG_ 1100 AutoTowAllw_D_StatMnu 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 AutoTowAllw_D_StatMnu 1;
+BA_ "GenSigSendType" SG_ 1100 AutoTowActv_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 AutoTowActv_B_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1100 GrossTrainWeight_M_Est 254;
+BA_ "GenSigStartValue" SG_ 1100 GrossTrainWeight_M_Est 254;
+BA_ "U_P702_MY2021_Rx" SG_ 1100 GrossTrainWeight_M_Est 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1100 GrossTrainWeight_M_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1100 GrossTrainWeight_M_Est 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1100 GrossTrainWeight_M_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmVeh_V_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmVeh_V_Dsply 1;
+BA_ "GenSigSendType" SG_ 1098 EdmSailMdeOn_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmSailMdeOn_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmSailMdeOn_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmPrev_Fe_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmPrev_Fe_Dsply 1;
+BA_ "GenSigSendType" SG_ 1098 EdmMsgTxt_D_Rq 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 1098 EdmLamp_D_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmLamp_D_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmLamp_D_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmCurrent_Fe_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmCurrent_Fe_Dsply 1;
+BA_ "GenSigSendType" SG_ 1098 EdmCmplnc_B_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmCmplnc_B_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmCmplnc_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1098 EdmCmplnc_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1098 EdmCmplnc_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1086 EngMnfld_P_Actl 2068;
+BA_ "U_P702_MY2021_Tx" SG_ 1086 EngMnfld_P_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1086 EngMnfld_P_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1086 FuelPumpPwr_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1086 FuelPumpPwr_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1086 BattULoChrg_U_Cmd 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1086 BattULoChrg_U_Cmd 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1086 BattULoChrg_U_Cmd 1;
+BA_ "UsedOnPgmDBC" SG_ 1086 ElLoadCtl_D_Rq 1;
+BA_ "ContentDependant" SG_ 1086 ElLoadCtl_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1086 ElLoadCtl_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1086 ElLoadCtl_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1071 EngAout_N_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1071 EngAout_N_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 1071 CluPdl_PcRate_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1071 CluPdl_PcRate_Actl 1;
+BA_ "ContentDependant" SG_ 1071 CluPdl_PcRate_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1071 CluPdl_PcRate_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1071 CluPdl_PcRate_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "ContentDependant" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "MetaData" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1071 CluPdlPosPcMeas_D_Qf 1;
+BA_ "CrossOver_InfoCAN" SG_ 1071 CluPdlPos_Pc_Meas 1;
+BA_ "UsedOnPgmDBC" SG_ 1071 CluPdlPos_Pc_Meas 1;
+BA_ "ContentDependant" SG_ 1071 CluPdlPos_Pc_Meas 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1071 CluPdlPos_Pc_Meas 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1071 CluPdlPos_Pc_Meas 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1071 CluPdlPos_Pc_Meas 1;
+BA_ "CrossOver_InfoCAN" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "UsedOnPgmDBC" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "ContentDependant" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1071 EngAoutIdl_N_Ntrl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 SlMde_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 SlMde_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 SlMde_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 SlMde_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 IsaOffst_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 IsaOffst_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 GrllShtrPos_D_Cmd 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 GrllShtrPos_D_Cmd 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 GrllShtrPos_D_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 GrllShtrPos_B_Falt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 GrllShtrPos_B_Falt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 GrllShtrPos_B_Falt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 ObdWarmUp_B_Complt 1;
+BA_ "ContentDependant" SG_ 1069 ObdWarmUp_B_Complt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 ObdWarmUp_B_Complt 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 EngMsgTxt_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1069 EngMsgTxt_D_Rq 1;
+BA_ "ContentDependant" SG_ 1069 EngMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 EngMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 EngMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 EngClnt_Te_ActlDiag 1;
+BA_ "ContentDependant" SG_ 1069 EngClnt_Te_ActlDiag 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1069 EngClnt_Te_ActlDiag 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1069 EngClnt_Te_ActlDiag 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 EngClnt_Te_ActlDiag 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 EngClnt_Te_ActlDiag 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 EngLoad_Pc_CalcDiag 1;
+BA_ "ContentDependant" SG_ 1069 EngLoad_Pc_CalcDiag 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1069 EngLoad_Pc_CalcDiag 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1069 EngLoad_Pc_CalcDiag 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 EngLoad_Pc_CalcDiag 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 EngLoad_Pc_CalcDiag 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 EngAirIn_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1069 EngAirIn_Te_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1069 EngAirIn_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1069 EngAirIn_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 EngAirIn_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 EngAirIn_Te_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1069 ApedPos_Pc_ActlDiag 1;
+BA_ "ContentDependant" SG_ 1069 ApedPos_Pc_ActlDiag 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1069 ApedPos_Pc_ActlDiag 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1069 ApedPos_Pc_ActlDiag 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1069 ApedPos_Pc_ActlDiag 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1069 ApedPos_Pc_ActlDiag 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 RearDiffOilTeWarn_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 RearDiffOilTeWarn_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1060 RearDiffOil_Te_Actl 77;
+BA_ "GenSigStartValue" SG_ 1060 RearDiffOil_Te_Actl 77;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 RearDiffOil_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 RearDiffOil_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 BpedDrvMsgTxt_B_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 BpedDrvMsgTxt_B_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1060 FuelLvl_Pc_DsplyEng 48;
+BA_ "GenSigStartValue" SG_ 1060 FuelLvl_Pc_DsplyEng 0;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 FuelLvl_Pc_DsplyEng 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 FuelLvl_Pc_DsplyEng 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 FuelLvlWarn_D_ActlEng 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 FuelLvlWarn_D_ActlEng 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 FuelRange_L_DsplyEng 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 FuelRange_L_DsplyEng 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1060 SelDrvMdePt_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1060 SelDrvMdePt_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1060 SelDrvMdePt_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 FohEng_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1057 FohEng_D_Rq 2;
+BA_ "ContentDependant" SG_ 1057 FohEng_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 1057 FohEng_D_Rq 2;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 FohEng_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 FohEng_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 EngIdlShutDwnTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 EngIdlShutDwnTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 EngIdlShutDown_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 EngIdlShutDown_D_Stat 1;
+BA_ "ContentDependant" SG_ 1057 EngIdlShutDown_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 EngIdlShutDown_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 EngIdlShutDown_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 1057 EngIdlShutDown_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 FUEL_ALCOHOL_PERCNT 1;
+BA_ "GenSigStartValueInteger" SG_ 1057 FUEL_ALCOHOL_PERCNT 255;
+BA_ "ContentDependant" SG_ 1057 FUEL_ALCOHOL_PERCNT 1;
+BA_ "GenSigStartValue" SG_ 1057 FUEL_ALCOHOL_PERCNT 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 FUEL_ALCOHOL_PERCNT 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 FUEL_ALCOHOL_PERCNT 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 TrnTotTq_Rt_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 TrnTotTq_Rt_Est 1;
+BA_ "ContentDependant" SG_ 1057 TrnTotTq_Rt_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 TrnTotTq_Rt_Est 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 TrnTotTq_Rt_Est 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 TrnTotLss_Tq_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 TrnTotLss_Tq_Est 1;
+BA_ "ContentDependant" SG_ 1057 TrnTotLss_Tq_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 TrnTotLss_Tq_Est 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 TrnTotLss_Tq_Est 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 ECMMILRequest 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 ECMMILRequest 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 ECMMILRequest 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 ECMMILRequest 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 AirCondFluidHi_P_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 AirCondFluidHi_P_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 AirCondFluidHi_P_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 AirCondFluidHi_P_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 OilPressureWarning 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 OilPressureWarning 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 OilPressureWarning 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 OilPressureWarning 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "ContentDependant" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 VehVLimStat_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "ContentDependant" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 VehVLimActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1057 CoolantFanStepAct 1;
+BA_ "UsedOnPgmDBC" SG_ 1057 CoolantFanStepAct 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1057 CoolantFanStepAct 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1057 CoolantFanStepAct 1;
+BA_ "CrossOver_InfoCAN" SG_ 1055 EcoCochInstNeg_B_Dsply 1;
+BA_ "UsedOnPgmDBC" SG_ 1055 EcoCochInstNeg_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochInstNeg_B_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochInstNeg_B_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochInstNeg_B_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1055 EcoCochShif_Pc_Dsply 255;
+BA_ "GenSigStartValue" SG_ 1055 EcoCochShif_Pc_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochShif_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochShif_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochShif_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1055 EcoCochInst_Pc_Dsply 1000;
+BA_ "GenSigStartValue" SG_ 1055 EcoCochInst_Pc_Dsply 100;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochInst_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochInst_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochInst_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1055 EcoCochIdlFuel_Pc_Dsply 255;
+BA_ "GenSigStartValue" SG_ 1055 EcoCochIdlFuel_Pc_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochIdlFuel_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochIdlFuel_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochIdlFuel_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1055 EcoCochDecel_Pc_Dsply 255;
+BA_ "GenSigStartValue" SG_ 1055 EcoCochDecel_Pc_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochDecel_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochDecel_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochDecel_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1055 EcoCochCrus_Pc_Dsply 255;
+BA_ "GenSigStartValue" SG_ 1055 EcoCochCrus_Pc_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochCrus_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochCrus_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochCrus_Pc_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1055 EcoCochA_Pc_Dsply 255;
+BA_ "GenSigStartValue" SG_ 1055 EcoCochA_Pc_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1055 EcoCochA_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 1055 EcoCochA_Pc_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 1055 EcoCochA_Pc_Dsply 1;
+BA_ "ContentDependant" SG_ 562 GearNtrl_No_Cs 1;
+BA_ "MetaData" SG_ 562 GearNtrl_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 562 GearNtrl_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 562 GearNtrl_No_Cs 1;
+BA_ "ContentDependant" SG_ 562 GearNtrl_No_Cnt 1;
+BA_ "MetaData" SG_ 562 GearNtrl_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 562 GearNtrl_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 562 GearNtrl_No_Cnt 1;
+BA_ "GenSigStartValueInteger" SG_ 562 GearNtrl_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 562 GearNtrl_D_Stat 2;
+BA_ "GenSigSendType" SG_ 562 GearNtrl_D_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 562 GearNtrl_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 562 GearNtrl_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 523 EngAirFiltMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 523 EngAirFiltMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 523 WaterInFuel_B_Falt 1;
+BA_ "UsedOnPgmDBC" SG_ 523 WaterInFuel_B_Falt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 523 WaterInFuel_B_Falt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 523 WaterInFuel_B_Falt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 523 UreaMnAdd_L2_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 523 UreaMnAdd_L2_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 523 VehUreaRnge3_L_DsplyMx 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 523 VehUreaRnge3_L_DsplyMx 1;
+BA_ "ECGUsedRxSignal" SG_ 523 VehUreaRnge3_L_DsplyMx 1;
+BA_ "GenSigStartValueInteger" SG_ 523 UreaMxAdd_L2_Actl 510;
+BA_ "GenSigStartValue" SG_ 523 UreaMxAdd_L2_Actl 510;
+BA_ "U_P702_MY2021_Tx" SG_ 523 UreaMxAdd_L2_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 523 UreaMxAdd_L2_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 517 FapLc_B_Err 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 517 FapLc_B_Err 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 517 BrkTot_Tq_RqFapLc 1;
+BA_ "U_P702_MY2021_Rx" SG_ 517 BrkTot_Tq_RqFapLc 1;
+BA_ "U_P702_MY2021_Tx" SG_ 517 BrkTot_Tq_RqFapLc 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 517 BrkTot_Tq_RqFapLc 1;
+BA_ "U_P702_MY2021_Tx" SG_ 517 TrnAin_Pc_RqDrv 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 517 TrnAin_Pc_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "UsedOnPgmDBC" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "GenSigStartValueInteger" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "MetaData" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "GenSigStartValue" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "U_P702_MY2021_Rx" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 EngAoutNActl_D_QF 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 EngAout3_N_Actl 1;
+BA_ "ContentDependant" SG_ 516 EngAout3_N_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 EngAout3_N_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 ApedPos_PcRate_ActlArb 1;
+BA_ "UsedOnPgmDBC" SG_ 516 ApedPos_PcRate_ActlArb 1;
+BA_ "U_P702_MY2021_Rx" SG_ 516 ApedPos_PcRate_ActlArb 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 516 ApedPos_PcRate_ActlArb 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 ApedPos_PcRate_ActlArb 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 ApedPos_PcRate_ActlArb 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "UsedOnPgmDBC" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "U_P702_MY2021_Rx" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "ECGUsedRxSignal" SG_ 516 ApedPos_Pc_ActlArb 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "MetaData" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 ApedPosPcActl_D_Qf 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 EngAout_N_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 516 EngAout_N_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 516 EngAout_N_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 516 EngAout_N_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 516 EngAout_N_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 EngAout_N_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 EngAout_N_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 516 EngAout_N_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 ApedPosPcActl_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 516 ApedPosPcActl_No_Cnt 1;
+BA_ "ContentDependant" SG_ 516 ApedPosPcActl_No_Cnt 1;
+BA_ "MetaData" SG_ 516 ApedPosPcActl_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 ApedPosPcActl_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 ApedPosPcActl_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 516 ApedPosPcActl_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 516 ApedPosPcActl_No_Cs 1;
+BA_ "ContentDependant" SG_ 516 ApedPosPcActl_No_Cs 1;
+BA_ "MetaData" SG_ 516 ApedPosPcActl_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 516 ApedPosPcActl_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 516 ApedPosPcActl_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 StrtrMtrDlyStrt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 StrtrMtrDlyStrt_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 VehVTrlrAid_B_Avail 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 VehVTrlrAid_B_Avail 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 VehVTrlrAid_B_Avail 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 StrtrMtrCtlMsgTxt_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 514 StrtrMtrCtlMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 StrtrMtrCtlMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 StrtrMtrCtlMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "MetaData" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 VehVActlEng_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "MetaData" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 VehVActlEng_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "UsedOnPgmDBC" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 Veh_V_RqCcSet 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "MetaData" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 VehVActlEng_D_Qf 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 Veh_V_ActlEng 1;
+BA_ "UsedOnPgmDBC" SG_ 514 Veh_V_ActlEng 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 Veh_V_ActlEng 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 514 Veh_V_ActlEng 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 514 Veh_V_ActlEng 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 Veh_V_ActlEng 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 Veh_V_ActlEng 1;
+BA_ "ECGUsedRxSignal" SG_ 514 Veh_V_ActlEng 1;
+BA_ "CrossOver_InfoCAN" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 514 GearRvrse_D_Actl 7;
+BA_ "GenSigStartValue" SG_ 514 GearRvrse_D_Actl 7;
+BA_ "U_CX727_MY2021_Rx" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 514 GearRvrse_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 514 StrtrMtrCtlMsgTxt_D2_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 514 StrtrMtrCtlMsgTxt_D2_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 512 PrplWhlTotTqRq_No_Cs 1;
+BA_ "ContentDependant" SG_ 512 PrplWhlTotTqRq_No_Cs 1;
+BA_ "MetaData" SG_ 512 PrplWhlTotTqRq_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 512 PrplWhlTotTqRq_No_Cs 1;
+BA_ "U_P702_MY2021_Tx" SG_ 512 PrplWhlTotTqRq_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 512 PrplWhlTotTqRq_No_Cnt 1;
+BA_ "ContentDependant" SG_ 512 PrplWhlTotTqRq_No_Cnt 1;
+BA_ "MetaData" SG_ 512 PrplWhlTotTqRq_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 512 PrplWhlTotTqRq_No_Cnt 1;
+BA_ "U_P702_MY2021_Tx" SG_ 512 PrplWhlTotTqRq_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 512 PrplWhlTot_Tq_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 512 PrplWhlTot_Tq_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 512 PrplWhlTot_Tq_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 512 PrplWhlTot_Tq_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 512 PrplWhlTot_Tq_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 512 PrplWhlTot_Tq_LimMn 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 512 PrplWhlTot_Tq_LimMn 1;
+BA_ "U_P702_MY2021_Rx" SG_ 512 PrplWhlTot_Tq_LimMn 1;
+BA_ "U_P702_MY2021_Tx" SG_ 512 PrplWhlTot_Tq_LimMn 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 512 PrplWhlTot_Tq_LimMn 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 512 PtDrvMde_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 512 PtDrvMde_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 381 EngOilLife_T_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 381 EngOilLife_T_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 381 EngOilSrvcMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 381 EngOilSrvcMsgTxt_D_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 381 EngOilSrvcMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 381 DistToNextOilChange 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 381 DistToNextOilChange 1;
+BA_ "U_P702_MY2021_Tx" SG_ 381 RunDryPrevent_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 381 RunDryPrevent_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 381 WaterInFuel 1;
+BA_ "UsedOnPgmDBC" SG_ 381 WaterInFuel 1;
+BA_ "U_P702_MY2021_Tx" SG_ 381 WaterInFuel 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 381 WaterInFuel 1;
+BA_ "ECGUsedRxSignal" SG_ 381 WaterInFuel 1;
+BA_ "CrossOver_InfoCAN" SG_ 381 GlowIndication 1;
+BA_ "UsedOnPgmDBC" SG_ 381 GlowIndication 1;
+BA_ "U_P702_MY2021_Tx" SG_ 381 GlowIndication 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 381 GlowIndication 1;
+BA_ "WakeupSignal" SG_ 380 EngOilLvlWarn_D_Rq1 1;
+BA_ "CrossOver_InfoCAN" SG_ 380 EngOilLvlWarn_D_Rq1 1;
+BA_ "U_P702_MY2021_Tx" SG_ 380 EngOilLvlWarn_D_Rq1 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 380 EngOilLvlWarn_D_Rq1 1;
+BA_ "CrossOver_InfoCAN" SG_ 380 EngExhBrkOnLamp_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 380 EngExhBrkOnLamp_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 380 EngExhBrkOnLamp_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 380 EngExhBrkAutoLamp_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 380 EngExhBrkAutoLamp_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 380 EngExhBrkAutoLamp_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 380 EngAout_N_MxAllw 1;
+BA_ "UsedOnPgmDBC" SG_ 380 EngAout_N_MxAllw 1;
+BA_ "U_P702_MY2021_Tx" SG_ 380 EngAout_N_MxAllw 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 380 EngAout_N_MxAllw 1;
+BA_ "CrossOver_InfoCAN" SG_ 380 EngExhBrkMde_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 380 EngExhBrkMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 380 EngExhBrkMde_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 380 EngExhBrkMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 380 EngExhBrkMde_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 377 HvacAirFullOut_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 HvacAirFullOut_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 FuelFlw_Vl_Dsply 1;
+BA_ "UsedOnPgmDBC" SG_ 377 FuelFlw_Vl_Dsply 1;
+BA_ "ContentDependant" SG_ 377 FuelFlw_Vl_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 FuelFlw_Vl_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 FuelFlw_Vl_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 377 FuelFlw_Vl_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 FuelFillInlet_B_Dsply 1;
+BA_ "UsedOnPgmDBC" SG_ 377 FuelFillInlet_B_Dsply 1;
+BA_ "ContentDependant" SG_ 377 FuelFillInlet_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 FuelFillInlet_B_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 FuelFillInlet_B_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 EngSrvcRqd_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 377 EngSrvcRqd_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 EngSrvcRqd_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 EngSrvcRqd_B_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 377 EngSrvcRqd_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 OdoCount 1;
+BA_ "UsedOnPgmDBC" SG_ 377 OdoCount 1;
+BA_ "ContentDependant" SG_ 377 OdoCount 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 OdoCount 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 OdoCount 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 EngOilLife_Pc_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 377 EngOilLife_Pc_Actl 1;
+BA_ "ContentDependant" SG_ 377 EngOilLife_Pc_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 EngOilLife_Pc_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 EngOilLife_Pc_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 377 EngOilLife_Pc_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 FuelFilterLamp_B_Dsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 FuelFilterLamp_B_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 FuelFilterLamp_B_Dsply 1;
+BA_ "ECGUsedRxSignal" SG_ 377 FuelFilterLamp_B_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 AirCondRec_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 377 AirCondRec_B_Rq 1;
+BA_ "ContentDependant" SG_ 377 AirCondRec_B_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 AirCondRec_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 AirCondRec_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 377 AirCondClutch_B_Stats 1;
+BA_ "UsedOnPgmDBC" SG_ 377 AirCondClutch_B_Stats 1;
+BA_ "ContentDependant" SG_ 377 AirCondClutch_B_Stats 1;
+BA_ "U_P702_MY2021_Tx" SG_ 377 AirCondClutch_B_Stats 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 377 AirCondClutch_B_Stats 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 GasPrtc_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 GasPrtc_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "ContentDependant" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 EngAout_Aa_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 376 DynoMde_B_Cmd 1;
+BA_ "U_P702_MY2021_Rx" SG_ 376 DynoMde_B_Cmd 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 376 DynoMde_B_Cmd 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 DynoMde_B_Cmd 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 DynoMde_B_Cmd 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 AslIconDsply_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 AslIconDsply_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 AslChime_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 AslChime_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 376 HvacHtrCore2_Te_Actl 200;
+BA_ "U_P702_MY2021_Tx" SG_ 376 HvacHtrCore2_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 EcssLamp_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 EcssLamp_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "MetaData" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 AirAmbTe_D_Qf 1;
+BA_ "CrossOver_InfoCAN" SG_ 376 AirAmb_Te_ActlFilt 1;
+BA_ "UsedOnPgmDBC" SG_ 376 AirAmb_Te_ActlFilt 1;
+BA_ "GenSigStartValueInteger" SG_ 376 AirAmb_Te_ActlFilt 512;
+BA_ "U_P702_MY2021_Tx" SG_ 376 AirAmb_Te_ActlFilt 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 AirAmb_Te_ActlFilt 1;
+BA_ "ECGUsedRxSignal" SG_ 376 AirAmb_Te_ActlFilt 1;
+BA_ "CrossOver_InfoCAN" SG_ 376 AirAmb_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 376 AirAmb_Te_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 376 AirAmb_Te_Actl 512;
+BA_ "U_P702_MY2021_Rx" SG_ 376 AirAmb_Te_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 376 AirAmb_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 AirAmb_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 AirAmb_Te_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 376 AirAmb_P_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 376 AirAmb_P_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 376 AirAmb_P_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 376 AirAmb_P_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 376 AirAmb_P_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 373 DieslPrtc2_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 373 DieslPrtc2_D_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 373 DieslPrtc2_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 373 DieslPrtcRgen_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 373 DieslPrtcRgen_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 373 DieslPrtcRgen_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 373 DieslPrtcRgen_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 373 DieslPrtcRgen_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 373 DieslPrtcRgen_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 373 EngTeColdPrtct_D_Stats 1;
+BA_ "UsedOnPgmDBC" SG_ 373 EngTeColdPrtct_D_Stats 1;
+BA_ "U_P702_MY2021_Tx" SG_ 373 EngTeColdPrtct_D_Stats 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 373 EngTeColdPrtct_D_Stats 1;
+BA_ "CrossOver_InfoCAN" SG_ 373 EngExhOvrTe_B_RqDsply 1;
+BA_ "UsedOnPgmDBC" SG_ 373 EngExhOvrTe_B_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 373 EngExhOvrTe_B_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 373 EngExhOvrTe_B_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 373 EngExhOvrTe_B_RqDsply 1;
+BA_ "GenSigStartValueInteger" SG_ 359 PrplWhlRgenMn_Tq_Actl 4095;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 PrplWhlRgenMn_Tq_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 PrplWhlRgenMn_Tq_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 PrplWhlRgenMn_Tq_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 ElPw_D_StatStrtStop 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 ElPw_D_StatStrtStop 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 ElPw_D_StatStrtStop 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 ElPw_D_StatStrtStop 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "ContentDependant" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 TrnAin_Tq_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 359 PrplWhlTot2_Tq_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 359 PwPckTq_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 Eng_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 359 Eng_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 Eng_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 Eng_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 Eng_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 Eng_D_Stat 1;
+BA_ "ECGUsedRxSignal" SG_ 359 Eng_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 PlgActvArb_B_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 359 PlgActvArb_B_Actl 1;
+BA_ "ContentDependant" SG_ 359 PlgActvArb_B_Actl 1;
+BA_ "GenSigStartValue" SG_ 359 PlgActvArb_B_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 359 PlgActvArb_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 ElPw_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 359 ElPw_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 ElPw_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 359 ElPw_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 ElPw_D_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 ElPw_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 ElPw_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "ContentDependant" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "MetaData" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 359 TrnAinTq_D_Qf 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 StopStrtStdby_D_Indic 1;
+BA_ "GenSigStartValueInteger" SG_ 358 StopStrtStdby_D_Indic 0;
+BA_ "U_P702_MY2021_Tx" SG_ 358 StopStrtStdby_D_Indic 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 StopStrtStdby_D_Indic 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 StopStrtIODTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 358 StopStrtIODTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 StopStrtIODTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 StopStrtDrvMde_D_Indic 1;
+BA_ "U_P702_MY2021_Tx" SG_ 358 StopStrtDrvMde_D_Indic 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 StopStrtDrvMde_D_Indic 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 StopStrtMsgTxt_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 358 StopStrtMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 StopStrtMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 OdoTripVerify_L_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 358 OdoTripVerify_L_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 OdoTripVerify_L_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 HiElPwInhbt_B_Stat 1;
+BA_ "ContentDependant" SG_ 358 HiElPwInhbt_B_Stat 1;
+BA_ "U_P702_MY2021_Tx" SG_ 358 HiElPwInhbt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 HiElPwInhbt_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 358 AutoStopPtDelta_I_Est 1;
+BA_ "GenSigStartValueInteger" SG_ 358 AutoStopPtDelta_I_Est 127;
+BA_ "ContentDependant" SG_ 358 AutoStopPtDelta_I_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 358 AutoStopPtDelta_I_Est 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 358 AutoStopPtDelta_I_Est 1;
+BA_ "UsedOnPgmDBC" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "GenSigStartValueInteger" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "MetaData" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "GenSigStartValue" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "U_P702_MY2021_Rx" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 BPedDrvAppl_D_QF 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 CmbbDeny_B_ActlPrpl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 CmbbDeny_B_ActlPrpl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 PrplTqMnSat_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 PrplTqMnSat_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "GenSigStartValue" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 357 BpedDrvAppl_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 CmbbEngTqMn_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 CmbbEngTqMn_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 357 Veh_V_DsplyCcSet 1;
+BA_ "UsedOnPgmDBC" SG_ 357 Veh_V_DsplyCcSet 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 Veh_V_DsplyCcSet 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 Veh_V_DsplyCcSet 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 AccEngStat_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 AccEngStat_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 357 CcMde_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 357 CcMde_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 357 CcMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 357 CcMde_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 CcMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 CcMde_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 357 CcStat_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 357 CcStat_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 357 CcStat_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 357 CcStat_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 357 CcStat_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 CcStat_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 CcStat_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 EngAout_N_MnAllw 1;
+BA_ "CrossOver_InfoCAN" SG_ 357 CcOvrrdActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 357 CcOvrrdActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 357 CcOvrrdActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 357 CcOvrrdActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 CcOvrrdActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 CcOvrrdActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 357 AccStopMde_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 357 AccStopMde_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 357 AccStopMde_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 357 AccStopMde_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 357 AccStopMde_D_Rq 1;
+BA_ "U_P702_MY2021_Tx" SG_ 355 AutoRgenTxt_B_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 355 AutoRgenTxt_B_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 355 AutoRgenTxt_B_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 355 AccFllwMdeActv_B_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 355 AccFllwMdeActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 355 AccFllwMdeActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 355 EngPtoMde_D_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 355 EngPtoMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 355 EngPtoMde_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 355 ManRgenTxt_D_RqDsply 1;
+BA_ "UsedOnPgmDBC" SG_ 355 ManRgenTxt_D_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 355 ManRgenTxt_D_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 355 ManRgenTxt_D_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 355 ManRgenTxt_D_RqDsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 355 ManRgenSoot_Pc_RqDsply 1;
+BA_ "UsedOnPgmDBC" SG_ 355 ManRgenSoot_Pc_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 355 ManRgenSoot_Pc_RqDsply 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 355 ManRgenSoot_Pc_RqDsply 1;
+BA_ "ECGUsedRxSignal" SG_ 355 ManRgenSoot_Pc_RqDsply 1;
+BA_ "U_P702_MY2021_Tx" SG_ 355 DieslMsgTxt_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 355 DieslMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 342 EngOvrhtMitgActv_D_Ind 1;
+BA_ "UsedOnPgmDBC" SG_ 342 EngOvrhtMitgActv_D_Ind 1;
+BA_ "ContentDependant" SG_ 342 EngOvrhtMitgActv_D_Ind 1;
+BA_ "U_P702_MY2021_Tx" SG_ 342 EngOvrhtMitgActv_D_Ind 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 342 EngOvrhtMitgActv_D_Ind 1;
+BA_ "CrossOver_InfoCAN" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "MetaData" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "U_P702_MY2021_Tx" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 342 EngClntTe_D_Qf 1;
+BA_ "CrossOver_InfoCAN" SG_ 342 EngGoutLss_Tq_Est 1;
+BA_ "ContentDependant" SG_ 342 EngGoutLss_Tq_Est 1;
+BA_ "U_P702_MY2021_Tx" SG_ 342 EngGoutLss_Tq_Est 1;
+BA_ "CrossOver_InfoCAN" SG_ 342 EngOil_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 342 EngOil_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 342 EngOil_Te_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 342 EngClnt_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 71 immoTarget1Status 1;
+BA_ "U_P702_MY2021_Rx" SG_ 71 immoTarget1Status 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 71 immoTarget1Status 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 71 immoTarget1Status 1;
+BA_ "U_P702_MY2021_Tx" SG_ 71 immoTarget1Status 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 71 immoTarget1Status 1;
+BA_ "UsedOnPgmDBC" SG_ 71 immoTarget1Data 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 71 immoTarget1Data 1;
+BA_ "U_P702_MY2021_Rx" SG_ 71 immoTarget1Data 1;
+BA_ "U_P702_MY2021_Tx" SG_ 71 immoTarget1Data 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 71 immoTarget1Data 1;
+BA_ "UsedOnPgmDBC" SG_ 71 immoTarget1Cmd 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 71 immoTarget1Cmd 1;
+BA_ "U_P702_MY2021_Rx" SG_ 71 immoTarget1Cmd 1;
+BA_ "U_P702_MY2021_Tx" SG_ 71 immoTarget1Cmd 1;
+BA_ "U_T6_MCA_MY2020_Tx" SG_ 71 immoTarget1Cmd 1;
+BA_ "GenSigSendType" SG_ 1822 TesterPhysicalResGWM_F1 3;
+BA_ "ECGUsedTxSignal" SG_ 1822 TesterPhysicalResGWM_F1 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1438 GWM_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_GWOnBoardTester 255;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1438 GWM_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_GWNMProxy 255;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_GWNMProxy 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1438 GWM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_AutoSarNMReserved4 255;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1438 GWM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_AutoSarNMReserved3 255;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1438 GWM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_AutoSarNMReserved2 255;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1438 GWM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_AutoSarNMReserved1 255;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1438 GWM_AutoSarNMNodeId 158;
+BA_ "ContentDependant" SG_ 1438 GWM_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1438 GWM_AutoSarNMNodeId 158;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1438 GWM_AutoSarNMControl 1;
+BA_ "ECGUsedTxSignal" SG_ 1438 GWM_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 954 GenericSwtch3_No_Actl 1;
+BA_ "ContentDependant" SG_ 954 GenericSwtch2_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 954 GenericSwtch2_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 954 GenericSwtch1_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1006 PersIndexIpmb_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1006 PersIndexIpmb_D_Actl 4;
+BA_ "GenSigStartValue" SG_ 1006 PersIndexIpmb_D_Actl 4;
+BA_ "GenSigSendType" SG_ 1006 PersIndexIpmb_D_Actl 3;
+BA_ "CrossOver_InfoCAN" SG_ 1006 FeatNoIpmbActl 1;
+BA_ "GenSigSendType" SG_ 1006 FeatNoIpmbActl 3;
+BA_ "CrossOver_InfoCAN" SG_ 1006 FeatConfigIpmbActl 1;
+BA_ "GenSigSendType" SG_ 1006 FeatConfigIpmbActl 3;
+BA_ "GenSigSendType" SG_ 820 AhbStatGfhbFdbk_D_Actl 3;
+BA_ "U_P702_MY2021_Tx" SG_ 820 AhbStatGfhbFdbk_D_Actl 1;
+BA_ "GenSigSendType" SG_ 820 HeadLghtDrvSide_B_Stat 3;
+BA_ "U_P702_MY2021_Tx" SG_ 820 HeadLghtDrvSide_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 820 HeadLghtHiOn_B_StatHcm 1;
+BA_ "GenSigSendType" SG_ 820 HeadLghtHiOn_B_StatHcm 3;
+BA_ "U_P702_MY2021_Tx" SG_ 820 HeadLghtHiOn_B_StatHcm 1;
+BA_ "CrossOver_InfoCAN" SG_ 820 Adaptive_Hdlmp_Fault 1;
+BA_ "GenSigSendType" SG_ 820 Adaptive_Hdlmp_Fault 3;
+BA_ "U_P702_MY2021_Tx" SG_ 820 Adaptive_Hdlmp_Fault 1;
+BA_ "GenSigStartValueInteger" SG_ 137 SteWhlOffstRq_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 137 SteWhlOffstRq_D_Stat 2;
+BA_ "U_P702_MY2021_Rx" SG_ 137 SteWhlOffstRq_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 137 SteWhlOffst_An_TotActl 32766;
+BA_ "GenSigStartValue" SG_ 137 SteWhlOffst_An_TotActl 32765;
+BA_ "U_P702_MY2021_Rx" SG_ 137 SteWhlOffst_An_TotActl 1;
+BA_ "GenSigStartValueInteger" SG_ 137 SteWhlBrkOffst_An_Actl 32766;
+BA_ "GenSigStartValue" SG_ 137 SteWhlBrkOffst_An_Actl 32765;
+BA_ "U_P702_MY2021_Rx" SG_ 137 SteWhlBrkOffst_An_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 137 SteWhlBrkAnActl_No_Cs 1;
+BA_ "MetaData" SG_ 137 SteWhlBrkAnActl_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 137 SteWhlBrkAnActl_No_Cs 1;
+BA_ "CrossOver_InfoCAN" SG_ 137 SteWhlBrkAnActl_No_Cnt 1;
+BA_ "MetaData" SG_ 137 SteWhlBrkAnActl_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 137 SteWhlBrkAnActl_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 129 SelDrvMdeSwtch_D_Stat4 1;
+BA_ "U_P702_MY2021_Rx" SG_ 129 SelDrvMdeSwtch_D_Stat4 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchView_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchSet_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchPhon_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchNav_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchMed_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchIod_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchHud_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchBack_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchMenu_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchUp_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchRght_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchOk_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchLeft_B_Stat 1;
+BA_ "WakeupSignal" SG_ 129 SteWhlSwtchDown_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 935 SodRight_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 935 SodRight_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 935 SodRight_D_Stat 2;
+BA_ "GenSigSendType" SG_ 935 SodRight_D_Stat 3;
+BA_ "GenSigSendType" SG_ 935 CtaAlrtRight2_D_Stat 3;
+BA_ "GenSigSendType" SG_ 935 BttRight_D_Stat 3;
+BA_ "GenSigSendType" SG_ 935 BttRight_D_RqDrv 3;
+BA_ "GenSigSendType" SG_ 935 CtaBrkRightMsgTxt_B_Rq 3;
+BA_ "GenSigSendType" SG_ 935 CtaRightBrkEnbl_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 935 CtaRightBrkEnbl_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 935 CtaRightBrkEnbl_B_Rq 1;
+BA_ "GenSigSendType" SG_ 935 CtaRightBrkDecel_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 935 CtaRightBrkDecel_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 935 CtaRightBrkDecel_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 935 Side_Detect_R_Illum 1;
+BA_ "GenSigStartValueInteger" SG_ 935 Side_Detect_R_Illum 100;
+BA_ "GenSigStartValue" SG_ 935 Side_Detect_R_Illum 100;
+BA_ "CrossOver_InfoCAN" SG_ 935 CtaSnsRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 935 CtaSnsRight_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 935 CtaAlrtRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 935 CtaAlrtRight_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 935 CtaRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 935 CtaRight_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 935 SodSnsRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 935 SodSnsRight_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 935 SodAlrtRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 935 SodAlrtRight_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 935 SodDetctRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 935 SodDetctRight_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 935 SodWarnRight_Prd_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 935 SodWarnRight_Prd_Rq 14;
+BA_ "GenSigStartValue" SG_ 935 SodWarnRight_Prd_Rq 14;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte8 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte8 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte8 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte7 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte7 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte7 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte6 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte6 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte6 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte5 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte5 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte5 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte4 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte4 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte4 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte3 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte3 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte3 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte2 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte2 1;
+BA_ "UsedOnPgmDBC" SG_ 1108 RCMSerialNoByte1 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1108 RCMSerialNoByte1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1108 RCMSerialNoByte1 1;
+BA_ "GenSigStartValueInteger" SG_ 261 ChrgStatDsply_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 261 ChrgStatDsply_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1146 TrlrAidSwtch_D_RqDrv 1;
+BA_ "GenSigStartValueInteger" SG_ 1146 TrlrAidCtl_U_RqDrv 4094;
+BA_ "GenSigStartValue" SG_ 1146 TrlrAidCtl_U_RqDrv 4093;
+BA_ "U_P702_MY2021_Rx" SG_ 1146 TrlrAidCtl_U_RqDrv 1;
+BA_ "U_P702_MY2021_Rx" SG_ 533 TrlrAidMde_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 533 OnbChrgGoTOn_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 533 OnbChrgGoTOn_D_Rq 2;
+BA_ "GenSigStartValue" SG_ 533 OnbChrgGoTOn_D_Rq 2;
+BA_ "CrossOver_InfoCAN" SG_ 533 OnbChrgGoTMnte_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 533 OnbChrgGoTMnte_D_Rq 1;
+BA_ "MetaData" SG_ 533 OnbChrgGoTMnte_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 533 OnbChrgGoTHr_T_Rq 30;
+BA_ "GenSigStartValue" SG_ 533 OnbChrgGoTHr_T_Rq 30;
+BA_ "CrossOver_InfoCAN" SG_ 533 OnbChrgGoTElement_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 533 OnbChrgGoTElement_D_Rq 1;
+BA_ "MetaData" SG_ 533 OnbChrgGoTElement_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 533 OnbChrgGoTDelete_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 533 OnbChrgClearAll_B_Rq 1;
+BA_ "ECGUsedTxSignal" SG_ 533 OnbChrgClearAll_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 533 OnbChrgGoTUpdate_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1041 ElCmpr_Pw_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAuxIsol_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 1067 BattULoAuxIsol_D_Rq 2;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAux_U_Rq 1;
+BA_ "GenSigStartValue" SG_ 1067 BattULoAux_U_Rq 3296;
+BA_ "GenSigStartValueInteger" SG_ 1067 BattULoAuxSoc_Pc_Actl 95;
+BA_ "GenSigStartValue" SG_ 1067 BattULoAuxSoc_Pc_Actl 95;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAuxSoc_Pc_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1067 BattULoAux_I_Actl 2048;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAux_I_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAux_D_Qlty 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoCrnkStrt_U_Pred 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoCrnkBelt_U_Pred 1;
+BA_ "GenSigStartValueInteger" SG_ 1067 BattULoAux_U_Actl 203;
+BA_ "GenSigStartValue" SG_ 1067 BattULoAux_U_Actl 203;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAux_U_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1067 BattULoAux_B_Falt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1112 BattTracChrgSustn_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1112 BattTracCnnct_D_Cmd 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1112 BattTracHvilOpen_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1112 BattTracDcdcDis_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1112 BattTracDelta_Te_Actl 164;
+BA_ "GenSigStartValue" SG_ 1112 BattTracDelta_Te_Actl 120;
+BA_ "ContentDependant" SG_ 1112 BattTracClntPmp_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 139 AfsPw_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 139 AfsPw_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 139 ActvFrontSteLck_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 139 ActvFrontSteLck_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 139 SelDrvMdeAdptSte_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1121 SelDrvMdeSwtch_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1121 SelDrvMdeSwtch_No_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1121 SelDrvMdeSwtch_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1121 SelDrvMdeSwtch_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1121 SelDrvMdeCnt_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1121 SelDrvMdeCnt_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1120 DrvSlipCtlMde_B_Rq3 1;
+BA_ "UsedOnPgmDBC" SG_ 1120 DrvSlipCtlMde_B_Rq3 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1120 DrvSlipCtlMde_B_Rq3 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1120 HybMdeSwtch_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1120 RearDiffLck_D_RqDrv 2;
+BA_ "GenSigStartValue" SG_ 1120 RearDiffLck_D_RqDrv 2;
+BA_ "U_P702_MY2021_Rx" SG_ 1120 RearDiffLck_D_RqDrv 1;
+BA_ "GenSigStartValueInteger" SG_ 1120 AwdMde_D_RqDrv 5;
+BA_ "GenSigStartValue" SG_ 1120 AwdMde_D_RqDrv 5;
+BA_ "U_P702_MY2021_Rx" SG_ 1120 AwdMde_D_RqDrv 1;
+BA_ "UsedOnPgmDBC" SG_ 1120 HdcSwtchPos_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1120 HdcSwtchPos_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1050 Outside_Air_Temp_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1050 Outside_Air_Temp_Stat 254;
+BA_ "GenSigStartValue" SG_ 1050 Outside_Air_Temp_Stat 254;
+BA_ "U_P702_MY2021_Rx" SG_ 1050 Outside_Air_Temp_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1050 Outside_Air_Temp_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 1137 RngPerChrgAvg_L_Dsply 4094;
+BA_ "GenSigStartValue" SG_ 1137 RngPerChrgAvg_L_Dsply 4093;
+BA_ "U_P702_MY2021_Tx" SG_ 1137 RngPerChrgAvg_L_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4Prev3X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4Prev1X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1255 BalrRight4CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1255 BalrRight4CurntX_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1254 BalrRight3Threat_D_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3Prev3X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3Prev1X_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1254 BalrRight3Fast_B_Stat 3;
+BA_ "GenSigSendType" SG_ 1254 BalrRight3Dsply_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1254 BalrRight3CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1254 BalrRight3CurntX_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2Prev3X_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1253 BalrRight2Threat_D_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2Prev1X_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1253 BalrRight2Fast_B_Stat 3;
+BA_ "GenSigSendType" SG_ 1253 BalrRight2Dsply_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1253 BalrRight2CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1253 BalrRight2CurntX_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1Prev3X_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1252 BalrRight1Threat_D_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1Prev1X_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1252 BalrRight1Fast_B_Stat 3;
+BA_ "GenSigSendType" SG_ 1252 BalrRight1Dsply_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1252 BalrRight1CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1252 BalrRight1CurntX_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4Prev3X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4Prev1X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1251 BalrLeft4CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1251 BalrLeft4CurntX_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3Prev3X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3Prev1X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1250 BalrLeft3CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1250 BalrLeft3CurntX_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2Prev3X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2Prev1X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1249 BalrLeft2CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1249 BalrLeft2CurntX_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1248 BalrLeft1Threat_D_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1Prev3Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1Prev3Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1Prev3X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1Prev3X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1Prev2Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1Prev2Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1Prev2X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1Prev2X_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1Prev1Y_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1Prev1Y_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1Prev1X_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1Prev1X_L_Actl 0;
+BA_ "GenSigSendType" SG_ 1248 BalrLeft1Fast_B_Stat 3;
+BA_ "GenSigSendType" SG_ 1248 BalrLeft1Dsply_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1CurntY_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1CurntY_L_Actl 0;
+BA_ "GenSigStartValueInteger" SG_ 1248 BalrLeft1CurntX_L_Actl 64;
+BA_ "GenSigStartValue" SG_ 1248 BalrLeft1CurntX_L_Actl 0;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 TrlrTrgtAcquire_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 TrlrRvrse_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 TrlrAid_D2_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 TrlrAidTrgtId_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1113 TrlrAid_An3_Actl 720;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 TrlrAid_An3_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1113 TrlrAid_AnRate2_Actl 400;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 TrlrAid_AnRate2_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1113 HitchToVehAxle_L_Calc 255;
+BA_ "GenSigStartValue" SG_ 1113 HitchToVehAxle_L_Calc 255;
+BA_ "U_P702_MY2021_Rx" SG_ 1113 HitchToVehAxle_L_Calc 1;
+BA_ "GenSigSendType" SG_ 1105 TrlrAidSwtchLamp_B_Rq 3;
+BA_ "GenSigSendType" SG_ 1105 TrlrHitchMsgTxt_D_Rq 3;
+BA_ "GenSigSendType" SG_ 1105 TrlrHitchIcon_D_Rq 3;
+BA_ "GenSigSendType" SG_ 1105 TrlrHitchChime_D_Rq 3;
+BA_ "GenSigSendType" SG_ 1105 TrlrAidEnbl_D_RqAdas 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1105 TrlrAidEnbl_D_RqAdas 1;
+BA_ "GenSigSendType" SG_ 1105 TrlrRvrseMsgTxt_D2_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1105 TrlrRvrseMsgTxt_D2_Rq 1;
+BA_ "GenSigSendType" SG_ 1105 TrlrRvrseEnbl_D2_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1105 TrlrRvrseEnbl_D2_Stat 1;
+BA_ "GenSigSendType" SG_ 1105 RbaMsg_D_Rq 3;
+BA_ "WakeupSignal" SG_ 1105 BrkDecel_B_RqRba 1;
+BA_ "CrossOver_InfoCAN" SG_ 1105 BrkDecel_B_RqRba 1;
+BA_ "UsedOnPgmDBC" SG_ 1105 BrkDecel_B_RqRba 1;
+BA_ "GenSigSendType" SG_ 1105 BrkDecel_B_RqRba 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1105 BrkDecel_B_RqRba 1;
+BA_ "WakeupSignal" SG_ 1105 BrkEnbl_B_RqRba 1;
+BA_ "CrossOver_InfoCAN" SG_ 1105 BrkEnbl_B_RqRba 1;
+BA_ "UsedOnPgmDBC" SG_ 1105 BrkEnbl_B_RqRba 1;
+BA_ "GenSigSendType" SG_ 1105 BrkEnbl_B_RqRba 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1105 BrkEnbl_B_RqRba 1;
+BA_ "GenSigStartValueInteger" SG_ 1105 Rba_D_Stat 1;
+BA_ "GenSigStartValue" SG_ 1105 Rba_D_Stat 1;
+BA_ "GenSigSendType" SG_ 1105 Rba_D_Stat 3;
+BA_ "GenSigSendType" SG_ 1105 RbaAlrt_D_Dsply 3;
+BA_ "GenSigSendType" SG_ 1105 RbaMnu_D_Rq 3;
+BA_ "GenSigSendType" SG_ 1105 CamraFrntStat_D_Stat 3;
+BA_ "GenSigSendType" SG_ 1105 TrlrHitchLamp_D_Rq2 3;
+BA_ "GenSigSendType" SG_ 938 SidePrkSnsR2_D_Stat 3;
+BA_ "GenSigSendType" SG_ 938 SidePrkSnsR1_D_Stat 3;
+BA_ "GenSigSendType" SG_ 938 SidePrkSnsL2_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 ApaMde_D_Stat 1;
+BA_ "GenSigSendType" SG_ 938 ApaMde_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 ApaActvSd_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 938 ApaActvSd_D_Actl 1;
+BA_ "GenSigStartValue" SG_ 938 ApaActvSd_D_Actl 1;
+BA_ "GenSigSendType" SG_ 938 ApaActvSd_D_Actl 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidSwtch_B_Stat 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidSwtch_B_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 ApaMde_D_Avail 1;
+BA_ "GenSigSendType" SG_ 938 ApaMde_D_Avail 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidSnsFrCrnr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidSnsFrCrnr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidSnsFrCntr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidSnsFrCntr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidSnsFlCrnr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidSnsFlCrnr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidSnsFlCntr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidSnsFlCntr_D_Stat 3;
+BA_ "GenSigSendType" SG_ 938 PrkBrkEl_B_RqFap 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 938 PrkBrkEl_B_RqFap 1;
+BA_ "U_P702_MY2021_Rx" SG_ 938 PrkBrkEl_B_RqFap 1;
+BA_ "CrossOver_InfoCAN" SG_ 938 RpaChime_D_Rq 1;
+BA_ "GenSigSendType" SG_ 938 RpaChime_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 FpaChime_D_Rq 1;
+BA_ "GenSigSendType" SG_ 938 FpaChime_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidMsgTxt_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 938 PrkAidMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 938 SidePrkSnsL1_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 938 PrkAidAudioMute_B_Rq 1;
+BA_ "GenSigSendType" SG_ 938 PrkAidAudioMute_B_Rq 3;
+BA_ "GenSigSendType" SG_ 939 ApaBrk_D_Rq 3;
+BA_ "GenSigSendType" SG_ 939 SidePrkSnsR4_D_Stat 3;
+BA_ "GenSigSendType" SG_ 939 SidePrkSnsR3_D_Stat 3;
+BA_ "GenSigSendType" SG_ 939 SidePrkSnsL4_D_Stat 3;
+BA_ "GenSigSendType" SG_ 939 SidePrkSnsL3_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidChime_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidChime_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidSnsRlCntr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidSnsRlCntr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidSnsRrCrnr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidSnsRrCrnr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidSnsRrCntr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidSnsRrCntr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidSnsRlCrnr_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidSnsRlCrnr_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidRear_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidRear_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAidFront_D_Stat 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidFront_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 939 PrkAid_D_Falt 1;
+BA_ "GenSigSendType" SG_ 939 PrkAid_D_Falt 3;
+BA_ "GenSigSendType" SG_ 939 ApaLongCtrlEnbl_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 939 ApaLongCtrlEnbl_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 939 ApaLongCtrlEnbl_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 939 ApaLongCtrlEnbl_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 939 ApaBrk_A_Rq 255;
+BA_ "U_P702_MY2021_Rx" SG_ 939 ApaBrk_A_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 939 ApaBrk_A_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 939 ApaBrk_A_Rq 1;
+BA_ "GenSigSendType" SG_ 939 PrkAidLamp_D_Rq 3;
+BA_ "GenSigStartValueInteger" SG_ 937 Veh_V_RqFap 0;
+BA_ "U_P702_MY2021_Rx" SG_ 937 Veh_V_RqFap 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 937 Veh_V_RqFap 1;
+BA_ "MetaData" SG_ 937 TrnRngDRqFap_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 937 TrnRngDRqFap_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 937 TrnRngDRqFap_No_Cs 1;
+BA_ "MetaData" SG_ 937 TrnRngDRqFap_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 937 TrnRngDRqFap_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 937 TrnRngDRqFap_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 937 TrnRng_D_RqFap 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 937 TrnRng_D_RqFap 1;
+BA_ "GenSigStartValueInteger" SG_ 937 FapLcDistToObj_L_Actl 254;
+BA_ "GenSigStartValue" SG_ 937 FapLcDistToObj_L_Actl 254;
+BA_ "U_P702_MY2021_Rx" SG_ 937 FapLcDistToObj_L_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 937 FapLcDistToObj_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 936 ApaSys_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 936 ApaSys_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 936 EPASExtAngleStatReq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 936 EPASExtAngleStatReq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 936 ExtSteeringAngleReq2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 936 ExtSteeringAngleReq2 1;
+BA_ "GenSigStartValueInteger" SG_ 877 RngImpctDrv_L_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 877 RngImpctDrv_L_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 877 RngImpctClim_L_Dsply 255;
+BA_ "U_P702_MY2021_Tx" SG_ 877 RngImpctClim_L_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 877 VehElEffAvg_No_Dsply 126;
+BA_ "GenSigStartValue" SG_ 877 VehElEffAvg_No_Dsply 126;
+BA_ "U_P702_MY2021_Tx" SG_ 877 VehElEffAvg_No_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 877 PwFlwFuelDrv_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 877 PwFlwFuelDrv_D_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 877 PwFlwFuelDrv_D_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 877 PwFlwFuelClimt_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 877 PwFlwFuelClimt_B_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 877 PwFlwFuelClimt_B_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 877 PwFlwFuelBatt_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 877 PwFlwFuelBatt_B_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 877 PwFlwFuelBatt_B_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 877 PwFlwBattClimt_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 877 PwFlwBattClimt_B_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 877 PwFlwBattClimt_B_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 877 PwFlwBatt_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 877 PwFlwBatt_D_Dsply 3;
+BA_ "U_P702_MY2021_Tx" SG_ 877 PwFlwBatt_D_Dsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 589 BattTrac2_Pw_LimChrg 1;
+BA_ "U_P702_MY2021_Rx" SG_ 589 BattTrac2_Pw_LimDchrg 1;
+BA_ "U_P702_MY2021_Rx" SG_ 589 BattTrac2_Pw_DchrgInst 1;
+BA_ "U_P702_MY2021_Rx" SG_ 589 BattTrac2_Pw_ChrgInst 1;
+BA_ "GenSigStartValueInteger" SG_ 588 BattTracSoc2_Pc_Actl 16382;
+BA_ "GenSigStartValue" SG_ 588 BattTracSoc2_Pc_Actl 16382;
+BA_ "U_P702_MY2021_Rx" SG_ 588 BattTracSoc2_Pc_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 588 BattTrac_Te_Actl 150;
+BA_ "GenSigStartValue" SG_ 588 BattTrac_Te_Actl 150;
+BA_ "U_P702_MY2021_Rx" SG_ 588 BattTrac_Te_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 588 BattTracDiagClr_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 588 BattTracDiagClr_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 587 BattTracClnt_Te_Actl 164;
+BA_ "GenSigStartValue" SG_ 587 BattTracClnt_Te_Actl 164;
+BA_ "CrossOver_InfoCAN" SG_ 587 BattTracWarnLamp_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 587 BattTracSrvcRqd_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 587 BattTracSoc_Pc_MxPrtct 700;
+BA_ "GenSigStartValue" SG_ 587 BattTracSoc_Pc_MxPrtct 700;
+BA_ "U_P702_MY2021_Rx" SG_ 587 BattTracSoc_Pc_MxPrtct 1;
+BA_ "GenSigStartValueInteger" SG_ 587 BattTracSoc_Pc_MnPrtct 300;
+BA_ "GenSigStartValue" SG_ 587 BattTracSoc_Pc_MnPrtct 30;
+BA_ "U_P702_MY2021_Rx" SG_ 587 BattTracSoc_Pc_MnPrtct 1;
+BA_ "GenSigStartValueInteger" SG_ 587 BattTracSoc_Pc_LimLo 400;
+BA_ "GenSigStartValue" SG_ 587 BattTracSoc_Pc_LimLo 400;
+BA_ "U_P702_MY2021_Rx" SG_ 587 BattTracSoc_Pc_LimLo 1;
+BA_ "GenSigStartValueInteger" SG_ 587 BattTracSoc_Pc_LimHi 600;
+BA_ "GenSigStartValue" SG_ 587 BattTracSoc_Pc_LimHi 600;
+BA_ "U_P702_MY2021_Rx" SG_ 587 BattTracSoc_Pc_LimHi 1;
+BA_ "CrossOver_InfoCAN" SG_ 389 HtrnOvrTeLamp_B_Dsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 389 HtrnAin_UHi_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 389 HtrnAin_UHi_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 389 HtrnSrvcRqd_B_Dsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 389 HtrnHvilOpen_B_Actl 1;
+BA_ "ECGUsedRxSignal" SG_ 389 HtrnHvilOpen_B_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 389 BattTrac_I_EstVsc 15000;
+BA_ "U_P702_MY2021_Rx" SG_ 1009 TrlrAidCancl_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1009 CenterStackRing_D_Actl 2;
+BA_ "GenSigStartValue" SG_ 1009 CenterStackRing_D_Actl 2;
+BA_ "CrossOver_InfoCAN" SG_ 1009 ValetMode_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 360 GsmSrvcRqd_B_Rq 1;
+BA_ "ContentDependant" SG_ 360 GsmSrvcRqd_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 360 TrnGearPwmFalt_B_Actl 1;
+BA_ "ContentDependant" SG_ 360 TrnGearPwmFalt_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 360 TrnGearPwmFalt_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 360 TrnGearPwmFalt_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 360 GearButtnStuck_B_Actl 1;
+BA_ "ContentDependant" SG_ 360 GearButtnStuck_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 360 GearButtnStuck_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 360 GearButtnStuck_B_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 122 BattTrac_U_LimLo 88;
+BA_ "GenSigStartValue" SG_ 122 BattTrac_U_LimLo 88;
+BA_ "U_P702_MY2021_Rx" SG_ 122 BattTrac_U_LimLo 1;
+BA_ "GenSigStartValueInteger" SG_ 122 BattTrac_U_LimHi 163;
+BA_ "GenSigStartValue" SG_ 122 BattTrac_U_LimHi 163;
+BA_ "U_P702_MY2021_Rx" SG_ 122 BattTrac_U_LimHi 1;
+BA_ "CrossOver_InfoCAN" SG_ 122 VehStrtInhbt_B_RqBatt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 122 VehStrtInhbt_B_RqBatt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 122 BattTracOffFst_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 122 BattTracOff_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 122 BattTracOff_B_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 122 BattTrac_U_Actl 1022;
+BA_ "GenSigStartValue" SG_ 122 BattTrac_U_Actl 1022;
+BA_ "U_P702_MY2021_Rx" SG_ 122 BattTrac_U_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 122 BattTrac_I_Actl 15000;
+BA_ "U_P702_MY2021_Rx" SG_ 122 BattTrac_I_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 90 TrnGsmNtmState_D_Actl 1;
+BA_ "ContentDependant" SG_ 90 TrnGsmNtmState_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGsmNtmState_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGsmNtmState_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 90 TrnGsmNtmState_D_Actl 1;
+BA_ "ContentDependant" SG_ 90 DrQltyDrv_D_StatGsm 1;
+BA_ "GenSigStartValue" SG_ 90 DrQltyDrv_D_StatGsm 6;
+BA_ "U_P702_MY2021_Rx" SG_ 90 DrQltyDrv_D_StatGsm 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 DrQltyDrv_D_StatGsm 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 90 DrQltyDrv_D_StatGsm 1;
+BA_ "ContentDependant" SG_ 90 TrnBtsiOvrrd_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnBtsiOvrrd_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnBtsiOvrrd_B_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 90 TrnRng_D_RqGsm 14;
+BA_ "GenSigStartValue" SG_ 90 TrnRng_D_RqGsm 14;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnRng_D_RqGsm 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnRng_D_RqGsm 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 90 PrkBrkActv_D_RqGsmGear 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 PrkBrkActv_D_RqGsmGear 1;
+BA_ "ContentDependant" SG_ 90 TrnValidGearRq_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnValidGearRq_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnValidGearRq_D_Stat 1;
+BA_ "ContentDependant" SG_ 90 TrnGearRqCnt_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearRqCnt_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearRqCnt_B_Actl 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_U_Actl 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_U_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_U_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_U_Actl 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlR2 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlR2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlR2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlR2 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlR1 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlR1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlR1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlR1 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlR0 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlR0 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlR0 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlR0 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlP2 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlP2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlP2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlP2 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlP1 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlP1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlP1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlP1 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlP0 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlP0 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlP0 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlP0 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlN2 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlN2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlN2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlN2 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlN1 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlN1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlN1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlN1 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlN0 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlN0 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlN0 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlN0 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlM2 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlM2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlM2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlM2 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlM1 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlM1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlM1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlM1 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlM0 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlM0 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlM0 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlM0 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlD2 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlD2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlD2 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlD2 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlD1 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlD1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlD1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlD1 1;
+BA_ "WakeupSignal" SG_ 90 TrnGearButtn_B_ActlD0 1;
+BA_ "ContentDependant" SG_ 90 TrnGearButtn_B_ActlD0 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGearButtn_B_ActlD0 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGearButtn_B_ActlD0 1;
+BA_ "ContentDependant" SG_ 90 TrnGear_No_Cs 1;
+BA_ "MetaData" SG_ 90 TrnGear_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGear_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGear_No_Cs 1;
+BA_ "ContentDependant" SG_ 90 TrnGear_No_Cnt 1;
+BA_ "MetaData" SG_ 90 TrnGear_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGear_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGear_No_Cnt 1;
+BA_ "WakeupSignal" SG_ 90 TrnGear_D_RqDrv 1;
+BA_ "ContentDependant" SG_ 90 TrnGear_D_RqDrv 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 TrnGear_D_RqDrv 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 TrnGear_D_RqDrv 1;
+BA_ "ContentDependant" SG_ 90 BrkSwtchPos_B_ActlGsm 1;
+BA_ "U_P702_MY2021_Rx" SG_ 90 BrkSwtchPos_B_ActlGsm 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 90 BrkSwtchPos_B_ActlGsm 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 ParkLampTrlrOut_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 TrlrLampCtl_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 TrlrBattChrg_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 StopLampTrlrOut_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 TurnLampTrlrRr_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 TurnLampTrlrRl_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1091 TrlrLampCnnct_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1091 TrlrLampCnnct_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1091 TrlrLampCnnct_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1091 TrlrLampCnnct_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1091 TrlrLampCnnct_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 138 SteWhlRelCalib_T_Actl 1;
+BA_ "ContentDependant" SG_ 138 SteWhlRelCalib_An_Sns 1;
+BA_ "U_P702_MY2021_Rx" SG_ 138 SteWhlRelCalib_An_Sns 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 138 SteWhlRelCalib_An_Sns 1;
+BA_ "WakeupSignal" SG_ 131 HeadLghtHiCtrl_D_RqAhb 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 HeadLghtHiCtrl_D_RqAhb 1;
+BA_ "GenSigStartValueInteger" SG_ 131 WiprFrontSwtch_D_Stat 9;
+BA_ "GenSigStartValue" SG_ 131 WiprFrontSwtch_D_Stat 9;
+BA_ "WakeupSignal" SG_ 131 HeadLghtHiOn_B_StatAhb 1;
+BA_ "CrossOver_InfoCAN" SG_ 131 HeadLghtHiOn_B_StatAhb 1;
+BA_ "WakeupSignal" SG_ 131 HeadLghtHiFlash_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 131 WiprFront_D_Stat 15;
+BA_ "GenSigStartValue" SG_ 131 WiprFront_D_Stat 15;
+BA_ "U_P702_MY2021_Rx" SG_ 131 WiprFront_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 WiprFront_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 131 WiprFront_D_Stat 1;
+BA_ "WakeupSignal" SG_ 131 TurnLghtSwtch_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 131 TurnLghtSwtch_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 131 TurnLghtSwtch_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 TurnLghtSwtch_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 131 LghtAmb_D_Sns 7;
+BA_ "GenSigStartValue" SG_ 131 LghtAmb_D_Sns 7;
+BA_ "U_P702_MY2021_Rx" SG_ 131 LghtAmb_D_Sns 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 AslButtnOnOffPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 AslButtnOnOffPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 AslButtnOnOffCnclPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 AslButtnOnOffCnclPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcButtnOnPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcButtnOnPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcButtnOnOffPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcButtnOnOffPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcButtnOnOffCnclPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcButtnOnOffCnclPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcButtnOffPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcButtnOffPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAsllButtnResPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAsllButtnResPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnSetIncPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnSetIncPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnSetDecPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnSetDecPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnResIncPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnResIncPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnOnPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnOnPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnIndxIncPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnIndxIncPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnIndxDecPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnIndxDecPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnDeny_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnDeny_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnCnclResPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnCnclResPress 1;
+BA_ "U_P702_MY2021_Rx" SG_ 131 CcAslButtnCnclPress 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 131 CcAslButtnCnclPress 1;
+BA_ "WakeupSignal" SG_ 787 DrLckCnt_No_ActlTgate 1;
+BA_ "WakeupSignal" SG_ 787 DrTgateChime2_D_Rq 1;
+BA_ "WakeupSignal" SG_ 787 DrTGate_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 787 DrTGate_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 787 DrTGate_D_Rq 1;
+BA_ "WakeupSignal" SG_ 787 PwLftgtIntSw_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 787 Power_Liftgate_Mode_Stt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 953 BattRgenLoDChrg_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 953 BattRgenLoChrg_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 953 WakeAlarm3_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 953 WakeAlarm3_D_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 953 WakeAlarm2_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 953 WakeAlarm2_D_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 953 WakeAlarm1_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 953 WakeAlarm1_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 953 WakeAlarm1_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 953 WakeAlarm1_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 953 WakeAlarm0_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 953 WakeAlarm0_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 1093 TrlrBrkActCnnct_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1093 TrlrBrkActCnnct_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1093 TrlrBrkActCnnct_B_Actl 1;
+BA_ "ContentDependant" SG_ 1093 StopLamp_B_RqTrlrBrk 1;
+BA_ "U_P702_MY2021_Rx" SG_ 792 FuelRange_L_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 792 FuelRange_L_Dsply 1;
+BA_ "ContentDependant" SG_ 792 ElTrip_L_Dsply 1;
+BA_ "ContentDependant" SG_ 792 ElLongTerm_L_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 968 SlMde_D_Rq 2;
+BA_ "GenSigStartValue" SG_ 968 SlMde_D_Rq 2;
+BA_ "U_P702_MY2021_Rx" SG_ 968 SlMde_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 968 SlMde_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 968 IsaOffst_D_Rq 14;
+BA_ "GenSigStartValue" SG_ 968 IsaOffst_D_Rq 14;
+BA_ "U_P702_MY2021_Rx" SG_ 968 IsaOffst_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 968 IsaOffst_D_Rq 1;
+BA_ "WakeupSignal" SG_ 819 Memory_3_SwPsngr_Stat 1;
+BA_ "WakeupSignal" SG_ 819 Memory_2_SwPsngr_Stat 1;
+BA_ "WakeupSignal" SG_ 819 Memory_1_SwPsngr_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 819 WndwPsngrSide_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 819 WndwPsngrSide_D_Stat 1;
+BA_ "WakeupSignal" SG_ 819 Pasngr_Lock_Sw_Stat 1;
+BA_ "WakeupSignal" SG_ 819 Pasngr_Lock_Sw_Cnt 1;
+BA_ "MetaData" SG_ 819 Pasngr_Lock_Sw_Cnt 1;
+BA_ "WakeupSignal" SG_ 819 ChildLckFdbckRp_B_Stat 1;
+BA_ "WakeupSignal" SG_ 818 ChildLckPw_N_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 818 WndwDrvSide_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 818 WndwDrvSide_D_Stat 1;
+BA_ "WakeupSignal" SG_ 818 KeyCylSwDrvDr_D_Stat 1;
+BA_ "GenSigInactiveValue" SG_ 818 Driver_Lock_Sw_Stat 0;
+BA_ "WakeupSignal" SG_ 818 Driver_Lock_Sw_Stat 1;
+BA_ "WakeupSignal" SG_ 818 Driver_Lock_Sw_Cnt 1;
+BA_ "MetaData" SG_ 818 Driver_Lock_Sw_Cnt 1;
+BA_ "WakeupSignal" SG_ 818 ChildLckPw_D_Rq 1;
+BA_ "WakeupSignal" SG_ 818 ChildLckFdbckRd_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 818 RvrseMirrorChime_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 806 StopStrtDrvMde_B_RqBtn 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 StopStrtDrvMde_B_RqBtn 1;
+BA_ "GenSigStartValueInteger" SG_ 806 HvacHtrCore_Te_Rq 0;
+BA_ "U_P702_MY2021_Rx" SG_ 806 HvacHtrCore_Te_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 HvacHtrCore_Te_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 806 ClimtHeat_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 ClimtHeat_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 806 ClimtCool_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 ClimtCool_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 806 HvacEvap_Te_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 806 HvacEvap_Te_Rq 400;
+BA_ "U_P702_MY2021_Rx" SG_ 806 HvacEvap_Te_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 HvacEvap_Te_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 806 HvacEvap_Te_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 806 HvacEvap_Te_Actl 400;
+BA_ "U_P702_MY2021_Rx" SG_ 806 HvacEvap_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 HvacEvap_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 806 HvacAirCond_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 806 HvacAirCond_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 HvacAirCond_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 806 HvacEvap_Te_Offst 1;
+BA_ "GenSigStartValueInteger" SG_ 806 HvacEvap_Te_Offst 400;
+BA_ "U_P702_MY2021_Rx" SG_ 806 HvacEvap_Te_Offst 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 HvacEvap_Te_Offst 1;
+BA_ "U_P702_MY2021_Rx" SG_ 806 ClimtPw_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 806 ClimtPw_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 765 EngExhMdeQuiet_D2_Rq 0;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 765 EdmSailMde_B_RqDrv 1;
+BA_ "WakeupSignal" SG_ 765 DrvInputRequired_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 765 AwdRnge_D_ActlIpc 1;
+BA_ "UsedOnPgmDBC" SG_ 765 AwdRnge_D_ActlIpc 1;
+BA_ "GenSigStartValueInteger" SG_ 765 AwdRnge_D_ActlIpc 7;
+BA_ "GenSigStartValue" SG_ 765 AwdRnge_D_ActlIpc 7;
+BA_ "U_P702_MY2021_Rx" SG_ 765 AwdRnge_D_ActlIpc 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 765 AwdRnge_D_ActlIpc 1;
+BA_ "GenSigStartValueInteger" SG_ 765 BalrSwtch_D_Stat 1;
+BA_ "GenSigStartValue" SG_ 765 BalrSwtch_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 765 BalrMde_D_Rq 0;
+BA_ "GenSigStartValueInteger" SG_ 765 WaitToStartLamp_D_Falt 1;
+BA_ "GenSigStartValue" SG_ 765 WaitToStartLamp_D_Falt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 765 WaitToStartLamp_D_Falt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 765 WaitToStartLamp_D_Falt 1;
+BA_ "GenSigStartValueInteger" SG_ 765 EsaOn_B_Rq 1;
+BA_ "GenSigStartValue" SG_ 765 EsaOn_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 765 EsaOn_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 765 Btt_L_Actl 126;
+BA_ "GenSigStartValue" SG_ 765 Btt_L_Actl 126;
+BA_ "U_P702_MY2021_Rx" SG_ 765 SelDrvMdeTxtReset_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 765 SelDrvMdeDsply_B_Avail 1;
+BA_ "CrossOver_InfoCAN" SG_ 765 Mc_VehUnitTempUsrSel_St 1;
+BA_ "CrossOver_InfoCAN" SG_ 559 EhData2_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 559 EhData2_No_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 559 EhData2_No_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 558 EhData1_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 558 EhData1_No_Actl 0;
+BA_ "U_P702_MY2021_Rx" SG_ 558 EhData1_No_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 558 EhData1_No_Actl 1;
+BA_ "GenSigSendType" SG_ 934 CtaAlrtLeft2_D_Stat 3;
+BA_ "GenSigSendType" SG_ 934 CtaBrkLeftMsgTxt_B_Rq 3;
+BA_ "GenSigSendType" SG_ 934 CtaLeftBrkDecel_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 934 CtaLeftBrkDecel_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 934 CtaLeftBrkDecel_B_Rq 1;
+BA_ "GenSigSendType" SG_ 934 CtaLeftBrkEnbl_B_Rq 3;
+BA_ "U_CX727_MY2021_Rx" SG_ 934 CtaLeftBrkEnbl_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 934 CtaLeftBrkEnbl_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 934 Side_Detect_L_Illum 1;
+BA_ "GenSigStartValueInteger" SG_ 934 Side_Detect_L_Illum 100;
+BA_ "GenSigStartValue" SG_ 934 Side_Detect_L_Illum 100;
+BA_ "GenSigSendType" SG_ 934 BttLeft_D_Stat 3;
+BA_ "GenSigSendType" SG_ 934 BttLeft_D_RqDrv 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 CtaSnsLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 934 CtaSnsLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 SodDetctLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 934 SodDetctLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 CtaLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 934 CtaLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 CtaAlrtLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 934 CtaAlrtLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 SodLeft_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 934 SodLeft_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 934 SodLeft_D_Stat 2;
+BA_ "GenSigSendType" SG_ 934 SodLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 SodSnsLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 934 SodSnsLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 SodAlrtLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 934 SodAlrtLeft_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 934 SodWarnLeft_Prd_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 934 SodWarnLeft_Prd_Rq 14;
+BA_ "GenSigStartValue" SG_ 934 SodWarnLeft_Prd_Rq 14;
+BA_ "CrossOver_InfoCAN" SG_ 1072 DrvSlipCtlMde_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1072 DrvSlipCtlMde_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 DrvSlipCtlMde_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 EngIdlShutDown_B_RqDrv 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 EngIdlShutDown_B_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 HsaMde_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1072 HsaMde_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 1072 HsaMde_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 NtrlTowMdeEnbl_B_RqDrv 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 NtrlTowMdeEnbl_B_RqDrv 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 NtrlTowMdeEnbl_B_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 BulbChkActv_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 ParkDetect_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1072 ParkDetect_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 ReducedGuard_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 TRLR_SWAY_CONFIG_CMD 1;
+BA_ "WakeupSignal" SG_ 1072 Power_Liftgate_Mode_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 Power_Liftgate_Mode_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 AccEnbl_B_RqDrv 1;
+BA_ "GenSigStartValueInteger" SG_ 1072 AccEnbl_B_RqDrv 1;
+BA_ "GenSigStartValue" SG_ 1072 AccEnbl_B_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 OdometerMasterValue 1;
+BA_ "UsedOnPgmDBC" SG_ 1072 OdometerMasterValue 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 OdometerMasterValue 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 OdometerMasterValue 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 1072 OdometerMasterValue 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 EngOilLife_B_RqReset 1;
+BA_ "UsedOnPgmDBC" SG_ 1072 EngOilLife_B_RqReset 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 EngOilLife_B_RqReset 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 EngOilLife_B_RqReset 1;
+BA_ "WakeupSignal" SG_ 1072 ePRNDL_MODE 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 ePRNDL_MODE 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 ePRNDL_MODE 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 ePRNDL_MODE 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 DrvSlipCtlMde_B_Rq2 1;
+BA_ "UsedOnPgmDBC" SG_ 1072 DrvSlipCtlMde_B_Rq2 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 DrvSlipCtlMde_B_Rq2 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 MetricActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1072 MetricActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 MetricActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 MetricActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 KeyTypeChngMykey_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 1072 ManRgen_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1072 ManRgen_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1072 ManRgen_D_Rq 1;
+BA_ "WakeupSignal" SG_ 909 IgnPsswrdDsply_B_Rq 1;
+BA_ "WakeupSignal" SG_ 909 ElPwPoint_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 SecurityMsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 909 HeadLghtHiPrmsn_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 909 HeadLghtHiPrmsn_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 909 HeadLghtHiPrmsn_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 SteWhlLckMsgTxt_D_Rq 1;
+BA_ "WakeupSignal" SG_ 909 immoMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 immoMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 PEBackupSlot_Stats 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 KeyMykeyTot_No_Cnt 1;
+BA_ "MetaData" SG_ 909 KeyMykeyTot_No_Cnt 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 Keycode_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 909 KeyAdmnTot_No_Cnt 1;
+BA_ "MetaData" SG_ 909 KeyAdmnTot_No_Cnt 1;
+BA_ "WakeupSignal" SG_ 963 ImpactEvntFdbck_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 ImpactEvntFdbck_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 963 ImpactEvntFdbck_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLampLoOut_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 963 HeadLampLoOut_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 CrnrLghtRight_Pc_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 CrnrLghtRight_Pc_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 CrnrLghtLeft_Pc_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 CrnrLghtLeft_Pc_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLghtHiFdbck_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 TrnNotInPrkChime_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 963 TrnNotInPrkChime_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 PrkLightChime_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 963 PrkLightChime_B_Rq 1;
+BA_ "WakeupSignal" SG_ 963 KeyInIgnWarn_B_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 KeyInIgnWarn_B_Cmd 1;
+BA_ "UsedOnPgmDBC" SG_ 963 KeyInIgnWarn_B_Cmd 1;
+BA_ "WakeupSignal" SG_ 963 HomeSafeLtChime_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HomeSafeLtChime_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 963 HomeSafeLtChime_B_Rq 1;
+BA_ "WakeupSignal" SG_ 963 StopLghtOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 StopLghtOn_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 963 StopLghtOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 StopLghtOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 RvrseLghtOn_B_Stat 1;
+BA_ "WakeupSignal" SG_ 963 PrkLght_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 PrkLght_D_Stat 1;
+BA_ "WakeupSignal" SG_ 963 HeadLghtSwtch_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLghtSwtch_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 963 HeadLghtSwtch_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 963 HeadLghtSwtch_D_Stat 2;
+BA_ "U_P702_MY2021_Rx" SG_ 963 HeadLghtSwtch_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLampLoFrOn_B_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 963 HeadLampLoFrOn_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 963 HeadLampLoFrOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 HeadLampLoFrOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLampLoFlOn_B_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 963 HeadLampLoFlOn_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 963 HeadLampLoFlOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 HeadLampLoFlOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLampLoActv_B_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 963 HeadLampLoActv_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 963 HeadLampLoActv_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 HeadLampLoActv_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 963 HeadLampLoActv_B_Stat 1;
+BA_ "WakeupSignal" SG_ 963 Headlamp_On_Wrning_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 Headlamp_On_Wrning_Cmd 1;
+BA_ "UsedOnPgmDBC" SG_ 963 Headlamp_On_Wrning_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 Park_Brake_Chime_Rqst 1;
+BA_ "UsedOnPgmDBC" SG_ 963 Park_Brake_Chime_Rqst 1;
+BA_ "WakeupSignal" SG_ 963 HeadLghtHiOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 HeadLghtHiOn_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 963 HeadLghtHiOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 HeadLghtHiOn_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 963 HeadLghtHiOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 BrkWarnInd_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 963 BrkWarnInd_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 Brk_Fluid_Lvl_Low 1;
+BA_ "UsedOnPgmDBC" SG_ 963 Brk_Fluid_Lvl_Low 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 ReducedGuard_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 963 ReducedGuard_D_Stat 1;
+BA_ "WakeupSignal" SG_ 963 Perimeter_Alarm_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 Perimeter_Alarm_Status 1;
+BA_ "WakeupSignal" SG_ 963 Courtesy_BSave_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 Courtesy_BSave_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 963 Courtesy_BSave_Stat 1;
+BA_ "GenSigStartValue" SG_ 963 Courtesy_BSave_Stat 1;
+BA_ "WakeupSignal" SG_ 963 WndwGlbl_D_Cmd 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 WndwGlbl_D_Cmd 1;
+BA_ "WakeupSignal" SG_ 963 PudLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 PudLamp_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 DayRnngLampOn_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 963 DayRnngLampOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 963 DayRnngLampOn_B_Stat 1;
+BA_ "WakeupSignal" SG_ 963 PerimeterAlarmChimeRq 1;
+BA_ "CrossOver_InfoCAN" SG_ 963 PerimeterAlarmChimeRq 1;
+BA_ "UsedOnPgmDBC" SG_ 963 PerimeterAlarmChimeRq 1;
+BA_ "UsedOnPgmDBC" SG_ 145 VehYawWActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 145 VehYawWActl_D_Qf 1;
+BA_ "MetaData" SG_ 145 VehYawWActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 145 VehYawWActl_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 145 VehYawWActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 145 VehYawWActl_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 145 VehRolWActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 145 VehRolWActl_D_Qf 1;
+BA_ "MetaData" SG_ 145 VehRolWActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 145 VehRolWActl_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 145 VehRolWActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 145 VehRolWActl_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 145 VehRollYawW_No_Cs 1;
+BA_ "MetaData" SG_ 145 VehRollYawW_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 145 VehRollYawW_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 145 VehRollYawW_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 145 VehRollYaw_No_Cnt 1;
+BA_ "MetaData" SG_ 145 VehRollYaw_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 145 VehRollYaw_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 145 VehRollYaw_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 145 VehYaw_W_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 145 VehYaw_W_Actl 65534;
+BA_ "GenSigStartValue" SG_ 145 VehYaw_W_Actl 65534;
+BA_ "U_CX727_MY2021_Rx" SG_ 145 VehYaw_W_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 145 VehYaw_W_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 145 VehRol_W_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 145 VehRol_W_Actl 65534;
+BA_ "GenSigStartValue" SG_ 145 VehRol_W_Actl 65534;
+BA_ "U_CX727_MY2021_Rx" SG_ 145 VehRol_W_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 145 VehRol_W_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 76 FirstRowBuckleMid 1;
+BA_ "UsedOnPgmDBC" SG_ 76 FirstRowBuckleMid 1;
+BA_ "GenSigStartValueInteger" SG_ 76 FirstRowBuckleMid 3;
+BA_ "GenSigStartValue" SG_ 76 FirstRowBuckleMid 3;
+BA_ "CrossOver_InfoCAN" SG_ 76 SecondRowBucklePsngr 1;
+BA_ "GenSigStartValueInteger" SG_ 76 SecondRowBucklePsngr 3;
+BA_ "GenSigStartValue" SG_ 76 SecondRowBucklePsngr 3;
+BA_ "CrossOver_InfoCAN" SG_ 76 SecondRowBuckleMid 1;
+BA_ "GenSigStartValueInteger" SG_ 76 SecondRowBuckleMid 3;
+BA_ "GenSigStartValue" SG_ 76 SecondRowBuckleMid 3;
+BA_ "CrossOver_InfoCAN" SG_ 76 SecondRowBuckleDriver 1;
+BA_ "GenSigStartValueInteger" SG_ 76 SecondRowBuckleDriver 3;
+BA_ "GenSigStartValue" SG_ 76 SecondRowBuckleDriver 3;
+BA_ "CrossOver_InfoCAN" SG_ 76 FirstRowBuckleDriver 1;
+BA_ "UsedOnPgmDBC" SG_ 76 FirstRowBuckleDriver 1;
+BA_ "GenSigStartValueInteger" SG_ 76 FirstRowBuckleDriver 3;
+BA_ "GenSigStartValue" SG_ 76 FirstRowBuckleDriver 3;
+BA_ "U_P702_MY2021_Rx" SG_ 76 FirstRowBuckleDriver 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 76 FirstRowBuckleDriver 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 76 FirstRowBuckleDriver 1;
+BA_ "CrossOver_InfoCAN" SG_ 76 RILReq 1;
+BA_ "UsedOnPgmDBC" SG_ 76 RILReq 1;
+BA_ "CrossOver_InfoCAN" SG_ 76 FirstRowBucklePsngr 1;
+BA_ "UsedOnPgmDBC" SG_ 76 FirstRowBucklePsngr 1;
+BA_ "GenSigStartValueInteger" SG_ 76 FirstRowBucklePsngr 3;
+BA_ "GenSigStartValue" SG_ 76 FirstRowBucklePsngr 3;
+BA_ "WakeupSignal" SG_ 76 RstrnImpactEvntStatus 1;
+BA_ "CrossOver_InfoCAN" SG_ 76 RstrnImpactEvntStatus 1;
+BA_ "UsedOnPgmDBC" SG_ 76 RstrnImpactEvntStatus 1;
+BA_ "U_P702_MY2021_Rx" SG_ 76 RstrnImpactEvntStatus 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 76 RstrnImpactEvntStatus 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 76 RstrnImpactEvntStatus 1;
+BA_ "CrossOver_InfoCAN" SG_ 76 PsngrFrntDetct_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 76 PsngrFrntDetct_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 76 PsngrFrntDetct_D_Actl 3;
+BA_ "GenSigStartValue" SG_ 76 PsngrFrntDetct_D_Actl 3;
+BA_ "CrossOver_InfoCAN" SG_ 76 EDRTriggerEvntSync 1;
+BA_ "CrossOver_InfoCAN" SG_ 76 PassRstrnInd_Req 1;
+BA_ "GenSigStartValueInteger" SG_ 76 PassRstrnInd_Req 3;
+BA_ "GenSigStartValue" SG_ 76 PassRstrnInd_Req 3;
+BA_ "UsedOnPgmDBC" SG_ 65 immoControlData_T1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 65 immoControlData_T1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 65 immoControlData_T1 1;
+BA_ "UsedOnPgmDBC" SG_ 65 immoControlCmd_T1 1;
+BA_ "U_P702_MY2021_Rx" SG_ 65 immoControlCmd_T1 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 65 immoControlCmd_T1 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 HILL_DESC_SW 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 HILL_DESC_SW 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 HILL_DESC_SW 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 HILL_DESC_SW 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 AutoRgen_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 AutoRgen_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1076 W2S_LAMP_OK 1;
+BA_ "GenSigStartValue" SG_ 1076 W2S_LAMP_OK 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 OdoTripRx_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 OdoTripRx_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 OdoTripRx_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 Veh_V_CompLimMx 1;
+BA_ "GenSigStartValueInteger" SG_ 1076 Veh_V_CompLimMx 4095;
+BA_ "GenSigStartValue" SG_ 1076 Veh_V_CompLimMx 4093;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 Veh_V_CompLimMx 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 Veh_V_CompLimMx 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 DrvSlipCtlMde_B_RqMyKey 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 DrvSlipCtlMde_B_RqMyKey 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 FuelLvlWarn_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 FuelSecndActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 FuelLvlPssvSide_No_Raw 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 FuelLvlPssvSide_No_Raw 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 FuelLvlPssvSide_No_Raw 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 FuelLvlPssvSide_No_Raw 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 FUEL_SENSOR_NUM 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 FUEL_SENSOR_NUM 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 FUEL_SENSOR_NUM 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 FUEL_SENSOR_NUM 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 FuelLvlActvSide_No_Raw 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 FuelLvlActvSide_No_Raw 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 FuelLvlActvSide_No_Raw 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 FuelLvlActvSide_No_Raw 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 FuelLvl_Pc_Dsply 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 FuelLvl_Pc_Dsply 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 FuelLvl_Pc_Dsply 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 FuelLvl_Pc_Dsply 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 DISPLAY_SPEED_SCALING 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 DISPLAY_SPEED_SCALING 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 DISPLAY_SPEED_SCALING 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 DISPLAY_SPEED_SCALING 1;
+BA_ "CrossOver_InfoCAN" SG_ 1076 DISPLAY_SPEED_OFFSET 1;
+BA_ "UsedOnPgmDBC" SG_ 1076 DISPLAY_SPEED_OFFSET 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1076 DISPLAY_SPEED_OFFSET 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1076 DISPLAY_SPEED_OFFSET 1;
+BA_ "GenSigStartValueInteger" SG_ 862 AutoStpHvacDelta_I_Est 192;
+BA_ "U_P702_MY2021_Rx" SG_ 862 HvacBlwrFront_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 862 HvacBlwrFront_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 862 CabnAmb_Te_Actl 114;
+BA_ "GenSigStartValue" SG_ 862 CabnAmb_Te_Actl 0;
+BA_ "U_P702_MY2021_Rx" SG_ 862 CabnAmb_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 862 HvacRemoteStrt_N_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 862 HvacRemoteStrt_N_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 862 HvacRemoteStrt_N_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 862 ClimtThrmlLoad_No_Actl 255;
+BA_ "GenSigStartValue" SG_ 862 ClimtThrmlLoad_No_Actl 255;
+BA_ "U_P702_MY2021_Rx" SG_ 862 ClimtThrmlLoad_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 PtWakeReas_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 VehOnSrc_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 VehOnSrc_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 StrtrMtrCtlDStat_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 StrtrMtrCtlDStat_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 EngStrtActv_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 EngStrtActv_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 EngStrt_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 EngStrt_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 DrvInCtl_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 DrvInCtl_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 AdvStrt_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 AdvStrt_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 931 CrnkInhbt_No_Cs 1;
+BA_ "ContentDependant" SG_ 931 CrnkInhbt_No_Cs 1;
+BA_ "MetaData" SG_ 931 CrnkInhbt_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 CrnkInhbt_No_Cs 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 CrnkInhbt_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 931 CrnkInhbt_No_Cnt 1;
+BA_ "ContentDependant" SG_ 931 CrnkInhbt_No_Cnt 1;
+BA_ "MetaData" SG_ 931 CrnkInhbt_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 CrnkInhbt_No_Cnt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 CrnkInhbt_No_Cnt 1;
+BA_ "GenSigStartValueInteger" SG_ 931 CrnkInhbt_B_Stat 1;
+BA_ "GenSigStartValue" SG_ 931 CrnkInhbt_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 CrnkInhbt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 CrnkInhbt_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 931 IgnPreOffActv_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 931 IgnPreOffActv_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 PtLatchActv_B_RqBcm 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 PtLatchActv_B_RqBcm 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 immoSecureIdleMode 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 immoSecureIdleMode 1;
+BA_ "WakeupSignal" SG_ 578 ReFuelSwtchStat_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 FuelPumpPwr_D_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 FuelPumpPwr_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 578 BattULo_U_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 578 BattULo_U_Actl 255;
+BA_ "GenSigStartValue" SG_ 578 BattULo_U_Actl 255;
+BA_ "U_P702_MY2021_Rx" SG_ 578 BattULo_U_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 BattULo_U_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 578 BattULo_U_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 578 PrkLckCtl_B_Enbl 1;
+BA_ "WakeupSignal" SG_ 578 PrkLckCtlMsgTxt_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 578 PrkLckCtlMsgTxt_D_Rq 1;
+BA_ "WakeupSignal" SG_ 578 PrkLckCtlAvail_T_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 578 PrkLckCtlAvail_T_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 BrkTrnShifLck_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 BrkTrnShifLck_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 578 DriverCrankingReq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 DriverCrankingReq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 DriverCrankingReq 1;
+BA_ "UsedOnPgmDBC" SG_ 578 EngOff_T_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 EngOff_T_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 EngOff_T_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 578 EngOff_T_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 578 DcacElPw_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 578 DcacElPw_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 DcacElPw_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 578 BattULo_I_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 578 BattULo_I_Actl 16383;
+BA_ "GenSigStartValue" SG_ 578 BattULo_I_Actl 16383;
+BA_ "U_P702_MY2021_Rx" SG_ 578 BattULo_I_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 578 BattULo_I_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DimmingLvlEvnt_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 DrStatDrvErrCnt_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 DrStatDrvErrCnt_B_Stat 1;
+BA_ "WakeupSignal" SG_ 947 TurnLghtRight_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 TurnLghtRight_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 TurnLghtRight_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 TurnLghtRightOn_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 947 TurnLghtRightOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 TurnLghtLeftOn_B_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 947 TurnLghtLeftOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 FogLghtRearOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 FogLghtRearOn_B_Stat 1;
+BA_ "WakeupSignal" SG_ 947 Backlit_LED_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Backlit_LED_Status 1;
+BA_ "WakeupSignal" SG_ 947 TurnLghtLeft_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 TurnLghtLeft_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 TurnLghtLeft_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 FogLghtFrontOn_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 FogLghtFrontOn_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 IgnKeyType_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 947 IgnKeyType_D_Actl 14;
+BA_ "GenSigStartValue" SG_ 947 IgnKeyType_D_Actl 14;
+BA_ "U_P702_MY2021_Rx" SG_ 947 IgnKeyType_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 IgnKeyType_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 947 IgnKeyType_D_Actl 1;
+BA_ "WakeupSignal" SG_ 947 Parklamp_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Parklamp_Status 1;
+BA_ "UsedOnPgmDBC" SG_ 947 Parklamp_Status 1;
+BA_ "GenSigStartValueInteger" SG_ 947 Parklamp_Status 1;
+BA_ "GenSigStartValue" SG_ 947 Parklamp_Status 1;
+BA_ "WakeupSignal" SG_ 947 Litval 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Litval 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 Litval 1;
+BA_ "WakeupSignal" SG_ 947 Key_In_Ignition_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Key_In_Ignition_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 947 Key_In_Ignition_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 947 Key_In_Ignition_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 Key_In_Ignition_Stat 1;
+BA_ "WakeupSignal" SG_ 947 Ignition_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Ignition_Status 1;
+BA_ "UsedOnPgmDBC" SG_ 947 Ignition_Status 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 Ignition_Status 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 Ignition_Status 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 947 Ignition_Status 1;
+BA_ "WakeupSignal" SG_ 947 Dimming_Lvl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Dimming_Lvl 1;
+BA_ "GenSigStartValueInteger" SG_ 947 Dimming_Lvl 12;
+BA_ "GenSigStartValue" SG_ 947 Dimming_Lvl 12;
+BA_ "WakeupSignal" SG_ 947 Day_Night_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Day_Night_Status 1;
+BA_ "UsedOnPgmDBC" SG_ 947 Day_Night_Status 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 Day_Night_Status 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 Day_Night_Status 1;
+BA_ "WakeupSignal" SG_ 947 Remote_Start_Status 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Remote_Start_Status 1;
+BA_ "WakeupSignal" SG_ 947 DrStatTgate_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatTgate_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DrStatRr_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatRr_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 DrStatRr_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DrStatRl_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatRl_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 DrStatRl_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DrStatPsngr_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatPsngr_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 DrStatPsngr_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DrStatInnrTgate_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatInnrTgate_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DrStatHood_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatHood_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 DrStatDrv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 DrStatDrv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 947 DrStatDrv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 DrStatDrv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 DrStatDrv_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 947 DrStatDrv_B_Actl 1;
+BA_ "WakeupSignal" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "ContentDependant" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 947 PrkBrkActv_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 LifeCycMde_D_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 947 LifeCycMde_D_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 947 LifeCycMde_D_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 947 LifeCycMde_D_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 947 LifeCycMde_D_Actl 1;
+BA_ "WakeupSignal" SG_ 947 Delay_Accy 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 Delay_Accy 1;
+BA_ "WakeupSignal" SG_ 947 CrashEvnt_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 CrashEvnt_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 947 CrashEvnt_D_Stat 3;
+BA_ "GenSigStartValue" SG_ 947 CrashEvnt_D_Stat 3;
+BA_ "CrossOver_InfoCAN" SG_ 947 FuelPmpInhbt_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 947 BodySrvcRqd_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BattULoChrg_URate_RqMx 1;
+BA_ "GenSigStartValueInteger" SG_ 1084 BattULoChrg_URate_RqMx 5;
+BA_ "GenSigStartValue" SG_ 1084 BattULoChrg_URate_RqMx 5;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BattULoChrg_URate_RqMx 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BattULoChrg_URate_RqMx 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BattULoChrg_U_RqMx 1;
+BA_ "GenSigStartValueInteger" SG_ 1084 BattULoChrg_U_RqMx 34;
+BA_ "GenSigStartValue" SG_ 1084 BattULoChrg_U_RqMx 34;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BattULoChrg_U_RqMx 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BattULoChrg_U_RqMx 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BattULoChrg_U_RqMn 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BattULoChrg_U_RqMn 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BattULoChrg_U_RqMn 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BattULoState_D_Qlty 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BattULoState_D_Qlty 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BattULoState_D_Qlty 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BSFault 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BSFault 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BSFault 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BattULo2_Te_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 1084 BattULo2_Te_Actl 127;
+BA_ "GenSigStartValue" SG_ 1084 BattULo2_Te_Actl 127;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BattULo2_Te_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BattULo2_Te_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BSBattSOC 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BSBattSOC 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BSBattSOC 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BSBattQDeltaRideAh 1;
+BA_ "GenSigStartValueInteger" SG_ 1084 BSBattQDeltaRideAh 12800;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BSBattQDeltaRideAh 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BSBattQDeltaRideAh 1;
+BA_ "UsedOnPgmDBC" SG_ 1084 BSBattQCapAh 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1084 BSBattQCapAh 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1084 BSBattQCapAh 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 EngStrtInhbt_B_RqBatt 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 EngStrtInhbt_B_RqBatt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 BattULoChrg_D_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 BattULoChrg_D_Rq 1;
+BA_ "WakeupSignal" SG_ 1068 PwSysULoFalt_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1068 PwSysULoFalt_D_Stat 1;
+BA_ "UsedOnPgmDBC" SG_ 1068 PwSysULoFalt_D_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1068 Shed_T_Eng_Off_B 1;
+BA_ "WakeupSignal" SG_ 1068 Shed_Feature_Group_ID 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 Shed_Feature_Group_ID 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 Shed_Feature_Group_ID 1;
+BA_ "CrossOver_InfoCAN" SG_ 1068 Shed_Drain_Eng_Off_B 1;
+BA_ "WakeupSignal" SG_ 1068 Shed_Level_Req 1;
+BA_ "CrossOver_InfoCAN" SG_ 1068 Shed_Level_Req 1;
+BA_ "UsedOnPgmDBC" SG_ 1068 Shed_Level_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 Shed_Level_Req 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 Shed_Level_Req 1;
+BA_ "UsedOnPgmDBC" SG_ 1068 ULoRgenTestMde_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 ULoRgenTestMde_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 ULoRgenTestMde_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 ChargeMode 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 ChargeMode 1;
+BA_ "CrossOver_InfoCAN" SG_ 1068 Batt_Lo_SoC_B 1;
+BA_ "UsedOnPgmDBC" SG_ 1068 PeriodicElLoad_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 1068 PeriodicElLoad_B_Stat 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 1068 PeriodicElLoad_B_Stat 1;
+BA_ "CrossOver_InfoCAN" SG_ 1068 Batt_Crit_SoC_B 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehVert2_A_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 146 VehVert2_A_Actl 8190;
+BA_ "GenSigStartValue" SG_ 146 VehVert2_A_Actl 8190;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehVert2_A_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 146 VehVert2_A_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehVert2_A_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehLatLongVertA_No_Cs 1;
+BA_ "MetaData" SG_ 146 VehLatLongVertA_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehLatLongVertA_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehLatLongVertA_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehLatLongVert_No_Cnt 1;
+BA_ "MetaData" SG_ 146 VehLatLongVert_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehLatLongVert_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehLatLongVert_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehLong2_A_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 146 VehLong2_A_Actl 8190;
+BA_ "GenSigStartValue" SG_ 146 VehLong2_A_Actl 8190;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehLong2_A_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 146 VehLong2_A_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehLong2_A_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehLat2_A_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 146 VehLat2_A_Actl 8190;
+BA_ "GenSigStartValue" SG_ 146 VehLat2_A_Actl 8190;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehLat2_A_Actl 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 146 VehLat2_A_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehLat2_A_Actl 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehVertAActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 146 VehVertAActl_D_Qf 1;
+BA_ "MetaData" SG_ 146 VehVertAActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 146 VehVertAActl_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehVertAActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehVertAActl_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "MetaData" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehLongAActl_D_Qf 1;
+BA_ "UsedOnPgmDBC" SG_ 146 VehLatAActl_D_Qf 1;
+BA_ "GenSigStartValueInteger" SG_ 146 VehLatAActl_D_Qf 1;
+BA_ "MetaData" SG_ 146 VehLatAActl_D_Qf 1;
+BA_ "GenSigStartValue" SG_ 146 VehLatAActl_D_Qf 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 146 VehLatAActl_D_Qf 1;
+BA_ "U_P702_MY2021_Rx" SG_ 146 VehLatAActl_D_Qf 1;
+BA_ "GenSigSendType" SG_ 1900 TesterPhysicalResCCM 3;
+BA_ "GenSigSendType" SG_ 1806 TesterPhysicalResIPMA 3;
+BA_ "CrossOver_InfoCAN" SG_ 997 PersIndexCcm_D_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 997 PersIndexCcm_D_Actl 4;
+BA_ "GenSigStartValue" SG_ 997 PersIndexCcm_D_Actl 4;
+BA_ "GenSigSendType" SG_ 997 PersIndexCcm_D_Actl 3;
+BA_ "CrossOver_InfoCAN" SG_ 997 FeatNoCcmActl 1;
+BA_ "GenSigSendType" SG_ 997 FeatNoCcmActl 3;
+BA_ "CrossOver_InfoCAN" SG_ 997 FeatConfigCcmActl 1;
+BA_ "GenSigSendType" SG_ 997 FeatConfigCcmActl 3;
+BA_ "GenSigStartValueInteger" SG_ 983 CmbbObjRelLong_V_Actl 1022;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjRelLong_V_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjRelLong_V_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 983 CmbbObjRelLat_V_Actl 510;
+BA_ "GenSigStartValue" SG_ 983 CmbbObjRelLat_V_Actl 510;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjRelLat_V_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjRelLat_V_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 983 CmbbObjDistLong_L_Actl 1022;
+BA_ "GenSigStartValue" SG_ 983 CmbbObjDistLong_L_Actl 1022;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjDistLong_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjDistLong_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 983 CmbbObjDistLat_L_Actl 510;
+BA_ "GenSigStartValue" SG_ 983 CmbbObjDistLat_L_Actl 510;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjDistLat_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjDistLat_L_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjConfdnc_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjConfdnc_D_Stat 1;
+BA_ "GenSigStartValueInteger" SG_ 983 CmbbObjColl_T_Actl 126;
+BA_ "GenSigStartValue" SG_ 983 CmbbObjColl_T_Actl 125;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjColl_T_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjColl_T_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 CmbbObjClass_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 CmbbObjClass_D_Stat 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 983 EsaEnbl_D2_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 983 EsaEnbl_D2_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1DistRigh_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1DistLeft_D_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbMde1_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbIntns1_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 980 AdbBrdr1Up_An_Rq 510;
+BA_ "GenSigStartValue" SG_ 980 AdbBrdr1Up_An_Rq 509;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1Up_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 980 AdbBrdr1Right_An_Rq 2046;
+BA_ "GenSigStartValue" SG_ 980 AdbBrdr1Right_An_Rq 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1Right_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 980 AdbBrdr1Low_An_Rq 510;
+BA_ "GenSigStartValue" SG_ 980 AdbBrdr1Low_An_Rq 509;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1Low_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 980 AdbBrdr1Left_An_Rq 2046;
+BA_ "GenSigStartValue" SG_ 980 AdbBrdr1Left_An_Rq 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1Left_An_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1CritRigh_T_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 980 AdbBrdr1CritLeft_T_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlRng_L_Max 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlRng_L_Max 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 HandsOffCnfm_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 HandsOffCnfm_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtl_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtl_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlRampType_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlRampType_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlPrecision_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlPrecision_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 979 LatCtlPathOffst_L_Actl 512;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlPathOffst_L_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlPathOffst_L_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 979 LatCtlPath_An_Actl 1000;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlPath_An_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlPath_An_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 979 LatCtlCurv_NoRate_Actl 4096;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlCurv_NoRate_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlCurv_NoRate_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 979 LatCtlCurv_No_Actl 1000;
+BA_ "U_CX727_MY2021_Rx" SG_ 979 LatCtlCurv_No_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 979 LatCtlCurv_No_Actl 1;
+BA_ "GenSigStartValueInteger" SG_ 976 SrpHghtRight_L_Actl 256;
+BA_ "GenSigStartValueInteger" SG_ 976 SrpHghtLeft_L_Actl 256;
+BA_ "GenSigSendType" SG_ 973 TsrVl2PrmntMsgTxt_D_Rq 3;
+BA_ "GenSigSendType" SG_ 973 TsrVl1PrmntMsgTxt_D_Rq 3;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrVl2RstrcMsgTxt2_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 973 TsrVl2RstrcMsgTxt2_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrVl2RstrcMsgTxt2_D_Rq 3;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrVl1RstrcMsgTxt2_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 973 TsrVl1RstrcMsgTxt2_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrVl1RstrcMsgTxt2_D_Rq 3;
+BA_ "GenSigSendType" SG_ 973 TsrOvtkMsgTxt2_D_Rq 3;
+BA_ "GenSigSendType" SG_ 973 WwaWarn_B_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVlUnitMsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrVlUnitMsgTxt_D_Rq 2;
+BA_ "GenSigStartValue" SG_ 973 TsrVlUnitMsgTxt_D_Rq 2;
+BA_ "GenSigSendType" SG_ 973 TsrVlUnitMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVLim2MsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrVLim2MsgTxt_D_Rq 255;
+BA_ "GenSigStartValue" SG_ 973 TsrVLim2MsgTxt_D_Rq 255;
+BA_ "GenSigSendType" SG_ 973 TsrVLim2MsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVLim1MsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrVLim1MsgTxt_D_Rq 255;
+BA_ "GenSigStartValue" SG_ 973 TsrVLim1MsgTxt_D_Rq 255;
+BA_ "GenSigSendType" SG_ 973 TsrVLim1MsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVl2StatMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrVl2StatMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVl2RstrcMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrVl2RstrcMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVl1StatMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrVl1StatMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrVl1RstrcMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrVl1RstrcMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrStatMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrStatMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrOvtkStatMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrOvtkStatMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrOvtkMsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrOvtkMsgTxt_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 973 TsrOvtkMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrOvtkMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrOswWarnMsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrOswWarnMsgTxt_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 973 TsrOswWarnMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrOswWarnMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 973 TsrMsgTxt_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 973 TsrMsgTxt_D_Rq 1;
+BA_ "GenSigStartValue" SG_ 973 TsrMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 973 TsrMsgTxt_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LkaDrvOvrrd_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 970 LkaActvStats_D2_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LkaActvStats_D2_Req 1;
+BA_ "GenSigStartValueInteger" SG_ 970 LaRefAng_No_Req 2048;
+BA_ "U_CX727_MY2021_Rx" SG_ 970 LaRefAng_No_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LaRefAng_No_Req 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 970 LaRampType_B_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LaRampType_B_Req 1;
+BA_ "GenSigStartValueInteger" SG_ 970 LaCurvature_No_Calc 2048;
+BA_ "U_CX727_MY2021_Rx" SG_ 970 LaCurvature_No_Calc 1;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LaCurvature_No_Calc 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 970 LdwActvStats_D_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LdwActvStats_D_Req 1;
+BA_ "CrossOver_InfoCAN" SG_ 970 LdwActvIntns_D_Req 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 970 LdwActvIntns_D_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 970 LdwActvIntns_D_Req 1;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3DistRigh_D_Stat 1;
+BA_ "GenSigSendType" SG_ 962 AdbBrdr3DistRigh_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3DistLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 962 AdbBrdr3DistLeft_D_Stat 3;
+BA_ "GenSigSendType" SG_ 962 AdbMde3_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbMde3_D_Rq 1;
+BA_ "GenSigSendType" SG_ 962 AdbIntns3_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbIntns3_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 962 AdbBrdr3Up_An_Rq 510;
+BA_ "GenSigStartValue" SG_ 962 AdbBrdr3Up_An_Rq 509;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3Up_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 962 AdbBrdr3Right_An_Rq 2046;
+BA_ "GenSigStartValue" SG_ 962 AdbBrdr3Right_An_Rq 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3Right_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 962 AdbBrdr3Low_An_Rq 510;
+BA_ "GenSigStartValue" SG_ 962 AdbBrdr3Low_An_Rq 509;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3Low_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 962 AdbBrdr3Left_An_Rq 2046;
+BA_ "GenSigStartValue" SG_ 962 AdbBrdr3Left_An_Rq 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3Left_An_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3CritRigh_T_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 962 AdbBrdr3CritLeft_T_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2DistRigh_D_Stat 1;
+BA_ "GenSigSendType" SG_ 961 AdbBrdr2DistRigh_D_Stat 3;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2DistLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 961 AdbBrdr2DistLeft_D_Stat 3;
+BA_ "GenSigSendType" SG_ 961 AdbMde2_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbMde2_D_Rq 1;
+BA_ "GenSigSendType" SG_ 961 AdbIntns2_D_Rq 3;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbIntns2_D_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 961 AdbBrdr2Up_An_Rq 510;
+BA_ "GenSigStartValue" SG_ 961 AdbBrdr2Up_An_Rq 509;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2Up_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 961 AdbBrdr2Right_An_Rq 2046;
+BA_ "GenSigStartValue" SG_ 961 AdbBrdr2Right_An_Rq 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2Right_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 961 AdbBrdr2Low_An_Rq 510;
+BA_ "GenSigStartValue" SG_ 961 AdbBrdr2Low_An_Rq 509;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2Low_An_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 961 AdbBrdr2Left_An_Rq 2046;
+BA_ "GenSigStartValue" SG_ 961 AdbBrdr2Left_An_Rq 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2Left_An_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2CritRigh_T_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 961 AdbBrdr2CritLeft_T_Stat 1;
+BA_ "MetaData" SG_ 394 HaDsply_No_Cs 1;
+BA_ "ContentDependant" SG_ 394 HaDsply_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 394 HaDsply_No_Cs 1;
+BA_ "GenSigSendType" SG_ 394 HaDsply_No_Cs 3;
+BA_ "MetaData" SG_ 394 HaDsply_No_Cnt 1;
+BA_ "ContentDependant" SG_ 394 HaDsply_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 394 HaDsply_No_Cnt 1;
+BA_ "GenSigSendType" SG_ 394 HaDsply_No_Cnt 3;
+BA_ "GenSigSendType" SG_ 394 AccStopStat_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccTrgDist2_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 AccTrgDist2_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccStopRes_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 AccStopRes_B_Dsply 3;
+BA_ "GenSigSendType" SG_ 394 TjaWarn_D_Rq 3;
+BA_ "GenSigSendType" SG_ 394 Tja_D_Stat 3;
+BA_ "GenSigSendType" SG_ 394 TjaMsgTxt_D_Dsply 3;
+BA_ "GenSigSendType" SG_ 394 IaccLamp_D_Rq 3;
+BA_ "GenSigSendType" SG_ 394 AccMsgTxt_D2_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 FcwDeny_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 FcwDeny_B_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 FcwMemStat_B_Actl 1;
+BA_ "GenSigSendType" SG_ 394 FcwMemStat_B_Actl 3;
+BA_ "ECGUsedRxSignal" SG_ 394 FcwMemStat_B_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccTGap_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 AccTGap_B_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 CadsAlignIncplt_B_Actl 1;
+BA_ "GenSigSendType" SG_ 394 CadsAlignIncplt_B_Actl 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccFllwMde_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 AccFllwMde_B_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 CadsRadrBlck_B_Actl 1;
+BA_ "GenSigSendType" SG_ 394 CadsRadrBlck_B_Actl 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 CmbbPostEvnt_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 CmbbPostEvnt_B_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccStopMde_B_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 AccStopMde_B_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 FcwMemSens_D_Actl 1;
+BA_ "GenSigSendType" SG_ 394 FcwMemSens_D_Actl 3;
+BA_ "ECGUsedRxSignal" SG_ 394 FcwMemSens_D_Actl 1;
+BA_ "CrossOver_InfoCAN" SG_ 394 FcwMsgTxt_D_Rq 1;
+BA_ "GenSigSendType" SG_ 394 FcwMsgTxt_D_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccWarn_D_Dsply 1;
+BA_ "GenSigSendType" SG_ 394 AccWarn_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 FcwVisblWarn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 394 FcwVisblWarn_B_Rq 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 FcwAudioWarn_B_Rq 1;
+BA_ "GenSigSendType" SG_ 394 FcwAudioWarn_B_Rq 3;
+BA_ "ECGUsedRxSignal" SG_ 394 FcwAudioWarn_B_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccTGap_D_Dsply 1;
+BA_ "GenSigStartValueInteger" SG_ 394 AccTGap_D_Dsply 3;
+BA_ "GenSigStartValue" SG_ 394 AccTGap_D_Dsply 3;
+BA_ "GenSigSendType" SG_ 394 AccTGap_D_Dsply 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 AccMemEnbl_B_RqDrv 1;
+BA_ "GenSigStartValueInteger" SG_ 394 AccMemEnbl_B_RqDrv 1;
+BA_ "GenSigStartValue" SG_ 394 AccMemEnbl_B_RqDrv 1;
+BA_ "GenSigSendType" SG_ 394 AccMemEnbl_B_RqDrv 3;
+BA_ "CrossOver_InfoCAN" SG_ 394 FdaMem_B_Stat 1;
+BA_ "GenSigSendType" SG_ 394 FdaMem_B_Stat 3;
+BA_ "UsedOnPgmDBC" SG_ 391 CmbbBrkDecel_No_Cnt 1;
+BA_ "MetaData" SG_ 391 CmbbBrkDecel_No_Cnt 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 391 CmbbBrkDecel_No_Cnt 1;
+BA_ "U_P702_MY2021_Rx" SG_ 391 CmbbBrkDecel_No_Cnt 1;
+BA_ "UsedOnPgmDBC" SG_ 391 CmbbBrkDecel_No_Cs 1;
+BA_ "MetaData" SG_ 391 CmbbBrkDecel_No_Cs 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 391 CmbbBrkDecel_No_Cs 1;
+BA_ "U_P702_MY2021_Rx" SG_ 391 CmbbBrkDecel_No_Cs 1;
+BA_ "UsedOnPgmDBC" SG_ 391 CmbbBrkDecel_A_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 391 CmbbBrkDecel_A_Rq 5129;
+BA_ "U_CX727_MY2021_Rx" SG_ 391 CmbbBrkDecel_A_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 391 CmbbBrkDecel_A_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 391 CmbbBrkPrchg_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 391 CmbbBrkPrchg_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 391 CmbbBrkPrchg_D_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 391 CmbbBrkPrchg_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 391 CmbbBrkDecel_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 391 CmbbBrkDecel_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 391 CmbbBrkDecel_B_Rq 1;
+BA_ "ECGUsedRxSignal" SG_ 391 CmbbBrkDecel_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 391 CmbbBaSens_D_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 391 CmbbBaSens_D_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 391 CmbbBaSens_D_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 390 AccBrkTot_A_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 390 AccBrkTot_A_Rq 5129;
+BA_ "U_CX727_MY2021_Rx" SG_ 390 AccBrkTot_A_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccBrkTot_A_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccPrpl_A_Pred 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccPrpl_A_Pred 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccVeh_V_Trg 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccVeh_V_Trg 1;
+BA_ "UsedOnPgmDBC" SG_ 390 AccBrkPrkEl_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 390 AccBrkPrkEl_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccBrkPrkEl_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 390 CmbbDeny_B_Actl 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 390 CmbbDeny_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 CmbbDeny_B_Actl 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 CmbbEngTqMn_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 CmbbEngTqMn_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccPrpl_A_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccPrpl_A_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccDeny_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccDeny_B_Rq 1;
+BA_ "WakeupSignal" SG_ 390 AccResumEnbl_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccResumEnbl_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccResumEnbl_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 390 AccCancl_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccCancl_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccCancl_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 390 AccBrkPrchg_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 390 AccBrkPrchg_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccBrkPrchg_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 390 AccBrkDecel_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 390 AccBrkDecel_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccBrkDecel_B_Rq 1;
+BA_ "UsedOnPgmDBC" SG_ 390 AccStopStat_B_Rq 1;
+BA_ "U_CX727_MY2021_Rx" SG_ 390 AccStopStat_B_Rq 1;
+BA_ "U_P702_MY2021_Rx" SG_ 390 AccStopStat_B_Rq 1;
+BA_ "U_T6_MCA_MY2020_Rx" SG_ 390 AccStopStat_B_Rq 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_GWOnBoardTester 255;
+BA_ "ContentDependant" SG_ 1441 TCCM_GWOnBoardTester 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_GWOnBoardTester 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_GWOnBoardTester 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_GWNMProxy 255;
+BA_ "ContentDependant" SG_ 1441 TCCM_GWNMProxy 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_GWNMProxy 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_GWNMProxy 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_AutoSarNMReserved4 255;
+BA_ "ContentDependant" SG_ 1441 TCCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_AutoSarNMReserved4 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_AutoSarNMReserved4 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_AutoSarNMReserved3 255;
+BA_ "ContentDependant" SG_ 1441 TCCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_AutoSarNMReserved3 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_AutoSarNMReserved3 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_AutoSarNMReserved2 255;
+BA_ "ContentDependant" SG_ 1441 TCCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_AutoSarNMReserved2 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_AutoSarNMReserved2 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_AutoSarNMReserved1 255;
+BA_ "ContentDependant" SG_ 1441 TCCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_AutoSarNMReserved1 255;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_AutoSarNMReserved1 1;
+BA_ "GenSigStartValueInteger" SG_ 1441 TCCM_AutoSarNMNodeId 161;
+BA_ "ContentDependant" SG_ 1441 TCCM_AutoSarNMNodeId 1;
+BA_ "GenSigStartValue" SG_ 1441 TCCM_AutoSarNMNodeId 161;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_AutoSarNMNodeId 1;
+BA_ "ContentDependant" SG_ 1441 TCCM_AutoSarNMControl 1;
+BA_ "U_P702_MY2021_Tx" SG_ 1441 TCCM_AutoSarNMControl 1;
+BA_ "GenSigSendType" SG_ 1787 TesterPhysicalResSODCMD 3;
+BA_ "GenSigSendType" SG_ 1779 TesterPhysicalReqSODCMD 3;
+BA_ "GenSigSendType" SG_ 1786 TesterPhysicalResSODCMC 3;
+BA_ "GenSigSendType" SG_ 1778 TesterPhysicalReqSODCMC 3;
+BA_ "CrossOver_InfoCAN" SG_ 1153 TerrMde_D_RqDrv 1;
+BA_ "UsedOnPgmDBC" SG_ 1153 TerrMde_D_RqDrv 1;
+BA_ "GenSigSendType" SG_ 942 PrkAidRdiusRight_L_Dsply 3;
+BA_ "GenSigSendType" SG_ 942 PrkAidRdiusLeft_L_Dsply 3;
+BA_ "GenSigSendType" SG_ 942 PrkAidDrvDir_D_Stat 3;
+BA_ "GenSigSendType" SG_ 942 PrkAidAcsyRear_D_Stat 3;
+BA_ "GenSigSendType" SG_ 942 PrkAidAcsyFront_D_Stat 3;
+BA_ "GenSigSendType" SG_ 930 BalrWndwRight_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 930 BalrSnsRight_D_Falt 0;
+BA_ "GenSigSendType" SG_ 930 BalrSnsRight_D_Falt 3;
+BA_ "GenSigStartValueInteger" SG_ 930 WndwPsngrRear_D_RqBalrr 0;
+BA_ "GenSigSendType" SG_ 930 WndwPsngrRear_D_RqBalrr 3;
+BA_ "GenSigStartValueInteger" SG_ 930 WndwPsngr_D_RqBalrr 0;
+BA_ "GenSigSendType" SG_ 930 WndwPsngr_D_RqBalrr 3;
+BA_ "GenSigStartValueInteger" SG_ 930 WndwDrvRear_D_RqBalrr 0;
+BA_ "GenSigSendType" SG_ 930 WndwDrvRear_D_RqBalrr 3;
+BA_ "GenSigStartValueInteger" SG_ 930 WndwDrv_D_RqBalrr 0;
+BA_ "GenSigSendType" SG_ 930 WndwDrv_D_RqBalrr 3;
+BA_ "GenSigStartValueInteger" SG_ 930 BalrRight_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 930 BalrRight_D_Stat 2;
+BA_ "GenSigSendType" SG_ 930 BalrRight_D_Stat 3;
+BA_ "GenSigSendType" SG_ 930 BalrMdeSelRight_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 930 BalrMdeRight_D_Stat 1;
+BA_ "GenSigStartValue" SG_ 930 BalrMdeRight_D_Stat 1;
+BA_ "GenSigSendType" SG_ 930 BalrMdeRight_D_Stat 3;
+BA_ "GenSigSendType" SG_ 930 BalrLckRight_B_Stat 3;
+BA_ "GenSigSendType" SG_ 930 BalrChimeRight_D_Rq 3;
+BA_ "GenSigSendType" SG_ 930 CamraRearOn_B_RqBalrr 3;
+BA_ "GenSigSendType" SG_ 930 DrLckCnt_No_ActlBalrr 3;
+BA_ "GenSigSendType" SG_ 930 DrLckActv_B_RqBalrr 3;
+BA_ "GenSigSendType" SG_ 929 BalrChimeLeft_D_Rq 3;
+BA_ "GenSigStartValueInteger" SG_ 929 BalrLeft_D_Stat 2;
+BA_ "GenSigStartValue" SG_ 929 BalrLeft_D_Stat 2;
+BA_ "GenSigSendType" SG_ 929 BalrLeft_D_Stat 3;
+BA_ "GenSigSendType" SG_ 929 BalrWndwLeft_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 929 WndwPsngrRear_D_RqBalrl 0;
+BA_ "GenSigSendType" SG_ 929 WndwPsngrRear_D_RqBalrl 3;
+BA_ "GenSigStartValueInteger" SG_ 929 WndwPsngr_D_RqBalrl 0;
+BA_ "GenSigSendType" SG_ 929 WndwPsngr_D_RqBalrl 3;
+BA_ "GenSigStartValueInteger" SG_ 929 WndwDrvRear_D_RqBalrl 0;
+BA_ "GenSigSendType" SG_ 929 WndwDrvRear_D_RqBalrl 3;
+BA_ "GenSigStartValueInteger" SG_ 929 WndwDrv_D_RqBalrl 0;
+BA_ "GenSigSendType" SG_ 929 WndwDrv_D_RqBalrl 3;
+BA_ "GenSigStartValueInteger" SG_ 929 BalrSnsLeft_D_Falt 0;
+BA_ "GenSigSendType" SG_ 929 BalrSnsLeft_D_Falt 3;
+BA_ "GenSigSendType" SG_ 929 BalrMdeSelLeft_B_Stat 3;
+BA_ "GenSigStartValueInteger" SG_ 929 BalrMdeLeft_D_Stat 1;
+BA_ "GenSigStartValue" SG_ 929 BalrMdeLeft_D_Stat 1;
+BA_ "GenSigSendType" SG_ 929 BalrMdeLeft_D_Stat 3;
+BA_ "GenSigSendType" SG_ 929 BalrLckLeft_B_Stat 3;
+BA_ "GenSigSendType" SG_ 929 CamraRearOn_B_RqBalrl 3;
+BA_ "GenSigSendType" SG_ 929 DrLckCnt_No_ActlBalrl 3;
+BA_ "GenSigSendType" SG_ 929 DrLckActv_B_RqBalrl 3;
+BA_ "CrossOver_InfoCAN" SG_ 402 ApaMdeStat_D_RqDrv 1;
+BA_ "CrossOver_InfoCAN" SG_ 402 CamraZoomMan_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 402 CamraOvrlStat_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 402 CamraOvrlDyn_D_Rq 1;
+BA_ "CrossOver_InfoCAN" SG_ 402 CamAutoTowbarZoom 1;
+BA_ "CrossOver_InfoCAN" SG_ 402 DistanceBarSetting 1;
+BA_ "GenSigStartValue" SG_ 924 DcacOut_Pw_Mx 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 924 DcacOut_Pw_Mx 1;
+BA_ "GenSigStartValue" SG_ 924 DcacOut2_Pw_Actl 8190;
+BA_ "U_P702_MY2021_Rx" SG_ 924 DcacOut2_Pw_Actl 1;
+BA_ "GenSigStartValue" SG_ 924 DcacOut1_Pw_Actl 8190;
+BA_ "U_P702_MY2021_Rx" SG_ 924 DcacOut1_Pw_Actl 1;
+BA_ "GenSigStartValue" SG_ 924 DcacIn_Pw_Mx 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 924 DcacIn_Pw_Mx 1;
+BA_ "GenSigStartValue" SG_ 923 DcacIn_U2_Actl 4094;
+BA_ "GenSigStartValue" SG_ 923 DcacIn_U_Actl 4094;
+BA_ "U_P702_MY2021_Rx" SG_ 923 DcacIn_U_Actl 1;
+BA_ "GenSigStartValue" SG_ 923 DcacIn_I_Actl 2046;
+BA_ "U_P702_MY2021_Rx" SG_ 923 DcacIn_I_Actl 1;
+BA_ "GenSigStartValue" SG_ 923 Dcac_Te_Actl 254;
+BA_ "U_P702_MY2021_Rx" SG_ 923 Dcac_Te_Actl 1;
+BA_ "GenSigSendType" SG_ 1998 TesterPhysicalResSODR 3;
+BA_ "GenSigSendType" SG_ 1996 TesterPhysicalResSODL 3;
+BA_ "GenSigSendType" SG_ 1988 TesterPhysicalReqSODL 3;
+BA_ "U_P702_MY2021_Rx" SG_ 922 DcacRdy_D_Stat 1;
+BA_ "GenSigStartValue" SG_ 922 DcacPlugPrsnt_B_Stat 1;
+BA_ "U_P702_MY2021_Rx" SG_ 922 DcacPlugPrsnt_B_Stat 1;
+VAL_ 823 DteAcceptNew_B_Rq 1 "Yes" 0 "No";
+VAL_ 824 DteCldTrlrOn_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldTrlrOff_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldTraffic_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldTerrain_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldRoute_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldPayload_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldExtTe_B_Stat 1 "Yes" 0 "No";
+VAL_ 824 DteCldDcac_B_Stat 1 "Yes" 0 "No";
+VAL_ 949 Tire_Press_RR_ORR_Data 65535 "Not_Supported" 65534 "Invalid" 65533 "Unknown";
+VAL_ 949 Tire_Press_LR_OLR_Data 65535 "Not_Supported" 65534 "Invalid" 65533 "Unknown";
+VAL_ 949 Tire_Press_LF_Data 65535 "Not_Supported" 65534 "Invalid" 65533 "Unknown";
+VAL_ 949 Tire_Press_RF_Data 65535 "Not_Supported" 65534 "Invalid" 65533 "Unknown";
+VAL_ 740 BattAuxCnnct_B_Cmd 1 "Close" 0 "Open";
+VAL_ 1160 DgtlCommPncReset_B_Req 1 "Yes" 0 "No";
+VAL_ 1160 DataMntrSustn_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 1160 PwSustnRdata_B_RqTelem 1 "Active" 0 "Inactive";
+VAL_ 776 ScChrgrPwMax_Pw_RqCld 4095 "Faulty";
+VAL_ 776 PrcondEdit_D_RqCld 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "High" 3 "Medium" 2 "Low" 1 "Off" 0 "Null";
+VAL_ 776 GoTEditMnte_T_RqCld 15 "Faulty" 14 "NoDataExists" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Minute_55" 10 "Minute_50" 9 "Minute_45" 8 "Minute_40" 7 "Minute_35" 6 "Minute_30" 5 "Minute_25" 4 "Minute_20" 3 "Minute_15" 2 "Minute_10" 1 "Minute_5" 0 "Minute_0";
+VAL_ 776 GoTEditHr_T_RqCld 31 "Faulty" 30 "NoDataExists";
+VAL_ 776 ChrgToPcEdit_Pc_RqCld 127 "Faulty" 126 "NoDataExists";
+VAL_ 776 ScFreshDataEnbl_B_Rq 1 "Yes" 0 "No";
+VAL_ 776 ScEnbl_D_RqCld 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 775 ScDayOfWeekId_D_RqCld 7 "Sunday" 6 "Saturday" 5 "Friday" 4 "Thursday" 3 "Wednesday" 2 "Tuesday" 1 "Monday" 0 "NotUsed";
+VAL_ 775 ScChrgDurSet_D_RqCld 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 775 ScChrgDur_T_RqCld 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 774 ScLocLongPostv_B_RqCld 1 "Yes" 0 "No";
+VAL_ 774 ScLocLattPostv_B_RqCld 1 "Yes" 0 "No";
+VAL_ 774 ScLocDelete_B_RqCld 1 "Request" 0 "NoRequest";
+VAL_ 811 DistToStopover_L_Actl 65535 "Faulty";
+VAL_ 811 ExtLghtDsply_D_Stat 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 811 ExtLghtRight_D_RqMnu 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 811 AutoLghtOvrrd_B_RqDrv 1 "Allowed" 0 "NotAllowed";
+VAL_ 811 ExtLghtRear_D_RqMnu 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 811 ExtLghtLeft_D_RqMnu 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 811 ExtLghtFront_D_RqMnu 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 811 GoTEditMnte_T_RqMnu 15 "Faulty" 14 "NoDataExists" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Minute_55" 10 "Minute_50" 9 "Minute_45" 8 "Minute_40" 7 "Minute_35" 6 "Minute_30" 5 "Minute_25" 4 "Minute_20" 3 "Minute_15" 2 "Minute_10" 1 "Minute_5" 0 "Minute_0";
+VAL_ 811 GoTEditHr_T_RqMnu 31 "Faulty" 30 "NoDataExists";
+VAL_ 850 VehElRngeNut_L_Dsply 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 850 NxtUsgSocEst_Pc_Dsply 255 "Faulty" 254 "NoDataExists";
+VAL_ 850 EstmChrgTimeLP_St 255 "Invalid";
+VAL_ 850 EstmChrgTimeHP_St 255 "Invalid";
+VAL_ 850 ChargeNowDuration_St 255 "Invalid";
+VAL_ 563 DrvBhavWarn_B_Rq 1 "On" 0 "Off";
+VAL_ 563 OfbChrgSetSync_D_Rq 3 "Fail" 2 "Success" 1 "InProgress" 0 "NoSyncInProgress";
+VAL_ 563 KeyOffPwMde_D_Stat 7 "NotUsed_6" 6 "NotUsed_5" 5 "NotUsed_4" 4 "NotUsed_3" 0 "Inactive" 1 "On" 2 "NotUsed_1" 3 "NotUsed_2";
+VAL_ 563 ModemReset_D_Stat 15 "NotUsed_10" 14 "NotUsed_9" 13 "NotUsed_8" 12 "NotUsed_7" 11 "NotUsed_6" 10 "NotUsed_5" 9 "NotUsed_4" 8 "NotUsed_3" 7 "NotUsed_2" 6 "NotUsed_1" 5 "WifiHotSpotResetComplete" 4 "CcsResetComplete" 3 "OnlineTrafficResetComplete" 2 "PaakResetComplete" 1 "ResetNotComplete" 0 "Null";
+VAL_ 563 FactoryReset_St 3 "NotUsed_2" 2 "NotUsed_1" 1 "FactoryDefaultsRestored" 0 "Null";
+VAL_ 570 SuspClkSync_No_Rq 255 "Faulty" 254 "NoDataExists";
+VAL_ 570 SuspRearRight_L_Actl 511 "Faulty";
+VAL_ 570 SuspFrntRight_L_Actl 511 "Faulty";
+VAL_ 570 SuspRear_L_Prev 511 "Fault";
+VAL_ 570 SuspRear_L_Actl 511 "Fault";
+VAL_ 570 SuspFrnt_L_Prev 511 "Fault";
+VAL_ 570 SuspFrnt_L_Actl 511 "Fault";
+VAL_ 837 Ccd_B_Falt 1 "Yes" 0 "No";
+VAL_ 837 SelDrvMdeSusp_D_Stat 3 "Faulty" 2 "TemporarilyNotAvailable" 1 "Available" 0 "NotAvailable";
+VAL_ 837 AdptDrvMdePt_D_Rq 7 "Faulty" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "Powertrain2Sport" 2 "Powertrain2Normal" 1 "Powertrain2Comfort" 0 "AdaptiveNotActive";
+VAL_ 837 AdptDrvMdeChassis_D_Rq 7 "Faulty" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "Chassis2Sport" 2 "Chassis2Normal" 1 "Chassis2Comfort" 0 "AdaptiveNotActive";
+VAL_ 837 CcdMsgTxt_D_RqDsply 15 "Unused8" 14 "Unused7" 13 "Unused6" 12 "Unused5" 11 "Unused4" 10 "Unused3" 9 "Unused2" 8 "StationaryMode" 7 "Mode_Change_Unavailable" 6 "CCD_Temporarily_Off" 5 "CCD_Service_Required" 4 "Faulty" 3 "Sport" 2 "Normal" 1 "Comfort" 0 "No_Mode_Selected";
+VAL_ 885 BattULoChrg_D_RqOta 1 "Yes" 0 "No";
+VAL_ 885 VehStrtInhbt_T_Dsply 15 "NotUsed_12" 14 "NotUsed_11" 13 "NotUsed_10" 12 "NotUsed_9" 11 "NotUsed_8" 10 "NotUsed_7" 9 "NotUsed_6" 8 "NotUsed_5" 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "PostOtaActivatePermFail" 2 "PostOtaActivateWarning" 1 "DuringOtaActivate" 0 "NoMessage";
+VAL_ 885 VehStrtInhbt_D_Dsply 15 "NotUsed_12" 14 "NotUsed_11" 13 "NotUsed_10" 12 "NotUsed_9" 11 "NotUsed_8" 10 "NotUsed_7" 9 "NotUsed_6" 8 "NotUsed_5" 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "PostOtaActivatePermFail" 2 "PostOtaActivateWarning" 1 "DuringOtaActivate" 0 "NoMessage";
+VAL_ 885 VehOnRqstr_D_Stat 11 "NotUsed_8" 10 "NotUsed_7" 9 "NotUsed_6" 8 "NotUsed_5" 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "FleetVehInhbt" 2 "StolenVehInhbt" 1 "OverTheAir" 0 "NoRequestor" 15 "NotUsed_12" 14 "NotUsed_11" 13 "NotUsed_10" 12 "NotUsed_9";
+VAL_ 885 VehStrtInhbt_D_RqCld 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 885 VehOn_D_RqCld 3 "NoControl" 2 "On" 1 "Off" 0 "Null";
+VAL_ 885 OtaActv_D_Stat 15 "NotUsed_10" 14 "NotUsed_9" 13 "NotUsed_8" 12 "NotUsed_7" 11 "NotUsed_6" 10 "NotUsed_5" 9 "NotUsed_4" 8 "NotUsed_3" 7 "NotUsed_2" 6 "NotUsed_1" 5 "NonInterruptible_Pending" 4 "NonInterruptible_Config" 3 "NonInterruptible_ER" 2 "NonInterruptible_AB" 1 "Interruptible_AB" 0 "NoInVehicleOta";
+VAL_ 810 OBCCSerial_D_Rq 3 "PresentAndProvisioned" 2 "PresentAndProvAlertAck" 1 "PresentAndUnprovisioned" 0 "NotPresent";
+VAL_ 810 TlghtTest_D_RqArb 3 "TestEndAcknowledge" 2 "StartTest" 1 "StopTest" 0 "Null";
+VAL_ 810 ChrgrPncSustn_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 810 NtfyDrvTrgtDist_L_Rq 4095 "Trip_dist_alert_disabled" 0 "Inactive";
+VAL_ 810 NtfyDrvSocLvl1_Pc_Rq 127 "TargetSOCNotificationAlert" 0 "Inactive";
+VAL_ 810 PtRmtRprt_D_Stat 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "SettingUpdated" 10 "FastChargeComplete" 9 "ChargeNotOccurring" 8 "OneTimeSocReached" 7 "BatteryTemperatureRemind" 6 "ReducedPerformance" 5 "LimitedPerformance" 4 "ChargeFault" 3 "ChargeComplete" 2 "VehiclePreconditioned" 1 "TripDistanceAchieved" 0 "NoReportRequest";
+VAL_ 810 ChrgrPncEnbl_D_Rq 3 "NotUsed" 2 "Enable" 1 "Disable" 0 "Null";
+VAL_ 810 ExtLghtDsply_B_StatArb 1 "On" 0 "Off";
+VAL_ 810 ExtLghtRight_D_RqOta 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 810 ExtLghtRear_D_RqOta 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 810 ExtLghtLeft_D_RqOta 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 810 ExtLghtFront_D_RqOta 7 "NotUsed" 6 "PressToOn3" 5 "PressToOff3" 4 "PressToOn2" 3 "PressToOff2" 2 "PressToOn1" 1 "PressToOff1" 0 "Reset";
+VAL_ 550 PtWakeupActv1_B_Rq 1 "Wake_up_Powertrain_via_HW" 0 "Don_t_Wake_Up_Powertrain";
+VAL_ 639 OfbChrgPrflUpdate_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 639 OfbChrgClearAll_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 639 OfbChrgGoTTouch_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 639 OfbChrgGoTPrcond_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 639 OfbChrgGoTOn_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 639 OfbChrgGoTMnte_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Minute_55" 10 "Minute_50" 9 "Minute_45" 8 "Minute_40" 7 "Minute_35" 6 "Minute_30" 5 "Minute_25" 4 "Minute_20" 3 "Minute_15" 2 "Minute_10" 1 "Minute_5" 0 "Minute_0";
+VAL_ 639 OfbChrgGoTHr_T_Rq 31 "Faulty" 30 "NoDataExists";
+VAL_ 639 OfbChrgGoTExtHtr_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 639 OfbChrgGoTDelete_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 639 OfbChrgGoTUpdate_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 530 OfbChrgToPcWknd_D_Actl 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 530 OfbChrgToPcWkdy_D_Actl 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 530 OfbChrgSetNow_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 530 OfbChrgSetDelete_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 530 OfbChrgLocIdUns_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 1142 ConsTipV_No_Dsply 1023 "Faulty" 1022 "NoDataExists";
+VAL_ 817 ChildLckMde_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 817 VehLckInd_D_Rq 3 "NotUsed" 2 "On_Day" 1 "On_Night" 0 "Off";
+VAL_ 817 DrTgateOpen_B_Rq 1 "Open" 0 "Null";
+VAL_ 817 DrTgateExtSwMde_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 817 Remote_Device_Feedback 7 "Unused3" 6 "Unused2" 5 "Unused1" 4 "Shutdown" 3 "Running" 2 "Starting" 1 "Acknowledge" 0 "Null";
+VAL_ 817 Veh_Lock_Requestor 31 "Unused8" 30 "Unused7" 29 "Unused6" 28 "Rgtm_Shutlock_Switch" 27 "Boundary_Alert" 26 "Transit_Vehicle_Relock" 25 "Transit_Cargo_Relock" 24 "Transit_Ajar_Lock" 23 "Diagnostics" 22 "Console_Lock" 21 "Child_Lock" 20 "Double_Lock" 19 "Passive_Pasenger" 18 "Passive_Driver" 17 "Slam_Lock_Protect" 16 "SYNC" 15 "Passport" 14 "Passive_Smart_Unlock" 13 "Autorelock" 12 "RemoteStart" 0 "Null" 1 "Autolock" 11 "Smart_Unlock" 10 "Sliding_Door" 9 "Passive" 8 "Remote" 7 "Programming" 6 "Powerslide" 5 "Keypad" 4 "Key_Cylinder" 3 "Interior" 2 "Auto_Unlock";
+VAL_ 817 R_Pwr_Sliding_Dr_Rqst 1 "Active" 0 "Null";
+VAL_ 817 Power_Liftgate_Rqst 1 "Active" 0 "Null";
+VAL_ 817 Power_Decklid_Rqst 1 "Active" 0 "Null";
+VAL_ 817 L_Pwr_Sliding_Dr_Rqst 1 "Active" 0 "Null";
+VAL_ 817 Veh_Lock_Sub_Id 15 "Unused7" 14 "Unused6" 13 "Unused5" 12 "Unused4" 11 "Unused3" 10 "Unused2" 9 "Unused1" 8 "Customer_8" 7 "Customer_7" 6 "Customer_6" 5 "Customer_5" 4 "Customer_4" 3 "Customer_3" 2 "Customer_2" 1 "Customer_1" 0 "Null";
+VAL_ 817 Veh_Lock_Status 3 "UNLOCK_DRV" 2 "UNLOCK_ALL" 1 "LOCK_ALL" 0 "LOCK_DBL";
+VAL_ 817 ChildLck_D_Dsply 3 "NOT_SUPPORTED" 2 "ERROR" 1 "CHILD_UNLOCK" 0 "CHILD_LOCK";
+VAL_ 817 WindowLockout_B_Stat 1 "Locked" 0 "Unlock";
+VAL_ 817 Lockmsgtxt_D_Rq 7 "MSG7" 6 "MSG6" 5 "MSG5" 4 "MSG4" 3 "MSG3" 2 "MSG2" 1 "MSG1" 0 "NO_WARNING";
+VAL_ 817 FobComm_D_Stat 3 "NotUsed" 2 "RemEngStartOK" 1 "RemEngStartFail" 0 "Null";
+VAL_ 817 LockInhibit 1 "Inhibit" 0 "No_Inhibit";
+VAL_ 879 WndwRearHeat_I_Actl 2047 "Faulty";
+VAL_ 879 WndwRearHeat_D_Stat 7 "NotUsed" 6 "FetLiftLimitReached" 5 "FetOpenCircuit" 4 "FetOutputShortToPower" 3 "FetOutputShortToGround" 2 "FetNotControlled" 1 "OnPowerToLoad" 0 "OffNoPowerToLoad";
+VAL_ 878 DcacGfciTest_B_Rq 1 "Pressed" 0 "Not_Pressed";
+VAL_ 878 DcacOut_Pw_DsplyMx 1023 "Faulty";
+VAL_ 878 DcacOut1_Pw_Dsply 63 "Faulty";
+VAL_ 878 DcacOut2_Pw_Dsply 63 "Faulty";
+VAL_ 878 DcacHw_D_Confg 15 "NotUsed_11" 14 "NotUsed_10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "NotUsed_4" 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Power_2300W" 3 "Power_7200W" 2 "Power_2400W" 1 "Power_2000W" 0 "NoDcacHardware";
+VAL_ 878 DcacFaltMsgTxt_D_Rq 15 "NotUsed" 14 "OvercurrentLP" 13 "EngineRun" 12 "Service" 11 "NotAvailable" 10 "PlugWarn" 9 "PlugWarnDrive" 8 "BreakerC" 7 "BreakerB" 6 "BreakerA" 5 "FuelLow" 4 "AcOnOutput" 3 "Temperature" 2 "Gfci" 1 "Overcurrent" 0 "Ok";
+VAL_ 878 DcacLoFuelMsgTxt_D_Rq 31 "Minute_31" 30 "Minute_30" 29 "Minute_29" 28 "Minute_28" 27 "Minute_27" 26 "Minute_26" 25 "Minute_25" 24 "Minute_24" 23 "Minute_23" 22 "Minute_22" 21 "Minute_21" 20 "Minute_20" 19 "Minute_19" 18 "Minute_18" 17 "Minute_17" 16 "Minute_16" 15 "Minute_15" 14 "Minute_14" 13 "Minute_13" 12 "Minute_12" 11 "Minute_11" 10 "Minute_10" 9 "Minute_9" 8 "Minute_8" 7 "Minute_7" 6 "Minute_6" 5 "Minute_5" 4 "Minute_4" 3 "Minute_3" 2 "Minute_2" 1 "Minute_1" 0 "Ok";
+VAL_ 878 DcacEngOnMsgTxt_D_Rq 3 "NotUsed" 2 "DisplayQuestion" 1 "DisplayWarning" 0 "Ok";
+VAL_ 878 DcacElPw_D_Stat 3 "NotUsed" 2 "High" 1 "Low" 0 "Off";
+VAL_ 878 PwBedPnlEnbl_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 878 DcacOn_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 878 DcacSys_B_Falt 1 "Yes" 0 "No";
+VAL_ 878 DcacLedCtl_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 395 SelDrvMdeCnfm_D_Stat 3 "NotUsed" 2 "Accepted" 1 "NotAccepted" 0 "Null";
+VAL_ 984 PersIndexIpma_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 984 AhbcRampingV_D_Rq 3 "Slow" 2 "Medium" 1 "Fast" 0 "Immediately";
+VAL_ 984 LaActvStats_D_Dsply 31 "Unused7" 30 "LA_Off" 29 "Unused5" 28 "Unused4" 27 "Unused3" 26 "Unused2" 25 "Unused1" 24 "InerveneLeft_InterveneRght" 23 "WarnLeft_InterveneRight" 22 "SuppressLeft_InterveneRght" 21 "AvailLeft_InterveneRhtt" 20 "NoLeft_InterveneRight" 19 "InterveneLeft_WarnRight" 18 "WarnLeft_WarnRight" 17 "SuppressLeft_WarnRight" 16 "AvailableLeft_WarnRight" 15 "NoLeft_WarnRight" 14 "InterveneLeft_SuppressRght" 13 "WarnLeft_SuppressRight" 12 "SuppressLeft_SuppressRight" 11 "AvailLeft_SuppressRight" 10 "NoLeft_SuppressRight" 9 "InterveneLeft_AvailRight" 8 "WarnLeft_AvailRight" 7 "SuppressLeft_AvailRight" 6 "AvailableLeft_AvailRight" 5 "NoLeft_AvailableRight" 4 "InterveneLeft_NoRight" 3 "WarnLeft_NoRight" 2 "SuppressLeft_NoRight" 1 "AvailableLeft_NoRight" 0 "NoLeft_NoRight";
+VAL_ 984 LaDenyStats_B_Dsply 1 "Unavailable" 0 "Available";
+VAL_ 984 LaHandsOff_D_Dsply 3 "Suppressed" 2 "Level2" 1 "Level1" 0 "HandsOn";
+VAL_ 984 CamraDefog_B_Req 1 "On" 0 "Off";
+VAL_ 984 CamraStats_D_Dsply 3 "FrtCam_TempUnavailOther" 2 "FrtCam_TempUnavailVisibile" 1 "Front_Camera_Service_Reqd" 0 "Front_Camera_OK";
+VAL_ 984 DasAlrtLvl_D_Dsply 5 "Alertness_Level_5" 4 "Alertness_Level_4" 3 "Alertness_Level_3" 2 "Alertness_Level_2" 1 "Alertness_Level_1" 0 "Undefined";
+VAL_ 984 DasStats_D_Dsply 3 "Available" 2 "Unavailable_Other" 1 "Feedback_due_to_Speed" 0 "Off";
+VAL_ 984 DasWarn_D_Dsply 3 "Undefined" 2 "Warning_Level_2" 1 "Warning_Level_1" 0 "No_Warning";
+VAL_ 984 AhbHiBeam_D_Rq 3 "NotUsed" 2 "HighBeamRecommended" 1 "LowBeamRecommended" 0 "DeactivatedUnavailable";
+VAL_ 985 LdwChime_B_Rq 1 "On" 0 "Off";
+VAL_ 985 TsrRegionTxt_D_Stat 31 "Faulty" 30 "NotUsed_8" 29 "NotUsed_7" 28 "NotUsed_6" 27 "NotUsed_5" 26 "NotUsed_4" 25 "NotUsed_3" 24 "NotUsed_2" 23 "NotUsed_1" 22 "Region_22" 21 "Region_21" 20 "Region_20" 19 "Region_19" 18 "Region_18" 17 "Region_17" 16 "Region_16" 15 "Region_15" 14 "Region_14" 13 "Region_13" 12 "Region_12" 11 "Region_11" 10 "Region_10" 9 "Region_09" 8 "Region_08" 7 "Region_07" 6 "Region_06" 5 "Region_05" 4 "Region_04" 3 "Region_03" 2 "Region_02" 1 "Region_01" 0 "NotDetermined";
+VAL_ 985 SblmPedCrossScnr_B_Stat 1 "Yes" 0 "No";
+VAL_ 985 LongCtrlEnbl_D_Rq 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "RemoteParking" 2 "Autohitch" 1 "AutomaticParking" 0 "None";
+VAL_ 985 SblmRndAbtScnr_B_Stat 1 "Yes" 0 "No";
+VAL_ 985 DasAlrtInfo_D_Dsply 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 985 IaccVLim_D_Rq 252 "NotUsed_2" 250 "LimitSpeed_250" 240 "LimitSpeed_240" 230 "LimitSpeed_230" 220 "LimitSpeed_220" 210 "LimitSpeed_210" 200 "LimitSpeed_200" 190 "LimitSpeed_190" 150 "LimitSpeed_150" 140 "LimitSpeed_140" 130 "LimitSpeed_130" 120 "LimitSpeed_120" 110 "LimitSpeed_110" 100 "LimitSpeed_100" 90 "LimitSpeed_90" 80 "LimitSpeed_80" 70 "LimitSpeed_70" 60 "LimitSpeed_60" 50 "LimitSpeed_50" 40 "LimitSpeed_40" 30 "LimitSpeed_30" 20 "LimtSpeed_20" 251 "NotUsed_1" 255 "Faulty" 254 "NoDataExists" 253 "NotUsed_3" 180 "LimitSpeed_180" 179 "LimitSpeed_179" 178 "LimitSpeed_178" 177 "LimitSpeed_177" 176 "LimitSpeed_176" 175 "LimitSpeed_175" 174 "LimitSpeed_174" 173 "LimitSpeed_173" 172 "LimitSpeed_172" 171 "LimitSpeed_171" 170 "LimitSpeed_170" 169 "LimitSpeed_169" 168 "LimitSpeed_168" 167 "LimitSpeed_167" 166 "LimitSpeed_166" 165 "LimitSpeed_165" 164 "LimitSpeed_164" 163 "LimitSpeed_163" 162 "LimitSpeed_162" 161 "LimitSpeed_161" 160 "LimitSpeed_160" 15 "LimitSpeed_15" 14 "LimitSpeed_14" 13 "LimitSpeed_13" 12 "LimitSpeed_12" 11 "LimitSpeed_11" 10 "LimitSpeed_10" 9 "LimitSpeed_9" 8 "LimitSpeed_8" 7 "LimitSpeed_7" 6 "LimitSpeed_6" 5 "LimitSpeed_5" 4 "LimitSpeed_4" 3 "LimitSpeed_3" 2 "LimitSpeed_2" 1 "LimitSpeed_1" 0 "LimitSpeed_0";
+VAL_ 985 IaccVLimUnit_D_Rq 3 "NoDataExists" 2 "Mph" 1 "Kph" 0 "Null";
+VAL_ 985 IsaVLim_D_Rq 252 "NotUsed_2" 250 "LimitSpeed_250" 240 "LimitSpeed_240" 230 "LimitSpeed_230" 220 "LimitSpeed_220" 210 "LimitSpeed_210" 200 "LimitSpeed_200" 190 "LimitSpeed_190" 150 "LimitSpeed_150" 140 "LimitSpeed_140" 130 "LimitSpeed_130" 120 "LimitSpeed_120" 110 "LimitSpeed_110" 100 "LimitSpeed_100" 90 "LimitSpeed_90" 80 "LimitSpeed_80" 70 "LimitSpeed_70" 60 "LimitSpeed_60" 50 "LimitSpeed_50" 40 "LimitSpeed_40" 30 "LimitSpeed_30" 20 "LimtSpeed_20" 251 "NotUsed_1" 255 "Faulty" 254 "NoDataExists" 253 "NotUsed_3" 180 "LimitSpeed_180" 179 "LimitSpeed_179" 178 "LimitSpeed_178" 177 "LimitSpeed_177" 176 "LimitSpeed_176" 175 "LimitSpeed_175" 174 "LimitSpeed_174" 173 "LimitSpeed_173" 172 "LimitSpeed_172" 171 "LimitSpeed_171" 170 "LimitSpeed_170" 169 "LimitSpeed_169" 168 "LimitSpeed_168" 167 "LimitSpeed_167" 166 "LimitSpeed_166" 165 "LimitSpeed_165" 164 "LimitSpeed_164" 163 "LimitSpeed_163" 162 "LimitSpeed_162" 161 "LimitSpeed_161" 160 "LimitSpeed_160" 15 "LimitSpeed_15" 14 "LimitSpeed_14" 13 "LimitSpeed_13" 12 "LimitSpeed_12" 11 "LimitSpeed_11" 10 "LimitSpeed_10" 9 "LimitSpeed_9" 8 "LimitSpeed_8" 7 "LimitSpeed_7" 6 "LimitSpeed_6" 5 "LimitSpeed_5" 4 "LimitSpeed_4" 3 "LimitSpeed_3" 2 "LimitSpeed_2" 1 "LimitSpeed_1" 0 "LimitSpeed_0";
+VAL_ 985 SblmStopScnr_B_Stat 1 "Yes" 0 "No";
+VAL_ 985 SblmYieldScnr_B_Stat 1 "Yes" 0 "No";
+VAL_ 985 IsaVLimUnit_D_Rq 3 "NoDataExists" 2 "Mph" 1 "Kph" 0 "Null";
+VAL_ 985 AdbDividedRoad_B_Stat 1 "Yes" 0 "No";
+VAL_ 985 LcwaMsgTxt_D_Stat 3 "SodXFaulty" 2 "SodXBlocked" 1 "TrailerConnected" 0 "NoMessage";
+VAL_ 985 AdbDrvSide_B_Stat 1 "Left_Hand_Traffic" 0 "Right_Hand_Traffic";
+VAL_ 992 MsgCntrDsplyOp_D_Rq 7 "Unused_2" 6 "Unused_1" 5 "Copy" 4 "Restore" 3 "Upload" 2 "Set" 1 "Query" 0 "Null";
+VAL_ 992 MsgCntrPersIndex_D_Rq 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 943 VehVActlAdas_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 943 AdasLcDistToObj_L_Actl 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 515 PtIgnSwtch_D_Stat 3 "Faulty" 2 "No_Data_Exists" 1 "On" 0 "Off";
+VAL_ 1111 TrlrYawWActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 1111 TrlrYaw_W_Actl 65535 "Faulty" 65534 "NoDataExists";
+VAL_ 1111 TrlrHitYaw_AnRate_Actl 4095 "Fault" 4094 "NoDataExists";
+VAL_ 1111 TrlrHitchYaw_D_Stat 15 "Faulty" 14 "NotUsed_4" 13 "NotUsed_3" 12 "NotUsed_2" 11 "NotUsed_1" 10 "FaultyYrsuConnection" 9 "FaultyYrsu" 8 "HiConfdLrndAngle" 7 "LowConfdLrndAngle" 6 "HiConfdAngleMem" 5 "LowConfdAngleMem" 4 "InitNoTadAngle" 3 "InitInputs" 2 "TadTrlrDataOutOfRange" 1 "TadNotWithinSpecification" 0 "NoConnectionWithYrsu";
+VAL_ 1111 TrlrHitchYaw_An_Actl 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 1106 TrlrSnsId_No_Actl -1 "Faulty_FFFFFFFFFFFF" -2 "NoDataExists_FFFFFFFFFFFE";
+VAL_ 982 LatCtl_D2_Rq 7 "NotUsed_5" 6 "NotUsed_4" 5 "NotUsed_3" 4 "NotUsed_2" 3 "SafeRampOut" 2 "PathFollowingExtendedMode" 1 "PathFollowingLimitedMode" 0 "NoLateralControl";
+VAL_ 982 HandsOffCnfm_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 982 LatCtlRampType_D_Rq 3 "Immediately" 2 "Fast" 1 "Medium" 0 "Slow";
+VAL_ 982 LatCtlPrecision_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "Precise" 0 "Comfortable";
+VAL_ 1104 DrvEngageLevel_D_Stat 7 "Faulty" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Disengaged" 3 "Distracted" 2 "Attentive" 1 "Invalid" 0 "NotDetermined";
+VAL_ 1104 DrvImpLvlConfid_D_Stat 7 "Faulty" 6 "NotUsed" 5 "High" 4 "MediumHigh" 3 "Medium" 2 "LowMedium" 1 "Low" 0 "NotDetermined";
+VAL_ 1104 DrvImpairLvl_D_Stat 15 "Faulty" 14 "NotUsed_5" 13 "NotUsed_4" 12 "NotUsed_3" 11 "NotUsed_2" 10 "NotUsed_1" 9 "Incapacitated" 8 "Asleep" 7 "Microsleep" 6 "MostDrowsy" 5 "Drowsy_4" 4 "Drowsy_3" 3 "Drowsy_2" 2 "LeastDrowsy" 1 "Alert" 0 "NotDetermined";
+VAL_ 1104 DrvEngLvlConfid_D_Stat 7 "Faulty" 6 "NotUsed" 5 "High" 4 "MediumHigh" 3 "Medium" 2 "LowMedium" 1 "Low" 0 "NotDetermined";
+VAL_ 1104 DrvCamPassIR_D_Stat 3 "Faulty" 2 "Blocked" 1 "Ok" 0 "TemporaryUnavailable";
+VAL_ 1104 DrvCamera_D_Stat 3 "Faulty" 2 "Blocked" 1 "Ok" 0 "TemporaryUnavailable";
+VAL_ 1104 DrvCamDrvIR_D_Stat 3 "Faulty" 2 "Blocked" 1 "Ok" 0 "TemporaryUnavailable";
+VAL_ 1104 DrvAttentZone_D_Stat 15 "Faulty" 14 "NotUsed_5" 13 "NotUsed_4" 12 "NotUsed_3" 11 "NotUsed_2" 10 "NotUsed_1" 9 "PassengerSideWindow" 8 "DriverSideWindow" 7 "DriverSideMirror" 6 "RearviewMirror" 5 "PassengerSideMirror" 4 "Infotainment" 3 "Cluster" 2 "FrontWindshield" 1 "Other" 0 "NotDetermined";
+VAL_ 1104 DrvAlertSt_D_Stat 3 "Faulty" 2 "EyesOffRoad" 1 "EyesOnRoad" 0 "NotDetermined";
+VAL_ 1114 TrailCtlSwtch_B_Stat2 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1114 TrlBrkInitOut_D_Rq 3 "Heavy" 2 "Medium" 1 "Light" 0 "Null";
+VAL_ 1116 TrlrAidSetup_D2_Rq 15 "NotUsed_9" 14 "NotUsed_8" 13 "NotUsed_7" 12 "NotUsed_6" 11 "NotUsed_5" 10 "NotUsed_4" 9 "NotUsed_3" 8 "NotUsed_2" 7 "NotUsed_1" 6 "CompleteSetup" 5 "ReturnToSetup" 4 "StickerNotCircled" 3 "ConfirmSetup" 2 "EndSetup" 1 "BeginSetup" 0 "Inactive";
+VAL_ 1116 TrlrAidEnbl_D2_Rq 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Deactivate" 2 "ActivateTrg" 1 "ActivateTba" 0 "Inactive";
+VAL_ 1116 TrlrRvrseCancl_B_Rq 1 "Cancel" 0 "Null";
+VAL_ 1116 TrlrIdType_D_Stat 3 "Gooseneck" 2 "FifthWheel" 1 "Conventional" 0 "Null";
+VAL_ 1116 TrlrAnOffstDir_D_Mem 3 "NotUSed" 2 "Right" 1 "Left_or_Center" 0 "Null";
+VAL_ 1085 ULoRgenTestMde_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1085 PwSrcULoOvrTe_B_Actl 1 "Yes" 0 "No";
+VAL_ 1085 PwSrcULoFalt_D_Stat 3 "Fault_No_Output" 2 "Fault_Reduced_Output" 1 "Fault_NonSpecific" 0 "No_Fault";
+VAL_ 1085 PwSrcULoDcnnt_B_Stat 1 "Loose_or_Disconnected" 0 "Connected";
+VAL_ 1085 PwSrcULo_Pc_Mx 255 "Fault";
+VAL_ 1085 PwSrcULoComm_B_Falt 1 "Fault" 0 "No_Fault";
+VAL_ 1085 PwSrcULo_I_Mx 255 "Fault";
+VAL_ 1085 PwSrcULo_I_Actl 255 "Fault";
+VAL_ 981 AdbBrdrTop_An_Rq 255 "Faulty" 254 "NoDataExists";
+VAL_ 981 AdbBrdrRight_L_Stat 511 "Faulty" 510 "NoDataExists";
+VAL_ 981 AdbBrdrRight_An_Rq 1023 "Faulty" 1022 "NoDataExists";
+VAL_ 981 AdbBrdrLeft_L_Stat 511 "Faulty" 510 "NoDataExists";
+VAL_ 981 AdbBrdrLeft_An_Rq 1023 "Faulty" 1022 "NoDataExists";
+VAL_ 981 AdbBrdrBottom_An_Rq 63 "Faulty" 62 "NoDataExists";
+VAL_ 981 AdbBeam_D_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "FullHighBeam" 3 "Spot_BothSide" 2 "Spot_OnlyRightSide" 1 "Spot_OnlyLeftSide" 0 "NoHighBeam";
+VAL_ 791 EngAirFilt_B_RqReset 1 "Yes" 0 "No";
+VAL_ 791 GpsElMdeSel_B_Rq 1 "On" 0 "Off";
+VAL_ 791 LongTermReset_B_Rq 1 "On" 0 "Off";
+VAL_ 791 DrvEffLvl_No_Stat 63 "Fault" 62 "NoDataExists";
+VAL_ 868 BattRgenLoStat_D_Qlty 3 "OK" 2 "Not_Within_Spec" 1 "Eval_In_Progress" 0 "Faulty";
+VAL_ 868 BattRgenLoPrtct_B_Stat 1 "Yes" 0 "No";
+VAL_ 868 BattRgenLoDChrg_D_Stat 3 "StuckClosed" 2 "StuckOpen" 1 "Closed" 0 "Open";
+VAL_ 868 BattRgenLoDchrg_B_Rq 1 "Yes" 0 "No";
+VAL_ 868 BattRgenLoChrg_D_Stat 3 "StuckClosed" 2 "StuckOpen" 1 "Closed" 0 "Open";
+VAL_ 868 BattRgenLoChrg_B_Rq 1 "Yes" 0 "No";
+VAL_ 868 BattRgenLo_B_Falt 1 "Yes" 0 "No";
+VAL_ 867 BattRgenLoBalnc_B_Rq 1 "Yes" 0 "No";
+VAL_ 867 BattRgenLo_Te_Actl 255 "Fault";
+VAL_ 865 BattRgenLo_U_Actl 2047 "Faulty";
+VAL_ 865 BattRgenLo_I_Actl 65535 "Faulty";
+VAL_ 1144 WakeAlarm0_B_Typ 1 "CanAndEcuDriveCircuit" 0 "CanOnly";
+VAL_ 1144 PreCondBatt_B_Actl 1 "On" 0 "Off";
+VAL_ 1144 HtrnDcdcDis_B_Rq 1 "Yes" 0 "No";
+VAL_ 1144 ChrgNowEvnt_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1144 CabinDrvSustn_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 1144 BattChrgTrgtSoC_D_Rq 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 1144 CabnEvapSovFront_B_Rq 1 "On" 0 "Off";
+VAL_ 1144 HeatCoreSovRear_B_Rq 1 "On" 0 "Off";
+VAL_ 1144 BattChlrSov_B_Rq 1 "On" 0 "Off";
+VAL_ 1144 CabnEvapSovRear_B_Rq 1 "On" 0 "Off";
+VAL_ 1144 BrkAppl_D_RqPt 3 "BrakesSlowRelease" 2 "BrakesFastRelease" 1 "BrakesEngage" 0 "NotActive";
+VAL_ 1144 HtrnCnnctPwr_B_Stat 1 "Asserted" 0 "NotAsserted";
+VAL_ 1144 PtcHtr_D_Stat 3 "Faulty" 2 "NotUsed" 1 "On" 0 "Off";
+VAL_ 1144 HtrnClntFlw_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 1144 BattTracDrvSustn_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 1144 BattTracClntVlv_B_Rq 1 "On" 0 "Off";
+VAL_ 1141 OfbChrgSetSync_D_Stat 3 "Fail" 2 "Success" 1 "InProgress" 0 "NoSyncInProgress";
+VAL_ 1141 PtRmtRprt_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "PlugInToMaintain12vBattery" 11 "SettingUpdated" 10 "FastChargeComplete" 9 "ChargeNotOccurring" 8 "OneTimeSocReached" 7 "BatteryTemperatureReminder" 6 "ReducedPerformance" 5 "LimitedPerformance" 4 "ChargeFault" 3 "ChargeComplete" 2 "VehiclePreconditioned" 1 "TripDistanceAchieved" 0 "NoReportRequest";
+VAL_ 1141 NtfctnConflict1_D_Rq 7 "NotUsed5" 6 "NotUsed4" 5 "NotUsed3" 4 "NotUsed2" 3 "NotUsed1" 2 "Clonflict_Exists" 1 "No_Conflict" 0 "Invalid";
+VAL_ 1140 RgenEvntLvl_Pc_Dsply 1023 "Fault" 1022 "NoDataExists";
+VAL_ 1140 BrkEvntComplt_B_Dsply 1 "On" 0 "Off";
+VAL_ 1140 PreCondStat_D_Dsply 7 "Reserved3" 6 "Reserved2" 5 "Reserved1" 4 "Faulted" 3 "Complete" 2 "In_Progress" 1 "Scheduled" 0 "Not_Scheduled";
+VAL_ 1139 BattChrgTrgtLMax_T_Est 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 1139 ActChrgStrtYr_No_Actl 31 "Invalid";
+VAL_ 1139 ActChrgStrtMin_No_Actl 63 "Invalid" 62 "Unknown";
+VAL_ 1139 ActChrgStrtHr_No_Actl 31 "Invalid" 30 "Unknown";
+VAL_ 1139 ActChrgStrtDay_No_Actl 31 "Invalid";
+VAL_ 1139 ActChrgStrMnth_No_Actl 15 "Invalid";
+VAL_ 1138 BattChrgTrgtLMin_T_Est 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 1138 ActChrgEndYr_No_Actl 31 "Invalid";
+VAL_ 1138 ActChrgEndMnth_No_Actl 15 "Invalid";
+VAL_ 1138 ActChrgEndMin_No_Actl 63 "Invalid" 62 "Unknown";
+VAL_ 1138 ActChrgEndHr_No_Actl 31 "Invalid" 30 "Unknown";
+VAL_ 1138 ActChrgEndDay_No_Actl 31 "Invalid";
+VAL_ 1089 Mtr2Aout_W_ActlMntr 1023 "Faulty";
+VAL_ 1089 Inv1_Te_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 1089 MtrTrac2Coil_Te_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 1089 MtrTrac2Falt_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1089 MtrTrac2TeAlrm_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1089 Mtr2CntlTeAlrm_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1089 MtrTrac2Inv_Te_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 1089 MtrTrac2_I_Actl 65535 "Faulty";
+VAL_ 1088 ChrgTMatch_B_Stat 1 "True" 0 "False";
+VAL_ 1088 ChrgStat_D2_Dsply 15 "NotUsed_2" 14 "NotUsed_1" 13 "ChargeTargetReached" 12 "DriveConditioning" 11 "CabinPreconditioning" 10 "ChargingSystemMaintain" 9 "ChargingInductive" 8 "ChargingDCFastChange" 7 "ChargingAC" 6 "ChargeScheduled" 5 "EvsePaused" 4 "EvseNotDetected" 3 "EvseNotCompatible" 2 "FaultOutsideCar" 1 "FaultInsideCar" 0 "NotReady";
+VAL_ 1088 HvacPrecondRecirc_D_Rq 3 "Last_User_Setting" 2 "Auto" 1 "Recirc" 0 "Outside";
+VAL_ 1088 HvacPrecondMode2_D_Rq 15 "NotUsed4" 14 "NotUsed3" 13 "NotUsed2" 12 "NotUsed1" 11 "Last_User_Settings" 10 "Auto" 9 "Max_Defrost" 8 "Windshield_Panel_Floor" 7 "Windshield_Panel" 6 "Windshield" 5 "Windshield_Floor" 4 "Floor" 3 "Panel_Floor" 2 "Panel" 1 "MAX_AC" 0 "Off";
+VAL_ 1088 HvacPrecondBlwr2_D_Rq 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "Last_User_Setting" 8 "Auto" 7 "Speed7" 6 "Speed6" 5 "Speed5" 4 "Speed4" 3 "Speed3" 2 "Speed2" 1 "Speed1" 0 "Off";
+VAL_ 1088 HvacPrecondAC_D_Rq 3 "Last_User_Setting" 2 "Auto" 1 "On" 0 "Off";
+VAL_ 1088 BattChrgInhbt_D_Rq 3 "MaintainTargetSoc" 2 "NotUsed" 1 "InhibitChargingThermal" 0 "Enable_Charging";
+VAL_ 1040 ElCmprEnbl_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 1016 ChrgGoTElement_B_Dsply 1 "Yes" 0 "No";
+VAL_ 1016 ChrgGoTTouchEnbl_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 1016 ChrgGoTTouch_B_Stat 1 "On" 0 "Off";
+VAL_ 1016 ChrgGoTPrcond_D_Stat 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 1016 ChrgGoTMnte_D_Stat 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Minute_55" 10 "Minute_50" 9 "Minute_45" 8 "Minute_40" 7 "Minute_35" 6 "Minute_30" 5 "Minute_25" 4 "Minute_20" 3 "Minute_15" 2 "Minute_10" 1 "Minute_5" 0 "Minute_0";
+VAL_ 1016 ChrgGoTHr_T_Stat 31 "Faulty" 30 "NoDataExists";
+VAL_ 1016 ChrgGoTExtHtrEnbl_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 1016 ChrgGoTExtHtr_B_Stat 1 "On" 0 "Off";
+VAL_ 1016 ChrgGoTAllOn_B_Stat 1 "On" 0 "Off";
+VAL_ 1013 ChrgToPcWkndSav_D_Stat 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 1013 ChrgToPcWkdySav_D_Stat 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 1013 ChrgNowEnbl_B_Saved 1 "On" 0 "Off";
+VAL_ 1013 ChrgLocIdUnsAck_B_Stat 1 "Yes" 0 "No";
+VAL_ 1012 ChrgNowCurnt_B_Dsply 1 "On" 0 "Off";
+VAL_ 1012 ChrgLocSaved_B_Dsply 1 "Yes" 0 "No";
+VAL_ 1012 ChrgLocLongPostv_B_Sav 1 "Yes" 0 "No";
+VAL_ 1012 ChrgLocLattPostv_B_Sav 1 "Yes" 0 "No";
+VAL_ 1011 ChrgLocLongPostv_B_Uns 1 "Yes" 0 "No";
+VAL_ 1011 ChrgLocLattPostv_B_Uns 1 "Yes" 0 "No";
+VAL_ 871 BattElecPerf_D_Actl 7 "NotUsed" 6 "Hot_Batt_Severe_Lim_Perf" 5 "Hot_Batt_Reduced_Perf" 4 "Hot_Batt_Close_to_lim_Per" 3 "Cold_Batt_Severe_Lim_Perf" 2 "Cold_Batt_Reduced_Perf" 1 "Cold_Batt_Close_to_lim_Pe" 0 "Ok_no_message_displayed";
+VAL_ 871 BattChrgTrgtLPt_T_Est 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 871 BattChrgTrgSocPt_T_Est 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 871 BattChrgCmpltPt_T_Est 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 786 RgenTrip_L_Dsply 65535 "Fault" 65534 "NoDataExists";
+VAL_ 786 ChrgStat_D_Dsply 7 "NotUsed" 6 "Complete" 5 "Scheduled" 4 "In_Progress" 3 "Fault_Outside_Car" 2 "Fault_Inside_Car" 1 "Fault_Unknown_Location" 0 "Not_Ready";
+VAL_ 72 immoTarget2Status 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "DISABLED_RESET   " 2 "ENABLED_NONMOTIVE_START" 1 "ENABLED_MOTIVE_START" 0 "DISABLED";
+VAL_ 72 immoTarget2Cmd 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "TARGET1_IDBLOCK2" 2 "TARGET1_IDBLOCK1" 1 "CHALLENGE" 0 "IDLE";
+VAL_ 912 CabnEvapSovFront_D_Stat 7 "NotUsed_1" 6 "FetLifeLimitReached" 5 "FetOpenCircuit" 4 "FetOutputShortToPower" 3 "FetOutputShortToGround" 2 "FetNotControlled" 1 "OnPowerToLoad" 0 "OffNoPowerToLoad";
+VAL_ 912 BattChlrSov_D_Stat 7 "NotUsed_1" 6 "FetLifeLimitReached" 5 "FetOpenCircuit" 4 "FetOutputShortToPower" 3 "FetOutputShortToGround" 2 "FetNotControlled" 1 "OnPowerToLoad" 0 "OffNoPowerToLoad";
+VAL_ 912 BattTracClntVlv_D_Stat 7 "NotUsed" 6 "FetLifeLimitReached" 5 "FetOpenCircuit" 4 "FetOutputShortToPower" 3 "FetOutputShortToGround" 2 "FetNotControlled" 1 "OnPowerToLoad" 0 "OffNoPowerToLoad";
+VAL_ 874 AirCondCluOpen_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 AirCondCluLife_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 AirCondCluGnd_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 AirCondClu_D_Stat 7 "NotUsed" 6 "FetLifeLimitReached" 5 "FetOpenCircuit" 4 "FetOutputShortToPower" 3 "FetOutputShortToGround" 2 "FetNotControlled" 1 "OnPowerToLoad" 0 "OffNoPowerToLoad";
+VAL_ 874 AirCondCluBatt_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattTracShrtGrnd_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattTracShrtBatt_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattTracOpnCirct_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattTracLifeLim_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattChlrShrtGrnd_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattChlrShrtBatt_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattChlrOpnCirct_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattChlrLifeLim_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 874 BattTracLow_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 651 TelematicsSrvc_D_St 7 "NotUsed" 6 "NotifyNotActivatedYet" 5 "NotActivatedYet" 4 "NotifyExpired" 3 "Expired" 2 "ExpiringSoon" 1 "Active" 0 "Null";
+VAL_ 651 EmgcyCallMute_D_Stat 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "ManualEmergencyCallMute" 2 "AutomaticEmergencyCallMute" 1 "EmergencyCallUnmute" 0 "Null";
+VAL_ 651 OfbChrgSetSync_D_Rq 3 "Fail" 2 "Success" 1 "InProgress" 0 "NoSyncInProgress";
+VAL_ 529 OnbChrgToPcWknd_D_Actl 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 529 OnbChrgToPcWkdy_D_Actl 7 "Percent_50" 6 "Percent_60" 5 "Percent_70" 4 "Percent_80" 3 "Percent_85" 2 "Percent_90" 1 "Percent_95" 0 "Percent_100";
+VAL_ 529 OnbChrgSetNow_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 529 OnbChrgSetDelete_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 529 OnbChrgPrflUpdate_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 529 OnbChrgLocIdUns_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 66 immoControlCmd_T2 0 "IDLE" 1 "MOTIVE_START_RQST" 2 "NONMOTIVE_START_RQST" 3 "RQST_TARGET2_IDBLOCK1" 4 "RQST_TARGET2_IDBLOCK2" 5 "Unused" 6 "ECHO_TARGET2_IDBLOCK2" 7 "SHUTDOWN";
+VAL_ 1124 GPS_Vdop 31 "Invalid" 30 "Unknown";
+VAL_ 1124 GPS_Speed 255 "Invalid" 254 "Unknown";
+VAL_ 1124 GPS_Sat_num_in_view 31 "Invalid" 30 "Unknown";
+VAL_ 1124 GPS_MSL_altitude 4095 "Fault" 4094 "Unknown";
+VAL_ 1124 GPS_Heading 65535 "Fault" 65534 "Unknown";
+VAL_ 1124 GPS_Hdop 31 "Invalid" 30 "Unknown";
+VAL_ 1124 GPS_dimension 2 "_3D" 1 "_2D" 0 "No_Fix";
+VAL_ 1119 CoolFanDcdc_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 1119 DcdcClntFlw_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 1123 GpsUtcYr_No_Actl 31 "Fault";
+VAL_ 1123 GpsUtcMnth_No_Actl 15 "Fault";
+VAL_ 1123 GPS_UTC_seconds 63 "Fault" 62 "Unknown";
+VAL_ 1123 GPS_UTC_minutes 63 "Fault" 62 "Unknown";
+VAL_ 1123 GPS_UTC_hours 31 "Invalid" 30 "Unknown";
+VAL_ 1123 GPS_Pdop 31 "Invalid" 30 "Unknown";
+VAL_ 1123 GPS_Compass_direction 7 "NorthWest" 6 "West" 5 "SouthWest" 4 "South" 3 "SouthEast" 2 "East" 1 "NorthEast" 0 "North";
+VAL_ 1123 GPS_Actual_vs_Infer_pos 1 "Inferred_Position" 0 "Actual_Postition";
+VAL_ 1123 Gps_B_Falt 1 "Yes" 0 "No";
+VAL_ 1122 GpsHsphLongEast_D_Actl 0 "Invalid" 1 "Eastern" 2 "Western" 3 "Fault";
+VAL_ 1122 GpsHsphLattSth_D_Actl 3 "Fault" 2 "Northern" 1 "Southern" 0 "Invalid";
+VAL_ 1122 GPS_Longitude_Minutes 63 "Fault" 62 "Unknown";
+VAL_ 1122 GPS_Longitude_Min_dec 16383 "Invalid" 16382 "Unknown";
+VAL_ 1122 GPS_Longitude_Degrees 511 "Fault" 510 "Unknown";
+VAL_ 1122 GPS_Latitude_Minutes 63 "Fault" 62 "Unknown";
+VAL_ 1122 GPS_Latitude_Min_dec 16383 "Invalid" 16382 "Unknown";
+VAL_ 1122 GPS_Latitude_Degrees 255 "Invalid" 254 "Unknown";
+VAL_ 1003 PersRecallSrc_D_Actl 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "MemorySwitch" 3 "RemoteStart" 2 "KeyFob" 1 "CenterStack" 0 "Null";
+VAL_ 1003 Pers4Key_D_Stat 3 "NotUsed_1" 2 "KeyUnAssociated" 1 "KeyAssociated" 0 "Null";
+VAL_ 1003 Pers3Key_D_Stat 3 "NotUsed_1" 2 "KeyUnAssociated" 1 "KeyAssociated" 0 "Null";
+VAL_ 1003 Pers2Key_D_Stat 3 "NotUsed_1" 2 "KeyUnAssociated" 1 "KeyAssociated" 0 "Null";
+VAL_ 1003 Pers1Key_D_Stat 3 "NotUsed_1" 2 "KeyUnAssociated" 1 "KeyAssociated" 0 "Null";
+VAL_ 1003 EmPrflNo_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Pers4" 3 "Pers3" 2 "Pers2" 1 "Pers1" 0 "Null";
+VAL_ 1003 EmPrflKeyAssoc_D_Stat 7 "WrongDevice" 6 "KeyAssociateFailed" 5 "KeyAssociateSuccess" 4 "KeyAlreadyInUse" 3 "KeyDisassociated" 2 "KeyAssociationExited" 1 "KeyAssociationEntered" 0 "Null";
+VAL_ 1003 VehKeyActv_D_Stat 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "NotUsed3" 10 "NotUsed2" 9 "NotUsed1" 8 "Key8Active" 7 "Key7Active" 6 "Key6Active" 5 "Key5Active" 4 "Key4Active" 3 "Key3Active" 2 "Key2Active" 1 "Key1Active" 0 "NoKeyActive";
+VAL_ 1003 PersNoPos_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 1003 PersSetupRestr_D_Actl 3 "Non_Moveable_Person" 2 "Moveable_Person" 1 "Vehicle" 0 "Factory";
+VAL_ 1003 PersSetupAccessCtrl 1 "Limited" 0 "Full";
+VAL_ 1003 PersConflict_D_Actl 1 "Conflict" 0 "No_Conflict";
+VAL_ 1003 AssocConfirm_D_Actl 0 "None" 7 "Associate" 6 "Keycode_Rejected" 5 "Keycode_Accepted" 4 "In_Progress" 3 "Erase" 2 "Duplicate" 1 "Disassociate";
+VAL_ 1003 PersNo_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "NotDetermined" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 994 PersStore_D_Rq 7 "Unused_2" 6 "Unused_1" 5 "Vehicle" 4 "PERS_4" 3 "PERS_3" 2 "PERS_2" 1 "PERS_1" 0 "Null";
+VAL_ 994 Pers4OptIn_B_Stats 1 "OPTED_IN" 0 "NOT_OPTED_IN";
+VAL_ 994 Pers3OptIn_B_Stats 1 "OPTED_IN" 0 "NOT_OPTED_IN";
+VAL_ 994 Pers2OptIn_B_Stats 1 "OPTED_IN" 0 "NOT_OPTED_IN";
+VAL_ 994 Pers1OptIn_B_Stats 1 "OPTED_IN" 0 "NOT_OPTED_IN";
+VAL_ 994 CtrStkPersIndex_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 994 CtrStkDsplyOp_D_Rq 7 "Unused_2" 6 "Unused_1" 5 "Copy" 4 "Restore" 3 "Upload" 2 "Set" 1 "Query" 0 "Null";
+VAL_ 778 PrkAidFront_D_RqDrv 2 "Status" 3 "NotUsed" 1 "Enabled" 0 "Disabled";
+VAL_ 778 PrkAidAcsyRear_D_RqDrv 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 778 PrkAidAcsyFront_D_RqDrv 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 778 Cta_D_Rq 3 "Unused" 2 "NoDataExists" 1 "On" 0 "Off";
+VAL_ 778 PrkAidRear_D_RqDrv 2 "Status" 3 "NotUsed" 1 "Enabled" 0 "Disabled";
+VAL_ 778 SteEffort_D_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "SpecialMode_2" 3 "SpecialMode_1" 2 "Comfort" 1 "Sport" 0 "Normal";
+VAL_ 778 Sod_D_Rq 2 "BLIS_On_Second_Warning_ON" 1 "BLIS_On_Second_Warning_OFF" 0 "Off";
+VAL_ 549 IPC_MyKeyVolLimit_St 0 "Invalid" 1 "Off" 2 "On";
+VAL_ 549 HdcOn_B_Rq 1 "On" 0 "Off";
+VAL_ 549 IPC_Attn_Info_Audio 7 "Unknown" 6 "Attenuation_6" 5 "Attenuation_5" 4 "Attenuation_4" 3 "Attenuation_3" 2 "Attenuation_2" 1 "Attenuation_1" 0 "No_Attenuation_of_Audio";
+VAL_ 549 BeltminderAudioMute 2 "On" 1 "Off" 0 "Invalid";
+VAL_ 549 Power_Up_Chime_Modules 1 "Active" 0 "Inactive";
+VAL_ 549 Chime_Source 2 "Cluster" 1 "Infotainment_Sys" 0 "Invalid";
+VAL_ 549 IPC_New_Attn_Event 1 "Active" 0 "Inactive";
+VAL_ 551 PmCabnLvl_D_Stat 7 "NotUsed_1" 6 "Level_6_Worst" 5 "Level_5" 4 "Level_4" 3 "Level_3" 2 "Level_2" 1 "Level_1_Best" 0 "NotKnown";
+VAL_ 551 PmCabn_D_Stat 3 "FilteringComplete" 2 "FilteringOn" 1 "FilteringOff" 0 "NotKnown";
+VAL_ 551 Cntr_Plg_Mode_Cmd 1 "Enable" 0 "Disable";
+VAL_ 551 ChrgCrdLckEnbl_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 551 PwRnngBoardT_D_Rq 3 "NotUsed" 2 "Timer2" 1 "Timer1" 0 "Inactive";
+VAL_ 551 PwRnngBoardSwtch_D_Rq 3 "NotUsed" 2 "DeployUnlocked" 1 "AlwaysActive" 0 "Inactive";
+VAL_ 551 PwRnngBoardMde_D_Rq 0 "Inactive" 1 "Off" 2 "Out" 3 "Auto";
+VAL_ 551 Btt_L_Actl2 127 "Faulty" 126 "NoDataExists";
+VAL_ 551 Rba_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 551 EmPrflNo_D_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Pers4" 3 "Pers3" 2 "Pers2" 1 "Pers1" 0 "Null";
+VAL_ 551 EmPrflButtnAssoc_D_Rq 3 "NotUsed" 2 "ExitButtonAssociation" 1 "EnterButtonAssociation" 0 "Null";
+VAL_ 551 EmPrflKeyAssoc_D_Rq 7 "NotUsed_3" 6 "DisassociatePhone" 5 "EnterPhoneAssociation" 4 "OverwriteKey" 3 "DisassociateKey" 2 "ExitKeyAssociation" 1 "EnterKeyAssociation" 0 "Null";
+VAL_ 551 Em_D_Stat 3 "NotSupported" 2 "ProfilesOff" 1 "ProfilesOn" 0 "Null";
+VAL_ 551 ChrgOvrdExitScrn_D_Rq 3 "NotUsed_1" 2 "Request_override" 1 "Do_not_request_override" 0 "Inactive";
+VAL_ 1010 MbdblActv_B_RqAdas 1 "Yes" 0 "No";
+VAL_ 1010 CbdblActv_B_RqAdas 1 "Yes" 0 "No";
+VAL_ 1010 AdbUrbanArea_B_Stat 1 "Yes" 0 "No";
+VAL_ 1070 BattULo24_D_Falt 3 "NotUsed" 2 "TemporaryFault" 1 "Fault" 0 "NoFault";
+VAL_ 1070 BattULo24_Te_Actl 127 "Fault";
+VAL_ 1070 BattULo24State_D_Qlty 3 "OK" 2 "Not_Within_Spec" 1 "Eval_In_Progress" 0 "Faulty";
+VAL_ 1070 BattULo24_I_Actl 16383 "Faulty";
+VAL_ 1070 BattULo24_B_Falt 1 "Yes" 0 "No";
+VAL_ 1186 SelDrvMdeAwd2_D_Stat 31 "Faulty" 30 "NotUsed_17" 29 "NotUsed_16" 28 "NotUsed_15" 27 "NotUsed_14" 26 "NotUsed_13" 25 "NotUsed_12" 24 "NotUsed_11" 23 "NotUsed_10" 22 "NotUsed_9" 21 "NotUsed_8" 20 "NotUsed_7" 19 "NotUsed_6" 18 "NotUsed_5" 17 "EvLaterChargeMode" 16 "EvNowMode" 15 "TrackMode" 14 "RoughRoadMode" 13 "NotAvailable" 12 "HighSpeedDesertMode_Baja" 11 "SportAdaptiveMode" 10 "RockCrawlMode" 9 "MudRutsMode" 8 "SandMode" 7 "EconomyMode" 6 "GrassGravelSnow" 5 "TowHaulMode" 4 "SportMode" 3 "Normal_4L" 2 "Normal_4A" 1 "Normal_2H" 0 "NormalMode";
+VAL_ 1186 RearDiffLckMsg_D_Rq 7 "Locker_Disabled" 6 "Locker_Enabled" 5 "Locker_Accel_Pedal" 4 "Speed4" 3 "Speed3" 2 "Spee2" 1 "Speed1" 0 "Normal__No_Message ";
+VAL_ 1186 RearDiffLckLamp_D_Rq 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 1186 RearDiffLck_Tq_Actl 4095 "Fault" 4094 "Unknown";
+VAL_ 1186 RearDiffFalt_D_Stat 3 "Diff_Failed_Closed" 2 "Diff_Failed_Open" 1 "Fault_Non_Specific" 0 "No_Fault";
+VAL_ 1186 LsdSrvcRqd_B_Rq 1 "On" 0 "Off";
+VAL_ 611 AwdSys_D_Stat 3 "Faulty" 2 "NotUsed" 1 "_4x4_L_H_Active" 0 "_4x4_L_H_Inactive";
+VAL_ 611 AwdStat_D_RqDsply 31 "NotUsed9" 30 "NotUsed8" 29 "NotUsed7" 28 "To_Engage_4x4_Release_Aped" 27 "To_Engage_4x4_Slow_To_3MPH" 26 "Shift_To_Neutral" 25 "Lkr_Mode_Unavail_TMS" 24 " _4x4_Mode_Unavail_TMS" 23 "Out_of_4Low_Crawl" 22 "AWD_PTU_Oil_Changed" 21 "Change_AWD_PTU_Oil" 20 "Neutral_Tow_Disabled" 19 "Neutral_Tow_Enabled" 18 "AWD_OFF" 17 "_4x4_Off_Road_Speed" 16 "_4x4_Extreme_Off_Road_Mode" 15 "_4x4_Exiting_Off_Road" 14 "_4x4_Off_Road_Mode" 10 "_4x4_Locked_Temporarily" 9 "Shift_In_Progress" 13 "Blocked_Shift_Assist" 12 "_4x4_Auto_Restored" 11 "_4x4_Disabled_Temporarily" 7 "Out_of_4Low__Neutral" 6 "Out_of_4Low__Brake" 5 "Out_of_4Low__Speed" 4 "Into_4Low__Clutch" 3 "Into_4Low__Neutral" 2 "Into_4Low__Brake" 1 "Into_4Low__Speed" 0 "Normal__No_Message" 8 "Out_of_4Low__Clutch";
+VAL_ 611 AwdLck_D_Stat 9 "Undefined" 8 "Under_External_Torque_Ctrl" 7 "Torque_Limited_by_Cmd" 6 "Fully_Locked_by_Cmd" 5 "Disabled" 4 "Warning" 3 "Fault" 2 "Inactive" 1 "Completely_Opened_by_Cmd" 0 "OK";
+VAL_ 611 AwdSrvcRqd_B_Rq 1 "On" 0 "Off";
+VAL_ 611 NtrlTowAvail_B_Stat 1 "Available" 0 "NotAvailable";
+VAL_ 611 AwdLck_Tq_Rq 4095 "Fault" 4094 "Unknown";
+VAL_ 611 AwdOffRoadMode_D_Stats 3 "Invalid" 2 "Extreme_Off_Road" 1 "Off_Road" 0 "Normal_Mode";
+VAL_ 611 AwdLoLamp_D_RqDsply 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 611 AwdHiLamp_D_RqDsply 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 611 AwdAutoLamp_D_RqDsply 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 611 Awd2wdLamp_D_RqDsply 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 611 AwdRnge_D_Actl 7 "Unknown" 6 "High_Range_2wd" 5 "High_Range_Auto" 4 "High_Range_Locked" 3 "Neutral" 2 "Low_Range_2wd" 1 "Low_Range_Auto" 0 "Low_Range_Locked";
+VAL_ 1047 TrlrAidSetup_D2_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "SetupAcquisitionSuccess" 4 "TbaTadMonitor" 3 "SetupStartAcquisition" 2 "SetupPrepForAcquisition" 1 "TbaActive" 0 "Null";
+VAL_ 1047 TrlrAidEnbl_D2_Stat 7 "NotUsed_1" 6 "TbaActiveExpertActive" 5 "TbaActiveExpertAvail" 4 "TbaOffTrgActive" 3 "TbaOffTrgSetup" 2 "TbaSetup" 1 "TbaActive" 0 "Inactive";
+VAL_ 1047 TrlrAidMsgTxt_D2_Rq 63 "Message63" 62 "Message62" 61 "Message61" 60 "Message60" 55 "Message55" 50 "Message50" 45 "Message45" 40 "Message40" 35 "Message35" 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1047 EsaOn_B_Stat 1 "On" 0 "Off";
+VAL_ 1047 SelDrvMdeSte_D_Stat 0 "NotAvailable" 1 "Available" 2 "TemporarilyNotAvailable" 3 "Faulty";
+VAL_ 972 LatCtlSte_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Denied" 3 "RampOut" 2 "ContLatControlInProgress" 1 "Available" 0 "Unavailable";
+VAL_ 972 LatCtlLim_D_Stat 3 "LimitWithDriverActive" 2 "LimitReached" 1 "LimitClose" 0 "LimitNotReached";
+VAL_ 972 LatCtlCpblty_D_Stat 3 "Faulty" 2 "ExtendedModeAvailable" 1 "LimitedModeAvailable" 0 "NoModeAvailable";
+VAL_ 972 LsmcBrkDecelEnbl_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "On" 0 "Off";
+VAL_ 972 TjaHandsOnCnfdnc_B_Est 1 "High_Confidence" 0 "Low_Confidence";
+VAL_ 972 LaHandsOff_B_Actl 1 "Hands_Off" 0 "Hands_On";
+VAL_ 972 LaActDeny_B_Actl 1 "LA_Denied" 0 "LA_Not_Denied";
+VAL_ 972 LaActAvail_D_Actl 3 "LKA_LCA_LDW_Avail" 2 "LCA_LKA_Avail_LDW_Suppress" 1 "LCA_LKA_Suppress_LDW_Avail" 0 "LCA_LKA_LDW_Suppress";
+VAL_ 130 TrlrHitchLamp_D_Rqst 1 "On" 0 "Off";
+VAL_ 130 VehVTrlrAid_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 130 DrvSteActv_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 130 DrvSte_Tq_Actl 255 "Invalid" 254 "Unknown";
+VAL_ 130 SteMdule_D_Stat 7 "NotUsed" 6 "EPAS_Failure3" 5 "EPAS_Failure2" 4 "System_Failure" 3 "EPAS_Shutdown" 2 "Normal_Op_Full_Assist" 1 "Normal_Op_Limited_Assist" 0 "EPAS_Initialization";
+VAL_ 130 SteMdule_U_Meas 255 "Invalid";
+VAL_ 130 SteMdule_I_Est 4095 "Invalid";
+VAL_ 130 EPAS_Failure 3 "SERVICE_POWER_STEERING_NOW" 2 "SERVICE_POWER_STEERING" 1 "POWER_STRG_ASSIST_FAULT" 0 "EPAS_OK_NO_MESSAGE";
+VAL_ 130 SteeringColumnTorque 255 "Invalid" 254 "Unknown";
+VAL_ 130 SAPPAngleControlStat6 1 "RequestedAngleNotReached" 0 "RequestedAngleCanBeReached";
+VAL_ 130 SAPPAngleControlStat5 1 "StrgColTorqueExceed_EAROn" 0 "ExternalSigContentOKforEAC";
+VAL_ 130 SAPPAngleControlStat4 1 "SpeedLimitExceededEAROn" 0 "ExternalSigContentOKforEAC";
+VAL_ 130 SAPPAngleControlStat3 1 "EARactiveNoReverseEngage" 0 "ExternalSigContentOKforEAC";
+VAL_ 130 SAPPAngleControlStat2 1 "Rel_ExtSteeringAngleReqx" 0 "NoRel_ExtSteeringAngleReqx";
+VAL_ 130 SAPPAngleControlStat1 3 "Fault" 2 "Active" 1 "Open" 0 "Closed";
+VAL_ 133 StePw_B_Rq 1 "Yes" 0 "No";
+VAL_ 133 StePinRelInit_An_Sns 65535 "Faulty" 65534 "NoDataExists";
+VAL_ 133 StePinCompAnEst_D_Qf 3 "OK" 2 "Degraded" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 1200 BrkHold_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "HeldSecondary" 3 "HeldSecure" 2 "Held" 1 "Inactive" 0 "Off";
+VAL_ 1200 HsaTrnAout_Tq_Rq 65535 "Fault" 65534 "Unknown";
+VAL_ 1200 BrkBstrVac_P_Actl 127 "Invalid";
+VAL_ 1200 YawStabilityIndex 511 "Fault" 510 "NoDataExists";
+VAL_ 1200 BrkTot_Tq_RqDrv 8191 "Fault";
+VAL_ 1200 HsaStat_D_Dsply 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "NotAvailable" 3 "SlowReleaseWithChime" 2 "SlowReleaseWithoutChime" 1 "Active" 0 "Inactive";
+VAL_ 1102 SelDrvMdePos12_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos11_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos10_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos09_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos08_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos07_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos06_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos05_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos04_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos03_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos02_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1102 SelDrvMdePos01_D_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1056 AutoEpbMsgTxt_D_Rq 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1056 AutoEpbDsply_D_Stat 1 "Available" 0 "NotAvailable";
+VAL_ 1056 AutoEpbButtnOn_B_Stat 1 "On" 0 "Off";
+VAL_ 1056 SelDrvMdePos12_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos11_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos10_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos09_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos08_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos07_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos06_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos05_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos04_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos03_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos02_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 SelDrvMdePos01_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 1056 ActvDrvMde_D2_Stat 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1056 SelDrvMde_D2_Rq 31 "Faulty" 30 "SelDrvMde31" 29 "SelDrvMde30" 28 "SelDrvMde29" 27 "SelDrvMde28" 26 "SelDrvMde27" 25 "SelDrvMde26" 24 "SelDrvMde25" 23 "SelDrvMde24" 22 "SelDrvMde23" 21 "SelDrvMde22" 20 "SelDrvMde21" 19 "SelDrvMde20" 18 "SelDrvMde19" 17 "SelDrvMde18" 16 "SelDrvMde17" 15 "SelDrvMde16" 14 "SelDrvMde15" 13 "SelDrvMde14" 12 "SelDrvMde13" 11 "SelDrvMde12" 10 "SelDrvMde11" 9 "SelDrvMde10" 8 "SelDrvMde09" 7 "SelDrvMde08" 6 "SelDrvMde07" 5 "SelDrvMde06" 4 "SelDrvMde05" 3 "SelDrvMde04" 2 "SelDrvMde03" 1 "SelDrvMde02" 0 "SelDrvMde01";
+VAL_ 1056 SelDrvMdePt_D_Rq 31 "Faulty" 30 "NotUsed15" 29 "NotUsed14" 28 "NotUsed13" 27 "NotUsed12" 26 "NotUsed11" 25 "NotUsed10" 24 "NotUsed9" 23 "NotUsed8" 22 "NotUsed7" 21 "NotUsed6" 20 "NotUsed5" 19 "NotUsed4" 18 "EvLaterChargerMode" 17 "EvNowMode" 16 "DragMode" 15 "HighSpeedDesertMode_Baja" 14 "SportAdaptiveMode" 13 "NotAvailable_13" 12 "NotAvailable_12" 11 "NotAvailable_11" 10 "NotAvailable_10" 9 "RockCrawlMode" 8 "MudRutsMode" 7 "SandMode" 6 "EconomyMode" 5 "GrassGravelSnow" 4 "NotAvailable_04" 3 "TowHaulMode" 2 "NotAvailable_02" 1 "SportMode" 0 "NormalMode";
+VAL_ 1056 SelDrvMdeMsgTxt_D_Rq 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1056 SelDrvMde_D_Stat 3 "NotUsed" 2 "DriveModeChangeRequest" 1 "DriveModeChangeSelection" 0 "NoDriveModeChangeRequest";
+VAL_ 1056 AwdMde_D_RqBrk 7 "Faulty" 6 "NotUsed2" 5 "NoRequest" 4 "Neutral" 3 "FourByFourLow" 2 "FourByFourHigh" 1 "FourByFourAuto" 0 "FourByTwo";
+VAL_ 1054 AirDamUp_B_RqBrk 1 "Up" 0 "NoRequest";
+VAL_ 1054 RbaBrk_D_Stat 3 "Denied" 2 "Active" 1 "Open" 0 "Closed";
+VAL_ 1054 SelDrvMdeChassis2_D_Rq 31 "Faulty" 30 "NotUsed17" 29 "NotUsed16" 28 "NotUsed15" 27 "NotUsed14" 26 "NotUsed13" 25 "NotUsed12" 24 "NotUsed11" 23 "NotUsed10" 22 "NotUsed9" 21 "NotUsed8" 20 "NotUsed7" 19 "NotUsed6" 18 "NotUsed5" 17 "NotUsed4" 16 "NotUsed3" 15 "NotUsed2" 14 "RoughRoadMode" 13 "TrackMode" 12 "HighSpeedDesertMode" 11 "TowHaulMode" 10 "RockCrawlMode" 9 "SandMode" 8 "MudAndRutsMode" 7 "LowMuMode" 6 "ComfortAdaptiveMode" 5 "ComfortMode" 4 "SportAdaptiveMode" 3 "SportMode" 2 "EconomyMode" 1 "NormalAdaptiveMode" 0 "NormalMode";
+VAL_ 1054 TrailCtl_D_Stat 7 "Faulty" 6 "DescentOnly" 5 "EnabledDeny" 4 "StandbyOverThreshold" 3 "StandbyOverride" 2 "Active" 1 "EnabledDescent" 0 "Off";
+VAL_ 1054 TrailCtlMsgTxt_D_Rq 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1054 BrkBstrVac_D_Stat 3 "NotUsed" 2 "BoosterVacEstimator" 1 "BoosterVacSensor" 0 "NoBoosterVacuumMonitor";
+VAL_ 1054 DrvSlipCtlOffLamp_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 1054 DrvSlipCtlMdeMsg_D_Rq 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1054 AutoHoldMsgTxt_D_Rq 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1054 CtaBrk_D_Stat 3 "Denied" 2 "Active" 1 "Open" 0 "Closed";
+VAL_ 1054 SelDrvMdeAwd_D_Rq 31 "Faulty" 30 "NotUsed_17" 29 "NotUsed_16" 28 "NotUsed_15" 27 "NotUsed_14" 26 "NotUsed_13" 25 "NotUsed_12" 24 "NotUsed_11" 23 "NotUsed_10" 22 "NotUsed_9" 21 "NotUsed_8" 20 "NotUsed_7" 19 "NotUsed_6" 18 "NotUsed_5" 17 "EvLaterChargeMode" 16 "EvNowMode" 15 "TrackMode" 14 "RoughRoadMode" 13 "NotAvailable" 12 "HighSpeedDesertMode_Baja" 11 "SportAdaptiveMode" 10 "RockCrawlMode" 9 "MudRutsMode" 8 "SandMode" 7 "EconomyMode" 6 "GrassGravelSnow" 5 "TowHaulMode" 4 "SportMode" 3 "Normal_4L" 2 "Normal_4A" 1 "Normal_2H" 0 "NormalMode";
+VAL_ 1054 AutoHoldSwMde_B_Ind 1 "On" 0 "Off";
+VAL_ 1054 AutoHoldMde_D_Ind 3 "Indication_3" 2 "Indication_2" 1 "Indication_1" 0 "Off";
+VAL_ 1054 SelDrvMdeChassis_D_Rq 31 "Faulty" 30 "NotUsed17" 29 "NotUsed16" 28 "NotUsed15" 27 "NotUsed14" 26 "NotUsed13" 25 "NotUsed12" 24 "NotUsed11" 23 "NotUsed10" 22 "NotUsed9" 21 "NotUsed8" 20 "NotUsed7" 19 "NotUsed6" 18 "NotUsed5" 17 "NotUsed4" 16 "NotUsed3" 15 "NotUsed2" 14 "NotUsed1" 13 "TrackMode" 12 "HighSpeedDesertMode" 11 "TowHaulMode" 10 "RockCrawlMode" 9 "SandMode" 8 "MudAndRutsMode" 7 "LowMuMode" 6 "ComfortAdaptiveMode" 5 "ComfortMode" 4 "SportAdaptiveMode" 3 "SportMode" 2 "EconomyMode" 1 "NormalAdaptiveMode" 0 "NormalMode";
+VAL_ 1054 ApaBrk_D_Stat 3 "Denied" 2 "Active" 1 "Open" 0 "Closed";
+VAL_ 1046 HsaMde_D_Mem 3 "Undefined" 2 "Manual" 1 "Automatic" 0 "Off";
+VAL_ 1046 BrkBstrVac_B_Rq 1 "Yes" 0 "No";
+VAL_ 1046 HdcMde_D_Actl 7 "Fault" 6 "Temporarily_Unavailable" 5 "NotEnabled_WrongGearSel" 4 "NotEnabled_SpdLimitExceed" 3 "Active_Braking" 2 "Not_Active_Braking" 1 "Off" 0 "Undefined";
+VAL_ 1046 RearDiffLck_Tq2_RqMx 4095 "Faulty";
+VAL_ 1046 TRLR_SWAY_EVNT_IN_PROG 1 "Yes" 0 "No";
+VAL_ 1046 TRLR_SWAY_CONFIG_STAT 1 "On" 0 "Off";
+VAL_ 1046 TCMode 1 "Active" 0 "Inactive";
+VAL_ 1046 DrvSlipCtlLamp_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 1046 Abs_B_Falt 1 "Yes" 0 "No";
+VAL_ 1046 DrvSlipCtlMde_D_Ind 3 "App_Specific_Off_Mode_3" 2 "App_Specific_Off_Mode_2" 1 "App_Specific_Off_Mode_1" 0 "Default_Mode";
+VAL_ 1046 DrvAntiLckLamp_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 1046 StabCtlBrk_B_Avail 1 "Yes" 0 "No";
+VAL_ 1046 DrvHdcWarnInfo_D_Rq 3 "Undefined" 2 "Lamp_On_Continuously" 1 "Lamp_Flashing" 0 "Lamp_Off_Continuously";
+VAL_ 1046 DrvHdcMsg_D_Rq 7 "Undefined" 6 "Speed_too_High" 5 "Temporarily_Unavailable" 4 "System_Fault" 3 "Select_Gear" 2 "Off" 1 "On" 0 "No_Message";
+VAL_ 1046 DrvHdcLampInfo_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 1046 BpedMove_D_Actl 3 "Unknown" 2 "DriverApplyingBrakePedal" 1 "NoAutonomousBrkPdlMovement" 0 "AutonomousBrkPedalMove";
+VAL_ 1046 ChimeBrk_B_Rq 1 "Yes" 0 "No";
+VAL_ 1046 BrkLamp_B_Rq 1 "Yes" 0 "No";
+VAL_ 1046 HILL_DESC_MC 7 "Fault_Detected" 6 "Cooling_Down" 5 "Abort_Apply_Brakes" 4 "Active" 3 "Disabled" 2 "Enabled" 1 "Off_Road" 0 "Normal";
+VAL_ 1046 RearDiffElckrOpen_B_Rq 1 "Yes" 0 "No";
+VAL_ 1045 VehStab_D_Stat 15 "Faulty" 14 "No_Data_Exists" 13 "NotUsed6" 12 "NotUsed5" 11 "NotUsed4" 10 "NotUsed3" 9 "NotUsed2" 8 "NotUsed1" 7 "High_SSRA_no_OS" 6 "Straight" 5 "Post_Oversteer" 4 "Post_Transition" 3 "Countersteer" 2 "Understeer" 1 "Oversteer" 0 "Linear";
+VAL_ 1045 BrkFluidLvl_D_Stat 3 "Invalid" 2 "Unknown" 1 "Low" 0 "OK";
+VAL_ 1045 LsmcBrkDecel_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Denied" 3 "FaultDegraded" 2 "FaultExt" 1 "On" 0 "Off";
+VAL_ 1045 VehYawNonLin_W_Rq 4095 "Fault" 4094 "Unknown";
+VAL_ 1045 VehYawLin_W_Rq 4095 "Fault" 4094 "Unknown";
+VAL_ 1045 VehVActlBrk_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 1044 StePinOffst_An_Est 65535 "Faulty" 65534 "NoDataExists";
+VAL_ 1044 StePinOffst_D_Stat 3 "FineOffset" 2 "CoarseOffset" 1 "StoredOffset" 0 "OffsetNotCalculated";
+VAL_ 1042 VehRol_An_Dsply 127 "Faulty" 126 "NoDataExists";
+VAL_ 1042 VehPtch_An_Dsply 127 "Faulty" 126 "NoDataExists";
+VAL_ 535 WhlRr_W_Meas 32767 "Fault" 32766 "Unknown";
+VAL_ 535 WhlRl_W_Meas 32767 "Fault" 32766 "Unknown";
+VAL_ 535 WhlFr_W_Meas 32767 "Fault" 32766 "Unknown";
+VAL_ 535 WhlFl_W_Meas 32767 "Fault" 32766 "Unknown";
+VAL_ 534 WhlDirRr_D_Actl 3 "Faulty" 2 "NoDataExists" 1 "Backward" 0 "Forward";
+VAL_ 534 WhlDirRl_D_Actl 3 "Faulty" 2 "NoDataExists" 1 "Backward" 0 "Forward";
+VAL_ 534 WhlDirFr_D_Actl 3 "Faulty" 2 "NoDataExists" 1 "Backward" 0 "Forward";
+VAL_ 534 WhlDirFl_D_Actl 3 "Faulty" 2 "NoDataExists" 1 "Backward" 0 "Forward";
+VAL_ 532 RgenTqFalt_B_Actl 1 "Fault" 0 "No_Fault";
+VAL_ 532 RgenBrkDynoMde_B_Actl 1 "TwoWheelDyno" 0 "NormalOperation";
+VAL_ 531 VehStop_D_Stat 3 "Faulty" 2 "NoDataExists" 1 "Yes" 0 "No";
+VAL_ 531 TracCtlPtActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 531 LscmbbMntr_B_Err 1 "DisplayMessage" 0 "NoMessage";
+VAL_ 531 LscmbbBrkDis_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 LscmbbDeny_B_ActlBrk 1 "Yes" 0 "No";
+VAL_ 531 PrkBrkYwLamp_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 531 PrkBrkRedLamp_D_Rq 3 "Fast_Flash" 2 "Slow_Flash" 1 "On" 0 "Off";
+VAL_ 531 LscmbbBrkDecel_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AbsActv_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 StabCtlBrkActv_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 CmbbBrkPrchg_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 CmbbBrkDecel_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 CmbbBaSensInc_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AccBrkWarm_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AccBrkTotTqMn_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AccBrkPrchgActv_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AccBrkDis_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AccBrkDeny_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 AccBrkActv_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 PrplDrgCtlActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 531 LscmbbBaSensInc_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 CmbbBrkDis_B_Actl 1 "Yes" 0 "No";
+VAL_ 531 CmbbDeny_B_ActlBrk 1 "Yes" 0 "No";
+VAL_ 531 CcDis_B_Cmd 1 "Yes" 0 "No";
+VAL_ 531 VehLongOvrGnd_A_Est 1023 "Fault" 1022 "Unknown";
+VAL_ 531 LscmbBrkPrchg_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 531 AccStopActv_B_ActlBrk 1 "Yes" 0 "No";
+VAL_ 531 AccDis_B_ActlEpb 1 "Yes" 0 "No";
+VAL_ 531 PrkBrkMsgTxt_D_Rq 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "No_Message";
+VAL_ 531 PrkBrkStatus 7 "GeneralFault_MaintenceMode" 6 "ECD_by_Brake_ECU_Active" 5 "EPB_Limphome_Active" 4 "Rear_Caliper_Open" 3 "RWU_By_EPB_Active" 2 "Rear_Caliper_Transition" 1 "Rear_Caliper_Closed" 0 "Not_Supported";
+VAL_ 136 SteWhlBrkOffst_An_Rq 32767 "Faulty" 32766 "NoDataExists";
+VAL_ 125 VehRolComp_W_Actl 4094 "NoDataExists" 4095 "Fault";
+VAL_ 125 VehVertComp_A_Actl 1022 "NoDataExists" 1023 "Fault";
+VAL_ 125 BrkTot_Tq_RqArb 8191 "Fault" 8190 "Unknown";
+VAL_ 125 BrkTot_Tq_Actl 8191 "Fault" 8190 "Unknown";
+VAL_ 125 HsaStat_D_Actl 7 "Faulty" 6 "FaultyWithDriverIndication" 5 "SlowRelease" 4 "FastRelease" 3 "ActiveBrakePedalReleased" 2 "ActiveBrakePedalPressed" 1 "FindingGradient" 0 "Inactive";
+VAL_ 119 VehTrvlDir_D_Stat 7 "Faulty" 6 "NoDataExists" 5 "NotUsed2" 4 "NotUsed1" 3 "Reverse" 2 "LikelyReverse" 1 "Forward" 0 "LikelyForward";
+VAL_ 119 VehOverGnd_V_Est 65535 "Invalid" 65534 "Unknown";
+VAL_ 119 VehLongComp_A_Actl 1023 "Fault" 1022 "NoDataExists";
+VAL_ 119 VehLatComp_A_Actl 1023 "Fault" 1022 "NoDataExists";
+VAL_ 119 VehYawComp_W_Actl 4095 "Fault" 4094 "NoDataExists";
+VAL_ 118 BrkCtrFnd_B_Stat 1 "Yes" 0 "No";
+VAL_ 118 DrvSte_D_Stat 15 "NotUsed10" 14 "NotUsed9" 13 "NotUsed8" 12 "NotUsed7" 11 "NotUsed6" 10 "NotUsed5" 9 "NotUsed4" 8 "NotUsed3" 7 "NotUsed2" 6 "NotUsed1" 5 "Request_Active" 4 "Ignition_Off" 3 "DSR_in_Normal_Idle_Mode" 2 "EPAS_Comm_Disturbed" 1 "DSR_Request_Not_Applicable" 0 "DSR_Deactivated";
+VAL_ 118 DrvSte_Tq_Rq 255 "Invalid" 254 "Unknown";
+VAL_ 118 EmgcyBrkLamp_D_Rq 3 "NotUsed" 2 "Active_at_standstill" 1 "Active_at_speed" 0 "Inactive";
+VAL_ 118 StopLamp_B_RqBrk 1 "Active" 0 "Inactive";
+VAL_ 73 immoSubTarget1Cmd_T1 7 "Unused3" 6 "Unused2" 5 "ECHO_TARGET1_IDBLOCK2" 4 "Unused1" 3 "RQST_TARGET1_IDBLOCK2" 2 "RQST_TARGET1_IDBLOCK1" 1 "RESPONSE" 0 "IDLE";
+VAL_ 561 TrnMsgTxt2_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "TransTooHot_LoudChime" 3 "PressBrake_LoudChime" 2 "PressBrake_SoftChime" 1 "PressBrake_NoChime" 0 "NoText_NoChime";
+VAL_ 561 TrnMsgTxt_D_Rq 15 "Message_15" 14 "Message_14" 13 "Message_13" 12 "Message_12" 11 "Message_11" 10 "Message_10" 9 "Message_9" 8 "Message_8" 7 "Message_7" 6 "Message_6" 5 "Message_5" 4 "Message_4" 3 "Message_3" 2 "Message_2" 1 "Message_1" 0 "NoMessage";
+VAL_ 330 TrnAout_W_ActlUnfilt 32767 "Fault" 32766 "Unknown";
+VAL_ 1090 Mtr2State_D_ActlMntr 7 "Faulty" 6 "NoDataExists" 5 "NotUsed_1" 4 "ReadinessState" 3 "DeactivationState" 2 "PowerGeneration" 1 "PowerConsumption" 0 "Null";
+VAL_ 1090 Inv1Ain_I_ActlMntr 32767 "Faulty" 32766 "NoDataExists";
+VAL_ 1090 HybVehMde_D_ActlMntr 7 "Faulty" 6 "NoDataExists" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Fuel" 2 "HybridElectric" 1 "AllElectric" 0 "Null";
+VAL_ 1090 ChrgStat_D_ActlMntr 7 "Faulty" 6 "NoDataExists" 5 "NotUsed" 4 "ChargingCompleted" 3 "NotCharging" 2 "ChargingInDrivingState" 1 "ChargingInParkingState" 0 "Null";
+VAL_ 1090 VehElRnge_L_Dsply 4094 "NoDataExists" 4095 "Fault";
+VAL_ 870 EngMdeMsgTxt_D_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Charge" 3 "GlowingCharge" 2 "Hybrid" 1 "Ev" 0 "NoMessage";
+VAL_ 870 RngPerChrgInst_L_Dsply 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 869 PwrFlowTxt_D_Dsply 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "Disply_Rgen_Chrg_Txt" 10 "Disp_Fast_Charge_Txt" 9 "Disp_Fast_Charge_Cmplt_Txt" 8 "Disp_Charge_Cmplt_Txt" 7 "Disp_Remote_Start_Txt" 6 "Disp_Eng_Drv_Txt" 5 "Disp_Elec_Drv_Txt" 4 "Disp_Idle_with_Chrg_Txt" 3 "Disp_Idle_Txt" 2 "Disp_Charg_HV_Batt_Txt" 1 "Disp_Hyb_Drive_Txt" 0 "No_Text";
+VAL_ 869 EngOnMsg2_D_Dsply 14 "_0xE_to_1F_NotUsed" 12 "Battery_Temperature" 11 "Hill_Decent_Control" 10 "Fuel_Maintenance" 9 "Oil_Maintenance" 8 "Normal_Operation" 7 "Low_Gear" 6 "Batt_Charging" 5 "Engine_Cold" 4 "Neutral_Gear" 3 "Heater_Setting" 2 "High_Speed" 1 "Acceleration" 0 "No_Display" 13 "Drive_Mode_Selection";
+VAL_ 869 EngOnMsg1_D_Dsply 14 "_0xE_to_1F_NotUsed" 12 "Battery_Temperature" 11 "Hill_Decent_Control" 10 "Fuel_Maintenance" 9 "Oil_Maintenance" 8 "Normal_Operation" 7 "Low_Gear" 6 "Batt_Charging" 5 "Engine_Cold" 4 "Neutral_Gear" 3 "Heater_Setting" 2 "High_Speed" 1 "Acceleration" 0 "No_Display" 13 "Drive_Mode_Selection";
+VAL_ 869 FuelMaintMde_D_Dsply 3 "Feature_Not_Present" 2 "In_Fuel_Maint_Mode" 1 "Close_to_Fuel_Maint" 0 "OK";
+VAL_ 869 EngActv_B_Dsply 1 "On" 0 "Off";
+VAL_ 869 EffWhlThresOn_B_Dsply 1 "On" 0 "Off";
+VAL_ 606 ElVehLaterMde_D_Stat 3 "NotUsed" 2 "Available" 1 "NotAvailable" 0 "Null";
+VAL_ 606 ElVehNowMde_D_Stat 3 "NotUsed" 2 "Available" 1 "NotAvailable" 0 "Null";
+VAL_ 374 GearEngag_D_Actl 7 "Undefined" 6 "Fwd_Clutch_Fully_Engaged" 5 "Neutral_Idle" 4 "Disengaged_to_Neutral_Idle" 3 "Disengaged_to_Neutral_Park" 2 "Engagement_in_Progress" 1 "InitializeFwdClutchEngagmt" 0 "Park_Neutral";
+VAL_ 374 TrnRng_D_Rq 15 "Fault" 14 "Unknown_Position" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Range6" 10 "Range5" 9 "Range4" 8 "Range3_M3_L3" 7 "Range2_M2_L2" 6 "Range1_M1_L1" 5 "Low" 4 "Sport_DriveSport_Mposition" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_ 374 TrnPrkSys_D_Actl 15 "Faulty" 14 "NotUsed_5" 13 "NotUsed_4" 12 "NotUsed_3" 11 "NotUsed_2" 10 "NotUsed_1" 9 "FrequencyError" 8 "OutOfRangeHigh" 7 "OutOfRangeLow" 6 "Override" 5 "OutOfPark" 4 "TransitionCloseToOutOfPark" 3 "AtNoSpring" 2 "TransitionCloseToPark" 1 "Park" 0 "NotKnown";
+VAL_ 374 GearLvr_D_ActlDrv 15 "Fault" 14 "Unknown_Position" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Range6" 10 "Range5" 9 "Range4" 8 "Range3_M3_L3" 7 "Range2_M2_L2" 6 "Range1_M1_L1" 5 "Low" 4 "Sport_DriveSport_Mposition" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_ 374 GearPos_D_Trg 15 "Unknown" 14 "Reverse" 13 "Undefined_5" 12 "Undefined_4" 11 "Undefined_3" 10 "Tenth" 9 "Ninth" 8 "Eighth" 7 "Seventh" 6 "Sixth" 5 "Fifth" 4 "Fourth" 3 "Third" 2 "Second" 1 "First" 0 "Neutral";
+VAL_ 374 GearPos_D_Actl 15 "Unknown" 14 "Reverse" 13 "Undefined_5" 12 "Undefined_4" 11 "Undefined_3" 10 "Tenth" 9 "Ninth" 8 "Eighth" 7 "Seventh" 6 "Sixth" 5 "Fifth" 4 "Fourth" 3 "Third" 2 "Second" 1 "First" 0 "Neutral";
+VAL_ 603 WhlDirAvgDrv_D_Actl 3 "Failed" 2 "Unknown" 1 "Backward" 0 "Forward";
+VAL_ 603 PrplTqMnRgen_B_Actl 1 "Yes" 0 "No";
+VAL_ 603 BattTracCnnct_D_Rq 3 "Undefined" 2 "Retain" 1 "Close" 0 "Open";
+VAL_ 602 HtrnWarnLamp_B_Dsply 1 "On" 0 "Off";
+VAL_ 602 HybPwLimOn_B_Stat 1 "Yes" 0 "No";
+VAL_ 602 PwPckTqRdy_B_Dsply 1 "On" 0 "Off";
+VAL_ 1152 BattTracDiagClr_B_Stat 1 "On" 0 "Off";
+VAL_ 1152 EngTeHi_B_Actl 1 "EngineTempHigh" 0 "Normal";
+VAL_ 1152 DcdcOn_B_Rq 1 "On" 0 "Off";
+VAL_ 1152 ULoBattSpprtSustn_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 1152 VehElEff_No_Avg 127 "Faulty" 126 "NoDataExists";
+VAL_ 872 PlgActvArb_B_Dsply 1 "On" 0 "Off";
+VAL_ 872 HybMdeStat_D_Dsply 7 "NotUsed2" 6 "EV_Charge" 5 "EV_Override" 4 "Forced_EV_Mode" 3 "Forced_Charge_Sustain_Mode" 2 "Auto_Charge_Sustain_Mode" 1 "Auto_Charge_Deplete_Mode" 0 "Null_State";
+VAL_ 560 SelDrvMdeSwtch_D_Stat3 3 "Faulty" 2 "SwitchState2" 1 "SwitchState1" 0 "NotPressed";
+VAL_ 560 TrnSrvcRqd_B_Rq 1 "On" 0 "Off";
+VAL_ 560 TrnShifActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 560 GearLvrPos_D_Actl 15 "Fault" 14 "Unknown_Position" 13 "Undefined_Treat_as__Fault" 12 "Undefined_Treat_as_Fault" 11 "sixth" 10 "fifth" 9 "fourth" 8 "third" 7 "second" 6 "first" 5 "Low" 4 "Sport_DriveSport" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_ 560 GboxOil_Te_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 369 SeatWorkSrfc_B_Falt 1 "Active" 0 "Inactive";
+VAL_ 369 TrnIpcDsplyRng2_D_Actl 15 "No_Range_Selected" 14 "Range_14" 13 "Range_13" 12 "Range_12" 11 "Range_11" 10 "Range_10" 9 "Range_9" 8 "Range_8" 7 "Range_7" 6 "Range_6" 5 "Range_5" 4 "Range_4" 3 "Range_3" 2 "Range_2" 1 "Range_1" 0 "NotUsed";
+VAL_ 369 TrnIpcDsplyRng_D_Stat 3 "NotUsed" 2 "Flash" 1 "On" 0 "Blank_No_Display";
+VAL_ 369 TrnIpcDsplyGear_D_Actl 15 "No_Gear_Selected" 14 "_14th_Gear" 13 "_13th_Gear" 12 "_12th_Gear" 11 "_11th_Gear" 10 "_10th_Gear" 9 "_9th_Gear" 8 "_8th_Gear" 7 "_7th_Gear" 6 "_6th_Gear" 5 "_5th_Gear" 4 "_4th_Gear" 3 "_3rd_Gear" 2 "_2nd_Gear" 1 "_1st_Gear" 0 "Neutral";
+VAL_ 369 TrnIpcDsplyMde_D_Stat 3 "Reserved_Blank_No_Display" 2 "Flash" 1 "On" 0 "Blank_No_Display";
+VAL_ 369 TrnIpcDsplyMde_D_Actl 7 "Manual_3" 6 "Manual_2" 5 "Manual_1_Low" 4 "Sport" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_ 369 TrnIpcDsplyGear_D_Stat 3 "Reserved_Blank_No_Display" 2 "Flash" 1 "On" 0 "Blank_No_Display";
+VAL_ 92 TrnLvrV_D_Rq 3 "Full_Speed" 2 "Aggressive" 1 "Normal" 0 "Quiet";
+VAL_ 92 TrnSbwSysHlth_D_Actl 3 "OK" 2 "Degraded" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 92 TrnGearNtmAllow_B_Stat 1 "Yes" 0 "No";
+VAL_ 92 TrnDtpCmd_D_Actl 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "Relatch" 3 "Deploy" 2 "Self_Test" 1 "No_Command" 0 "NotUsed1";
+VAL_ 92 GearSelLck_D_Rq 3 "PreventionBlocker" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_ 92 TrnValidGear_D_Cnfm 3 "Accept" 2 "Reject" 1 "Internal_Request" 0 "No_Command";
+VAL_ 92 TrnNtrlTowCmd_D_Actl 3 "NotUsed" 2 "Neutral_Tow_Entry" 1 "Car_Wash_Mode" 0 "Normal_Mode";
+VAL_ 92 TrnGearCmd_Pc_ActlPt 1023 "Fault";
+VAL_ 92 TrnGear_D_RqPt 7 "Fault" 6 "NotUsed" 5 "Manual" 4 "Drive" 3 "Neutral" 2 "Reverse" 1 "Park" 0 "No_Gear";
+VAL_ 92 TrnCmdState_B_Actl 1 "Yes" 0 "No";
+VAL_ 92 PrkBrkActv_D_RqTrnGear 3 "NotUsed2" 2 "RequestParkBrakeEngage" 1 "NoRequest" 0 "NotUsed1";
+VAL_ 92 TrnGearMsgTxt_D_Rq 15 "Message_15" 14 "Message_14" 13 "Message_13" 12 "Message_12" 11 "Message_11" 10 "Message_10" 9 "Message_9" 8 "Message_8" 7 "Message_7" 6 "Message_6" 5 "Message_5" 4 "Message_4" 3 "Message_3" 2 "Message_2" 1 "Message_1" 0 "NoMessage";
+VAL_ 1087 BattRgenLoChrg_D_RqEng 3 "Disable" 2 "Retain" 1 "Closed" 0 "Open";
+VAL_ 1087 AdasLcObtclAbrt_B_Stat 1 "Yes" 0 "No";
+VAL_ 1087 BattRgenLoDChrg_D_RqEng 3 "Disable" 2 "Retain" 1 "Closed" 0 "Open";
+VAL_ 1087 AirDamPos_D_Stat 3 "Faulty" 2 "NotUsed" 1 "Down" 0 "Up";
+VAL_ 1087 FapLcInhbt_B_Rq 1 "Yes" 0 "No";
+VAL_ 1087 FapLcStopHold_B_Rq 1 "Yes" 0 "No";
+VAL_ 1087 FapLcPrchgBrk_B_Rq 1 "Yes" 0 "No";
+VAL_ 1087 FapLcObstcl_B_Stat 1 "Yes" 0 "No";
+VAL_ 1087 FapLcMaxGrdInhbt_B_Stat 1 "Yes" 0 "No";
+VAL_ 1087 FapLcMaxGrdAbrt_B_Stat 1 "Yes" 0 "No";
+VAL_ 1087 FapLcActv_B_Stat 1 "Yes" 0 "No";
+VAL_ 332 UreaLvlQlty_D_RqDsply 7 "NotUsed_5" 6 "NotUsed_4" 5 "NotUsed_3" 4 "NotUsed_2" 3 "NotUsed_1" 2 "FlashChime" 1 "On" 0 "Off";
+VAL_ 332 UreaLvlTxtWarn_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "System_Error" 10 "Engine_Idled_See_Manual" 9 "Engine_Idled_Upon_Refuel" 8 "Speed_Limited_To_XX_mph" 7 "XXmph_Max_Upon_Restart" 6 "Speed_Limited_To_YY_mph" 5 "YYmph_Max_Upon_Restart" 4 "SpdLimtd_YYmph_In_XXmiles" 3 "ExFlRange_XXMiles_ScndWarn" 2 "Exh_Fluid_Range_XX_Miles" 1 "Exh_Fluid_Under_Half_Full" 0 "Exh_Fluid_Over_Half_Full";
+VAL_ 332 UreaQltySysWarn_D_Rq 7 "Undefined" 6 "ZZ_Overrides" 5 "EngineIdled" 4 "Engine_Idle_Upon_Refuel" 3 "SPEED_LIMITED_to_YY_mph" 2 "YY_MPH_MAX_UPON_Restart" 1 "CONTAMINATED_ExhFluid" 0 "NoQualityProblem";
+VAL_ 332 DieslPrtcWarn_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "OCR_ExhFilterClean_Stopped" 10 "OCR_ExhFilterCleaned" 9 "RgnOff_AtLimit" 8 "RgnOff_OverLoaded" 7 "RgnOff_Loaded" 6 "Exhaust_Filter_Full" 5 "DPF_OverLimit" 4 "DPF_AtLimit" 3 "ExhFilter_Drive_Completed" 2 "Cleaning_Exhaust_Filter" 1 "DPF_OverLoaded" 0 "DPF_Normal_Operation";
+VAL_ 332 UreaQltyFlg_B_RqDsply 1 "True" 0 "False";
+VAL_ 332 UreaQltySys_D_RqDsply 7 "Undefined" 6 "ZZ_Overrides" 5 "EngineIdled" 4 "Engine_Idle_Upon_Refuel" 3 "SPEED_LIMITED_to_YY_mph" 2 "YY_MPH_MAX_UPON_Restart" 1 "CONTAMINATED_ExhFluid" 0 "NoQualityProblem";
+VAL_ 332 UreaLvlTxt_D_RqDsply 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "System_Error" 10 "Engine_Idled_See_Manual" 9 "Engine_Idled_Upon_Refuel" 8 "Speed_Limited_To_XX_mph" 7 "XXmph_Max_Upon_Restart" 6 "Speed_Limited_To_YY_mph" 5 "YYmph_Max_Upon_Restart" 4 "SpdLimtd_YYmph_In_XXmiles" 3 "ExFlRange_XXMiles_ScndWarn" 2 "Exh_Fluid_Range_XX_Miles" 1 "Exh_Fluid_Under_Half_Full" 0 "Exh_Fluid_Over_Half_Full";
+VAL_ 1100 EngExhMdeQuiet_D2_Stat 7 "Faulty" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Track" 3 "Sport" 2 "Normal" 1 "Stealth" 0 "Null";
+VAL_ 1100 HvacCmprLim_D_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "CompressorHeadPressure" 4 "AvailableTorque" 3 "PedalPosition" 2 "RPM" 1 "ECT" 0 "NoLimit";
+VAL_ 1100 WakeAlarm1_B_Typ 1 "CanAndEcuDriveCircuit" 0 "CanOnly";
+VAL_ 1100 Veh_V_DsplyTrailCtlSet 63 "Faulty";
+VAL_ 1100 TrailCtlPt_B_Falt 1 "Fault" 0 "No_Fault";
+VAL_ 1100 AutoTowAllw_D_StatMnu 3 "TowHaulCommandedOn" 2 "AutoTowHaulEnabled" 1 "AutoTowHaulDisabled" 0 "NoSelection";
+VAL_ 1100 AutoTowActv_B_Stat 1 "Yes" 0 "No";
+VAL_ 1100 GrossTrainWeight_M_Est 255 "Faulty" 254 "NoDataExists";
+VAL_ 1098 EdmSailMdeOn_B_Stat 1 "On" 0 "Off";
+VAL_ 1098 EdmMsgTxt_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "OverallGoodScore" 10 "WorkOnCompliance" 9 "GoodCompliance" 8 "WorkOnGearShifting" 7 "GoodGearShifting" 6 "WorkOnEfficientSpeed" 5 "GoodEfficientSpeed" 4 "WorkOnDeceleration" 3 "GoodDeceleration" 2 "WorkOnAcceleration" 1 "GoodAcceleration" 0 "NoMessage";
+VAL_ 1098 EdmLamp_D_Dsply 15 "NotUsed_7" 14 "NotUsed_6" 13 "NotUsed_5" 12 "NotUsed_4" 11 "NotUsed_3" 10 "NotUsed_2" 9 "NotUsed_1" 8 "CoastingEngineBrake" 7 "CoastingShiftToNeutral" 6 "FreewayJunction" 5 "Curve2" 4 "Curve1" 3 "SpeedLimit" 2 "Crossing" 1 "FreewayExit" 0 "NoRecommendation";
+VAL_ 1098 EdmCmplnc_B_Dsply 1 "Yes" 0 "No";
+VAL_ 1086 FuelPumpPwr_B_Rq 1 "On" 0 "Off";
+VAL_ 1086 ElLoadCtl_D_Rq 7 "Unused3" 6 "Unused2" 5 "Unused1" 4 "HoldAllDrvrInvisibleLoads" 3 "StdDriverInvisibleLoadsOn" 2 "AllDriverInvisibleLoadsOn" 1 "All_Possible_Loads_Off" 0 "No_Request";
+VAL_ 1071 CluPdlPosPcMeas_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 1069 SlMde_D_Stat 3 "IsaNotConfigured" 2 "Manual_Mode" 1 "Auto_Mode" 0 "Null";
+VAL_ 1069 SlMde_D_RqDsply 3 "NotUsed" 2 "ManualSpeed_LimiterSymbol" 1 "AutoSpeed_LimiterSymbol" 0 "NoSpeed_LimiterSymbol";
+VAL_ 1069 IsaOffst_D_Stat 15 "Faulty" 14 "Null" 13 "Thirteen" 12 "Twelve" 11 "Eleven" 10 "Ten" 9 "Nine" 8 "Eight" 7 "Seven" 6 "Six" 5 "Five" 4 "Four" 3 "Three" 2 "Two" 1 "One" 0 "Zero";
+VAL_ 1069 GrllShtrPos_D_Cmd 15 "Fully_Open" 14 "Position14" 13 "Position13" 12 "Position12" 11 "Position11" 10 "Position10" 9 "Position9" 8 "Position8" 7 "Position7" 6 "Position6" 5 "Position5" 4 "Position4" 3 "Position3" 2 "Position2" 1 "Position1" 0 "Fully_Closed";
+VAL_ 1069 GrllShtrPos_B_Falt 1 "Fault" 0 "No_Fault";
+VAL_ 1069 ObdWarmUp_B_Complt 1 "Yes" 0 "No";
+VAL_ 1069 EngMsgTxt_D_Rq 3 "Undefined_2" 2 "Undefined_1" 1 "Power_Reduced_to_LowerTemp" 0 "No_Message";
+VAL_ 1069 EngAirIn_Te_Actl 1023 "Fault" 1022 "Unknown";
+VAL_ 1060 RearDiffOilTeWarn_B_Rq 1 "On" 0 "Off";
+VAL_ 1060 RearDiffOil_Te_Actl 511 "Faulty";
+VAL_ 1060 BpedDrvMsgTxt_B_Dsply 1 "On" 0 "Off";
+VAL_ 1060 FuelLvlWarn_D_ActlEng 7 "DteLevel5Lowest" 6 "DteLevel4" 5 "DteLevel3" 4 "DteLevel2NonMyKey" 3 "DteLevel1MyKey" 2 "VeryLow" 1 "Low" 0 "OK";
+VAL_ 1060 SelDrvMdePt_D_Stat 0 "NotAvailable" 1 "Available" 2 "TemporarilyNotAvailable" 3 "Faulty";
+VAL_ 1057 FohEng_D_Rq 3 "AutoEnable_ParkEnable" 2 "AutoDisable_ParkEnable" 1 "AutoEnable_ParkDisable" 0 "Disable_Stop";
+VAL_ 1057 EngIdlShutDwnTxt_D_Rq 3 "NotUsed" 2 "EngineShutdownOnPrevDrive" 1 "FeatureDisabledDueToFault" 0 "NoMessage";
+VAL_ 1057 EngIdlShutDown_D_Stat 3 "Not_used" 2 "Engine_Shutdown" 1 "Initiated_Countdown" 0 "Normal_Operation";
+VAL_ 1057 FUEL_ALCOHOL_PERCNT 255 "Invalid";
+VAL_ 1057 TrnTotTq_Rt_Est 65535 "Fault" 65534 "Unknown";
+VAL_ 1057 TrnTotLss_Tq_Est 255 "Fault" 254 "Unknown";
+VAL_ 1057 ECMMILRequest 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 1057 AirCondFluidHi_P_Actl 255 "Fault" 254 "Unknown";
+VAL_ 1057 OilPressureWarning 1 "Low_Pressure_Lamp_On" 0 "Normal_Pressure_Lamp_Off";
+VAL_ 1057 VehVLimStat_D_Actl 7 "Undefined_3" 6 "Undefined_2" 5 "Undefined_1" 4 "ASL_Fault_Condition" 3 "Active_and_Limiting" 2 "Active_but_Not_Limiting" 1 "Standby" 0 "Off";
+VAL_ 1057 VehVLimActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 1057 CoolantFanStepAct 31 "Unused7" 30 "Unused6" 29 "Unused5" 28 "Unused4" 27 "Unused3" 26 "Unused2" 25 "Unused1" 23 "Step23" 22 "Step22" 21 "Step21" 20 "Step20" 19 "Step19" 18 "Step18" 17 "Step17" 16 "Step16" 15 "Step15" 14 "Step14" 13 "Step13" 12 "Step12" 11 "Step11" 10 "Step10" 9 "Step9" 8 "Step8" 7 "Step7" 6 "Step6" 5 "Step5" 4 "Step4" 3 "Step3" 2 "Step2" 1 "Step1" 24 "Max_Fan_Speed_Req" 0 "Fan_Cmd_Off";
+VAL_ 1055 EcoCochInstNeg_B_Dsply 1 "True" 0 "False";
+VAL_ 562 GearNtrl_D_Stat 3 "Faulty" 2 "NoDataExists" 1 "Yes" 0 "No";
+VAL_ 523 EngAirFiltMsgTxt_D_Rq 7 "NotUsed_2" 6 "NotUsed_1" 5 "EngineAirFilterMonitorFalt" 4 "ResetComplete" 3 "Clogged" 2 "ReplaceNow" 1 "ReplaceSoon" 0 "NoMessage";
+VAL_ 523 WaterInFuel_B_Falt 1 "Fault" 0 "No_Fault";
+VAL_ 523 UreaMnAdd_L2_Actl 255 "Faulty";
+VAL_ 523 UreaMxAdd_L2_Actl 511 "Faulty";
+VAL_ 517 FapLc_B_Err 1 "Yes" 0 "No";
+VAL_ 516 EngAoutNActl_D_QF 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 516 EngAout3_N_Actl 65535 "Invalid";
+VAL_ 516 ApedPos_PcRate_ActlArb 255 "Fault" 254 "Unknown";
+VAL_ 516 ApedPosPcActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 514 StrtrMtrDlyStrt_B_Stat 1 "Yes" 0 "No";
+VAL_ 514 VehVTrlrAid_B_Avail 1 "Yes" 0 "No";
+VAL_ 514 StrtrMtrCtlMsgTxt_D_Rq 7 "Start_In_Gear_Allowed" 6 "Pending_Start_Cancelled" 5 "Start_Pending_Please_Wait" 4 "Cranking_Limit_Exceeded" 3 "Press_Brk_and_Shift_to_P_N" 2 "Press_Clutch_and_Brake" 1 "Press_Clutch_To_Start" 0 "No_Display";
+VAL_ 514 VehVActlEng_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 514 GearRvrse_D_Actl 7 "Fault" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Active_confirmed" 2 "Active_not_confirmed" 1 "Inactive_confirmed" 0 "Inactive_not_confirmed";
+VAL_ 514 StrtrMtrCtlMsgTxt_D2_Rq 3 "NoRequestPcmStartingMsgCtl" 2 "ShiftToNeutralToStart" 1 "ShiftToParkToStart" 0 "NoRequestBcmStartingMsgCtl";
+VAL_ 512 PtDrvMde_D_Stat 15 "Faulty" 14 "NotUsed11" 13 "NotUsed10" 12 "NotUsed9" 11 "NotUsed8" 10 "NotUsed7" 9 "NotUsed6" 8 "NotUsed5" 7 "Drag" 6 "Rock" 5 "Baja" 4 "Sand" 3 "TowHaulGradeAssist" 2 "SnowWet" 1 "Sport" 0 "Normal";
+VAL_ 381 EngOilSrvcMsgTxt_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "ResetComplete" 3 "ResetInProgress" 2 "ChangeOilNow" 1 "ChangeOilSoon" 0 "NoText";
+VAL_ 381 RunDryPrevent_B_Stat 1 "True" 0 "False";
+VAL_ 381 WaterInFuel 1 "On" 0 "Off";
+VAL_ 381 GlowIndication 1 "On" 0 "Off";
+VAL_ 380 EngOilLvlWarn_D_Rq1 7 "Undefined_3" 6 "Undefined_2" 5 "Engine_Oil_Monitor_Fault" 3 "Engine_Oil_High" 2 "Engine_Oil_Critical_Low" 1 "Engine_Oil_Low" 0 "No_Message" 4 "Engine_Oil_Critical_High";
+VAL_ 380 EngExhBrkOnLamp_B_Rq 1 "On" 0 "Off";
+VAL_ 380 EngExhBrkAutoLamp_B_Rq 1 "On" 0 "Off";
+VAL_ 380 EngExhBrkMde_D_Actl 6 "ExhBrkDisable_NoError" 5 "ExhBrkActive_AUTO" 4 "ExhBrkActive_ON" 3 "ExhBrkRequest_AUTO" 2 "ExhBrkRequest_ON" 1 "ExhBrkNoRequest_OFF" 0 "ExhBrkUnavailable_Error";
+VAL_ 377 HvacAirFullOut_B_Rq 1 "Yes" 0 "No";
+VAL_ 377 FuelFillInlet_B_Dsply 1 "Yes" 0 "No";
+VAL_ 377 EngSrvcRqd_B_Rq 1 "Engine_Service_Required" 0 "No_engine_service_required";
+VAL_ 377 OdoCount 255 "Invalid";
+VAL_ 377 FuelFilterLamp_B_Dsply 1 "On" 0 "Off";
+VAL_ 377 AirCondRec_B_Rq 1 "Yes" 0 "No";
+VAL_ 377 AirCondClutch_B_Stats 1 "Yes" 0 "No";
+VAL_ 376 GasPrtc_D_RqDsply 7 "NotUsed_5" 6 "NotUsed_4" 5 "NotUsed_3" 4 "NotUsed_2" 3 "NotUsed_1" 2 "GpfOverLimit" 1 "GpfAtLimit" 0 "NormalOperation";
+VAL_ 376 DynoMde_B_Cmd 1 "Two_Wheel_Dyno" 0 "Normal_Operation";
+VAL_ 376 AslIconDsply_D_Rq 3 "On_Passive_Overridden" 2 "On_Active" 1 "On_Passive" 0 "Off";
+VAL_ 376 AslChime_B_Rq 1 "Yes" 0 "No";
+VAL_ 376 HvacHtrCore2_Te_Actl 1023 "Faulty";
+VAL_ 376 EcssLamp_D_RqDsply 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 376 AirAmbTe_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 376 AirAmb_P_Actl 63 "Fault" 62 "NoDataExists";
+VAL_ 373 DieslPrtc2_D_RqDsply 15 "NotUsed4" 14 "NotUsed3" 13 "NotUsed2" 12 "NotUsed1" 11 "OCR_ExhFilterClean_Stopped" 10 "OCR_ExhFilterCleaned" 9 "RgnOff_AtLimit" 8 "RgnOff_Overloaded" 7 "RgnOff_Loaded" 6 "Exhaust_Filter_Full" 5 "DPF_Overlimit" 4 "DPF_AtLimit" 3 "ExhFilter_Drive_Completed" 2 "Cleaning_Exhaust_Filter" 1 "DPF_Overloaded" 0 "DPF_Normal_Operation";
+VAL_ 373 DieslPrtcRgen_D_Actl 3 "Undefined" 2 "Regen_Level_2" 1 "Regen_Level_1" 0 "No_regen";
+VAL_ 373 EngTeColdPrtct_D_Stats 3 "Engine_Warm_RdcPwr" 2 "OK_to_Drive" 1 "Engine_Warm_PlsWait" 0 "Normal_Operation";
+VAL_ 373 EngExhOvrTe_B_RqDsply 1 "Active" 0 "Inactive";
+VAL_ 359 PrplWhlRgenMn_Tq_Actl 8191 "Faulty";
+VAL_ 359 ElPw_D_StatStrtStop 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "Supported_Level_4" 8 "Supported_Level_3" 7 "Supported_Level_2" 6 "Supported_Level_1" 5 "Limited_Support" 4 "Fault_Limited" 3 "LV_Event_in_Progress" 2 "Not_Supported_Imminent" 1 "Supported_All" 0 "Not_Supported";
+VAL_ 359 PrplWhlTot2_Tq_Actl 65535 "Fault" 65534 "NoDataExists";
+VAL_ 359 PwPckTq_D_Stat 3 "PwPckOn_TqAvailable" 2 "StartInPrgrss_TqNotAvail" 1 "PwPckOn_TqNotAvailable" 0 "PwPckOff_TqNotAvailable";
+VAL_ 359 Eng_D_Stat 3 "NotUsed" 2 "EngAutoStopped" 1 "EngOn" 0 "EngOff";
+VAL_ 359 PlgActvArb_B_Actl 1 "On" 0 "Off";
+VAL_ 359 ElPw_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Fault_Limited" 3 "LV_Event_In_Progress" 2 "Not_Supported_Imminent" 1 "Supported" 0 "Not_Supported";
+VAL_ 359 TrnAinTq_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 358 StopStrtStdby_D_Indic 6 "NotUsed2" 5 "Telltale_Struck_Out" 4 "Telltale_Flashing_Amber" 3 "Telltale_On_Amber" 2 "Telltale_Flashing_Green" 1 "Telltale_On_Green" 0 "Telltale_Off" 7 "NotUsed3";
+VAL_ 358 StopStrtIODTxt_D_Rq 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 358 StopStrtDrvMde_D_Indic 3 "NotUsed" 2 "StartStop_IndirectDeselect" 1 "StopStart_Deselected" 0 "StopStart_Selected";
+VAL_ 358 StopStrtMsgTxt_D_Rq 15 "Message_15" 14 "Message_14" 13 "Message_13" 12 "Message_12" 11 "Message_11" 10 "Message_10" 9 "Message_9" 8 "Message_8" 7 "Message_7" 6 "Message_6" 5 "Message_5" 4 "Message_4" 3 "Message_3" 2 "Message_2" 1 "Message_1" 0 "NoMessage";
+VAL_ 358 OdoTripVerify_L_Actl 16777215 "Fault";
+VAL_ 358 HiElPwInhbt_B_Stat 1 "Inhibit" 0 "No_Inibit";
+VAL_ 358 AutoStopPtDelta_I_Est 255 "Fault";
+VAL_ 357 BPedDrvAppl_D_QF 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 357 CmbbDeny_B_ActlPrpl 1 "Yes" 0 "No";
+VAL_ 357 PrplTqMnSat_B_Actl 1 "Yes" 0 "No";
+VAL_ 357 BpedDrvAppl_D_Actl 3 "_Not_Allowed" 2 "Driver_Braking" 1 "Driver_Not_Braking" 0 "Not_Allowed";
+VAL_ 357 CmbbEngTqMn_B_Actl 1 "Yes" 0 "No";
+VAL_ 357 Veh_V_DsplyCcSet 255 "Fault" 254 "Unknown";
+VAL_ 357 AccEngStat_D_Actl 7 "Undefined_2" 6 "Undefined_1" 5 "ACCSoonCancel_due_Low_Spd" 4 "Shift_Down_Recommendation" 3 "Shift_Up_Recommendation" 2 "ACCNotAllowedToBeActivated" 1 "ACCStandby_due_Auto_Cancel" 0 "Normal_Operation";
+VAL_ 357 CcMde_D_Actl 7 "TapDownWaiting" 6 "TapUpWaiting" 5 "Resuming_Low" 4 "Resuming_High" 3 "Decelerating" 2 "Accelerating" 1 "Keeping_Speed" 0 "Not_Active";
+VAL_ 357 CcStat_D_Actl 7 "Undefined_2" 6 "Undefined_1" 5 "Active" 4 "Active_Que_Assist" 3 "Standby" 2 "Standby_Denied" 1 "Denied" 0 "Off";
+VAL_ 357 CcOvrrdActv_B_Actl 1 "Cruise_Overridden" 0 "Cruise_Req_Not_Overridden";
+VAL_ 357 AccStopMde_D_Rq 3 "Stop_Mode_Active" 2 "EPBApplyOrBrakeReleaseWarn" 1 "Limit_Rolling_Speed" 0 "Stop_Mode_Not_Active";
+VAL_ 355 AutoRgenTxt_B_RqDsply 1 "AutExhFilterCleanOFF" 0 "AutExhFilterCleanON";
+VAL_ 355 AccFllwMdeActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 355 EngPtoMde_D_Actl 7 "Undefined" 6 "Split_Shaft_Stationary" 5 "Not_Used_2" 4 "PTO_Mobile" 3 "Not_Used_1" 2 "PTO_Stationary" 1 "BCP" 0 "Off";
+VAL_ 355 ManRgenTxt_D_RqDsply 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Cleaning_Aborted_Stopped" 3 "Cleaning_Completed" 2 "Cleaning_In_Progress" 1 "Cleaning_Allowed" 0 "Cleaning_Not_Allowed";
+VAL_ 355 ManRgenSoot_Pc_RqDsply 127 "Fault";
+VAL_ 355 DieslMsgTxt_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "ReducedEnginePower" 0 "NoMessage";
+VAL_ 342 EngOvrhtMitgActv_D_Ind 3 "Undefined" 2 "Mode2" 1 "Mode1" 0 "Normal_Mode";
+VAL_ 342 EngClntTe_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 342 EngOil_Te_Actl 255 "Fault" 254 "Unknown";
+VAL_ 71 immoTarget1Status 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "DISABLED_RESET   " 2 "ENABLED_NONMOTIVE_START" 1 "ENABLED_MOTIVE_START" 0 "DISABLED";
+VAL_ 71 immoTarget1Cmd 7 "Unused4" 6 "Unused3" 5 "Unused2" 4 "Unused1" 3 "TARGET1_IDBLOCK2" 2 "TARGET1_IDBLOCK1" 1 "CHALLENGE" 0 "IDLE";
+VAL_ 1006 PersIndexIpmb_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 820 AhbStatGfhbFdbk_D_Actl 3 "GfhbHighBeamFullyOn" 2 "GfhbHighBeamPartlyOn" 1 "GfhbHighBeamOff" 0 "GfhbUnavailable";
+VAL_ 820 HeadLghtDrvSide_B_Stat 1 "Left_Hand_Traffic" 0 "Right_Hand_Traffic";
+VAL_ 820 HeadLghtHiOn_B_StatHcm 1 "On" 0 "Off";
+VAL_ 820 Adaptive_Hdlmp_Fault 1 "Yes" 0 "No";
+VAL_ 137 SteWhlOffstRq_D_Stat 3 "Faulty" 2 "NoDataExists" 1 "Allow_External_Angle_Req" 0 "Deny_External_Angle_Req";
+VAL_ 137 SteWhlOffst_An_TotActl 32767 "Faulty" 32766 "NoDataExists";
+VAL_ 137 SteWhlBrkOffst_An_Actl 32767 "Faulty" 32766 "NoDataExists";
+VAL_ 129 SelDrvMdeSwtch_D_Stat4 3 "Faulty" 2 "SwitchState2" 1 "SwitchState1" 0 "NotPressed";
+VAL_ 129 SteWhlSwtchView_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchSet_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchPhon_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchNav_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchMed_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchIod_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchHud_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchBack_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchMenu_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteEffortInc_B_RqDrv 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SelDrvMdeInc_B_RqDrv 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SelDrvMdeDec_B_RqDrv 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SuspDampInc_B_RqDrv 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchUp_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchRght_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchOk_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchLeft_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchDown_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchHome_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 129 SteWhlSwtchInfo_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 935 SodRight_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Invalid" 3 "Disabled" 2 "On" 1 "Trailer_Tow_Off" 0 "Off";
+VAL_ 935 CtaAlrtRight2_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "AlertZone4" 3 "AlertZone3" 2 "AlertZone2" 1 "AlertZone1" 0 "Off";
+VAL_ 935 BttRight_D_Stat 7 "NotUsed" 6 "Disabled" 5 "Off" 4 "OffTemp" 3 "NotConnected" 2 "Pending" 1 "Connected" 0 "NotDetermined";
+VAL_ 935 BttRight_D_RqDrv 3 "NotUsed" 2 "Request" 1 "NoRequest" 0 "Null";
+VAL_ 935 CtaBrkRightMsgTxt_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 935 CtaRightBrkEnbl_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 935 CtaRightBrkDecel_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 935 CtaSnsRight_D_Stat 3 "Invalid" 2 "System_Failure" 1 "Blocked" 0 "Clear";
+VAL_ 935 CtaAlrtRight_D_Stat 1 "On" 0 "Off";
+VAL_ 935 CtaRight_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Invalid" 3 "Disabled" 2 "On" 1 "Trailer_Tow_Off" 0 "Off";
+VAL_ 935 SodSnsRight_D_Stat 3 "Second_Warning_Audio" 2 "System_Failure" 1 "Blocked" 0 "Clear";
+VAL_ 935 SodAlrtRight_D_Stat 3 "Bulb_Proveout" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 935 SodDetctRight_D_Stat 4 "Sensor_Blocked" 3 "Sensor_Fault" 2 "Flash_On" 1 "Alert_On" 0 "AlertOff_FlashOff_SensrClr";
+VAL_ 1108 RCMSerialNoByte8 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte7 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte6 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte5 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte4 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte3 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte2 255 "Invalid" 254 "Unknown";
+VAL_ 1108 RCMSerialNoByte1 255 "Invalid" 254 "Unknown";
+VAL_ 261 ChrgStatDsply_D_Rq 3 "NotUsed_2" 2 "NotUsed_1" 1 "On" 0 "Off";
+VAL_ 261 NextUsageTimeToggle_Rq 0 "Inactive" 2 "Disable" 1 "Enable";
+VAL_ 261 LongTermParking_Rq 0 "Inactive" 1 "On" 2 "Off" 3 "NotUsed";
+VAL_ 261 ModemReset_D_Rq 15 "NotUsed_11" 14 "NotUsed_10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "NotUsed_4" 7 "NotUsed_3" 6 "BrandConnectReset2" 5 "BrandConnectReset1" 4 "CcsReset" 3 "OnlineTrafficReset" 2 "PaakReset" 1 "WifiHotspotReset" 0 "Null";
+VAL_ 261 StopStrtDrvMde_B_RqBtn3 1 "Pressed" 0 "Not_Pressed";
+VAL_ 261 TCU_ESN_D_Rq 3 "NotUsed" 2 "TCU_ESN_Request" 1 "NoRequest" 0 "Inactive";
+VAL_ 261 FactoryReset_Rq 1 "ResetFactoryDefaults" 0 "Inactive";
+VAL_ 1146 TrlrAidSwtch_D_RqDrv 3 "Faulty" 2 "NotUsed" 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1146 TrlrAidCtl_U_RqDrv 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 533 DcacGfciTestBttn_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 533 DcacPwResetButtn_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 533 DcacPwOffButtn_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 533 DcacPwLoButtn_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 533 DcacPwHiButtn_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 533 DcacPwButtn_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 533 TrlrHitch_D_RqMnu 15 "NotUsed_10" 14 "NotUsed_9" 13 "NotUsed_8" 12 "NotUsed_7" 11 "NotUsed_6" 10 "NotUsed_5" 9 "NotUsed_4" 8 "NotUsed_3" 7 "NotUsed_2" 6 "NotUsed_1" 5 "GoToTraileringDomain" 4 "Confirm" 3 "TurnOnTba" 2 "TurnOnAutohitch" 1 "CancelAutohitch" 0 "NoRequest";
+VAL_ 533 AutoEpbZoomView_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 533 AutoEpbButtn_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 533 TrlrAidMde_D_Rq 3 "Mode_3" 2 "Mode_2" 1 "Mode_1" 0 "NoRequest";
+VAL_ 533 TCU_Init_Actvtn_St 3 "NotUsed" 2 "InitialActivateDeny" 1 "InitialActivateAccept" 0 "Invalid";
+VAL_ 533 TCU_Final_Actvtn_St 3 "NotUsed" 2 "FinalActivateDeny" 1 "FinalActivateAccept" 0 "Invalid";
+VAL_ 533 OtaTrg_D_Stat 3 "NotUsed_1" 2 "Accepted" 1 "NotAccepted" 0 "Null";
+VAL_ 533 OnbChrgGoTTouch_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 533 OnbChrgGoTPrcond_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 533 OnbChrgGoTOn_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 533 OnbChrgGoTMnte_D_Rq 15 "NotUsed_4" 14 "NotUsed_3" 13 "NotUsed_2" 12 "NotUsed_1" 11 "Minute_55" 10 "Minute_50" 9 "Minute_45" 8 "Minute_40" 7 "Minute_35" 6 "Minute_30" 5 "Minute_25" 4 "Minute_20" 3 "Minute_15" 2 "Minute_10" 1 "Minute_5" 0 "Minute_0";
+VAL_ 533 OnbChrgGoTHr_T_Rq 31 "Faulty" 30 "NoDataExists";
+VAL_ 533 OnbChrgGoTExtHtr_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 533 OnbChrgGoTDelete_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 533 OnbChrgClearAll_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 533 PaakMyKey_D_Rq 3 "NotUsed" 2 "ConfirmNewPaakMyKey" 1 "RequestNewPaakMyKey" 0 "None";
+VAL_ 533 OnbChrgGoTUpdate_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 1041 ElCmprUHi_D_Stat 3 "Overvoltage" 2 "Undervoltage" 1 "InRange" 0 "Undetermined";
+VAL_ 1041 ElCmprOverTe_D_Stat 3 "OverTempStop" 2 "OverTempWarning" 1 "Normal" 0 "Undefined";
+VAL_ 1041 ElCmpr_N_Actl 255 "Invalid";
+VAL_ 1041 ElCmpr_Pw_Actl 255 "Invalid";
+VAL_ 1041 ElCmpr_D_Stat 7 "Signal_Invalid" 6 "Comp_Off_ActlSpd_Abnormal" 5 "Comp_Off_TrgtSpd_OutRange" 4 "Comp_Shutdown" 3 "Comp_Stopped_Self_Protect" 2 "Comp_Degraded" 1 "Comp_On" 0 "Comp_Off";
+VAL_ 1041 ElCmprPerfErr_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprInnrErr_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprLostComm_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprOverLoad_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprOverTe_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprBattURng_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprBattSysU_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1041 ElCmprSysU_D_Falt 3 "NotUsed" 2 "Pass" 1 "Fail" 0 "Not_Diagnose_Yet";
+VAL_ 1067 BattULoAuxIsol_D_Rq 3 "Undefined" 2 "Retain" 1 "Close" 0 "Open";
+VAL_ 1067 BattULoAux_U_Rq 4095 "Faulty";
+VAL_ 1067 BattULoAux_I_Actl 4095 "Faulty";
+VAL_ 1067 BattULoAux_D_Qlty 3 "OK" 2 "Not_Within_Specifications" 1 "Eval_In_Progress" 0 "Faulty";
+VAL_ 1067 BattULoAux_U_Actl 255 "Faulty";
+VAL_ 1067 BattULoAux_B_Falt 1 "Fault" 0 "No_Fault";
+VAL_ 1112 BattTracChrgSustn_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 1112 BattTracCnnct_D_Cmd 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "WeldCheck" 3 "OkToDischarge" 2 "Closed" 1 "Precharge" 0 "Open";
+VAL_ 1112 BattTracHvilOpen_B_Stat 1 "Open" 0 "Closed";
+VAL_ 1112 BattTracDcdcDis_B_Rq 1 "Yes" 0 "No";
+VAL_ 1112 HtrnClntPump_D_Stat 3 "Faulty" 2 "No_Data_Exists" 1 "On" 0 "Off";
+VAL_ 1112 BattTracClntPmp_D_Stat 3 "Faulty" 2 "No_Data_Exists" 1 "On" 0 "Off";
+VAL_ 139 AfsPw_B_Rq 1 "Yes" 0 "No";
+VAL_ 139 AccButtnGpTogglePress2 1 "Pressed" 0 "Not_Pressed";
+VAL_ 139 TjaButtnOnOffPress2 1 "Pressed" 0 "Not_Pressed";
+VAL_ 139 ActvFrontSteMsgTxt_D_Rq 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 139 ActvFrontSteLck_D_Stat 3 "Test_passed" 2 "Test_failed" 1 "Test_cannot_run" 0 "Test_incomplete";
+VAL_ 139 SelDrvMdeAdptSte_D_Stat 3 "Faulty" 2 "TemporarilyNotAvailable" 1 "Available" 0 "NotAvailable";
+VAL_ 139 AslButtnOnOffPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 AslButtnOnOffCnclPres2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcButtnOnPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcButtnOnOffPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcButtnOnOffCnclPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcButtnOffPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAsllButtnResPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnSetPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnSetIncPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnSetDecPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnResIncPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnResDecPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnOnPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnOnOffCncl2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnOffCnclPres2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnIndxIncPres2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnIndxDecPres2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnDeny_B_Actl2 1 "Yes" 0 "No";
+VAL_ 139 CcAslButtnCnclResPres2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 CcAslButtnCnclPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 AccButtnGapIncPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 139 AccButtnGapDecPress2 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 1121 SelDrvMdeSwtch_D_Stat 3 "Faulty" 2 "SwitchState2" 1 "SwitchState1" 0 "NotPressed";
+VAL_ 1121 SelDrvMdeCnt_D_Stat 4 "FourCounts" 3 "ThreeCounts" 2 "TwoCounts" 1 "OneCount" 0 "ZeroCounts" 7 "SevenOrMoreCounts" 6 "SixCounts" 5 "FiveCounts";
+VAL_ 1120 DrvSlipCtlMde_B_Rq3 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1120 HybMdeSwtch_B_Rq 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1120 TrailCtlSwtch_B_Stat3 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1120 RearDiffLck_D_RqDrv 3 "Faulty" 2 "NoRequest" 1 "On" 0 "Off";
+VAL_ 1120 AwdMde_D_RqDrv 7 "Faulty" 6 "NotUsed2" 5 "NoRequest" 4 "Neutral" 3 "FourByFourLow" 2 "FourByFourHigh" 1 "FourByFourAuto" 0 "FourByTwo";
+VAL_ 1120 HdcSwtchPos_B_Actl 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1050 AutoHoldSwtch_D_Stat 3 "Faulty" 2 "NotUsed" 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1050 LpdbPtc3_B_Rq 1 "On" 0 "Off";
+VAL_ 1050 LpdbPtc2_B_Rq 1 "On" 0 "Off";
+VAL_ 1050 LpdbPtc1_B_Rq 1 "On" 0 "Off";
+VAL_ 1050 LpdbHeatWiprPrk_B_Rq 1 "On" 0 "Off";
+VAL_ 1050 LpdbDfrstRearOn_B_Rq 1 "On" 0 "Off";
+VAL_ 1050 SteWhlHeat_D_Rq 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "Reserved_3" 8 "Reserved_2" 7 "Reserved_1" 6 "Level_3_Heating" 5 "Level_3_Heating_LS" 4 "Level_2_Heating" 3 "Level_2_Heating_LS" 2 "Level_1_Heating" 1 "Level_1_Heating_LS" 0 "Off";
+VAL_ 1050 MirrorHeatOn_B_Rq 1 "True" 0 "False";
+VAL_ 1050 Remote_Start_QuietMode 1 "Quiet" 0 "Not_Quiet";
+VAL_ 1050 Outside_Air_Temp_Stat 255 "Invalid" 254 "Unknown";
+VAL_ 1137 RngPerChrgAvg_L_Dsply 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 1255 BalrRight4Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1255 BalrRight4Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1255 BalrRight4Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1254 BalrRight3Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1254 BalrRight3Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1254 BalrRight3Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1253 BalrRight2Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1253 BalrRight2Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1253 BalrRight2Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1252 BalrRight1Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1252 BalrRight1Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1252 BalrRight1Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1251 BalrLeft4Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1251 BalrLeft4Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1251 BalrLeft4Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1250 BalrLeft3Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1250 BalrLeft3Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1250 BalrLeft3Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1249 BalrLeft2Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1249 BalrLeft2Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1249 BalrLeft2Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1248 BalrLeft1Threat_D_Stat 1 "Yes" 0 "No";
+VAL_ 1248 BalrLeft1Fast_B_Stat 1 "Yes" 0 "No";
+VAL_ 1248 BalrLeft1Dsply_B_Stat 1 "Yes" 0 "No";
+VAL_ 1113 TrlrTrgtAcquire_D_Stat 7 "Faulty" 6 "NotUsed_2" 5 "NotUsed_1" 4 "RVCforTBA_Activated" 3 "Processing" 2 "TargetNotAcquired" 1 "TargetAcquired" 0 "Null";
+VAL_ 1113 TrlrAnOffstDir_D_Calc 3 "NotUSed" 2 "Right" 1 "Left_or_Center" 0 "Null";
+VAL_ 1113 TrlrAnCalib_B_Complt 1 "Yes" 0 "No";
+VAL_ 1113 TrlrRvrse_D_Stat 3 "Faulty" 2 "TrailerReverseGuidanceLite" 1 "On" 0 "Off";
+VAL_ 1113 TrlrAid_D2_Stat 15 "Faulty" 14 "NotUsed_4" 13 "NotUsed_3" 12 "NotUsed_2" 11 "NotUsed_1" 10 "DirtyCamera" 9 "IncorrectLighting" 8 "TrackingLost" 7 "TrackingUnknownConfidence" 6 "TrackingHighConfidence" 5 "TrackingMediumConfidence" 4 "TrackingLowConfidence" 3 "TurnRequested" 2 "DriveStraighRequested" 1 "Initializing" 0 "NotTracking";
+VAL_ 1113 TrlrAid_An3_Actl 2047 "Faulty";
+VAL_ 1113 TrlrAid_AnRate2_Actl 1023 "Faulty";
+VAL_ 1113 HitchToVehAxle_L_Calc 255 "Faulty";
+VAL_ 1105 TrlrAidSwtchLamp_B_Rq 1 "On" 0 "Off";
+VAL_ 1105 TrlrHitchMsgTxt_D_Rq 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage" 63 "Message63" 47 "Message47";
+VAL_ 1105 TrlrHitchIcon_D_Rq 15 "Icon15" 14 "Icon14" 13 "Icon13" 12 "Icon12" 11 "Icon11" 10 "Icon10" 9 "Icon9" 8 "Icon8" 7 "Icon7" 6 "Icon6" 5 "Icon5" 4 "Icon4" 3 "Icon3" 2 "Icon2" 1 "Icon1" 0 "NoIcon";
+VAL_ 1105 TrlrHitchChime_D_Rq 7 "NotUsed_1" 6 "NotUsed_1" 5 "WarningChime" 4 "NonCriticalAlertChime" 3 "StopNowChime" 2 "ManeuveringReadyChime" 1 "TrailerFoundChime" 0 "NoChime";
+VAL_ 1105 TrlrAidEnbl_D_RqAdas 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "Deactivate" 2 "NotAvailable" 1 "ActiveTba" 0 "Inactive";
+VAL_ 1105 TrlrRvrseMsgTxt_D2_Rq 31 "Message31" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 1105 TrlrRvrseEnbl_D2_Stat 7 "NotUsed" 6 "TbaActiveExpertActive" 5 "TbaActiveExpertAvail" 4 "TbaOffTrgActive" 3 "TbaOffTrgSetup" 2 "TbaSetup" 1 "TbaActive" 0 "Inactive";
+VAL_ 1105 RbaMsg_D_Rq 3 "Faulty" 2 "Unavailable" 1 "Off" 0 "Null";
+VAL_ 1105 BrkDecel_B_RqRba 1 "Enable" 0 "Disable";
+VAL_ 1105 BrkEnbl_B_RqRba 1 "Enable" 0 "Disable";
+VAL_ 1105 Rba_D_Stat 3 "NotUsed" 2 "Disabled" 1 "On" 0 "Off";
+VAL_ 1105 RbaAlrt_D_Dsply 3 "Both" 2 "Text" 1 "Graphic" 0 "Off";
+VAL_ 1105 RbaMnu_D_Rq 3 "NotUsed" 2 "Active" 1 "Inactive" 0 "None";
+VAL_ 1105 CamraFrntStat_D_Stat 3 "No_Data_Present" 2 "NotUsed" 1 "On" 0 "Off";
+VAL_ 1105 TrlrHitchLamp_D_Rq2 1 "On" 0 "Off";
+VAL_ 938 SidePrkSnsR2_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 938 SidePrkSnsR1_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 938 SidePrkSnsL2_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 938 ApaMde_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "POA" 3 "PPA" 2 "SAPP" 1 "Off" 0 "Null";
+VAL_ 938 ApaActvSd_D_Actl 3 "Dirver_Side" 2 "Passenger_Side" 1 "No_Side" 0 "Null";
+VAL_ 938 PrkAidSwtch_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 938 ApaMde_D_Avail 15 "NotUsed7" 14 "NotUsed6" 13 "NotUsed5" 12 "NotUsed4" 11 "NotUsed3" 10 "NotUsed2" 9 "NotUsed1" 8 "PPA_POA" 7 "SAPP_POA" 6 "POA" 5 "PPA" 4 "SAPP" 3 "SAPP_PPA_POA" 2 "SAPP_PPA" 1 "None" 0 "Null";
+VAL_ 938 PrkAidSnsFrCrnr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 938 PrkAidSnsFrCntr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 938 PrkAidSnsFlCrnr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 938 PrkAidSnsFlCntr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 938 PrkBrkEl_B_RqFap 1 "Yes" 0 "No";
+VAL_ 938 RpaChime_D_Rq 15 "Zone15_Chime" 14 "Zone14_Chime" 13 "Zone13_Chime" 12 "Zone12_Chime" 11 "Zone11_Chime" 10 "Zone10_Chime" 9 "Zone9_Chime" 8 "Zone8_Chime" 7 "Zone7_Chime" 6 "Zone6_Chime" 5 "Zone5_Chime" 4 "Zone4_Chime" 3 "Zone3_Chime" 2 "Zone2_Chime" 1 "Zone1_Chime" 0 "No_Chime";
+VAL_ 938 FpaChime_D_Rq 15 "Zone15_Chime" 14 "Zone14_Chime" 13 "Zone13_Chime" 12 "Zone12_Chime" 11 "Zone11_Chime" 10 "Zone10_Chime" 9 "Zone9_Chime" 8 "Zone8_Chime" 7 "Zone7_Chime" 6 "Zone6_Chime" 5 "Zone5_Chime" 4 "Zone4_Chime" 3 "Zone3_Chime" 2 "Zone2_Chime" 1 "Zone1_Chime" 0 "No_Chime";
+VAL_ 938 PrkAidMsgTxt_D_Rq 15 "All_Sns_Blk" 14 "R_Sns_ON_F_Sns_Blk" 13 "R_Sns_Blk_F_Sns_ON" 12 "R_Sns_Inactive_Trlr_atch" 11 "Not_Avail_Trlr_attchd" 10 "Fail_Mode_no_Chime" 9 "Fail_Mode_with_Chime" 8 "R_Sns_Trlr_F_Sns_Blk" 7 "NotUsed3" 6 "Park_Sys_Alternate_Mode" 5 "R_Snsrs_On_F_Snsrs_On" 4 "NotUsed2" 3 "Reset_Message_Warn" 2 "R_Snsrs_Off_F_Snsrs_On" 1 "R_Snsrs_On_F_Snsrs_Off" 0 "All_Park_Sensors_Off";
+VAL_ 938 SidePrkSnsL1_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 938 PrkAidAudioMute_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 939 ApaBrk_D_Rq 3 "NotUsed" 2 "LowDecel" 1 "HighDecel" 0 "NoRequest";
+VAL_ 939 SidePrkSnsR4_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 939 SidePrkSnsR3_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 939 SidePrkSnsL4_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 939 SidePrkSnsL3_D_Stat 15 "NotUsed" 14 "NotFullyScannedYet" 13 "NoObjectInSector" 12 "Zone12" 11 "Zone11" 10 "Zone10" 9 "Zone9" 8 "Zone8" 7 "Zone7" 6 "Zone6" 5 "Zone5" 4 "Zone4" 3 "Zone3" 2 "Zone2" 1 "Zone1" 0 "Off";
+VAL_ 939 PrkAidChime_D_Stat 3 "Fault" 2 "No_Data_Exists" 1 "On" 0 "Off";
+VAL_ 939 PrkAidSnsRlCntr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 939 PrkAidSnsRrCrnr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 939 PrkAidSnsRrCntr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 939 PrkAidSnsRlCrnr_D_Stat 15 "Zone_15" 14 "Zone_14" 13 "Zone_13" 12 "Zone_12" 11 "Zone_11" 10 "Zone_10" 9 "Zone_9" 8 "Zone_8" 7 "Zone_7" 6 "Zone_6" 5 "Zone_5" 4 "Zone_4" 3 "Zone_3" 2 "Zone_2" 1 "Zone_1" 0 "Off";
+VAL_ 939 PrkAidRear_D_Stat 3 "Faulted" 2 "Unused" 1 "Enabled" 0 "Disabled";
+VAL_ 939 PrkAidFront_D_Stat 3 "Faulted" 2 "Unused" 1 "Enabled" 0 "Disabled";
+VAL_ 939 PrkAid_D_Falt 7 "NotUsed2" 6 "NotUsed1" 5 "Failure_Front_PSM_Sensors" 4 "No_Data_Exists" 3 "Failure_Rear_Sensors" 2 "Speaker_Fault" 1 "ECU_Fault" 0 "No_Fault";
+VAL_ 939 ApaLongCtrlEnbl_D_Rq 1 "Enable" 0 "Disable";
+VAL_ 939 PrkAidLamp_D_Rq 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 937 TrnRng_D_RqFap 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Backwards" 3 "Forwards" 2 "NoMotion" 1 "Immobilize" 0 "NoRequest";
+VAL_ 937 FapLcDistToObj_L_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 936 ApaButtnPrssd_B_Stat 1 "Pressed" 0 "Not_Pressed";
+VAL_ 936 ApaSys_D_Stat 7 "Faulty" 6 "Finished" 5 "NotAccessible" 4 "ApaCancelled" 3 "Overspeed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 936 ApaSteWhl_D_RqDrv 3 "TakeControl" 2 "RemoveHands" 1 "NoRequest" 0 "Null";
+VAL_ 936 ApaSteScanMde_D_Stat 3 "Steering" 2 "Scanning" 1 "NotScanning" 0 "Null";
+VAL_ 936 ApaSelSapp_D_Stat 3 "NotConfigured" 2 "NotSelectable" 1 "Selectable" 0 "Null";
+VAL_ 936 ApaSelPpa_D_Stat 3 "NotConfigured" 2 "NotSelectable" 1 "Selectable" 0 "Null";
+VAL_ 936 ApaSelPoa_D_Stat 3 "NotConfigured" 2 "NotSelectable" 1 "Selectable" 0 "Null";
+VAL_ 936 ApaScan_D_Stat 3 "ParkSlotReady" 2 "ParkSlotFound" 1 "NoParkSlot" 0 "Null";
+VAL_ 936 ApaLongCtl_D_RqDrv 7 "NotUsed3" 6 "NotUsed2" 5 "ReleaseBrake" 4 "DriveBackward" 3 "DriveForward" 2 "Stop" 1 "NoRequest" 0 "Null";
+VAL_ 936 ApaGearShif_D_RqDrv 7 "NotUSed2" 6 "NotUsed1" 5 "ShiftToP" 4 "ShiftToN" 3 "ShiftToD" 2 "ShiftToR" 1 "NoRequest" 0 "Null";
+VAL_ 936 ApaActvSide2_D_Stat 3 "NoSide" 2 "Right" 1 "Left" 0 "Null";
+VAL_ 936 ApaAcsy_D_RqDrv 7 "CloseDoor" 6 "SelectSideRight" 5 "SelectSideLeft" 4 "CheckForObject" 3 "PressApaButton" 2 "SelectSide" 1 "NoRequest" 0 "Null";
+VAL_ 936 ApaTrgtDist_D_Stat 15 "Step15" 14 "Step14" 13 "Step13" 12 "Step12" 11 "Step11" 10 "Step10" 9 "Step9" 8 "Step8" 7 "Step7" 6 "Step6" 5 "Step5" 4 "Step4" 3 "Step3" 2 "Step2" 1 "Step1" 0 "Off";
+VAL_ 936 ApaChime_D_Rq 7 "NotUsed2" 6 "NotUsed1" 5 "Warning_Chime" 4 "Finish_Chime" 3 "Stop_Now_Chime" 2 "Spot_Ready_Chime" 1 "Spot_Found_Chime" 0 "No_Chime";
+VAL_ 936 EPASExtAngleStatReq 1 "Request" 0 "NoRequest";
+VAL_ 936 ExtSteeringAngleReq2 32767 "Invalid" 32766 "Unknown";
+VAL_ 877 VehElEffAvg_No_Dsply 127 "Faulty" 126 "NoDataExists";
+VAL_ 877 PwFlwFuelDrv_D_Dsply 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "FlwFromFuelToAllWhls" 2 "FlwFromFuelToFrontWhls" 1 "FlwFromFuelToRearWhls" 0 "NoFlow";
+VAL_ 877 PwFlwFuelClimt_B_Dsply 1 "On" 0 "Off";
+VAL_ 877 PwFlwFuelBatt_B_Dsply 1 "On" 0 "Off";
+VAL_ 877 PwFlwBattClimt_B_Dsply 1 "On" 0 "Off";
+VAL_ 877 PwFlwBatt_D_Dsply 15 "NotUsed_8" 14 "NotUsed_7" 13 "NotUsed_6" 12 "NotUsed_5" 11 "NotUsed_4" 10 "NotUsed_3" 9 "NotUsed_2" 8 "NotUsed_1" 7 "FlwFromWallToBatt" 6 "FlwFromAllWhlsToBatt" 5 "FlwFromBattToAllWhls" 4 "FlwFromFrontWhlsToBatt" 3 "FlwFromBattToFrontWhls" 2 "FlwFromRearWhlsToBatt" 1 "FlwFromBattToRearWhls" 0 "NoFlow";
+VAL_ 588 BattTracSoc2_Pc_Actl 16383 "Faulty" 16382 "NoDataExists";
+VAL_ 588 BattTrac_Te_Actl 1023 "Fault" 1022 "Unknown";
+VAL_ 588 BattTracDiagClr_B_Rq 1 "On" 0 "Off";
+VAL_ 587 BattTracWarnLamp_B_Rq 1 "On" 0 "Off";
+VAL_ 587 BattTracSrvcRqd_B_Rq 1 "On" 0 "Off";
+VAL_ 389 HtrnOvrTeLamp_B_Dsply 1 "On" 0 "Off";
+VAL_ 389 HtrnMil_D_Rq 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 389 HtrnAin_UHi_Actl 1023 "Fault" 1022 "Unknown";
+VAL_ 389 HtrnSrvcRqd_B_Dsply 1 "On" 0 "Off";
+VAL_ 389 HtrnHvilOpen_B_Actl 1 "HVIL_is_Open" 0 "Normal_Operation";
+VAL_ 389 PtWakeupDeltaT_T_Rq 2047 "Fault" 2046 "NoDataExists";
+VAL_ 389 PreCondActv_B_Actl 1 "On" 0 "Off";
+VAL_ 389 DrvCondTpRrDefrs_B_Rq 1 "On" 0 "Off";
+VAL_ 389 BattTrac_I_EstVsc 32767 "Fault" 32766 "NoDataExists";
+VAL_ 1009 ChrgCordUnlock_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 1009 AutoHoldSwtch_D_Stat3 3 "Faulty" 2 "NotUsed" 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1009 TrlrTrgtAcquire_D_Rq 7 "NotUsed_2" 6 "NotUsed_1" 5 "ActivateRVCforTBA" 4 "CancelAcquisition" 3 "RetryAcquisition" 2 "AcquisitionSuccessful" 1 "StartAcquisition" 0 "Inactive";
+VAL_ 1009 TrlrAidCancl_B_Rq 1 "Cancel" 0 "Null";
+VAL_ 1009 CenterStackRing_D_Actl 3 "LimitedOn" 2 "On" 1 "Off" 0 "Null";
+VAL_ 1009 ValetMode_D_Stat 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 1009 TrlrAidSetup_D_Stat 7 "Faulty" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "EnterParameters" 2 "EndSetup" 1 "BeginSetup" 0 "Null";
+VAL_ 360 GsmSrvcRqd_B_Rq 1 "Yes" 0 "No";
+VAL_ 360 TrnGearPwmFalt_B_Actl 1 "Yes" 0 "No";
+VAL_ 360 GearButtnStuck_B_Actl 1 "Yes" 0 "No";
+VAL_ 122 VehStrtInhbt_B_RqBatt 1 "Yes" 0 "No";
+VAL_ 122 BattTracOffFst_D_Actl 3 "Unexpected_Contactor_Open" 2 "Restraints_Impact_Event" 1 "Interlock_Open" 0 "Normal";
+VAL_ 122 BattTracOff_B_Actl 1 "Yes" 0 "No";
+VAL_ 122 BattTracMil_D_Rq 3 "Not_Used" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 122 BattTrac_U_Actl 1023 "Fault" 1022 "Unknown";
+VAL_ 122 BattTrac_I_Actl 32767 "Fault" 32766 "Unknown";
+VAL_ 90 TrnGsmNtmState_D_Actl 3 "Faulty" 2 "Neutral_Tow_Mode" 1 "Car_Wash_Mode" 0 "None";
+VAL_ 90 DrQltyDrv_D_StatGsm 7 "Faulty" 6 "NoDataExists" 5 "NotUsed2" 4 "NotUsed1" 3 "ClosedDegraded" 2 "OpenDegraded" 1 "ClosedOkay" 0 "OpenOkay";
+VAL_ 90 TrnBtsiOvrrd_B_Stat 1 "Override" 0 "Null";
+VAL_ 90 GsmGearMsgTxt_D_Rq 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 90 TrnRng_D_RqGsm 15 "Fault" 14 "UnknownPosition" 13 "Undefined_2" 12 "Undefined_1" 11 "_6" 10 "_5" 9 "_4" 8 "_3" 7 "_2" 6 "_1" 5 "Low" 4 "Sport_DriveSport" 3 "Drive" 2 "Neutral" 1 "Reverse" 0 "Park";
+VAL_ 90 PrkBrkActv_D_RqGsmGear 3 "NotUsed" 2 "RequestParkBrakeEngage" 1 "NoRequest" 0 "Null";
+VAL_ 90 TrnValidGearRq_D_Stat 3 "Valid_Request" 2 "Valid_Degraded_Request" 1 "Invalid_Request" 0 "No_Request";
+VAL_ 90 TrnGearButtn_U_Actl 255 "Fault";
+VAL_ 90 TrnGearButtn_B_ActlR2 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlR1 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlR0 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlP2 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlP1 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlP0 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlN2 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlN1 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlN0 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlM2 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlM1 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlM0 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlD2 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlD1 1 "Yes" 0 "No";
+VAL_ 90 TrnGearButtn_B_ActlD0 1 "Yes" 0 "No";
+VAL_ 90 TrnGear_D_RqDrv 31 "Fault" 30 "NotUsed_25" 29 "NotUsed_24" 28 "NotUsed_23" 27 "NotUsed_22" 26 "Return_to_Park" 25 "NotUsed_20" 24 "NotUsed_19" 23 "NotUsed_18" 22 "NotUsed_17" 21 "Return_To_Park" 20 "NotUsed_15" 19 "NotUsed_14" 18 "NotUsed_13" 17 "NotUsed_12" 16 "Manual" 15 "Not_Used11" 14 "Not_Used10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "Drive" 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "Neutral" 3 "NotUsed_1" 2 "Reverse" 1 "Park" 0 "No_Gear";
+VAL_ 90 BrkSwtchPos_B_ActlGsm 1 "Yes" 0 "No";
+VAL_ 1091 ParkLampTrlrOut_B_Stat 1 "Out" 0 "Null";
+VAL_ 1091 TrlrLampCtl_D_Stat 3 "NotUsed" 2 "TrlrLampCnnctDrvFailure" 1 "TrlrLampNotCnnctDrvFailure" 0 "Null";
+VAL_ 1091 TrlrBattChrg_D_Stat 3 "Reverse" 2 "Normal" 1 "Low" 0 "Null";
+VAL_ 1091 StopLampTrlrOut_B_Stat 1 "Out" 0 "Null";
+VAL_ 1091 TurnLampTrlrRr_B_Stat 1 "Out" 0 "Null";
+VAL_ 1091 TurnLampTrlrRl_B_Stat 1 "Out" 0 "Null";
+VAL_ 1091 TrlrLampCnnct_B_Actl 1 "Yes" 0 "No";
+VAL_ 138 SteWhlRelCalib_An_Sns 32767 "Fault" 32766 "NoDataExists";
+VAL_ 131 AccButtnGapDecPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 HeadLghtHiCtrl_D_RqAhb 7 "NotUsed2" 6 "NotUsed1" 5 "Auto_HiBeam" 4 "Auto_LoBeam" 3 "Flash" 2 "Man_HiBeam" 1 "Man_LoBeam" 0 "Null";
+VAL_ 131 AhbStat_B_Dsply 1 "On" 0 "Off";
+VAL_ 131 WiprFrontSwtch_D_Stat 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "PositionNotDetermined" 8 "High" 7 "Low" 6 "Position6" 5 "Position5" 4 "Position4" 3 "Position3" 2 "Position2" 1 "Position1" 0 "Off";
+VAL_ 131 HeadLghtHiOn_B_StatAhb 1 "On" 0 "Off";
+VAL_ 131 HeadLghtHiFlash_D_Actl 3 "NotUsed" 2 "High" 1 "Flash_to_Pass" 0 "Null";
+VAL_ 131 TjaButtnOnOffPress 1 "Pressed" 0 "Not_Pressed";
+VAL_ 131 AccButtnGapTogglePress 1 "Pressed" 0 "Not_Pressed";
+VAL_ 131 HeadLghtHiFlash_D_Stat 3 "NotUsed" 2 "High" 1 "Flash_to_Pass" 0 "Null";
+VAL_ 131 WiprFront_D_Stat 15 "NO_DATA_EXISTS" 14 "STALLED" 13 "RESERVED" 12 "AUTO_ADJUST" 11 "COURTESYWIPE" 10 "AUTO_HIGH" 9 "AUTO_LOW" 8 "WASH" 7 "MIST_FLICK" 6 "MAN_HIGH" 5 "MAN_LOW" 4 "MAN_INT_ON" 3 "MAN_INT_OFF" 2 "OFF_MOVING" 1 "AUTO_OFF" 0 "OFF";
+VAL_ 131 TurnLghtSwtch_D_Stat 3 "Unused_Treat_As_Off" 2 "Right" 1 "Left" 0 "Off";
+VAL_ 131 LghtAmb_D_Sns 7 "No_Data_Exists" 6 "Unused2" 5 "Unused1" 4 "Tunnel_Off" 3 "Tunnel_On" 2 "Twilight" 1 "Light" 0 "Dark";
+VAL_ 131 AccButtnGapIncPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 AslButtnOnOffPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 AslButtnOnOffCnclPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcButtnOnPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcButtnOnOffPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcButtnOnOffCnclPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcButtnOffPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAsllButtnResPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnSetPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnSetIncPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnSetDecPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnResIncPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnResDecPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnOnPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnOnOffCncl 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnOffCnclPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnIndxIncPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnIndxDecPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnDeny_B_Actl 1 "Yes" 0 "No";
+VAL_ 131 CcAslButtnCnclResPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 CcAslButtnCnclPress 1 "Button_Pressed" 0 "Button_Not_Pressed";
+VAL_ 131 LaSwtchPos_D_Stat 3 "Fault" 2 "Unused" 1 "Pressed" 0 "Open";
+VAL_ 787 DrTgateChime2_D_Rq 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Long_Repeated" 3 "Fast" 2 "Short" 1 "Long" 0 "Off";
+VAL_ 787 DrTGate_D_Rq 3 "NotUsed" 2 "Closing" 1 "Opening" 0 "Not_Moving";
+VAL_ 787 PwLftgtIntSw_B_Stat 1 "Pressed" 0 "Null";
+VAL_ 787 Power_Liftgate_Mode_Stt 2 "Unused" 3 "Not_Supported" 1 "Enabled" 0 "Disabled";
+VAL_ 953 BattRgenLoDChrg_D_Rq 3 "DoNotCare" 2 "Retain" 1 "Closed" 0 "Open";
+VAL_ 953 BattRgenLoChrg_D_Rq 3 "DoNotCare" 2 "Retain" 1 "Closed" 0 "Open";
+VAL_ 953 ChrgCordLck_B_Stat 1 "Unlock" 0 "Null";
+VAL_ 953 WakeAlarm3_D_Stat 3 "PublisherReset" 2 "Wake" 1 "AlarmRunning" 0 "AlarmOff";
+VAL_ 953 WakeAlarm2_D_Stat 3 "PublisherReset" 2 "Wake" 1 "AlarmRunning" 0 "AlarmOff";
+VAL_ 953 WakeAlarm1_D_Stat 3 "PublisherReset" 2 "Wake" 1 "AlarmRunning" 0 "AlarmOff";
+VAL_ 953 WakeAlarm0_D_Stat 3 "PublisherReset" 2 "Wake" 1 "AlarmRunning" 0 "AlarmOff";
+VAL_ 1093 TrlBrkInitOut_D_Stat 3 "Heavy" 2 "Medium" 1 "Light" 0 "Null";
+VAL_ 1093 TrlrBrkMde_D_Actl 1 "Electric_Over_Hydraulic" 0 "Electric";
+VAL_ 1093 TrlrBrkDsply_B_Rq 1 "Yes" 0 "No";
+VAL_ 1093 TrlrBrkDcnnt_B_Actl 1 "Yes" 0 "No";
+VAL_ 1093 TrlrBrkActCnnct_B_Actl 1 "Yes" 0 "No";
+VAL_ 1093 StopLamp_B_RqTrlrBrk 1 "Yes" 0 "No";
+VAL_ 1093 TrlrBrkCtl_B_Falt 1 "Yes" 0 "No";
+VAL_ 1093 TrlrBrkActCirct_B_Falt 1 "Yes" 0 "No";
+VAL_ 792 ElTrip_L_Dsply 65535 "Fault" 65534 "No_Data_Exists";
+VAL_ 792 ElLongTerm_L_Dsply 16777215 "Fault" 16777214 "No_Data_Exists";
+VAL_ 968 SlMde_D_Rq 3 "IsaNotConfigured" 2 "Manual_Mode" 1 "Auto_Mode" 0 "Null";
+VAL_ 968 IsaOffst_D_Rq 15 "Faulty" 14 "Null" 13 "Thirteen" 12 "Twelve" 11 "Eleven" 10 "Ten" 9 "Nine" 8 "Eight" 7 "Seven" 6 "Six" 5 "Five" 4 "Four" 3 "Three" 2 "Two" 1 "One" 0 "Zero";
+VAL_ 819 Memory_3_SwPsngr_Stat 1 "Pressed" 0 "Null";
+VAL_ 819 Memory_2_SwPsngr_Stat 1 "Pressed" 0 "Null";
+VAL_ 819 Memory_1_SwPsngr_Stat 1 "Pressed" 0 "Null";
+VAL_ 819 BLISLEDStatPassSide 3 "Fault" 2 "Unused" 1 "On" 0 "Off";
+VAL_ 819 WndwPsngrSide_D_Stat 3 "BothWindow_Operating" 2 "RearWindow_Operating" 1 "FrontWindow_Operating" 0 "NoWindows_Operating";
+VAL_ 819 Pasngr_Lock_Sw_Stat 3 "Invalid" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_ 819 ChildLckFdbckRp_B_Stat 1 "Locked" 0 "Unlock";
+VAL_ 818 BLISLEDStatDriverSide 3 "Fault" 2 "Unused" 1 "On" 0 "Off";
+VAL_ 818 WndwDrvSide_D_Stat 3 "BothWindow_Operating" 2 "RearWindow_Operating" 1 "FrontWindow_Operating" 0 "NoWindows_Operating";
+VAL_ 818 KeyCylSwDrvDr_D_Stat 3 "NotUsed" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_ 818 Driver_Lock_Sw_Stat 3 "Invalid" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_ 818 ChildLckPw_D_Rq 1 "Active" 0 "Null";
+VAL_ 818 ChildLckFdbckRd_B_Stat 1 "Locked" 0 "Unlock";
+VAL_ 818 RvrseMirrorChime_B_Rq 1 "Yes" 0 "No";
+VAL_ 806 SnowPlowMde_B_Enbl 1 "Enable" 0 "Disable";
+VAL_ 806 StopStrtDrvMde_B_RqBtn 1 "Pressed" 0 "Not_Pressed";
+VAL_ 806 ClimtHeat_D_Rq 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "PtcHtrTestMde" 3 "Defrost_Defog" 2 "FastTempPullDownHeatingReq" 1 "OpportunisticHeatingReq" 0 "NoHeatingRequest";
+VAL_ 806 ClimtCool_D_Rq 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "ElACTestMde" 3 "Defrost_Defog" 2 "FastTempPullDownCoolReq" 1 "OpportunisticCoolingReq" 0 "NoCoolingRequest";
+VAL_ 806 HvacEvap_Te_Actl 1023 "Fault";
+VAL_ 806 HvacAirCond_B_Rq 1 "Yes" 0 "No";
+VAL_ 806 ClimtPw_B_Rq 1 "Yes" 0 "No";
+VAL_ 765 Mc_VehTimeFrmtUsrSel_St 2 "24h_mode" 1 "12h_mode" 0 "Invalid";
+VAL_ 765 Running_Board_Cmd 3 "Unused" 2 "Manually_Deployed" 1 "All_Enabled" 0 "All_Disabled";
+VAL_ 765 EngExhMdeQuiet_D2_Rq 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Track" 3 "Sport" 2 "Normal" 1 "Stealth" 0 "Null";
+VAL_ 765 EdmSailMde_B_RqDrv 1 "On" 0 "Off";
+VAL_ 765 DrvInputRequired_B_Rq 1 "Yes" 0 "No";
+VAL_ 765 AwdRnge_D_ActlIpc 7 "Unknown" 6 "High_Range_2wd" 5 "High_Range_Auto" 4 "High_Range_Locked" 3 "Neutral" 2 "Low_Range_2wd" 1 "Low_Range_Auto" 0 "Low_Range_Locked";
+VAL_ 765 BalrSwtch_D_Stat 3 "NotUsed" 2 "Pressed" 1 "NotPressed" 0 "Null";
+VAL_ 765 BalrMde_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Null";
+VAL_ 765 WaitToStartLamp_D_Falt 3 "NotUsed" 2 "Wait_to_start_lamp_failed" 1 "Diagnosis_not_ready" 0 "Wait_to_start_lamp_OK";
+VAL_ 765 EsaOn_B_Rq 1 "On" 0 "Off";
+VAL_ 765 BttOn_B_Rq 1 "On" 0 "Off";
+VAL_ 765 Btt_L_Actl 127 "Faulty" 126 "NoDataExists";
+VAL_ 765 SelDrvMdeTxtReset_B_Rq 1 "Yes" 0 "No";
+VAL_ 765 SelDrvMdeDsply_B_Avail 1 "Available" 0 "NotAvailable";
+VAL_ 765 Mc_VehUntTrpCoUsrSel_St 0 "TripComputer_metric" 1 "TripComputer_imperial";
+VAL_ 765 Mc_VehUnitTempUsrSel_St 0 "Temperature_deg_c" 1 "Temperature_deg_f";
+VAL_ 765 Mc_VehLangUsrSel_St 30 "Slovak" 29 "Arabic" 28 "Cantonese" 27 "Mandarin_Chinese" 26 "Korean" 25 "Japanese_Kanji" 24 "Japanese_Katakana" 23 "Braz_Portuguese" 22 "EU_Portuguese" 21 "Finish" 20 "Norwegian" 19 "Danish" 18 "Swedish" 17 "Hungarian" 16 "Greek" 15 "Czech" 14 "Polish" 13 "Flemish" 12 "Dutch" 11 "Russian" 10 "Turkish" 9 "Mex_Spanish" 8 "EU_Spanish" 7 "Cana_French" 6 "EU_French" 5 "Italian" 4 "German" 3 "NA_English" 2 "UK_English" 1 "Unknown" 0 "Invalid";
+VAL_ 934 CtaAlrtLeft2_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "AlertZone4" 3 "AlertZone3" 2 "AlertZone2" 1 "AlertZone1" 0 "Off";
+VAL_ 934 CtaBrkLeftMsgTxt_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 934 CtaLeftBrkDecel_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 934 CtaLeftBrkEnbl_B_Rq 1 "Enable" 0 "Disable";
+VAL_ 934 BttLeft_D_Stat 7 "NotUsed" 6 "Disabled" 5 "Off" 4 "OffTemp" 3 "NotConnected" 2 "Pending" 1 "Connected" 0 "NotDetermined";
+VAL_ 934 BttLeft_D_RqDrv 3 "NotUsed" 2 "Request" 1 "NoRequest" 0 "Null";
+VAL_ 934 CtaSnsLeft_D_Stat 3 "Invalid" 2 "System_Failure" 1 "Blocked" 0 "Clear";
+VAL_ 934 SodDetctLeft_D_Stat 4 "Sensor_Blocked" 3 "Sensor_Fault" 2 "Flash_On" 1 "Alert_On" 0 "AlertOff_FlashOff_SensrClr";
+VAL_ 934 CtaLeft_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Invalid" 3 "Disabled" 2 "On" 1 "Trailer_Tow_Off" 0 "Off";
+VAL_ 934 CtaAlrtLeft_D_Stat 1 "On" 0 "Off";
+VAL_ 934 SodLeft_D_Stat 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "Invalid" 3 "Disabled" 2 "On" 1 "Trailer_Tow_Off" 0 "Off";
+VAL_ 934 SodSnsLeft_D_Stat 3 "Second_Warning_Audio" 2 "System_Failure" 1 "Blocked" 0 "Clear";
+VAL_ 934 SodAlrtLeft_D_Stat 3 "Bulb_Proveout" 2 "Flash" 1 "On" 0 "Off";
+VAL_ 1072 LscmbbStat_B_Actl 1 "On" 0 "Off";
+VAL_ 1072 HaDsplyCpblty_B_Stat 1 "Available" 0 "NotAvailable";
+VAL_ 1072 AccDeny_B_RqIpc 1 "Yes" 0 "No";
+VAL_ 1072 DrvSlipCtlMde_D_Rq 3 "App_Specific_Off_Mode_3" 2 "App_Specific_Off_Mode_2" 1 "App_Specific_Off_Mode_1" 0 "Default_Mode";
+VAL_ 1072 EngIdlShutDown_B_RqDrv 1 "Inhibit" 0 "No_Inibit";
+VAL_ 1072 HsaMde_D_Rq 3 "Undefined" 2 "Manual" 1 "Automatic" 0 "Off";
+VAL_ 1072 NtrlTowMdeEnbl_B_RqDrv 1 "Yes" 0 "No";
+VAL_ 1072 BulbChkActv_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1072 ParkDetect_Stat 1 "Park" 0 "Not_Park";
+VAL_ 1072 ReducedGuard_D_Rq 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 1072 TrlrBrkMde_D_Rq 1 "ElectricOverHydraulic" 0 "Electric";
+VAL_ 1072 TRLR_SWAY_CONFIG_CMD 1 "On" 0 "Off";
+VAL_ 1072 TRAILER_BRAKE_CONFIG 1 "Yes" 0 "No";
+VAL_ 1072 Power_Liftgate_Mode_Cmd 1 "Enable" 0 "Disable";
+VAL_ 1072 AccEnbl_B_RqDrv 1 "Adaptive_Cruise" 0 "Normal_Cruise";
+VAL_ 1072 OdometerMasterValue 16777215 "Invalid";
+VAL_ 1072 EngOilLife_B_RqReset 1 "Yes" 0 "No";
+VAL_ 1072 ePRNDL_MODE 1 "On" 0 "Off";
+VAL_ 1072 DrvSlipCtlMde_B_Rq2 1 "Pressed" 0 "Not_Pressed";
+VAL_ 1072 MetricActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 1072 KeyTypeChngMykey_D_Rq 3 "Search_PE_BackupSlot" 2 "Clear_All_MyKeys" 1 "Request_New_MyKey" 0 "None";
+VAL_ 1072 ManRgen_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "CustInitManExhFilterClean" 0 "No_Customer_Request";
+VAL_ 909 IgnPsswrdDsply_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 909 ElPwPoint_D_Rq 3 "On" 2 "Off2" 1 "Off1" 0 "Null";
+VAL_ 909 PoliceIdlMde_D_Stat 15 "NotUsed_7" 14 "NotUsed_6" 13 "NotUsed_5" 12 "NotUsed_4" 11 "NotUsed_3" 10 "NotUsed_2" 9 "PepsActive" 8 "Decommissioned" 7 "ActiveFault" 6 "ArmFault" 5 "PrearmedFault" 4 "OffFault" 3 "Active" 2 "Arm" 1 "Prearmed" 0 "Off";
+VAL_ 909 DrLatchMsgTxt_D_Rq 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 909 SecurityMsgTxt_D_Rq 3 "Message3" 2 "Message2" 1 "Message1" 0 "NoMessage";
+VAL_ 909 PrmtrAlrmEvnt_D_Stat 15 "Diag_Tamper" 14 "Trailer" 13 "Shock_Sensor" 12 "Post_Crash" 11 "Panic" 10 "Intrusion" 9 "Inclination" 8 "Ign_Tamper" 7 "LG_Door" 6 "Decklid" 5 "Hood" 4 "PR_Door" 3 "PF_Door" 2 "DR_Door" 1 "DF_Door" 0 "Null";
+VAL_ 909 HeadLghtHiPrmsn_D_Stat 3 "CancelAndSuppress" 2 "Cancel" 1 "Hold" 0 "AllowChange";
+VAL_ 909 SteWhlLckMsgTxt_D_Rq 3 "NotUsed" 2 "Message_2" 1 "Message_1" 0 "No_Message";
+VAL_ 909 immoMsgTxt_D_Rq 15 "Immo_Msg_15" 14 "Immo_Msg_14" 13 "Immo_Msg_13" 12 "Immo_Msg_12" 11 "Immo_Msg_11" 10 "Immo_Msg_10" 9 "Immo_Msg_9" 8 "Immo_Msg_8" 7 "Immo_Msg_7" 6 "Immo_Msg_6" 5 "Immo_Msg_5" 4 "Immo_Msg_4" 3 "Immo_Msg_3" 2 "Immo_Msg_2" 1 "Immo_Msg_1" 0 "Immo_Msg_0_Null";
+VAL_ 909 PrsnlDevcChrgEnbl_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 909 TracKeyMde_D_Stat 3 "NotUsed" 2 "NotActive" 1 "Active" 0 "ModeNotDetermined";
+VAL_ 909 PEBackupSlot_Stats 3 "No_Valid_FOB_In_Slot" 2 "MyKey_FOB_In_Slot" 1 "Standard_FOB_In_Slot" 0 "Null";
+VAL_ 909 KeyMykeyTot_No_Cnt 13 "Thirteen" 12 "Twelve" 11 "Eleven" 10 "Ten" 9 "Nine" 8 "Eight" 7 "Seven" 6 "Six" 5 "Five" 4 "Four" 3 "Three" 2 "Two" 1 "One" 0 "Zero" 15 "Invalid" 14 "Unlimited";
+VAL_ 909 KeyAdmnTot_No_Cnt 13 "Thirteen" 12 "Twelve" 11 "Eleven" 10 "Ten" 9 "Nine" 8 "Eight" 7 "Seven" 6 "Six" 5 "Five" 4 "Four" 3 "Three" 2 "Two" 1 "One" 0 "Zero" 15 "Invalid" 14 "Unlimited";
+VAL_ 963 Illuminated_Entry_Stat 3 "Invalid" 2 "Unknown" 1 "On" 0 "Off";
+VAL_ 963 Dr_Courtesy_Light_Stat 3 "Invalid" 2 "Unknown" 1 "On" 0 "Off";
+VAL_ 963 Courtesy_Delay_Status 3 "Invalid" 2 "Unknown" 1 "On" 0 "Off";
+VAL_ 963 ImpactEvntFdbck_D_Stat 3 "NotUsed" 2 "EventComplete" 1 "EventInProgress" 0 "Normal";
+VAL_ 963 WrlssAcsyChrgInhbt_B_Rq 1 "Yes" 0 "No";
+VAL_ 963 PudLampPsngr_D_Rq 3 "Ramp_Down" 2 "Ramp_Up" 1 "On" 0 "Off";
+VAL_ 963 HeadLampLoOut_B_Stat 1 "Out" 0 "Null";
+VAL_ 963 HeadLghtHiFdbck_D_Stat 3 "NotUsed" 2 "Cancel" 1 "Hold" 0 "Allow_Change";
+VAL_ 963 PudLampDrv_D_Rq 3 "Ramp_Down" 2 "Ramp_Up" 1 "On" 0 "Off";
+VAL_ 963 TrnNotInPrkChime_B_Rq 1 "On" 0 "Off";
+VAL_ 963 PrkLightChime_B_Rq 1 "On" 0 "Off";
+VAL_ 963 KeyInIgnWarn_B_Cmd 1 "On" 0 "Off";
+VAL_ 963 HomeSafeLtChime_B_Rq 1 "On" 0 "Off";
+VAL_ 963 StopLghtOn_B_Stat 1 "On" 0 "Off";
+VAL_ 963 RvrseLghtOn_B_Stat 1 "On" 0 "Off";
+VAL_ 963 PrkLght_D_Stat 3 "Park_Both" 2 "Park_Right" 1 "Park_Left" 0 "Off";
+VAL_ 963 HeadLghtSwtch_D_Stat 3 "Autolamp" 2 "Headlamp" 1 "Parklamp" 0 "Off";
+VAL_ 963 HeadLampLoFrOn_B_Stat 1 "Low" 0 "Not_Low";
+VAL_ 963 HeadLampLoFlOn_B_Stat 1 "Low" 0 "Not_Low";
+VAL_ 963 HeadLampLoActv_B_Stat 1 "On" 0 "Off";
+VAL_ 963 Headlamp_On_Wrning_Cmd 1 "On" 0 "Off";
+VAL_ 963 Park_Brake_Chime_Rqst 1 "On" 0 "Off";
+VAL_ 963 HeadLghtHiOn_B_Stat 1 "On" 0 "Off";
+VAL_ 963 BrkWarnInd_B_Rq 1 "On" 0 "Off";
+VAL_ 963 Brk_Fluid_Lvl_Low 3 "Invalid" 2 "Unknown" 1 "Low" 0 "OK";
+VAL_ 963 ReducedGuard_D_Stat 3 "NotUsed" 2 "Alarm_On" 1 "Alarm_Off_Previously_On" 0 "Alarm_Off";
+VAL_ 963 Perimeter_Alarm_Status 3 "Activated" 2 "Armed" 1 "Prearmed" 0 "Disarmed";
+VAL_ 963 Courtesy_BSave_Stat 3 "Invalid" 2 "Unknown" 1 "No_Effect" 0 "Off";
+VAL_ 963 DrTgateLck_D_Stat 3 "NotUsed" 2 "Unlock" 1 "Lock" 0 "Null";
+VAL_ 963 WndwGlbl_D_Cmd 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "GLEARN" 3 "GCLOSE" 2 "GOPEN" 1 "GSTOP" 0 "Null";
+VAL_ 963 PudLamp_D_Rq 3 "RAMP_DOWN" 2 "RAMP_UP" 1 "ON" 0 "OFF";
+VAL_ 963 DayRnngLampOn_B_Stat 1 "On" 0 "Off";
+VAL_ 963 PerimeterAlarmChimeRq 1 "On" 0 "Off";
+VAL_ 145 VehYawWActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 145 VehRolWActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 145 VehYaw_W_Actl 65535 "Faulty" 65534 "NoDataExists";
+VAL_ 145 VehRol_W_Actl 65535 "Faulty" 65534 "NoDataExists";
+VAL_ 76 FirstRowBuckleMid 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_ 76 SecondRowBucklePsngr 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_ 76 SecondRowBuckleMid 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_ 76 SecondRowBuckleDriver 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_ 76 FirstRowBuckleDriver 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_ 76 RILReq 3 "Not_Used" 2 "Plant_Mode" 1 "On" 0 "Off";
+VAL_ 76 FirstRowBucklePsngr 3 "Unknown" 2 "Unbelted" 1 "Belted" 0 "Faulty";
+VAL_ 76 RstrnImpactEvntStatus 7 "Invalid" 6 "Not_Used_4" 5 "Threshold_2_Exceeded" 4 "Not_Used_3" 3 "Threshold_1_Exceeded" 2 "Not_Used_2" 1 "Not_Used_1" 0 "Normal";
+VAL_ 76 PsngrFrntDetct_D_Actl 3 "Unknown" 2 "Empty" 0 "Faulty" 1 "Occupied";
+VAL_ 76 EDRTriggerEvntSync 1 "Threshold_Exceeded" 0 "Normal";
+VAL_ 76 PassRstrnInd_Req 3 "ABOnNotIllum_OffNotIllum" 2 "AirbagOnNot_Illum_OffIllum" 1 "AirbagOn_Illum_OffNotIllum" 0 "AirbagOn_Illum_Off_Illum";
+VAL_ 65 immoControlCmd_T1 0 "IDLE" 1 "MOTIVE_START_RQST" 2 "NONMOTIVE_START_RQST" 3 "RQST_TARGET1_IDBLOCK1" 4 "RQST_TARGET1_IDBLOCK2" 5 "Unused" 6 "ECHO_TARGET1_IDBLOCK2" 7 "SHUTDOWN";
+VAL_ 1076 HILL_DESC_SW 1 "On" 0 "Off";
+VAL_ 1076 AutoRgen_D_Rq 3 "NotUsed" 2 "AutExhFilterCleanOFF" 1 "AutExhFilterCleanON" 0 "No_Mode_Selected";
+VAL_ 1076 W2S_LAMP_OK 1 "Yes" 0 "No";
+VAL_ 1076 OdoTripRx_B_Actl 1 "Yes" 0 "No";
+VAL_ 1076 DrvSlipCtlMde_B_RqMyKey 1 "On" 0 "Off";
+VAL_ 1076 FuelLvlWarn_D_Actl 3 "NotUsed" 2 "VeryLow" 1 "Low" 0 "OK";
+VAL_ 1076 FuelSecndActv_B_Actl 1 "Yes" 0 "No";
+VAL_ 1076 FUEL_SENSOR_NUM 1 "Dual_Sensors" 0 "Single_Sensor";
+VAL_ 862 AutoStpHvacDelta_I_Est 255 "Fault";
+VAL_ 862 HvacBlwrFront_D_Stat 31 "Not_Used" 20 "Full_On" 19 "95_Percent" 18 "90_Percent" 17 "85_Percent" 16 "80_Percent" 15 "75_Percent" 14 "70_Percent" 13 "65_Percent" 12 "60_Percent" 11 "55_Percent" 10 "50_Percent" 9 "45_Percent" 8 "40_Percent" 7 "35_Percent" 6 "30_Percent" 5 "25_Percent" 4 "20_Percent" 3 "15_Percent" 2 "10_Percent" 1 "5_Percent" 0 "Off";
+VAL_ 862 CabnAmb_Te_Actl 255 "Fault";
+VAL_ 862 ClimtThrmlLoad_No_Actl 255 "Fault";
+VAL_ 931 PtWakeReas_D_Stat 15 "NotUsed_9" 14 "NotUsed_8" 13 "NotUsed_7" 12 "NotUsed_6" 11 "NotUsed_5" 10 "NotUsed_4" 9 "NotUsed_3" 8 "NotUsed_2" 7 "NotUsed_1" 6 "ElapsedTime" 5 "ThirdPartyWakeup" 4 "DoorAjar" 3 "EarlyWake" 2 "NonMotiveStart" 1 "MotiveStart" 0 "Null";
+VAL_ 931 VehOnSrc_D_Stat 15 "NotUsed_11" 14 "NotUsed_10" 13 "NotUsed_9" 12 "NotUsed_8" 11 "NotUsed_7" 10 "NotUsed_6" 9 "NotUsed_5" 8 "NotUsed_4" 7 "NotUsed_3" 6 "NotUsed_2" 5 "NotUsed_1" 4 "OverTheAir" 3 "RemoteParkAssist" 2 "RemoteStart" 1 "Manual" 0 "Off";
+VAL_ 931 EngStrtActv_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 931 EngStrt_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 931 DrvInCtl_B_Stat 1 "Yes" 0 "No";
+VAL_ 931 AdvStrt_D_Stat 15 "NotUsed_15" 14 "NotUsed_14" 13 "NotUsed_13" 12 "NotUsed_12" 11 "NotUsed_11" 10 "NotUsed_10" 9 "NotUsed_9" 8 "NotUsed_8" 7 "NotUsed_7" 6 "NotUsed_6" 5 "NotUsed_5" 4 "NotUsed_4" 3 "NotUsed_3" 2 "NotUsed_2" 1 "NotUsed_1" 0 "NoAction";
+VAL_ 931 CrnkInhbt_B_Stat 1 "Inhibit" 0 "NoInhibit";
+VAL_ 931 IgnPreOffActv_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 578 PtLatchActv_B_RqBcm 1 "On" 0 "Off";
+VAL_ 578 immoSecureIdleMode 3 "NotUsed2" 2 "NotUsed1" 1 "Active" 0 "Inactive";
+VAL_ 578 ReFuelSwtchStat_D_Actl 3 "NotUsed2" 2 "NotUsed1" 1 "On" 0 "Off";
+VAL_ 578 FuelPumpPwr_D_Stat 7 "NotUsed3" 6 "NotUsed2" 5 "NotUsed1" 4 "Power_Off_Default" 3 "Power_Off_Command" 2 "Power_Off_Service" 1 "Power_Off_Impact" 0 "Power_On";
+VAL_ 578 BattULo_U_Actl 255 "Fault";
+VAL_ 578 PrkLckCtl_B_Enbl 1 "Enable" 0 "Disable";
+VAL_ 578 PrkLckCtlMsgTxt_D_Rq 3 "BTSI_DI_3" 2 "BTSI_DI_2" 1 "BTSI_DI_1" 0 "Null_BTSI_DI";
+VAL_ 578 BrkTrnShifLck_B_Stat 1 "Shift" 0 "NoShift";
+VAL_ 578 PrkLckCtlUnlck_D_Stat 3 "Trans_And_Steer_Unlckd" 2 "Steering_Unlckd" 1 "Transmission_Unlckd" 0 "Null";
+VAL_ 578 PrkLckCtlTow_B_Enbl 1 "Enable" 0 "Disable";
+VAL_ 578 DriverCrankingReq 1 "Crank_Request" 0 "No_Crank_Request";
+VAL_ 578 EngOff_T_Actl 65535 "Invalid";
+VAL_ 578 DcacElPw_D_Rq 3 "NotUsed" 2 "AC_HighPower_Requested" 1 "AC_LowPower_Requested" 0 "AC_Power_NotRequested";
+VAL_ 578 BattULo_I_Actl 16383 "Fault";
+VAL_ 947 ValetMode_D_Mem 1 "On" 0 "Off";
+VAL_ 947 DrStatDrvErrCnt_B_Stat 1 "Yes" 0 "No";
+VAL_ 947 TurnLghtRight_D_Rq 3 "Seq" 2 "On" 1 "Off" 0 "Null";
+VAL_ 947 TurnLghtRightOn_B_Stat 1 "On" 0 "Off";
+VAL_ 947 TurnLghtLeftOn_B_Stat 1 "On" 0 "Off";
+VAL_ 947 FogLghtRearOn_B_Stat 1 "On" 0 "Off";
+VAL_ 947 Backlit_LED_Status 15 "Unused3" 14 "Unused2" 13 "Unused1" 12 "Night_12" 11 "Night_11" 10 "Night_10" 9 "Night_9" 8 "Night_8" 7 "Night_7" 6 "Night_6" 5 "Night_5" 4 "Night_4" 3 "Night_3" 2 "Night_2" 1 "Night_1" 0 "Off";
+VAL_ 947 TurnLghtLeft_D_Rq 3 "Seq" 2 "On" 1 "Off" 0 "Null";
+VAL_ 947 FogLghtFrontOn_B_Stat 1 "On" 0 "Off";
+VAL_ 947 IgnKeyType_D_Actl 15 "Invalid" 14 "Unknown" 3 "Key_Not_Prgrm_Read_Failure" 2 "Key_In_Ign_My_Key" 1 "Key_In_Ign_Standard_Key" 0 "Key_Read_In_Progress";
+VAL_ 947 Parklamp_Status 3 "Invalid" 2 "Unknown" 1 "On" 0 "Off";
+VAL_ 947 Litval 255 "Invalid" 254 "Unknown" 5 "Day" 4 "Twilight_4" 3 "Twilight_3" 2 "Twilight_2" 1 "Twilight_1" 0 "Night";
+VAL_ 947 Key_In_Ignition_Stat 1 "In" 0 "Out";
+VAL_ 947 Ignition_Status 0 "Unknown" 1 "Off" 15 "Invalid" 8 "Start" 4 "Run" 2 "Accessory";
+VAL_ 947 Dimming_Lvl 255 "Invalid" 254 "Unknown" 18 "Day_6" 17 "Day_5" 16 "Day_4" 15 "Day_3" 14 "Day_2" 13 "Day_1" 12 "Night_12" 11 "Night_11" 10 "Night_10" 9 "Night_9" 8 "Night_8" 7 "Night_7" 6 "Night_6" 5 "Night_5" 4 "Night_4" 3 "Night_3" 2 "Night_2" 1 "Night_1" 0 "Off";
+VAL_ 947 Day_Night_Status 3 "NotUsed" 2 "Night" 1 "Day" 0 "Null";
+VAL_ 947 Remote_Start_Status 3 "Invalid" 2 "Unknown" 1 "Remote" 0 "Null";
+VAL_ 947 DrStatTgate_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 DrStatRr_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 DrStatRl_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 DrStatPsngr_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 DrStatInnrTgate_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 DrStatHood_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 DrStatDrv_B_Actl 1 "Ajar" 0 "Closed";
+VAL_ 947 PrkBrkActv_B_Actl 1 "Active" 0 "Inactive";
+VAL_ 947 LifeCycMde_D_Actl 3 "Transport" 2 "NotUsed" 1 "Factory" 0 "Normal";
+VAL_ 947 Delay_Accy 1 "On" 0 "Off";
+VAL_ 947 CrashEvnt_D_Stat 3 "Invalid" 2 "Fuel_Cutoff_Event" 1 "Deploy_Event" 0 "No_Event";
+VAL_ 947 FuelPmpInhbt_B_Stat 1 "Inhibit" 0 "No_Inibit";
+VAL_ 947 BodySrvcRqd_B_Rq 1 "Yes" 0 "No";
+VAL_ 1084 BattULoState_D_Qlty 3 "OK" 2 "Not_Within_Specifications" 1 "Eval_In_Progress" 0 "Fault";
+VAL_ 1084 BSFault 1 "Fault" 0 "No_Fault";
+VAL_ 1084 BattULo2_Te_Actl 127 "Fault";
+VAL_ 1068 EngStrtInhbt_B_RqBatt 1 "Start_Inhibit" 0 "Dont_Care";
+VAL_ 1068 BattULoChrg_D_Rq 3 "Low_Battery_Temperature" 2 "Charging_Requested" 1 "Chrg_Requested_HighCurrent" 0 "No_Request";
+VAL_ 1068 PwSysULoFalt_D_Stat 15 "Not_Used_6" 14 "LowBatterySOC" 13 "PSS_Shed2_Contin" 12 "Not_Used_4" 11 "Not_Used_3" 10 "Not_Used_2" 9 "BattMonitoringSensorFault" 8 "LowBattVoltDuringPwSrcOn" 7 "LowBatt2_PowerSaveMode" 6 "LowBatt1_Warning" 5 "Overvoltage" 4 "Fault_NoOutput" 3 "Fault_ReducedOutput" 2 "Fault_Nonspecific" 1 "Cluster_Proveout" 0 "No_Fault";
+VAL_ 1068 Shed_T_Eng_Off_B 1 "Active" 0 "Inactive";
+VAL_ 1068 Shed_Feature_Group_ID 16 "PtcHeater" 14 "HtdMirr" 13 "HvacRearBlwr_Third" 12 "HvacRearBlwr_Second" 11 "HvacRearBlwr_First" 31 "All LSHED1 Features" 10 "Htd_Windscrn" 9 "SpltHtdBcklight_HtdMirr" 8 "HtdBcklight_HtdMirr" 7 "HtdCoolSeat_FrtDriver" 6 "HtdCoolSeat_FrtPass" 5 "HtdCoolSeat_RearPass" 4 "HtdCoolSeat_RearDriver" 3 "SmartTrlrTowBattCharge" 2 "Htd_StrWhl" 1 "Htd_Washer_Fluid" 0 "No_LSHED1_Features" 15 "Engine_Coolant_Fan";
+VAL_ 1068 Shed_Drain_Eng_Off_B 1 "Active" 0 "Inactive";
+VAL_ 1068 Shed_Level_Req 7 "Unused_2" 6 "Loads_On" 5 "SHED_ENG_OFF" 4 "SOON_ENG_OFF" 3 "SHED2_CONTIN" 2 "SHED2_TRANS" 1 "SHED1" 0 "NO_SHED";
+VAL_ 1068 ULoRgenTestMde_B_Rq 1 "Request" 0 "NoRequest";
+VAL_ 1068 ChargeMode 7 "Undefined_2" 6 "Undefined_1" 5 "Battery_Identify" 4 "Battery_Refresh" 3 "SlowRegenAllowNoDischarge" 2 "Fast_Regen_Allowed" 1 "Slow_Regen_Allowed" 0 "Conventional_Charging";
+VAL_ 1068 IdleSpeedIncrease_El 1 "Yes" 0 "No";
+VAL_ 1068 Batt_Lo_SoC_B 1 "Active" 0 "Inactive";
+VAL_ 1068 PeriodicElLoad_B_Stat 1 "Active" 0 "Inactive";
+VAL_ 1068 Batt_Crit_SoC_B 1 "Active" 0 "Inactive";
+VAL_ 146 VehVert2_A_Actl 8191 "Faulty" 8190 "NoDataExists";
+VAL_ 146 VehLong2_A_Actl 8191 "Faulty" 8190 "NoDataExists";
+VAL_ 146 VehLat2_A_Actl 8191 "Faulty" 8190 "NoDataExists";
+VAL_ 146 VehVertAActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 146 VehLongAActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 146 VehLatAActl_D_Qf 3 "OK" 2 "Not_Within_Specifications" 1 "No_Data_Exists" 0 "Faulty";
+VAL_ 997 PersIndexCcm_D_Actl 7 "Unused_3" 6 "Unused_2" 5 "Unused_1" 4 "Vehicle" 3 "PERS_4" 2 "PERS_3" 1 "PERS_2" 0 "PERS_1";
+VAL_ 983 CmbbObjRelLong_V_Actl 1023 "Faulty" 1022 "NoDataExists";
+VAL_ 983 CmbbObjRelLat_V_Actl 511 "Faulty" 510 "NoDataExists";
+VAL_ 983 CmbbObjDistLong_L_Actl 1023 "Faulty" 1022 "NoDataExists";
+VAL_ 983 CmbbObjDistLat_L_Actl 511 "Faulty" 510 "NoDataExists";
+VAL_ 983 CmbbObjConfdnc_D_Stat 3 "High" 2 "Medium" 1 "Low" 0 "NotDetermined";
+VAL_ 983 CmbbObjColl_T_Actl 127 "Faulty" 126 "NoDataExists";
+VAL_ 983 CmbbObjClass_D_Stat 15 "NotUsed_9" 14 "NotUsed_8" 13 "NotUsed_7" 12 "NotUsed_6" 11 "NotUsed_5" 10 "NotUsed_4" 9 "NotUsed_3" 8 "NotUsed_2" 7 "NotUsed_1" 6 "Unclassified_Vehicle" 5 "Bicycle" 4 "Pedestrian" 3 "Truck" 2 "Motorcycle" 1 "Vehicle" 0 "Undetermined";
+VAL_ 983 EsaEnbl_D2_Rq 3 "NotConfigured" 2 "Enabled" 1 "Pending" 0 "Disabled";
+VAL_ 980 AdbBrdr1DistRigh_D_Stat 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_ 980 AdbBrdr1DistLeft_D_Stat 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_ 980 AdbMde1_D_Rq 3 "MarkerLightFlashing" 2 "MarkerLightConstant" 1 "Spot" 0 "None";
+VAL_ 980 AdbIntns1_D_Rq 3 "Maximum" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 980 AdbBrdr1Up_An_Rq 511 "Faulty" 510 "NoDataExists";
+VAL_ 980 AdbBrdr1Right_An_Rq 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 980 AdbBrdr1Low_An_Rq 511 "Faulty" 510 "NoDataExists";
+VAL_ 980 AdbBrdr1Left_An_Rq 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 979 HandsOffCnfm_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 979 LatCtl_D_Rq 7 "NotUsed4" 6 "NotUsed3" 5 "NotUsed2" 4 "NotUsed1" 3 "InterventionRight" 2 "InterventionLeft" 1 "ContinuousPathFollowing" 0 "NoLateralControl";
+VAL_ 979 LatCtlRampType_D_Rq 3 "Immediately" 2 "Fast" 1 "Medium" 0 "Slow";
+VAL_ 979 LatCtlPrecision_D_Rq 3 "NotUsed2" 2 "NotUsed1" 1 "Precise" 0 "Comfortable";
+VAL_ 976 SuspClkSync_No_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 976 SrpSigValid_B_Stat 1 "True" 0 "False";
+VAL_ 976 SrpHghtRight_L_Actl 511 "Faulty" 510 "NoDataExists";
+VAL_ 976 SrpHghtLeft_L_Actl 511 "Faulty" 510 "NoDataExists";
+VAL_ 976 SrpEventRight_D_Stat 3 "Faulty" 2 "Bump" 1 "Pothole" 0 "NoEvent";
+VAL_ 976 SrpEventLeft_D_Stat 3 "Faulty" 2 "Bump" 1 "Pothole" 0 "NoEvent";
+VAL_ 976 SrpDistRight_L_Actl 511 "Faulty" 510 "NoDataExists";
+VAL_ 976 SrpDistLeft_L_Actl 511 "Faulty" 510 "NoDataExists";
+VAL_ 973 TsrVl2PrmntMsgTxt_D_Rq 3 "NotUsed" 2 "ShowPermanentlyWithSupp" 1 "ShowPermanentlyWithoutSupp" 0 "DoNotShowSignPermanent";
+VAL_ 973 TsrVl1PrmntMsgTxt_D_Rq 3 "NotUsed" 2 "ShowPermanentlyWithSupp" 1 "ShowPermanentlyWithoutSupp" 0 "DoNotShowSignPermanent";
+VAL_ 973 TsrVl2RstrcMsgTxt2_D_Rq 7 "NotUsed" 6 "Time" 5 "Trailer" 4 "Snow" 3 "RainWet" 2 "NoRecognizableRestrictn" 1 "NoSpeedLimitRestrictn" 0 "Null";
+VAL_ 973 TsrVl1RstrcMsgTxt2_D_Rq 7 "NotUsed" 6 "Time" 5 "Trailer" 4 "Snow" 3 "RainWet" 2 "NoRecognizableRestrictn" 1 "NoSpeedLimitRestrictn" 0 "Null";
+VAL_ 973 TsrOvtkMsgTxt2_D_Rq 15 "NotUsed5" 14 "NotUsed4" 13 "NotUsed3" 12 "NotUsed2" 11 "NotUsed1" 10 "LimForTrucksCancelled" 9 "LimForTrucksWoQlfdRstrc" 8 "LimForTrucksWithoutRstrc" 7 "LimAllCancelled" 6 "LimAllWithRstrcTime" 5 "LimAllWithRstrcTrailer" 4 "LimAllWithRstrcSnow" 3 "LimAllWithRstrcRain" 2 "LimAllWithoutQlfdRstrc" 1 "LimAllWithoutRestriction" 0 "OvertakingAllowed";
+VAL_ 973 WwaWarn_B_Rq 1 "On" 0 "Off";
+VAL_ 973 TsrVlUnitMsgTxt_D_Rq 3 "NoDataExists" 2 "Mph" 1 "Kph" 0 "Null";
+VAL_ 973 TsrVLim2MsgTxt_D_Rq 255 "NoLimit" 254 "NotUsed2" 253 "NotUsed1" 252 "NotToBeDisplayed" 251 "LimitCancelled" 31 "1F_FA_Message31_250" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "Null";
+VAL_ 973 TsrVLim1MsgTxt_D_Rq 255 "NoLimit" 254 "NotUsed2" 253 "NotUsed1" 252 "NotToBeDisplayed" 251 "LimitCancelled" 31 "1F_FA_Message31_250" 30 "Message30" 29 "Message29" 28 "Message28" 27 "Message27" 26 "Message26" 25 "Message25" 24 "Message24" 23 "Message23" 22 "Message22" 21 "Message21" 20 "Message20" 19 "Message19" 18 "Message18" 17 "Message17" 16 "Message16" 15 "Message15" 14 "Message14" 13 "Message13" 12 "Message12" 11 "Message11" 10 "Message10" 9 "Message9" 8 "Message8" 7 "Message7" 6 "Message6" 5 "Message5" 4 "Message4" 3 "Message3" 2 "Message2" 1 "Message1" 0 "Null";
+VAL_ 973 TsrVl2StatMsgTxt_D_Rq 3 "LimitOutdated" 2 "LimitReiable" 1 "LimitChanged" 0 "Null";
+VAL_ 973 TsrVl2RstrcMsgTxt_D_Rq 3 "NotUsed" 2 "NoRecognizableRestriction" 1 "NoSpeedLimitRestriction" 0 "Null";
+VAL_ 973 TsrVl1StatMsgTxt_D_Rq 3 "LimitOutdated" 2 "LimitReiable" 1 "LimitChanged" 0 "Null";
+VAL_ 973 TsrVl1RstrcMsgTxt_D_Rq 3 "NotUsed" 2 "NoRecognizableRestriction" 1 "NoSpeedLimitRestriction" 0 "Null";
+VAL_ 973 TsrStatMsgTxt_D_Rq 7 "NotUsed" 6 "NoDataExists" 5 "TSR_Error" 4 "Available_NavigationOnly" 3 "Available_CameraOnly" 2 "Available_FusionMode" 1 "TSR_Off" 0 "Null";
+VAL_ 973 TsrOvtkStatMsgTxt_D_Rq 3 "LimitOutdated" 2 "LimitReiable" 1 "LimitChanged" 0 "Null";
+VAL_ 973 TsrOvtkMsgTxt_D_Rq 7 "LimForTrucksCancelled" 6 "LimForTrucksWoQlfdRstrc" 5 "LimForTrucksWithoutRstrc" 4 "LimAllCancelled" 3 "LimAllWithoutQlfdRstrc" 2 "LimAllWithoutRestriction" 1 "OvertakingAllowed" 0 "Null";
+VAL_ 973 TsrOswWarnMsgTxt_D_Rq 3 "NotUsed" 2 "True" 1 "False" 0 "Null";
+VAL_ 973 TsrMsgTxt_D_Rq 15 "NotUsed6" 14 "NotUsed5" 13 "NotUsed4" 12 "NotUsed3" 11 "NotUsed2" 10 "NotUsed1" 9 "RecgnzdSignNotUsblForDsply" 8 "LimitedSystemPerformance" 7 "OffRoad" 6 "RegionNotSupported" 5 "CountryNotSupported" 4 "WrngNavDatIncompDatCarrier" 3 "NoNavDataAvailable" 2 "NoNavAvailableSwitchedOff" 1 "NoInformationAllOK" 0 "Null";
+VAL_ 970 LkaDrvOvrrd_D_Rq 3 "Level_3" 2 "Level_2" 1 "Level_1" 0 "Level_0";
+VAL_ 970 LkaActvStats_D2_Req 7 "NotUsed" 6 "LkaIncrIntervRight" 5 "LkaSupprRight" 4 "LkaStandIntervRight" 3 "LkaSupprLeft" 2 "LkaStandIntervLeft" 1 "LkaIncrIntervLeft" 0 "LkaNoInterv";
+VAL_ 970 LaRefAng_No_Req 4095 "Fault";
+VAL_ 970 LaRampType_B_Req 1 "Quick" 0 "Smooth";
+VAL_ 970 LaCurvature_No_Calc 4095 "Fault";
+VAL_ 970 LdwActvStats_D_Req 7 "LDW_Suppress_Right_Left" 6 "Not_Used2" 5 "LDW_Suppress_Right" 4 "LDW_Warning_Right" 3 "LDW_Suppress_Left" 2 "LDW_Warning_Left" 1 "LDW_DemoVibration" 0 "LDW_Idle";
+VAL_ 970 LdwActvIntns_D_Req 3 "High" 2 "Medium" 1 "Low" 0 "None";
+VAL_ 962 AdbBrdr3DistRigh_D_Stat 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_ 962 AdbBrdr3DistLeft_D_Stat 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_ 962 AdbMde3_D_Rq 3 "MarkerLightFlashing" 2 "MarkerLightConstant" 1 "Spot" 0 "None";
+VAL_ 962 AdbIntns3_D_Rq 3 "Maximum" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 962 AdbBrdr3Up_An_Rq 511 "Faulty" 510 "NoDataExists";
+VAL_ 962 AdbBrdr3Right_An_Rq 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 962 AdbBrdr3Low_An_Rq 511 "Faulty" 510 "NoDataExists";
+VAL_ 962 AdbBrdr3Left_An_Rq 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 961 AdbBrdr2DistRigh_D_Stat 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_ 961 AdbBrdr2DistLeft_D_Stat 15 "DistGreater800m" 14 "Dist700mTo800m" 13 "Dist600mTo700m" 12 "Dist500mTo600m" 11 "Dist400mTo500m" 10 "Dist300mTo400m" 9 "Dist200mTo300m" 8 "Dist175mTo200m" 7 "Dist150mTo175m" 6 "Dist125mTo150m" 5 "Dist100mTo125m" 4 "Dist75mTo100m" 3 "Dist50mTo75m" 2 "Dist25mTo50m" 1 "Dist15mTo25m" 0 "Dist0mTo15m";
+VAL_ 961 AdbMde2_D_Rq 3 "MarkerLightFlashing" 2 "MarkerLightConstant" 1 "Spot" 0 "None";
+VAL_ 961 AdbIntns2_D_Rq 3 "Maximum" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 961 AdbBrdr2Up_An_Rq 511 "Faulty" 510 "NoDataExists";
+VAL_ 961 AdbBrdr2Right_An_Rq 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 961 AdbBrdr2Low_An_Rq 511 "Faulty" 510 "NoDataExists";
+VAL_ 961 AdbBrdr2Left_An_Rq 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 394 AccStopStat_D_Dsply 3 "PressResume" 2 "Stopped" 1 "ResumeReady" 0 "NoDisplay";
+VAL_ 394 AccTrgDist2_D_Dsply 15 "DIST_ACTIVE_13_Farthest" 14 "DIST_ACTIVE_12" 13 "DIST_ACTIVE_11" 12 "DIST_ACTIVE_10" 11 "DIST_ACTIVE_9" 10 "DIST_ACTIVE_8" 9 "DIST_ACTIVE_7" 8 "DIST_ACTIVE_6" 7 "DIST_ACTIVE_5" 6 "DIST_ACTIVE_4" 5 "DIST_ACTIVE_3" 4 "DIST_ACTIVE_2" 3 "DIST_ACTIVE_1_Closest" 2 "DIST_ACTIVE_No_Target" 1 "DIST_STANDBY" 0 "DIST_OFF";
+VAL_ 394 AccStopRes_B_Dsply 1 "Yes" 0 "No";
+VAL_ 394 TjaWarn_D_Rq 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "HardTakeOverLevel2" 2 "HardTakeOverLevel1" 1 "TrafficJamAssistCancel" 0 "NoWarning";
+VAL_ 394 Tja_D_Stat 7 "NotUsed_1" 6 "ActiveWarningRight" 5 "ActiveWarningLeft" 4 "ActiveInterventionRight" 3 "ActiveInterventionLeft" 2 "Active" 1 "Standby" 0 "Off";
+VAL_ 394 TjaMsgTxt_D_Dsply 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "TurnOnAdaptCruiseControl" 2 "TrafficJamAssistSelected" 1 "TrafficJamAssistUnavailabl" 0 "NoMessage";
+VAL_ 394 IaccLamp_D_Rq 3 "NotUsed_2" 2 "NotUsed_1" 1 "DisplayIaccIcon" 0 "DoNotDisplayIaccIcon";
+VAL_ 394 AccMsgTxt_D2_Rq 15 "NotUsed_1" 14 "NCC_Enabled_Warning" 13 "IACC_TJA_Selected" 12 "ACC_TJA_Selected" 11 "IACC_Selected" 10 "Press_Brake_To_Hold" 9 "Only_Following_In_Low_Spd" 8 "TJA_Unavailable" 7 "Shift_Down" 6 "IACC_Unavailable" 5 "ACC_Selected" 4 "ACC_Overridden" 3 "Brake_Capacity_Warning" 2 "ACC_Cancelled" 1 "ACC_Unavailable" 0 "No_Text";
+VAL_ 394 FcwDeny_B_Dsply 1 "Yes" 0 "No";
+VAL_ 394 FcwMemStat_B_Actl 1 "On" 0 "Off";
+VAL_ 394 AccTGap_B_Dsply 1 "Yes" 0 "No";
+VAL_ 394 CadsAlignIncplt_B_Actl 1 "Yes" 0 "No";
+VAL_ 394 AccFllwMde_B_Dsply 1 "Yes" 0 "No";
+VAL_ 394 CadsRadrBlck_B_Actl 1 "Yes" 0 "No";
+VAL_ 394 CmbbPostEvnt_B_Dsply 1 "Yes" 0 "No";
+VAL_ 394 AccStopMde_B_Dsply 1 "Yes" 0 "No";
+VAL_ 394 FcwMemSens_D_Actl 3 "FCW_Sensitivity_3" 2 "FCW_Sensitivity_2" 1 "FCW_Sensitivity_1" 0 "Not_Used";
+VAL_ 394 FcwMsgTxt_D_Rq 7 "Undefined_3" 6 "Undefined_2" 5 "Low_Visibility" 4 "Unavailable_DueTo_LowSpeed" 3 "Available" 2 "Unavailable" 1 "Off" 0 "No_Text";
+VAL_ 394 AccWarn_D_Dsply 3 "BrakeReleaseWarn_In_StopMd" 2 "Brake_Capacity_Warning" 1 "Cancel_Warning" 0 "No_Warning";
+VAL_ 394 FcwVisblWarn_B_Rq 1 "On" 0 "Off";
+VAL_ 394 FcwAudioWarn_B_Rq 1 "On" 0 "Off";
+VAL_ 394 AccTGap_D_Dsply 7 "Undefined_2" 6 "Undefined_1" 5 "Time_Gap_5" 4 "Time_Gap_4" 3 "Time_Gap_3" 2 "Time_Gap_2" 1 "Time_Gap_1" 0 "Not_Used";
+VAL_ 394 AccMemEnbl_B_RqDrv 1 "Adaptive_Cruise" 0 "Normal_Cruise";
+VAL_ 394 FdaMem_B_Stat 1 "On" 0 "Off";
+VAL_ 391 HudBlk3_B_Rq 1 "Yes" 0 "No";
+VAL_ 391 HudBlk2_B_Rq 1 "Yes" 0 "No";
+VAL_ 391 HudBlk1_B_Rq 1 "Yes" 0 "No";
+VAL_ 391 HudFlashRate_D_Actl 3 "Unused" 2 "Flash_4Hz_50Prct_DutyCycle" 1 "On" 0 "Off";
+VAL_ 391 CmbbBrkPrchg_D_Rq 3 "Undefined" 2 "Level_2_PreCharge_Request" 1 "Level_1_PreCharge_Request" 0 "No_PreCharge_Request";
+VAL_ 391 CmbbBrkDecel_B_Rq 1 "Yes" 0 "No";
+VAL_ 391 CmbbBaSens_D_Rq 3 "Level_3" 2 "Level_2" 1 "Level_1" 0 "Normal";
+VAL_ 390 AccBrkPulse_B_Rq 1 "True" 0 "False";
+VAL_ 390 AccAutoResum_D_Rq 3 "NotUsed" 2 "Active" 1 "Pending" 0 "Off";
+VAL_ 390 AccBrkPrkEl_B_Rq 1 "Yes" 0 "No";
+VAL_ 390 Cmbb_B_Enbl 1 "Yes" 0 "No";
+VAL_ 390 CmbbOvrrd_B_RqDrv 1 "Yes" 0 "No";
+VAL_ 390 CmbbDeny_B_Actl 1 "Yes" 0 "No";
+VAL_ 390 CmbbEngTqMn_B_Rq 1 "Yes" 0 "No";
+VAL_ 390 AccDeny_B_Rq 1 "Yes" 0 "No";
+VAL_ 390 AccResumEnbl_B_Rq 1 "Yes" 0 "No";
+VAL_ 390 AccCancl_B_Rq 1 "Yes" 0 "No";
+VAL_ 390 AccBrkPrchg_B_Rq 1 "Yes" 0 "No";
+VAL_ 390 AccBrkDecel_B_Rq 1 "Active" 0 "Inactive";
+VAL_ 390 AccStopStat_B_Rq 1 "Yes" 0 "No";
+VAL_ 1153 TerrMde_D_RqDrv 7 "Fail_Safe_Default" 6 "Dynamic_Mode" 5 "Rock_Crawl_Mode" 4 "Mud_Ruts_Mode" 3 "Sand_Mode" 2 "Undefined" 1 "Low_Mu_Mode" 0 "Special_Operating_Mode_Off";
+VAL_ 942 PrkAidDrvDir_D_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "BackwardNegative" 4 "ForwardNegative" 3 "BackwardPositive" 2 "ForwardPositive" 1 "NoMotion" 0 "DirectionNotKnown";
+VAL_ 942 PrkAidAcsyRear_D_Stat 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 942 PrkAidAcsyFront_D_Stat 3 "NotUsed" 2 "On" 1 "Off" 0 "Null";
+VAL_ 930 BalrWndwRight_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 930 BalrSnsRight_D_Falt 3 "Invalid" 2 "SystemFailure" 1 "Blocked" 0 "Clear";
+VAL_ 930 WndwPsngrRear_D_RqBalrr 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 930 WndwPsngr_D_RqBalrr 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 930 WndwDrvRear_D_RqBalrr 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 930 WndwDrv_D_RqBalrr 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 930 BalrRight_D_Stat 3 "Inhibited" 2 "Disabled" 1 "On" 0 "Off";
+VAL_ 930 BalrMdeSelRight_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 930 BalrMdeRight_D_Stat 3 "NotUsed" 2 "High" 1 "Medium" 0 "Low";
+VAL_ 930 BalrLckRight_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 930 BalrChimeRight_D_Rq 3 "NotUsed" 2 "Soft" 1 "Normal" 0 "Off";
+VAL_ 930 CamraRearOn_B_RqBalrr 1 "Active" 0 "Inactive";
+VAL_ 930 DrLckActv_B_RqBalrr 1 "Active" 0 "Null";
+VAL_ 929 BalrChimeLeft_D_Rq 3 "NotUsed" 2 "Soft" 1 "Normal" 0 "Off";
+VAL_ 929 BalrLeft_D_Stat 3 "Inhibited" 2 "Disabled" 1 "On" 0 "Off";
+VAL_ 929 BalrWndwLeft_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 929 WndwPsngrRear_D_RqBalrl 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 929 WndwPsngr_D_RqBalrl 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 929 WndwDrvRear_D_RqBalrl 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 929 WndwDrv_D_RqBalrl 3 "NotUsed" 2 "Stop" 1 "AutoUp" 0 "NoRequest";
+VAL_ 929 BalrSnsLeft_D_Falt 3 "Invalid" 2 "SystemFailure" 1 "Blocked" 0 "Clear";
+VAL_ 929 BalrMdeSelLeft_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 929 BalrMdeLeft_D_Stat 3 "NotUsed" 2 "High" 1 "Medium" 0 "Low";
+VAL_ 929 BalrLckLeft_B_Stat 1 "Enable" 0 "Disable";
+VAL_ 929 CamraRearOn_B_RqBalrl 1 "Active" 0 "Inactive";
+VAL_ 929 DrLckActv_B_RqBalrl 1 "Active" 0 "Null";
+VAL_ 402 PrkAidSwtch_D_RqMnu 1 "Pressed" 0 "Not_Pressed";
+VAL_ 402 ApaSwtch_D_RqMnu 3 "NotUsed2" 2 "NotUsed1" 1 "Pressed" 0 "Not_Pressed";
+VAL_ 402 ApaMdeStat_D_RqDrv 7 "Faulty" 6 "Off" 5 "NotUsed2" 4 "NotUsed1" 3 "POA" 2 "PPA" 1 "SAPP" 0 "Inactive";
+VAL_ 402 CamraViewSplit_B_Rq 1 "On" 0 "Off";
+VAL_ 402 CamraZoomMan_D_Rq 7 "Unknown" 6 "Invalid" 5 "Zoom_Level_V" 4 "Zoom_Level_IV" 3 "Zoom_Level_III" 2 "Zoom_Level_II" 1 "Zoom_Level_I" 0 "Off";
+VAL_ 402 CamraOvrlStat_D_Rq 1 "On" 0 "Off";
+VAL_ 402 CamraOvrlDyn_D_Rq 1 "On" 0 "Off";
+VAL_ 402 CamAutoTowbarZoom 1 "On" 0 "Off";
+VAL_ 402 DistanceBarSetting 1 "On" 0 "Off";
+VAL_ 924 DcacOut_Pw_Mx 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 924 DcacOut2_Pw_Actl 8191 "Faulty" 8190 "NoDataExists";
+VAL_ 924 DcacOut1_Pw_Actl 8191 "Faulty" 8190 "NoDataExists";
+VAL_ 924 DcacIn_Pw_Mx 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 923 DcacIn_U2_Actl 4095 "Faulty" 4094 "NoDataExists";
+VAL_ 923 DcacIn_U_Actl 4095 "Fault" 4094 "NoDataExists";
+VAL_ 923 DcacIn_I_Actl 2047 "Faulty" 2046 "NoDataExists";
+VAL_ 923 Dcac_Te_Actl 255 "Faulty" 254 "NoDataExists";
+VAL_ 922 DcacBp2BrkrOpn_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacBp1BrkrOpn_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacIpRcBrkrOpn_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacRdy_D2_Stat 3 "Faulted" 2 "RecoverableFault" 1 "Active" 0 "Idle";
+VAL_ 922 DcacOvrld_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacOverTe_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacGfci_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacErr_B_Stat 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacAcUDetct_B_Falt 1 "Faulted" 0 "NotFaulted";
+VAL_ 922 DcacRdy_D_Stat 7 "NotUsed_2" 6 "NotUsed_1" 5 "Faulted" 4 "ProtectionTempearture" 3 "ProtectionOverload" 2 "ProtectionGfci" 1 "Active" 0 "Idle";
+VAL_ 922 DcacPlugPrsnt_B_Stat 1 "Yes" 0 "No";
+VAL_ 922 DcacClntFlw_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";
+VAL_ 922 CoolFanDcac_D_Rq 3 "High" 2 "Medium" 1 "Low" 0 "Off";


### PR DESCRIPTION
Added new DBC for 2022 Ford Edge. Edge PSCM reports SteeringPinion_Data at ID 85 which is different from the currently supported models using ID 7e. ford_edge_pt.dbc was started from ford_lincoln_base_pt.dbc with an updated ID for SteeringPinion_Data