### PR TITLE
parser: declutter nanos usage

### DIFF
--- a/can/parser.cc
+++ b/can/parser.cc
@@ -263,7 +263,7 @@ void CANParser::UpdateCans(uint64_t nanos, const capnp::DynamicStruct::Reader& c
 }
 
 void CANParser::UpdateValid(uint64_t nanos) {
-  const bool show_missing = (last_nanos - first_nanos) > 8e9;
+  const bool show_missing = (nanos - first_nanos) > 8e9;
 
   bool _valid = true;
   bool _counters_valid = true;


### PR DESCRIPTION
added here: https://github.com/commaai/opendbc/commit/87af8c4ac192e263bdd4e832d71bb10f480172ec

it's the same thing

After https://github.com/commaai/opendbc/pull/934 we can clean a bunch more up here