### PR TITLE
Update from deprecated github action

### DIFF
--- a/.github/workflows/repo.yml
+++ b/.github/workflows/repo.yml
@@ -12,7 +12,7 @@ jobs:
     container:
       image: ghcr.io/commaai/opendbc:latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: pre-commit autoupdate
       run: |
         git config --global --add safe.directory '*'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     #  matrix:
     #    run: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Docker image
       run: eval "$BUILD"
     - name: Build opendbc
@@ -28,7 +28,7 @@ jobs:
     name: static analysis
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Docker image
       run: eval "$BUILD"
     - name: Build opendbc
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && github.repository == 'commaai/opendbc'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build Docker image
       run: eval "$BUILD"
     - name: Push to dockerhub


### PR DESCRIPTION
Switch to the v4 checkout instead of v3 as that is now deprecated and gives a warning in the job status on github.
https://github.com/marketplace/actions/checkout