### PR TITLE
VW MQB: Additional TSK support

### DIFF
--- a/vw_mqb_2010.dbc
+++ b/vw_mqb_2010.dbc
@@ -1144,19 +1144,43 @@ BO_ 288 TSK_06: 8 Motor_Diesel_MQB
  SG_ TSK_Status : 24|3@1+ (1,0) [0|7] "" Gateway_MQB,Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB
  SG_ TSK_v_Begrenzung_aktiv : 27|1@1+ (1,0) [0|1] "" Gateway_MQB,Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB
  SG_ TSK_Standby_Anf_ESP : 28|1@1+ (1,0) [0|1] "" Gateway_MQB
+ SG_ TSK_Freig_WU : 29|1@1+ (1.0,0.0) [0.0|1] ""  Gateway_MQB
  SG_ TSK_Freig_Verzoeg_Anf : 30|1@1+ (1,0) [0|1] "" Gateway_MQB,Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB
  SG_ TSK_Limiter_ausgewaehlt : 31|1@1+ (1,0) [0|1] "" Gateway_MQB,Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB
+ SG_ TSK_Wunsch_Uebersetz : 32|10@1+ (0.0245,0) [0.0245|25.0635] ""  Gateway_MQB
+ SG_ TSK_Hauptschalter_GRA_ACC : 42|2@1+ (1.0,0.0) [0.0|3] ""  Gateway_MQB
+ SG_ TSK_SRBM_Anf_ASIL : 44|3@1+ (1.0,0.0) [0.0|7] ""  Gateway_MQB
  SG_ TSK_ax_Getriebe_02 : 48|9@1+ (0.024,-2.016) [-2.016|10.224] "Unit_MeterPerSeconSquar" Gateway_MQB,Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB
  SG_ TSK_Zwangszusch_ESP : 57|1@1+ (1,0) [0|1] "" Gateway_MQB
  SG_ TSK_zul_Regelabw : 58|6@1+ (0.024,0) [0|1.512] "Unit_MeterPerSeconSquar" Gateway_MQB,Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB
 
 BO_ 798 TSK_07: 8 Motor_Diesel_MQB
- SG_ TSK_07_CRC : 0|8@1+ (1,0) [0|255] "" Gateway_MQB
- SG_ TSK_07_BZ : 8|4@1+ (1,0) [0|15] "" Gateway_MQB
- SG_ TSK_Wunschgeschw : 12|10@1+ (0.32,0) [0|326.72] "Unit_KiloMeterPerHour" Gateway_MQB
- SG_ TSK_Texte_Primaeranz : 48|5@1+ (1,0) [0|31] "" Gateway_MQB
- SG_ TSK_Limiter_Anzeige : 55|1@1+ (1,0) [0|1] "" Gateway_MQB
- SG_ TSK_Status_Anzeige : 61|3@1+ (1,0) [0|7] "" Gateway_MQB
+ SG_ TSK_07_CRC : 0|8@1+ (1,0) [0|255] ""  Gateway_MQB,Getriebe_AQ
+ SG_ TSK_07_BZ : 8|4@1+ (1,0) [0|15] ""  Gateway_MQB,Getriebe_AQ
+ SG_ TSK_Wunschgeschw : 12|10@1+ (0.32,0) [0.00|326.72] "Unit_KiloMeterPerHour"  Gateway_MQB,Getriebe_AQ
+ SG_ TSK_Texte : 40|5@1+ (1.0,0.0) [0.0|31] ""  Gateway_MQB
+ SG_ TSK_Akustik : 45|3@1+ (1.0,0.0) [0.0|7] ""  Gateway_MQB
+ SG_ TSK_Texte_Primaeranz : 48|5@1+ (1.0,0.0) [0.0|31] ""  Gateway_MQB
+ SG_ TSK_Limiter_Fahrerinfo : 53|2@1+ (1.0,0.0) [0.0|3] ""  Gateway_MQB
+ SG_ TSK_Limiter_Anzeige : 55|1@1+ (1.0,0.0) [0.0|1] ""  Gateway_MQB
+ SG_ TSK_Fahrzeugstatus_GRA : 56|1@1+ (1.0,0.0) [0.0|1] ""  Gateway_MQB
+ SG_ TSK_Fahrzeugstatus_Limiter : 57|1@1+ (1.0,0.0) [0.0|1] ""  Gateway_MQB
+ SG_ MO_Motorlaufwarnung : 58|1@1+ (1.0,0.0) [0.0|1] ""  Gateway_MQB
+ SG_ TSK_Status_Anzeige : 61|3@1+ (1.0,0.0) [0.0|7] ""  Gateway_MQB
+
+BO_ 346 TSK_08: 8 Motor_Diesel_MQB
+ SG_ TSK_08_CRC : 0|8@1+ (1,0) [0|255] ""  Frontradar
+ SG_ TSK_08_BZ : 8|4@1+ (1,0) [0|15] ""  Frontradar
+ SG_ MO_Anforderung_HMS : 12|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ TSK_Status_EA : 32|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ TSK_vMax_Fahrerassistenz : 40|9@1+ (1,0) [0|510] ""  Frontradar
+ SG_ TSK_Einheit_vMax_Fahrerassistenz : 49|1@1+ (1,0) [0|1] ""  Frontradar
+ SG_ TSK_Status_PLA : 50|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ TSK_aktives_System : 53|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ TSK_erhoehter_Fahrwiderstand : 56|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ TSK_Anf_Antriebsmoment : 57|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ TSK_Status_ARA : 58|3@1+ (1,0) [0|7] "" Vector__XXX
+ SG_ TSK_Status_IPA : 61|3@1+ (1,0) [0|7] "" Vector__XXX
 
 BO_ 1716 VIN_01: 8 Gateway_MQB
  SG_ VIN_01_MUX M : 0|2@1+ (1,0) [0|3] ""  Airbag_MQB
@@ -1480,6 +1504,15 @@ CM_ SG_ 1720 KBI_Variante_USA "In diesem Signal wird die HW-Variante des Kombis 
 VAL_ 159 EPS_HCA_Status 0 "disabled" 1 "initializing" 2 "fault" 3 "ready" 4 "rejected" 5 "active" ;
 VAL_ 173 GE_Fahrstufe 5 "P" 6 "R" 7 "N" 8 "D" 9 "S" 10 "E" 13 "T" 14 "T" ;
 VAL_ 288 TSK_Status 0 "init" 1 "disabled" 2 "enabled" 3 "regulating" 4 "accel_pedal_override" 5 "brake_only" 6 "temp_fault" 7 "perm_fault" ;
+VAL_ 288 TSK_v_Begrenzung_aktiv 0 "inaktiv" 1 "aktiv" ;
+VAL_ 288 TSK_Standby_Anf_ESP 0 "keine_Standby_Anforderung" 1 "Standby_Anforderung" ;
+VAL_ 288 TSK_Freig_WU 0 "TSK_Uebersetzungswunsch_nicht_freigegeben" 1 "TSK_Uebersetzungswunsch_freigegeben" ;
+VAL_ 288 TSK_Freig_Verzoeg_Anf 0 "Verzoegerungsanforderung_nicht_freigegeben" 1 "Verzoegerungsanforderung_freigegeben" ;
+VAL_ 288 TSK_Limiter_ausgewaehlt 0 "kein_Limiter_ausgewaehlt" 1 "Limiter_ausgewaehlt" ;
+VAL_ 288 TSK_Wunsch_Uebersetz 0 "Init" ;
+VAL_ 288 TSK_Hauptschalter_GRA_ACC 0 "Init" 1 "Aus" 2 "Ein" 3 "Fehler" ;
+VAL_ 288 TSK_ax_Getriebe_02 511 "Neutralwert" ;
+VAL_ 288 TSK_Zwangszusch_ESP 0 "keine_ESP_ASR_Beeinflussung" 1 "ESP_ASR_Beeinflussung" ;
 VAL_ 294 EA_ACC_Sollstatus 0 "Init" 1 "ACC_aktivieren" 2 "ACC_deaktivieren" ;
 VAL_ 294 EA_Ruckprofil 0 "Init" 1 "Profil_1" 2 "Profil_2" 3 "Profil_3" 4 "Profil_4" 5 "Profil_5" 6 "Profil_6" 7 "Profil_7" ;
 VAL_ 294 HCA_01_Sendestatus 0 "HCA_sendet_mit_1000ms" 1 "HCA_sendet_mit_20ms" ;
@@ -1487,6 +1520,26 @@ VAL_ 294 HCA_01_LM_OffSign 0 "positives_Vorzeichen" 1 "negatives_Vorzeichen" ;
 VAL_ 294 HCA_01_Status_HCA 0 "deaktiviert" 1 "reserviert" 2 "reserviert" 3 "funktionsbereit" 4 "reserviert" 5 "HCA_Momenteneingriff_1" 6 "MA_Aktiv" 7 "HCA_Momenteneingriff_2" 8 "reserviert" 9 "reserviert" 10 "reserviert" 11 "reserviert" 12 "reserviert" 13 "reserviert" 14 "reserviert" 15 "reserviert" ;
 VAL_ 294 EA_Ruckfreigabe 0 "keine_Freigabe" 1 "Freigabe" ;
 VAL_ 294 EA_ACC_Wunschgeschwindigkeit 1023 "Init" ;
+VAL_ 346 MO_Anforderung_HMS 0 "keine_Anforderung" 1 "halten" 2 "parken" 3 "halten_Standby" 4 "anfahren" 5 "Loesen_ueber_Rampe" ;
+VAL_ 346 TSK_Status_EA 0 "Aus" 1 "Init_oder_nicht_verbaut" 3 "Aktiv" 4 "Uebertreten" 5 "Abschaltung_laeuft" 6 "Reversibel_aus" 7 "Irreversibel_Aus" ;
+VAL_ 346 TSK_vMax_Fahrerassistenz 511 "Init_ungueltig_keine_Beschraenkung" ;
+VAL_ 346 TSK_Einheit_vMax_Fahrerassistenz 0 "kmh" 1 "mph" ;
+VAL_ 346 TSK_Status_PLA 0 "Aus_Funktionsbereit" 1 "Init_oder_nicht_verbaut" 2 "aktivierbar" 3 "aktiv" 5 "Abschaltung_laeuft" 6 "reversibel_aus" 7 "Fehler" ;
+VAL_ 346 TSK_aktives_System 0 "keine_Funktion_aktiv" 1 "GRA_ACC" 2 "ARA" 3 "Speedlimiter" 4 "IPA" 5 "PLA" 6 "PEA_Ausrollassistent" 7 "EA" ;
+VAL_ 346 TSK_erhoehter_Fahrwiderstand 0 "kein_erhoehter_Fahrwiderstand" 1 "erhoehter_Fahrwiderstand" ;
+VAL_ 346 TSK_Anf_Antriebsmoment 0 "keine_Anforderung" 1 "Anforderung_aktiv" ;
+VAL_ 346 TSK_Status_ARA 0 "Aus" 1 "Init_oder_nicht_verbaut" 2 "aktivierbar" 3 "aktiv" 5 "abschaltung_laeuft" 6 "reversibel_aus" 7 "Fehler" ;
+VAL_ 346 TSK_Status_IPA 0 "Aus_Funktionsbereit" 1 "Init_oder_nicht_verbaut" 2 "aktivierbar" 3 "aktiv" 5 "Abschaltung_laueft" 6 "reversibel_aus" 7 "Fehler" ;
+VAL_ 798 TSK_Wunschgeschw 1022 "keine_Anzeige" 1023 "kein_Wert_im_Speicher" ;
+VAL_ 798 TSK_Texte 0 "kein_Text" 1 "GRA_Modus_ausgewaehlt" 2 "ACC_Modus_ausgewaehlt" 3 "Lim_Modus_ausgewaehlt" 4 "Lim_nicht_verfuegbar_ESC_passiv" 5 "GRA_nicht_verfuegbar_ESC_passiv" 6 "Lim_nicht_verfuegbar_Charisma" 7 "GRA_nicht_verfuegbar_Charisma" 8 "Lim_nicht_verfuegbar_HDC" 9 "GRA_nicht_verfuegbar_HDC" ;
+VAL_ 798 TSK_Akustik 0 "keine_Akustik" 1 "einzelner_Warnton" 2 "dauerhafter_Warnton" ;
+VAL_ 798 TSK_Texte_Primaeranz 0 "keine_Anzeige" 1 "GRA_Symbol_passiv_xxx_kmh_mph" 2 "GRA_Symbol_aktiv_xxx_kmh_mph" 3 "Bremse_ueberhitzt" 4 "Limiter_Modus_aktiviert" 5 "GRA_Modus_aktiviert" 6 "ACC_Modus_aktiviert" 7 "Opt_Geschwindigkeitswarnung" 8 "Opt_und_akustische_GeschwWarnung" 9 "Opt_GeschwWarnung_dauerhaft_mit_einmal_Akustik" 10 "Limiter_passiv_mit_Akustik" 11 "Limiter_Fehler_mit_Akustik" 12 "Limiter_Symbol_passiv_xxx_kmh_mph" 13 "Limiter_Symbol_aktiv_xxx_kmh_mph" 14 "Popup_Geschw_zu_hoch__Resume_unzulaessig" ;
+VAL_ 798 TSK_Limiter_Fahrerinfo 0 "keine_Info" 1 "Limit_erreicht" 2 "Ueberschritten" 3 "Vom_Fahrer_Ueberstimmt" ;
+VAL_ 798 TSK_Limiter_Anzeige 0 "Display_Anzeige_GRA_ACC" 1 "Display_Anzeige_Limiter" ;
+VAL_ 798 TSK_Fahrzeugstatus_GRA 0 "GRA_verfuegbar" 1 "GRA_nicht_verfuegbar" ;
+VAL_ 798 TSK_Fahrzeugstatus_Limiter 0 "Limiter_verfuegbar" 1 "Limiter_nicht_verfuegbar" ;
+VAL_ 798 MO_Motorlaufwarnung 0 "keine_Anzeige" 1 "Anforderung_Motorlaufwarnung" ;
+VAL_ 798 TSK_Status_Anzeige 0 "Hauptschalter_aus" 1 "Init" 2 "passiv" 3 "aktiv" 4 "Uebertreten" 5 "Limitiierung_aktiv" 6 "reversibel_aus" 7 "irreversibel_aus" ;
 VAL_ 780 ACC_Wunschgeschw_02 1023 "keine_Anzeige" ;
 VAL_ 780 ACC_Status_Prim_Anz 0 "Symbol nicht beleuchtet" 1 "Farbe 1 (typisch 'gruen')" 2 "Farbe 2 (typisch 'rot')" 3 "Farbe 3 (typisch 'gelb')" ;
 VAL_ 780 ACC_Abstandsindex 0 "Sonderanzeige_graue_Fahrbahn" 1022 "Sonderanzeige_graue_Fahrbahn" 1023 "Sonderanzeige_Fahrbahn_mit_gruenem_roten_Bereich" ;


### PR DESCRIPTION
Updates to `TSK_06` and `TSK_07`, new message `TSK_08`, with VAL enums.

Holding in Draft while we figure out how to detect switchable CC/ACC modes on the cars that support it. It's unclear how we'll detect that yet, and if it's in `TSK_07` or `TSK_08` I'll need to add checksum support code.