### PR TITLE
packer: log undefined address/signal as error

### DIFF
--- a/can/packer.cc
+++ b/can/packer.cc
@@ -44,7 +44,7 @@ CANPacker::CANPacker(const std::string& dbc_name) {
 std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &signals) {
   auto msg_it = message_lookup.find(address);
   if (msg_it == message_lookup.end()) {
-    LOGE("undefined address - %d", address);
+    LOGE("undefined address %d", address);
     return {};
   }
 

--- a/can/packer.cc
+++ b/can/packer.cc
@@ -42,7 +42,13 @@ CANPacker::CANPacker(const std::string& dbc_name) {
 }
 
 std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalPackValue> &signals) {
-  std::vector<uint8_t> ret(message_lookup[address].size, 0);
+  auto msg_it = message_lookup.find(address);
+  if (msg_it == message_lookup.end()) {
+    LOGE("undefined address - %d", address);
+    return {};
+  }
+
+  std::vector<uint8_t> ret(msg_it->second.size, 0);
 
   // set all values for all given signal/value pairs
   bool counter_set = false;
@@ -50,7 +56,7 @@ std::vector<uint8_t> CANPacker::pack(uint32_t address, const std::vector<SignalP
     auto sig_it = signal_lookup.find(std::make_pair(address, sigval.name));
     if (sig_it == signal_lookup.end()) {
       // TODO: do something more here. invalid flag like CANParser?
-      WARN("undefined signal %s - %d\n", sigval.name.c_str(), address);
+      LOGE("undefined signal %s - %d\n", sigval.name.c_str(), address);
       continue;
     }
     const auto &sig = sig_it->second;


### PR DESCRIPTION
split from https://github.com/commaai/opendbc/pull/942

from

```
cp.make_can_msg('test', 0, {'hi': 2})
undefined signal hi - 0
Out[3]: [0, 0, b'', 0]
cp.make_can_msg(999, 0, {'hi': 2})
undefined signal hi - 999
Out[4]: [999, 0, b'', 0]
```

to

```
cp.make_can_msg('test', 0, {'hi': 2})
opendbc/can/packer.cc: undefined address - 0
Out[3]: [0, 0, b'', 0]
cp.make_can_msg(999, 0, {'hi': 2})
opendbc/can/packer.cc: undefined address - 999
Out[4]: [999, 0, b'', 0]
```