### PR TITLE
parser: check avg freq

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -51,7 +51,9 @@ public:
   std::vector<std::vector<double>> all_vals;
 
   uint64_t last_seen_nanos;
-  uint64_t check_threshold;
+  double frequency = 0.0;
+  uint64_t sum_intervals = 0;
+  uint64_t message_count = 0;
 
   uint8_t counter;
   uint8_t counter_fail;
@@ -61,6 +63,8 @@ public:
 
   bool parse(uint64_t nanos, const std::vector<uint8_t> &dat);
   bool update_counter_generic(int64_t v, int cnt_size);
+  double getAverageFreq(uint64_t current_nanos) const;
+  bool isFreqBelowThreshold(uint64_t current_nanos, double threshold) const;
 };
 
 class CANParser {

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -100,16 +100,12 @@ double MessageState::getAverageFreq(uint64_t current_nanos) const {
     return 0.0; // Not enough messages
   }
 
-  // Calculate the total interval from the first message to the current time
   double total_interval = ((current_nanos - last_seen_nanos) + sum_intervals) / 1e9;
-  // Calculate the average interval
-  double average_interval = total_interval / (message_count - 1);
-  return 1.0 / average_interval;
+  return (message_count - 1) / total_interval;
 }
 
 bool MessageState::isFreqBelowThreshold(uint64_t current_nanos, double threshold) const {
-  double avg_freq = getAverageFreq(current_nanos);
-  return avg_freq < (frequency * (1.0 - threshold));
+  return getAverageFreq(current_nanos) < (frequency * (1.0 - threshold));
 }
 
 
@@ -242,9 +238,7 @@ void CANParser::UpdateValid(uint64_t nanos) {
 
   bool _valid = true;
   bool _counters_valid = true;
-  for (const auto& kv : message_states) {
-    const auto& state = kv.second;
-
+  for (const auto& [_, state] : message_states) {
     if (state.counter_fail >= MAX_BAD_COUNTER) {
       _counters_valid = false;
     }

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -7,6 +7,10 @@
 
 #include "opendbc/can/common.h"
 
+// The allowed deviation from the expected frequency, expressed as a fraction.
+// For example, a threshold of 0.1 allows the average frequency to be up to 10% lower than the expected value.
+const double FREQ_THRESHOLD = 0.5;
+
 int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
   int64_t ret = 0;
 
@@ -28,6 +32,13 @@ int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
 
 
 bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
+  if (last_seen_nanos != 0 && nanos > last_seen_nanos) {
+    // Update the sum of intervals with the time since the last message
+    sum_intervals += (nanos - last_seen_nanos);
+  }
+  last_seen_nanos = nanos;
+  message_count++;
+
   std::vector<double> tmp_vals(parse_sigs.size());
   bool checksum_failed = false;
   bool counter_failed = false;
@@ -67,8 +78,6 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
     vals[i] = tmp_vals[i];
     all_vals[i].push_back(vals[i]);
   }
-  last_seen_nanos = nanos;
-
   return true;
 }
 
@@ -84,6 +93,23 @@ bool MessageState::update_counter_generic(int64_t v, int cnt_size) {
   }
   counter = v;
   return counter_fail < MAX_BAD_COUNTER;
+}
+
+double MessageState::getAverageFreq(uint64_t current_nanos) const {
+  if (message_count < 2) {
+    return 0.0; // Not enough messages
+  }
+
+  // Calculate the total interval from the first message to the current time
+  double total_interval = ((current_nanos - last_seen_nanos) + sum_intervals) / 1e9;
+  // Calculate the average interval
+  double average_interval = total_interval / (message_count - 1);
+  return 1.0 / average_interval;
+}
+
+bool MessageState::isFreqBelowThreshold(uint64_t current_nanos, double threshold) const {
+  double avg_freq = getAverageFreq(current_nanos);
+  return avg_freq < (frequency * (1.0 - threshold));
 }
 
 
@@ -108,10 +134,11 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
 
     // msg is not valid if a message isn't received for 10 consecutive steps
     if (frequency > 0) {
-      state.check_threshold = (1000000000ULL / frequency) * 10;
+      state.frequency = frequency;
 
+      uint64_t check_threshold = (1000000000ULL / frequency) * 10;
       // bus timeout threshold should be 10x the fastest msg
-      bus_timeout_threshold = std::min(bus_timeout_threshold, state.check_threshold);
+      bus_timeout_threshold = std::min(bus_timeout_threshold, check_threshold);
     }
 
     const Msg *msg = dbc->addr_to_msg.at(address);
@@ -222,17 +249,19 @@ void CANParser::UpdateValid(uint64_t nanos) {
       _counters_valid = false;
     }
 
-    const bool missing = state.last_seen_nanos == 0;
-    const bool timed_out = (nanos - state.last_seen_nanos) > state.check_threshold;
-    if (state.check_threshold > 0 && (missing || timed_out)) {
-      if (show_missing && !bus_timeout) {
-        if (missing) {
-          LOGE_100("0x%X '%s' NOT SEEN", state.address, state.name.c_str());
-        } else if (timed_out) {
-          LOGE_100("0x%X '%s' TIMED OUT", state.address, state.name.c_str());
+    if (state.frequency > 0) {
+      const bool missing = state.last_seen_nanos == 0;
+      const bool timed_out = state.last_seen_nanos < nanos && state.isFreqBelowThreshold(nanos, FREQ_THRESHOLD);
+      if (missing || timed_out) {
+        if (show_missing && !bus_timeout) {
+          if (missing) {
+            LOGE_100("0x%X '%s' NOT SEEN", state.address, state.name.c_str());
+          } else if (timed_out) {
+            LOGE_100("0x%X '%s' TIMED OUT", state.address, state.name.c_str());
+          }
         }
-      }
       _valid = false;
+      }
     }
   }
   can_invalid_cnt = _valid ? 0 : (can_invalid_cnt + 1);


### PR DESCRIPTION
resolve https://github.com/commaai/opendbc/issues/850

- [ ] Introduce Exponential Moving Average (EMA) for frequency tracking, as implemented in [this PR](https://github.com/commaai/openpilot/pull/34107).
- [ ] reset and restart message's average frequency calculation when it falls below the threshold (invalid) and a new message arrives.
