### PR TITLE
CANParser: Update CAN data handling functions to accept  raw data and size parameters

### DIFF
--- a/can/common.h
+++ b/can/common.h
@@ -26,14 +26,14 @@
 void init_crc_lookup_tables();
 
 // Car specific functions
-unsigned int honda_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int toyota_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int subaru_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int chrysler_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int volkswagen_mqb_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int xor_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int hkg_can_fd_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
-unsigned int pedal_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
+unsigned int honda_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int toyota_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int subaru_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int chrysler_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int volkswagen_mqb_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int xor_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int hkg_can_fd_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
+unsigned int pedal_checksum(uint32_t address, const Signal &sig, const uint8_t *data, size_t size);
 
 class MessageState {
 public:
@@ -54,7 +54,7 @@ public:
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
-  bool parse(uint64_t nanos, const std::vector<uint8_t> &dat);
+  bool parse(uint64_t nanos, const uint8_t *msg, const size_t msg_size);
   bool update_counter_generic(int64_t v, int cnt_size);
 };
 

--- a/can/common_dbc.h
+++ b/can/common_dbc.h
@@ -38,7 +38,7 @@ struct Signal {
   double factor, offset;
   bool is_little_endian;
   SignalType type;
-  unsigned int (*calc_checksum)(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
+  unsigned int (*calc_checksum)(uint32_t address, const Signal &sig, const uint8_t *data, const size_t size);
 };
 
 struct Msg {
@@ -68,7 +68,7 @@ typedef struct ChecksumState {
   int counter_start_bit;
   bool little_endian;
   SignalType checksum_type;
-  unsigned int (*calc_checksum)(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
+  unsigned int (*calc_checksum)(uint32_t address, const Signal &sig, const uint8_t *data, const size_t size);
 } ChecksumState;
 
 DBC* dbc_parse(const std::string& dbc_path);

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -84,7 +84,7 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
   if (sig_it_checksum != signal_lookup.end()) {
     const auto &sig = sig_it_checksum->second;
     if (sig.calc_checksum != nullptr) {
-      unsigned int checksum = sig.calc_checksum(address, sig, ret);
+      unsigned int checksum = sig.calc_checksum(address, sig, ret.data(), ret.size());
       set_value(ret, sig, checksum);
     }
   }


### PR DESCRIPTION
When parsing CAN messages, `CanParser` creates a memory copy for each message solely to satisfy the checksum calculation function's requirement, which expects a `std::vector<uint8_t>` as parameter. This approach is inefficient and slows down the parsing process.  

> std::vector<uint8_t> data(dat.size(), 0);
> memcpy(data.data(), dat.begin(), dat.size());
> 

This PR updates all functions responsible for handling CAN data to accept raw data pointers `uint8_t* data` and size parameters `size_t size` instead of using `std::vector<uint8_t>`. This adjustment aims to enhance performance and reduce memory overhead by avoiding unnecessary memory allocations and copies associated with vector usage.