### PR TITLE
Show detail sentence in car docs

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -22,6 +22,7 @@ class Column(Enum):
   AUTO_RESUME = "Resume from stop"
   HARDWARE = "Hardware Needed"
   VIDEO = "Video"
+  DETAIL_SENTENCE = "Detail"
 
 
 class Star(Enum):
@@ -219,6 +220,21 @@ def split_name(name: str) -> tuple[str, str, str]:
   return make, model, years
 
 
+# prevent squashing into too thin column
+def format_with_nbsp(text):
+    words = text.split()
+    result = words[0]
+    cur_chunk_len = len(result)
+    for word in words[1:]:
+      cur_chunk_len += len(word)
+      if cur_chunk_len >= 35:
+        result += ' ' + word
+        cur_chunk_len = len(word)
+      else:
+        result += '&nbsp;' + word
+    return result
+
+
 @dataclass
 class CarDocs:
   # make + model + model years
@@ -313,6 +329,8 @@ class CarDocs:
 
     self.all_footnotes = all_footnotes
     self.detail_sentence = self.get_detail_sentence(CP)
+
+    self.row[Column.DETAIL_SENTENCE] = f'<details><summary>Detail</summary><sub>{format_with_nbsp(self.detail_sentence)}</sub></details>'
 
     return self
 


### PR DESCRIPTION
Useful for generating car docs diff in CI (work in progress [here](https://github.com/commaai/openpilot/pull/33273)).

<img width="1043" alt="Screenshot 2024-08-21 at 12 09 27 PM" src="https://github.com/user-attachments/assets/12084874-2ce8-464d-a115-b886d25a9d29">
<img width="1021" alt="Screenshot 2024-08-21 at 12 11 31 PM" src="https://github.com/user-attachments/assets/46cbe64e-69c9-47bf-af6e-2404cac1ed88">
