### PR TITLE
parser:  refactor value dictionary update logic

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <unordered_map>
@@ -65,7 +66,6 @@ class CANParser {
 private:
   const int bus;
   const DBC *dbc = NULL;
-  std::unordered_map<uint32_t, MessageState> message_states;
 
 public:
   bool can_valid = false;
@@ -75,15 +75,16 @@ public:
   uint64_t last_nonempty_nanos = 0;
   uint64_t bus_timeout_threshold = 0;
   uint64_t can_invalid_cnt = CAN_INVALID_CNT;
+  std::unordered_map<uint32_t, MessageState> message_states;
 
   CANParser(int abus, const std::string& dbc_name,
             const std::vector<std::pair<uint32_t, int>> &messages);
   CANParser(int abus, const std::string& dbc_name, bool ignore_checksum, bool ignore_counter);
-  void update(const std::vector<CanData> &can_data, std::vector<SignalValue> &vals);
-  void query_latest(std::vector<SignalValue> &vals, uint64_t last_ts = 0);
+  std::set<uint32_t> update(const std::vector<CanData> &can_data);
 
 protected:
-  void UpdateCans(const CanData &can);
+  void clearAllValues();
+  void updateCans(const CanData &can, std::set<uint32_t> &updated_addresses);
   void UpdateValid(uint64_t nanos);
 };
 

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -4,6 +4,7 @@
 from libc.stdint cimport uint8_t, uint32_t, uint64_t
 from libcpp cimport bool
 from libcpp.pair cimport pair
+from libcpp.set cimport set
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.unordered_map cimport unordered_map
@@ -52,13 +53,6 @@ cdef extern from "common_dbc.h":
     unordered_map[uint32_t, const Msg*] addr_to_msg
     unordered_map[string, const Msg*] name_to_msg
 
-  cdef struct SignalValue:
-    uint32_t address
-    uint64_t ts_nanos
-    string name
-    double value
-    vector[double] all_values
-
   cdef struct SignalPackValue:
     string name
     double value
@@ -76,11 +70,18 @@ cdef extern from "common.h":
     uint64_t nanos
     vector[CanFrame] frames
 
+  cdef cppclass MessageState:
+    vector[Signal] parse_sigs
+    vector[double] vals
+    vector[vector[double]] all_vals
+    uint64_t last_seen_nanos
+
   cdef cppclass CANParser:
     bool can_valid
     bool bus_timeout
+    unordered_map[uint32_t, MessageState] message_states
     CANParser(int, string, vector[pair[uint32_t, int]]) except +
-    void update(vector[CanData]&, vector[SignalValue]&) except +
+    set[uint32_t] update(vector[CanData]&) except +
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/opendbc/can/common_dbc.h
+++ b/opendbc/can/common_dbc.h
@@ -10,14 +10,6 @@ struct SignalPackValue {
   double value;
 };
 
-struct SignalValue {
-  uint32_t address;
-  uint64_t ts_nanos;
-  std::string name;
-  double value;  // latest value
-  std::vector<double> all_values;  // all values from this cycle
-};
-
 enum SignalType {
   DEFAULT,
   COUNTER,

--- a/opendbc/can/tests/test_packer_parser.py
+++ b/opendbc/can/tests/test_packer_parser.py
@@ -126,6 +126,11 @@ class TestCanParserPacker:
     assert parser.vl["STEERING_CONTROL"]["STEER_TORQUE"] == 300
     assert parser.vl_all["STEERING_CONTROL"]["STEER_TORQUE"] == [300]
 
+  def test_parser_empty_message(self):
+    parser = CANParser("toyota_nodsu_pt_generated", [("ACC_CONTROL", 0)])
+    addr = parser.update_strings([])
+    assert len(addr) == 0
+
   def test_packer_parser(self):
     msgs = [
       ("Brake_Status", 0),
@@ -264,7 +269,7 @@ class TestCanParserPacker:
           can_msgs[frame].append(packer.make_can_msg("VSA_STATUS", 0, values))
           idx += 1
 
-      parser.update_strings([[0, m] for m in can_msgs])
+      parser.update_strings([[random.randint(0, 255), m] for m in can_msgs])
       vl_all = parser.vl_all["VSA_STATUS"]["USER_BRAKE"]
 
       assert vl_all == user_brake_vals


### PR DESCRIPTION
Main Changes:

1. Removed the `SignalValue` struct and the `query_latest()` function. These were previously used to copy updated values to Cython code and initializing the value dictionary in Cython's `__init__` method when query_latest() was called with empty CAN strings.
2. Exposed `MessageState` to Cython code, enabling direct access to values from `MessageState` after an update.
3. Tracked updated messages using and returning a set of updated_address in MessageState::update. This ensures that every update is captured and is not related to the `current_nanos`.
4. Simplified and robustified the initialization of the value dictionary maps.

These changes significantly simplify the update logic, improve performance, and eliminate issues related to the problematic `last_nanos`  and `current_nanos` in query_latest(). This refactor fixes multiple issues, including:

   - [Issue 1068](https://github.com/commaai/opendbc/issues/1068)
   - [Issue 913](https://github.com/commaai/opendbc/issues/913)
   - [Issue 1066](https://github.com/commaai/opendbc/issues/1066) (partially resolved)

Remaining Tasks for Issue 1066 (will be resolved in another PR):
    - Ensure the `vals` in MessageState are always the newest.
    - Ensure `all_vals` are sorted by received time.