### PR TITLE
CANPacker: fix incorrect  `counters` assignment

### DIFF
--- a/can/packer.cc
+++ b/can/packer.cc
@@ -61,9 +61,9 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
     }
     set_value(ret, sig, ival);
 
-    counter_set = counter_set || (sigval.name == "COUNTER");
-    if (counter_set) {
+    if (sigval.name == "COUNTER") {
       counters[address] = sigval.value;
+      counter_set = true;
     }
   }
 

--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -60,6 +60,7 @@ class TestCanParserPacker(unittest.TestCase):
       cnt = random.randint(0, 255)
       msg = packer.make_can_msg("CAN_FD_MESSAGE", 0, {
         "COUNTER": cnt,
+        "SIGNED": 0
       })
       dat = can_list_to_can_capnp([msg, ])
       parser.update_strings([dat])


### PR DESCRIPTION
Fix multiple counters assignments when `COUNTER` is not the last signal. 

For example, `counters[address] `could be incorrectly set to the 'SIGNED' value (1) in make_can_msg():
```
 msg = packer.make_can_msg("CAN_FD_MESSAGE", 0, {
        "COUNTER": 10,
        "SIGNED" : 1,
      })
```

