### PR TITLE
CAN packer/parser: clean up after alloc

### DIFF
--- a/can/packer_pyx.pyx
+++ b/can/packer_pyx.pyx
@@ -26,6 +26,10 @@ cdef class CANPacker:
       msg = self.dbc[0].msgs[i]
       self.name_to_address[string(msg.name)] = msg.address
 
+  def __dealloc__(self):
+    if self.packer:
+      del self.packer
+
   cdef vector[uint8_t] pack(self, addr, values):
     cdef vector[SignalPackValue] values_thing
     values_thing.reserve(len(values))

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -66,6 +66,10 @@ cdef class CANParser:
     self.can = new cpp_CANParser(bus, dbc_name, message_v)
     self.update_strings([])
 
+  def __dealloc__(self):
+    if self.can:
+      del self.can
+
   def update_strings(self, strings, sendcan=False):
     for v in self.vl_all.values():
       for l in v.values():  # no-cython-lint


### PR DESCRIPTION
test_car_interfaces with 300 examples:

```
system base: 66.1G
no dealloc: 92.8G
packer dealloc: 75.5G
packer + parser dealloc: 71.9G
```