### PR TITLE
Revert "GM: implement allow throttle/brakes"

### DIFF
--- a/opendbc/car/gm/carcontroller.py
+++ b/opendbc/car/gm/carcontroller.py
@@ -94,11 +94,8 @@ class CarController(CarControllerBase):
           self.apply_brake = int(round(interp(actuators.accel, self.params.BRAKE_LOOKUP_BP, self.params.BRAKE_LOOKUP_V)))
           # Don't allow any gas above inactive regen while stopping
           # FIXME: brakes aren't applied immediately when enabling at a stop
-          if stopping or not actuators.allowThrottle:
+          if stopping:
             self.apply_gas = self.params.INACTIVE_REGEN
-
-          if not actuators.allowBrake:
-            self.apply_brake = 0
 
         idx = (self.frame // 4) % 4
 

--- a/opendbc/car/structs.py
+++ b/opendbc/car/structs.py
@@ -220,9 +220,6 @@ class CarControl:
     steerOutputCan: float = auto_field()
     steeringAngleDeg: float = auto_field()
 
-    allowBrake: bool = auto_field()
-    allowThrottle: bool = auto_field()
-
     curvature: float = auto_field()
 
     speed: float = auto_field()  # m/s


### PR DESCRIPTION
We can't add fields without them being in cereal or openpilot CI will fail on the conversion. We will want to split this co-dependence in the future.

Reverts commaai/opendbc#1185