### PR TITLE
Sconscript: enable openpilot compilation for macOS

### DIFF
--- a/can/SConscript
+++ b/can/SConscript
@@ -9,11 +9,10 @@ src = ["dbc.cc", "parser.cc", "packer.cc", "common.cc"]
 libs = [common, "capnp", "kj", "zmq"]
 
 # shared library for openpilot
-libdbc = envDBC.SharedLibrary('libdbc', src, LIBS=libs)
+LINKFLAGS = envDBC["LINKFLAGS"] + ["-Wl,-install_name,@rpath/libdbc.dylib"] if arch == "Darwin" else envDBC["LINKFLAGS"]
+libdbc = envDBC.SharedLibrary('libdbc', src, LIBS=libs, LINKFLAGS=LINKFLAGS)
 
 # static library for tools like cabana
-if arch == "Darwin":
-  envDBC["LINKFLAGS"] += ["-Wl,-install_name,@rpath/libdbc.dylib"]
 envDBC.Library('libdbc_static', src, LIBS=libs)
 
 # Build packer and parser

--- a/can/SConscript
+++ b/can/SConscript
@@ -9,7 +9,7 @@ src = ["dbc.cc", "parser.cc", "packer.cc", "common.cc"]
 libs = [common, "capnp", "kj", "zmq"]
 
 # shared library for openpilot
-LINKFLAGS = envDBC["LINKFLAGS"] + ["-Wl,-install_name,@rpath/libdbc.dylib"] if arch == "Darwin" else envDBC["LINKFLAGS"]
+LINKFLAGS = envDBC["LINKFLAGS"] + ["-Wl,-install_name,@loader_path/libdbc.dylib"] if arch == "Darwin" else envDBC["LINKFLAGS"]
 libdbc = envDBC.SharedLibrary('libdbc', src, LIBS=libs, LINKFLAGS=LINKFLAGS)
 
 # static library for tools like cabana
@@ -18,8 +18,6 @@ envDBC.Library('libdbc_static', src, LIBS=libs)
 # Build packer and parser
 lenv = envCython.Clone()
 lenv["LINKFLAGS"] += [libdbc[0].get_labspath()]
-if arch == "Darwin":
-  lenv["LINKFLAGS"] += [f'-Wl,-rpath,{File(libdbc[0]).dir.abspath}']
 parser = lenv.Program('parser_pyx.so', 'parser_pyx.pyx')
 packer = lenv.Program('packer_pyx.so', 'packer_pyx.pyx')
 

--- a/can/SConscript
+++ b/can/SConscript
@@ -19,7 +19,7 @@ envDBC.Library('libdbc_static', src, LIBS=libs)
 lenv = envCython.Clone()
 lenv["LINKFLAGS"] += [libdbc[0].get_labspath()]
 if arch == "Darwin":
-  lenv["LINKFLAGS"] += [libdbc[0].get_labspath(), f'-Wl,-rpath,{File(libdbc[0]).dir.abspath}']
+  lenv["LINKFLAGS"] += [f'-Wl,-rpath,{File(libdbc[0]).dir.abspath}']
 parser = lenv.Program('parser_pyx.so', 'parser_pyx.pyx')
 packer = lenv.Program('packer_pyx.so', 'packer_pyx.pyx')
 

--- a/can/SConscript
+++ b/can/SConscript
@@ -9,7 +9,9 @@ src = ["dbc.cc", "parser.cc", "packer.cc", "common.cc"]
 libs = [common, "capnp", "kj", "zmq"]
 
 # shared library for openpilot
-LINKFLAGS = envDBC["LINKFLAGS"] + ["-Wl,-install_name,@loader_path/libdbc.dylib"] if arch == "Darwin" else envDBC["LINKFLAGS"]
+LINKFLAGS = envDBC["LINKFLAGS"]
+if arch == "Darwin":
+  LINKFLAGS += ["-Wl,-install_name,@loader_path/libdbc.dylib"]
 libdbc = envDBC.SharedLibrary('libdbc', src, LIBS=libs, LINKFLAGS=LINKFLAGS)
 
 # static library for tools like cabana

--- a/can/SConscript
+++ b/can/SConscript
@@ -1,4 +1,4 @@
-Import('env', 'envCython', 'cereal', 'common')
+Import('env', 'envCython', 'cereal', 'common', 'arch')
 
 import os
 
@@ -12,11 +12,15 @@ libs = [common, "capnp", "kj", "zmq"]
 libdbc = envDBC.SharedLibrary('libdbc', src, LIBS=libs)
 
 # static library for tools like cabana
+if arch == "Darwin":
+  envDBC["LINKFLAGS"] += ["-Wl,-install_name,@rpath/libdbc.dylib"]
 envDBC.Library('libdbc_static', src, LIBS=libs)
 
 # Build packer and parser
 lenv = envCython.Clone()
 lenv["LINKFLAGS"] += [libdbc[0].get_labspath()]
+if arch == "Darwin":
+  lenv["LINKFLAGS"] += [libdbc[0].get_labspath(), f'-Wl,-rpath,{File(libdbc[0]).dir.abspath}']
 parser = lenv.Program('parser_pyx.so', 'parser_pyx.pyx')
 packer = lenv.Program('packer_pyx.so', 'packer_pyx.pyx')
 


### PR DESCRIPTION
prereq for: https://github.com/commaai/openpilot/pull/32909

Good reference: http://clarkkromenaker.com/post/library-dynamic-loading-mac/#:~:text=On%20Mac%20and%20Linux%2C%20the,path%20embedded%20inside%20the%20executable.

MacOS linking to dynamic library on scons is very weird, and RPATH is not well supported on macOS.

reference:
Similar trouble I encounter: https://github.com/SCons/scons/issues/3128
Weird behaviour on macOS for rpath: https://github.com/SCons/scons/issues/2127

Edit:
Uses `@loader_path` instead, for relative path to the file referencing the dynamic lib
