### PR TITLE
fix: relax ci timout 1min->2min

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
   unit-tests:
     name: unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     #strategy:
     #  fail-fast: false
     #  matrix:
@@ -32,7 +32,7 @@ jobs:
   static-analysis:
     name: static analysis
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 2
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5


### PR DESCRIPTION
some time ci execution reached to over 1 minutes. so this PR change ci timeout 1min to 2min.

![Screenshot 2024-08-18 at 20 00 35](https://github.com/user-attachments/assets/3bdcceb0-3361-4a1b-92fb-14190eb79da9)
