### PR TITLE
assert expected openpilot undefined message behavior

### DIFF
--- a/can/tests/test_packer_parser.py
+++ b/can/tests/test_packer_parser.py
@@ -382,6 +382,18 @@ class TestCanParserPacker(unittest.TestCase):
     with self.assertRaises(RuntimeError):
       CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 10), ("ACC_CONTROL", 10)])
 
+  def test_allow_undefined_msgs(self):
+    # TODO: we should throw an exception for these, but we need good
+    #  discovery tests in openpilot first
+    packer = CANPacker("toyota_nodsu_pt_generated")
+
+    self.assertEqual(packer.make_can_msg("ACC_CONTROL", 0, {"UNKNOWN_SIGNAL": 0}),
+                     [835, 0, b'\x00\x00\x00\x00\x00\x00\x00N', 0])
+    self.assertEqual(packer.make_can_msg("UNKNOWN_MESSAGE", 0, {"UNKNOWN_SIGNAL": 0}),
+                     [0, 0, b'', 0])
+    self.assertEqual(packer.make_can_msg(0, 0, {"UNKNOWN_SIGNAL": 0}),
+                     [0, 0, b'', 0])
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
https://github.com/commaai/opendbc/pull/942 would now throw an uncaught [out_of_range C++ exception](https://cplusplus.com/reference/map/map/at/) for the packer when given unexpected message names

We probably do want to throw an exception (or at least log it), but we need really good discovery tests to catch anything before it becomes an exception in a user's car