### PR TITLE
CANParser: 2x faster parsing

### DIFF
--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -1,7 +1,6 @@
 # distutils: language = c++
 # cython: c_string_encoding=ascii, language_level=3
 
-cimport cython
 from cython.operator cimport dereference as deref, preincrement as preinc
 from libcpp.pair cimport pair
 from libcpp.string cimport string
@@ -72,8 +71,6 @@ cdef class CANParser:
     if self.can:
       del self.can
 
-  @cython.wraparound(False)
-  @cython.boundscheck(False)
   def update_strings(self, strings, sendcan=False):
     for address in self.addresses:
       self.vl_all[address].clear()

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -5,7 +5,6 @@ from cython.operator cimport dereference as deref, preincrement as preinc
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.vector cimport vector
-from libcpp.unordered_set cimport unordered_set
 from libc.stdint cimport uint32_t
 
 from .common cimport CANParser as cpp_CANParser
@@ -20,6 +19,7 @@ cdef class CANParser:
     cpp_CANParser *can
     const DBC *dbc
     vector[SignalValue] can_values
+    vector[uint32_t] addresses
 
   cdef readonly:
     dict vl
@@ -54,11 +54,12 @@ cdef class CANParser:
       if address not in address_to_msg_name:
         raise RuntimeError(f"could not find message {repr(c[0])} in DBC {self.dbc_name}")
       message_v.push_back((address, c[1]))
+      self.addresses.push_back(address)
 
       name = address_to_msg_name[address]
       self.vl[address] = {}
       self.vl[name] = self.vl[address]
-      self.vl_all[address] = {}
+      self.vl_all[address] = defaultdict(list)
       self.vl_all[name] = self.vl_all[address]
       self.ts_nanos[address] = {}
       self.ts_nanos[name] = self.ts_nanos[address]
@@ -71,24 +72,38 @@ cdef class CANParser:
       del self.can
 
   def update_strings(self, strings, sendcan=False):
-    for v in self.vl_all.values():
-      for l in v.values():  # no-cython-lint
-        l.clear()
+    for address in self.addresses:
+     self.vl_all[address].clear()
 
     cdef vector[SignalValue] new_vals
-    cdef unordered_set[uint32_t] updated_addrs
-
     self.can.update_strings(strings, new_vals, sendcan)
     cdef vector[SignalValue].iterator it = new_vals.begin()
     cdef SignalValue* cv
+    cdef uint32_t cur_address = -1
+    updated_addrs = set()
+
+    # Store references to dictionaries
+    cdef dict vl
+    vl_all = {}
+    cdef dict ts_nanos
+
     while it != new_vals.end():
       cv = &deref(it)
+
+      # Check if the address has changed
+      if cv.address != cur_address:
+        cur_address = cv.address
+        vl = self.vl[cur_address]
+        vl_all = self.vl_all[cur_address]
+        ts_nanos = self.ts_nanos[cur_address]
+
+        updated_addrs.add(cur_address)
+
       # Cast char * directly to unicode
       cv_name = <unicode>cv.name
-      self.vl[cv.address][cv_name] = cv.value
-      self.vl_all[cv.address][cv_name] = cv.all_values
-      self.ts_nanos[cv.address][cv_name] = cv.ts_nanos
-      updated_addrs.insert(cv.address)
+      vl[cv_name] = cv.value
+      vl_all[cv_name] = cv.all_values
+      ts_nanos[cv_name] = cv.ts_nanos
       preinc(it)
 
     return updated_addrs

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -76,7 +76,7 @@ cdef class CANParser:
   @cython.boundscheck(False)
   def update_strings(self, strings, sendcan=False):
     for address in self.addresses:
-     self.vl_all[address].clear()
+      self.vl_all[address].clear()
 
     # Predeclare variables
     cdef vector[SignalValue] new_vals

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -75,20 +75,16 @@ cdef class CANParser:
     for address in self.addresses:
       self.vl_all[address].clear()
 
-    # Predeclare variables
     cdef vector[SignalValue] new_vals
-    cdef vector[SignalValue].iterator it
-    cdef SignalValue* cv
-    cdef uint32_t cur_address = -1
-    cdef unicode cv_name
-    cdef dict ts_nanos
-    cdef dict vl
+    cur_address = -1
+    vl = {}
     vl_all = {}
+    ts_nanos = {}
     updated_addrs = set()
 
-    # Iterate through new_vals
     self.can.update_strings(strings, new_vals, sendcan)
-    it = new_vals.begin()
+    cdef vector[SignalValue].iterator it = new_vals.begin()
+    cdef SignalValue* cv
     while it != new_vals.end():
       cv = &deref(it)
 
@@ -98,7 +94,6 @@ cdef class CANParser:
         vl = self.vl[cur_address]
         vl_all = self.vl_all[cur_address]
         ts_nanos = self.ts_nanos[cur_address]
-
         updated_addrs.add(cur_address)
 
       # Cast char * directly to unicode

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -78,19 +78,20 @@ cdef class CANParser:
     for address in self.addresses:
      self.vl_all[address].clear()
 
+    # Predeclare variables
     cdef vector[SignalValue] new_vals
-    self.can.update_strings(strings, new_vals, sendcan)
-
-    cdef vector[SignalValue].iterator it = new_vals.begin()
+    cdef vector[SignalValue].iterator it
     cdef SignalValue* cv
     cdef uint32_t cur_address = -1
-    updated_addrs = set()
-
-    # Store references to dictionaries
+    cdef unicode cv_name
+    cdef dict ts_nanos
     cdef dict vl
     vl_all = {}
-    cdef dict ts_nanos
+    updated_addrs = set()
 
+    # Iterate through new_vals
+    self.can.update_strings(strings, new_vals, sendcan)
+    it = new_vals.begin()
     while it != new_vals.end():
       cv = &deref(it)
 

--- a/can/parser_pyx.pyx
+++ b/can/parser_pyx.pyx
@@ -1,6 +1,7 @@
 # distutils: language = c++
 # cython: c_string_encoding=ascii, language_level=3
 
+cimport cython
 from cython.operator cimport dereference as deref, preincrement as preinc
 from libcpp.pair cimport pair
 from libcpp.string cimport string
@@ -71,12 +72,15 @@ cdef class CANParser:
     if self.can:
       del self.can
 
+  @cython.wraparound(False)
+  @cython.boundscheck(False)
   def update_strings(self, strings, sendcan=False):
     for address in self.addresses:
      self.vl_all[address].clear()
 
     cdef vector[SignalValue] new_vals
     self.can.update_strings(strings, new_vals, sendcan)
+
     cdef vector[SignalValue].iterator it = new_vals.begin()
     cdef SignalValue* cv
     cdef uint32_t cur_address = -1


### PR DESCRIPTION
Issue: The following two code blocks consume nearly two-thirds of cython's update_string()'s runtime:

```
for v in self.vl_all.values():
  for l in v.values():  # no-cython-lint
    l.clear()
```

```
while it != new_vals.end():
  cv = &deref(it)
  # Cast char * directly to unicode
  cv_name = <unicode>cv.name
  self.vl[cv.address][cv_name] = cv.value
  self.vl_all[cv.address][cv_name] = cv.all_values
  self.ts_nanos[cv.address][cv_name] = cv.ts_nanos
  updated_addrs.insert(cv.address)
  preinc(it)

```
Resolve:
1. Clear only the address key's value instead of all key-value pairs, as the name key's value refers to the address. This change halves the execution time of the first block of code.
2. Since the vector return from CanParser::update_strings() groups data by address, caching dictionary references for each address key reduces redundant lookups. This simple adjustment significantly cuts execution time by at least half, often more.
3. disable wraparound and boundcheck, update_string does not require these two options. disabling them can slightly improve performance

the results of running `selfdrive/debug/check_can_parser_performance.py` :

Before:

> 6000 CAN packets, 10 runs
> 283.51 mean ms, 297.98 max ms, 275.58 min ms, 5.45 std ms
> 0.0473 mean ms / CAN packet

After:

> 6000 CAN packets, 10 runs
> 128.54 mean ms, 148.90 max ms, 119.80 min ms, 9.34 std ms
> 0.0214 mean ms / CAN packet
> 
