### PR TITLE
Initializes CRC lookup tables at module initialization

### DIFF
--- a/can/common.cc
+++ b/can/common.cc
@@ -102,11 +102,15 @@ void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]) {
   }
 }
 
-void init_crc_lookup_tables() {
-  // At init time, set up static lookup tables for fast CRC computation.
-  gen_crc_lookup_table_8(0x2F, crc8_lut_8h2f);    // CRC-8 8H2F/AUTOSAR for Volkswagen
-  gen_crc_lookup_table_16(0x1021, crc16_lut_xmodem);    // CRC-16 XMODEM for HKG CAN FD
-}
+// Initializes CRC lookup tables at module initialization
+struct  CrcInitializer {
+  CrcInitializer() {
+    gen_crc_lookup_table_8(0x2F, crc8_lut_8h2f);    // CRC-8 8H2F/AUTOSAR for Volkswagen
+    gen_crc_lookup_table_16(0x1021, crc16_lut_xmodem);    // CRC-16 XMODEM for HKG CAN FD
+  }
+};
+
+static CrcInitializer crcInitializer;
 
 unsigned int volkswagen_mqb_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d) {
   // Volkswagen uses standard CRC8 8H2F/AUTOSAR, but they compute it with

--- a/can/common.cc
+++ b/can/common.cc
@@ -103,7 +103,7 @@ void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]) {
 }
 
 // Initializes CRC lookup tables at module initialization
-struct  CrcInitializer {
+struct CrcInitializer {
   CrcInitializer() {
     gen_crc_lookup_table_8(0x2F, crc8_lut_8h2f);    // CRC-8 8H2F/AUTOSAR for Volkswagen
     gen_crc_lookup_table_16(0x1021, crc16_lut_xmodem);    // CRC-16 XMODEM for HKG CAN FD

--- a/can/common.h
+++ b/can/common.h
@@ -24,8 +24,6 @@
 #define MAX_BAD_COUNTER 5
 #define CAN_INVALID_CNT 5
 
-void init_crc_lookup_tables();
-
 // Car specific functions
 unsigned int honda_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);
 unsigned int toyota_checksum(uint32_t address, const Signal &sig, const std::vector<uint8_t> &d);

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -38,7 +38,6 @@ CANPacker::CANPacker(const std::string& dbc_name) {
       signal_lookup[std::make_pair(msg.address, sig.name)] = sig;
     }
   }
-  init_crc_lookup_tables();
 }
 
 std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &signals) {

--- a/can/parser.cc
+++ b/can/parser.cc
@@ -96,7 +96,6 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
   : bus(abus), aligned_buf(kj::heapArray<capnp::word>(1024)) {
   dbc = dbc_lookup(dbc_name);
   assert(dbc);
-  init_crc_lookup_tables();
 
   bus_timeout_threshold = std::numeric_limits<uint64_t>::max();
 
@@ -149,7 +148,6 @@ CANParser::CANParser(int abus, const std::string& dbc_name, bool ignore_checksum
 
   dbc = dbc_lookup(dbc_name);
   assert(dbc);
-  init_crc_lookup_tables();
 
   for (const auto& msg : dbc->msgs) {
     MessageState state = {


### PR DESCRIPTION
This PR introduces a static initializer to set up CRC lookup tables directly at module load time, ensuring thread-safe initialization and preventing race conditions.

Benefits
1. Ensures thread-safe initialization.
2. Eliminates the need for explicit initialization calls.
3. Prevents multiple initializations and race conditions.
 