### PR TITLE
Tesla: Move DI_speed to correct bus and update signals within

### DIFF
--- a/opendbc/dbc/tesla_model3_party.dbc
+++ b/opendbc/dbc/tesla_model3_party.dbc
@@ -144,13 +144,6 @@ BO_ 880 EPAS3S_sysStatus: 8 PARTY
  SG_ EPAS3S_internalSASQF : 4|1@0+ (1,0) [0|1] ""  gtw
  SG_ EPAS3S_currentTuneMode : 7|3@0+ (1,0) [0|5] ""  gtw
 
-BO_ 599 DI_speed: 8 PARTY
- SG_ DI_uiSpeedUnits : 32|1@1+ (1,0) [0|1] ""  das
- SG_ DI_uiSpeed : 24|8@1+ (1,0) [0|254] ""  das
- SG_ DI_vehicleSpeed : 12|12@1+ (0.08,-40) [-40|285] "kph"  park
- SG_ DI_speedCounter : 8|4@1+ (1,0) [0|15] ""  park
- SG_ DI_speedChecksum : 0|8@1+ (1,0) [0|255] ""  park
-
 BO_ 1160 DAS_steeringControl: 4 PARTY
  SG_ DAS_steeringControlChecksum : 31|8@0+ (1,0) [0|255] ""  aps
  SG_ DAS_steeringControlCounter : 19|4@0+ (1,0) [0|15] ""  aps
@@ -291,9 +284,6 @@ VAL_ 880 EPAS3S_steeringFault 0 "NO_FAULT" 1 "FAULT" ;
 VAL_ 880 EPAS3S_steeringReduced 0 "NORMAL_ASSIST" 1 "REDUCED_ASSIST" ;
 VAL_ 880 EPAS3S_internalSASQF 1 "IN_SPEC" 0 "UNDEFINABLE_ACCURACY" ;
 VAL_ 880 EPAS3S_currentTuneMode 3 "STEERING_TUNE_RWD_COMFORT" 1 "STEERING_TUNE_DM_STANDARD" 5 "STEERING_TUNE_RWD_SPORT" 0 "STEERING_TUNE_DM_COMFORT" 4 "STEERING_TUNE_RWD_STANDARD" 2 "STEERING_TUNE_DM_SPORT" ;
-VAL_ 599 DI_uiSpeedUnits 0 "DI_SPEED_MPH" 1 "DI_SPEED_KPH" ;
-VAL_ 599 DI_uiSpeed 255 "DI_UI_SPEED_SNA" ;
-VAL_ 599 DI_vehicleSpeed 4095 "SNA" ;
 VAL_ 1160 DAS_steeringControlType 2 "LANE_KEEP_ASSIST" 0 "NONE" 1 "ANGLE_CONTROL" 3 "EMERGENCY_LANE_KEEP" ;
 VAL_ 1160 DAS_steeringAngleRequest 16384 "ZERO_ANGLE" ;
 VAL_ 297 SCCM_steeringAngleValidity 3 "SNA" 2 "INIT" 0 "INVALID" 1 "VALID" ;

--- a/opendbc/dbc/tesla_model3_vehicle.dbc
+++ b/opendbc/dbc/tesla_model3_vehicle.dbc
@@ -236,6 +236,15 @@ BO_ 1013 ID3F5VCFRONT_lighting: 8 VEH
  SG_ VCFRONT_indicatorRightRequest : 2|2@1+ (1,0) [0|2] ""  Receiver
  SG_ VCFRONT_indicatorLeftRequest : 0|2@1+ (1,0) [0|2] ""  Receiver
 
+BO_ 599 DI_speed: 8 VEH
+ SG_ DI_speedChecksum : 0|8@1+ (1,0) [0|255] ""  VehicleBus
+ SG_ DI_speedCounter : 8|4@1+ (1,0) [0|15] ""  VehicleBus
+ SG_ DI_opdVehicleModelSpeedRef : 12|12@1+ (0.08,-40) [-40|287.6] "kph"  VehicleBus
+ SG_ DI_uiSpeed : 24|9@1+ (1,0) [0|511] ""  VehicleBus
+ SG_ DI_uiSpeedUnits : 33|1@1+ (1,0) [0|1] ""  VehicleBus
+ SG_ DI_vehicleSpeed : 43|13@1+ (0.08,-40) [-40|615.28] "kph"  VehicleBus
+ SG_ DI_velocityEstimatorState : 56|3@1+ (1,0) [0|7] ""  VehicleBus
+
 VAL_ 568 SpdCtrlLvr_Stat 32 "DN_1ST" 16 "UP_1ST" 8 "DN_2ND" 4 "UP_2ND" 2 "RWD" 1 "FWD" 0 "IDLE" ;
 VAL_ 568 DTR_Dist_Rq 255 "SNA" 200 "ACC_DIST_7" 166 "ACC_DIST_6" 133 "ACC_DIST_5" 100 "ACC_DIST_4" 66 "ACC_DIST_3" 33 "ACC_DIST_2" 0 "ACC_DIST_1" ;
 VAL_ 568 TurnIndLvr_Stat 3 "SNA" 2 "RIGHT" 1 "LEFT" 0 "IDLE" ;
@@ -337,3 +346,7 @@ VAL_ 258 VCLEFT_mirrorState 3 "MIRROR_STATE_FOLD_UNFOLD" 1 "MIRROR_STATE_TILT_X"
 VAL_ 258 VCLEFT_mirrorHeatState 2 "HEATER_STATE_OFF" 4 "HEATER_STATE_FAULT" 1 "HEATER_STATE_ON" 0 "HEATER_STATE_SNA" 3 "HEATER_STATE_OFF_UNAVAILABLE";
 VAL_ 258 VCLEFT_frontLatchStatus 8 "LATCH_FAULT" 2 "LATCH_CLOSED" 1 "LATCH_OPENED" 3 "LATCH_CLOSING" 7 "LATCH_DEFAULT" 4 "LATCH_OPENING" 5 "LATCH_AJAR" 6 "LATCH_TIMEOUT" 0 "LATCH_SNA";
 VAL_ 258 VCLEFT_mirrorFoldState 4 "MIRROR_FOLD_STATE_UNFOLDING" 1 "MIRROR_FOLD_STATE_FOLDED" 3 "MIRROR_FOLD_STATE_FOLDING" 0 "MIRROR_FOLD_STATE_UNKNOWN" 2 "MIRROR_FOLD_STATE_UNFOLDED";
+VAL_ 599 DI_velocityEstimatorState 0 "NOT_INITIALIZED" 1 "WHEELS_NORMAL" 2 "WHEELS_REDUCED" 3 "BACKUP_WHEELS_A" 4 "BACKUP_WHEELS_B" 5 "BACKUP_MOTOR" ;
+VAL_ 599 DI_vehicleSpeed 8191 "SNA" ;
+VAL_ 599 DI_uiSpeedUnits 0 "MPH" 1 "KPH" ;
+VAL_ 599 DI_uiSpeed 511 "DI_UI_SPEED_SNA" ;


### PR DESCRIPTION
This PR moves the DI_speed message definition to the correct bus and updates the signals within to match the actual canbus data from model 3/Y

DI_speed doesn't exist on the party bus (at least not at 599).

At the moment nothing uses DI_speed so it wasn't discovered that it wasn't present on party bus. As such this change is a no-op to OP behavior on Tesla, but enables a future improvement to use uiSpeed for vEgoCluster

verification: bbbf82d987d681bc/000001cc--b24bcec625/0