### PR TITLE
Refactor MessageState to Use `Msg` Struct and Simplify Initialization

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -41,23 +41,20 @@ struct CanData {
 
 class MessageState {
 public:
-  std::string name;
-  uint32_t address;
-  unsigned int size;
-
-  std::vector<Signal> parse_sigs;
+  Msg msg;
   std::vector<double> vals;
   std::vector<std::vector<double>> all_vals;
 
-  uint64_t last_seen_nanos;
-  uint64_t check_threshold;
+  uint64_t last_seen_nanos = 0;
+  uint64_t check_threshold = 0;
 
-  uint8_t counter;
-  uint8_t counter_fail;
+  uint8_t counter = 0;
+  uint8_t counter_fail = 0;
 
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
+  MessageState(const Msg *msg, uint64_t threshold, bool no_checksum = false, bool no_counter = false);
   bool parse(uint64_t nanos, const std::vector<uint8_t> &dat);
   bool update_counter_generic(int64_t v, int cnt_size);
 };


### PR DESCRIPTION
Refactors the MessageState class to improve its structure and initialization process:

1. Replaced multiple member variables with a single `struct Msg` to encapsulate message-related data. These member variables were essentially duplicates of the struct Msg's members.
2. Added a constructor `MessageState::MessageState` to simplify the initialization process.
3. Updated the code to use the new struct and constructor for better readability and maintainability.

This refactor enhances code clarity, reduces redundancy, and streamlines the initialization process.

