### PR TITLE
Toyota: raise max longitudinal accel to 2 m/s^2

### DIFF
--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -15,7 +15,7 @@ PEDAL_TRANSITION = 10. * CV.MPH_TO_MS
 
 
 class CarControllerParams:
-  ACCEL_MAX = 1.5  # m/s2, lower than allowed 2.0 m/s2 for tuning reasons
+  ACCEL_MAX = 2.0  # m/s2
   ACCEL_MIN = -3.5  # m/s2
 
   STEER_STEP = 1


### PR DESCRIPTION
In line with the rest of the cars.

Toyota was first added here at 1.5 for an unknown reason (experimental port?): https://github.com/commaai/one/pull/33

It was the second port in the car folder, after Honda (1 m/s^2??): https://github.com/commaai/one/blob/4db5f6f8970b3bbdbe54877d64ff0606c3f86cda/selfdrive/car/honda/interface.py#L393C18-L393C69

openpilot PR: https://github.com/commaai/openpilot/pull/33386