### PR TITLE
Remove subaru engine and transmission fw versions, add to extra_ecus

### DIFF
--- a/opendbc/car/subaru/fingerprints.py
+++ b/opendbc/car/subaru/fingerprints.py
@@ -21,17 +21,6 @@ FW_VERSIONS = {
       b'\x00\x00e@\x1f@ $',
       b"\x00\x00e~\x1f@ '",
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xbb,\xa0t\x07',
-      b'\xd1,\xa0q\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\x00>\xf0\x00\x00',
-      b'\x00\xfe\xf7\x00\x00',
-      b'\x01\xfe\xf7\x00\x00',
-      b'\x01\xfe\xf9\x00\x00',
-      b'\x01\xfe\xfa\x00\x00',
-    ],
   },
   CAR.SUBARU_ASCENT_2023: {
     (Ecu.abs, 0x7b0, None): [
@@ -42,12 +31,6 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x05!\x08\x1dK\x05!\x08\x01/',
-    ],
-    (Ecu.engine, 0x7a2, None): [
-      b'\xe5,\xa0P\x07',
-    ],
-    (Ecu.transmission, 0x7a3, None): [
-      b'\x04\xfe\xf3\x00\x00',
     ],
   },
   CAR.SUBARU_LEGACY: {
@@ -64,18 +47,6 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00e\x80\x00\x1f@ \x19\x00',
       b'\x00\x00e\x9a\x00\x00\x00\x00\x00\x00',
-    ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xde"a0\x07',
-      b'\xde,\xa0@\x07',
-      b'\xe2"aq\x07',
-      b'\xe2,\xa0@\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xa5\xf6\x05@\x00',
-      b'\xa5\xfe\xc7@\x00',
-      b'\xa7\xf6\x04@\x00',
-      b'\xa7\xfe\xc4@\x00',
     ],
   },
   CAR.SUBARU_IMPREZA: {
@@ -118,45 +89,6 @@ FW_VERSIONS = {
       b'\x00\x00e+\x00\x00\x00\x00',
       b'\x00\x00e+\x1f@ \x14',
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xaa\x00Bu\x07',
-      b'\xaa\x01bt\x07',
-      b'\xaa!`u\x07',
-      b'\xaa!au\x07',
-      b'\xaa!av\x07',
-      b'\xaa!aw\x07',
-      b'\xaa!dq\x07',
-      b'\xaa!ds\x07',
-      b'\xaa!dt\x07',
-      b'\xaaafs\x07',
-      b'\xbe!as\x07',
-      b'\xbe!at\x07',
-      b'\xbeacr\x07',
-      b'\xc5!`r\x07',
-      b'\xc5!`s\x07',
-      b'\xc5!ap\x07',
-      b'\xc5!ar\x07',
-      b'\xc5!as\x07',
-      b'\xc5!dr\x07',
-      b'\xc5!ds\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xe3\xd0\x081\x00',
-      b'\xe3\xd5\x161\x00',
-      b'\xe3\xe5F1\x00',
-      b'\xe3\xf5\x06\x00\x00',
-      b'\xe3\xf5\x07\x00\x00',
-      b'\xe3\xf5C\x00\x00',
-      b'\xe3\xf5F\x00\x00',
-      b'\xe3\xf5G\x00\x00',
-      b'\xe4\xe5\x021\x00',
-      b'\xe4\xe5\x061\x00',
-      b'\xe4\xf5\x02\x00\x00',
-      b'\xe4\xf5\x07\x00\x00',
-      b'\xe5\xf5\x04\x00\x00',
-      b'\xe5\xf5$\x00\x00',
-      b'\xe5\xf5B\x00\x00',
-    ],
   },
   CAR.SUBARU_IMPREZA_2020: {
     (Ecu.abs, 0x7b0, None): [
@@ -185,37 +117,6 @@ FW_VERSIONS = {
       b'\x00\x00e\xa4\x00\x00\x00\x00',
       b'\x00\x00e\xa4\x1f@ (',
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xca!`0\x07',
-      b'\xca!`p\x07',
-      b'\xca!ap\x07',
-      b'\xca!f@\x07',
-      b'\xca!fp\x07',
-      b'\xcaacp\x07',
-      b'\xcc!`p\x07',
-      b'\xcc!fp\x07',
-      b'\xcc"f0\x07',
-      b'\xe6!`@\x07',
-      b'\xe6!fp\x07',
-      b'\xe6"f0\x07',
-      b'\xe6"fp\x07',
-      b'\xf3"f@\x07',
-      b'\xf3"fp\x07',
-      b'\xf3"fr\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xe6\x15\x042\x00',
-      b'\xe6\xf5\x04\x00\x00',
-      b'\xe6\xf5$\x00\x00',
-      b'\xe6\xf5D0\x00',
-      b'\xe7\xf5\x04\x00\x00',
-      b'\xe7\xf5D0\x00',
-      b'\xe7\xf6B0\x00',
-      b'\xe9\xf5"\x00\x00',
-      b'\xe9\xf5B0\x00',
-      b'\xe9\xf6B0\x00',
-      b'\xe9\xf6F0\x00',
-    ],
   },
   CAR.SUBARU_CROSSTREK_HYBRID: {
     (Ecu.abs, 0x7b0, None): [
@@ -228,11 +129,6 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00el\x1f@ #',
-    ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xd7!`@\x07',
-      b'\xd7!`p\x07',
-      b'\xf4!`0\x07',
     ],
   },
   CAR.SUBARU_FORESTER: {
@@ -259,24 +155,6 @@ FW_VERSIONS = {
       b'\x00\x00e\x97\x00\x00\x00\x00',
       b'\x00\x00e\x97\x1f@ 0',
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xb6"`A\x07',
-      b'\xb6\xa2`A\x07',
-      b'\xcb"`@\x07',
-      b'\xcb"`p\x07',
-      b'\xcf"`0\x07',
-      b'\xcf"`p\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\x1a\xe6B1\x00',
-      b'\x1a\xe6F1\x00',
-      b'\x1a\xf6B0\x00',
-      b'\x1a\xf6B`\x00',
-      b'\x1a\xf6F`\x00',
-      b'\x1a\xf6b0\x00',
-      b'\x1a\xf6b`\x00',
-      b'\x1a\xf6f`\x00',
-    ],
   },
   CAR.SUBARU_FORESTER_HYBRID: {
     (Ecu.abs, 0x7b0, None): [
@@ -287,12 +165,6 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\x00\x00eY\x1f@ !',
-    ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xd2\xa1`r\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\x1b\xa7@a\x00',
     ],
   },
   CAR.SUBARU_FORESTER_PREGLOBAL: {
@@ -309,23 +181,6 @@ FW_VERSIONS = {
       b'\x00\x00c\xe9\x1f@ \x03',
       b'\x00\x00d5\x1f@ \t',
       b'\x00\x00d\xd3\x1f@ \t',
-    ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xa7"@0\x07',
-      b'\xa7"@p\x07',
-      b'\xa7)\xa0q\x07',
-      b'\xba"@@\x07',
-      b'\xba"@p\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\x1a\xf6F`\x00',
-      b'\xda\xf2`p\x00',
-      b'\xda\xf2`\x80\x00',
-      b'\xda\xfd\xe0\x80\x00',
-      b'\xdc\xf2@`\x00',
-      b'\xdc\xf2``\x00',
-      b'\xdc\xf2`\x80\x00',
-      b'\xdc\xf2`\x81\x00',
     ],
   },
   CAR.SUBARU_LEGACY_PREGLOBAL: {
@@ -345,20 +200,6 @@ FW_VERSIONS = {
       b'\x00\x00c\x94\x1f@\x10\x08',
       b'\x00\x00c\xb7\x1f@\x10\x16',
       b'\x00\x00c\xec\x1f@ \x04',
-    ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xa0"@q\x07',
-      b'\xa0+@p\x07',
-      b'\xab*@r\x07',
-      b'\xab+@p\x07',
-      b'\xb4"@0\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xbd\xf2\x00`\x00',
-      b'\xbe\xf2\x00p\x00',
-      b'\xbe\xfb\xc0p\x00',
-      b'\xbf\xf2\x00\x80\x00',
-      b'\xbf\xfb\xc0\x80\x00',
     ],
   },
   CAR.SUBARU_OUTBACK_PREGLOBAL: {
@@ -387,32 +228,6 @@ FW_VERSIONS = {
       b'\x00\x00c\xd1\x1f@\x10\x17',
       b'\x00\x00c\xec\x1f@ \x04',
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xa0"@\x80\x07',
-      b'\xa0*@q\x07',
-      b'\xa0*@u\x07',
-      b'\xa0+@@\x07',
-      b'\xa0bAq\x07',
-      b'\xab"@@\x07',
-      b'\xab"@s\x07',
-      b'\xab*@@\x07',
-      b'\xab+@@\x07',
-      b'\xb4"@0\x07',
-      b'\xb4"@p\x07',
-      b'\xb4"@r\x07',
-      b'\xb4+@p\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xbd\xf2@`\x00',
-      b'\xbd\xf2@\x81\x00',
-      b'\xbd\xfb\xe0\x80\x00',
-      b'\xbe\xf2@p\x00',
-      b'\xbe\xf2@\x80\x00',
-      b'\xbe\xfb\xe0p\x00',
-      b'\xbf\xe2@\x80\x00',
-      b'\xbf\xf2@\x80\x00',
-      b'\xbf\xfb\xe0b\x00',
-    ],
   },
   CAR.SUBARU_OUTBACK_PREGLOBAL_2018: {
     (Ecu.abs, 0x7b0, None): [
@@ -435,26 +250,6 @@ FW_VERSIONS = {
       b'\x00\x00d\xfe\x00\x00\x00\x00',
       b'\x00\x00d\xfe\x1f@ \x15',
       b'\x00\x00e\x19\x1f@ \x15',
-    ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xb5"@P\x07',
-      b'\xb5"@p\x07',
-      b'\xb5+@@\x07',
-      b'\xb5b@1\x07',
-      b'\xb5q\xe0@\x07',
-      b'\xc4"@0\x07',
-      b'\xc4+@0\x07',
-      b'\xc4b@p\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xbb\xf2@`\x00',
-      b'\xbb\xfb\xe0`\x00',
-      b'\xbc\xaf\xe0`\x00',
-      b'\xbc\xe2@\x80\x00',
-      b'\xbc\xf2@\x80\x00',
-      b'\xbc\xf2@\x81\x00',
-      b'\xbc\xfb\xe0`\x00',
-      b'\xbc\xfb\xe0\x80\x00',
     ],
   },
   CAR.SUBARU_OUTBACK: {
@@ -484,27 +279,6 @@ FW_VERSIONS = {
       b'\x00\x00e\x9a\x00\x00\x00\x00\x00\x00',
       b'\x00\x00e\x9a\x00\x1f@ 1\x00',
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xbc"`@\x07',
-      b'\xbc"`q\x07',
-      b'\xbc,\xa0q\x07',
-      b'\xbc,\xa0u\x07',
-      b'\xde"`0\x07',
-      b'\xde,\xa0@\x07',
-      b'\xe2"`0\x07',
-      b'\xe2"`p\x07',
-      b'\xe2"`q\x07',
-      b'\xe3,\xa0@\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\xa5\xf6D@\x00',
-      b'\xa5\xfe\xf6@\x00',
-      b'\xa5\xfe\xf7@\x00',
-      b'\xa5\xfe\xf8@\x00',
-      b'\xa7\x8e\xf40\x00',
-      b'\xa7\xf6D@\x00',
-      b'\xa7\xfe\xf4@\x00',
-    ],
   },
   CAR.SUBARU_FORESTER_2022: {
     (Ecu.abs, 0x7b0, None): [
@@ -524,20 +298,6 @@ FW_VERSIONS = {
       b'\x04!\x08\x01.\x07!\x08\x022',
       b'\r!\x08\x017\n!\x08\x003',
     ],
-    (Ecu.engine, 0x7e0, None): [
-      b'\xd5"`0\x07',
-      b'\xd5"a0\x07',
-      b'\xf1"`q\x07',
-      b'\xf1"aq\x07',
-      b'\xfa"ap\x07',
-    ],
-    (Ecu.transmission, 0x7e1, None): [
-      b'\x1d\x86B0\x00',
-      b'\x1d\xf6B0\x00',
-      b'\x1e\x86B0\x00',
-      b'\x1e\x86F0\x00',
-      b'\x1e\xf6D0\x00',
-    ],
   },
   CAR.SUBARU_OUTBACK_2023: {
     (Ecu.abs, 0x7b0, None): [
@@ -550,14 +310,6 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x787, None): [
       b'\t!\x08\x046\x05!\x08\x01/',
-    ],
-    (Ecu.engine, 0x7a2, None): [
-      b'\xed,\xa0q\x07',
-      b'\xed,\xa2q\x07',
-    ],
-    (Ecu.transmission, 0x7a3, None): [
-      b'\xa8\x8e\xf41\x00',
-      b'\xa8\xfe\xf41\x00',
     ],
   },
 }

--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -269,7 +269,13 @@ FW_QUERY_CONFIG = FwQueryConfig(
   # We don't get the EPS from non-OBD queries on GEN2 cars. Note that we still attempt to match when it exists
   non_essential_ecus={
     Ecu.eps: list(CAR.with_flags(SubaruFlags.GLOBAL_GEN2)),
-  }
+  },
+  extra_ecus=[
+    (Ecu.engine, 0x7e0, None),
+    (Ecu.engine, 0x7e2, None),
+    (Ecu.transmission, 0x7e1, None),
+    (Ecu.transmission, 0x7a3, None),
+  ],
 )
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION
This PR removes Subaru engine and transmission fw versions to simplify fingerprinting (less fw versions PR-s to merge) and improve the first-use experience for openpilot

**Verification**

I checked all the different models that use same ecu fw version for the remaining essential ecus and did not find any overlaps over all three:
```
Ecu.abs, 0x7b0, None, b'\xa2 \x193\x00', CAR.SUBARU_IMPREZA
Ecu.abs, 0x7b0, None, b'\xa2 \x193\x00', CAR.SUBARU_IMPREZA_2020
Ecu.abs, 0x7b0, None, b'\xa2 \x194\x00', CAR.SUBARU_IMPREZA
Ecu.abs, 0x7b0, None, b'\xa2 \x194\x00', CAR.SUBARU_IMPREZA_2020

Ecu.eps, 0x746, None, b'k\xb0\x00\x00', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.eps, 0x746, None, b'k\xb0\x00\x00', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.eps, 0x746, None, b'{\xb0\x00\x01', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.eps, 0x746, None, b'{\xb0\x00\x01', CAR.SUBARU_OUTBACK_PREGLOBAL_2018

Ecu.fwdCamera, 0x787, None, b'\x00\x00c\x94\x1f@\x10\x08', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\x94\x1f@\x10\x08', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xb7\x1f@\x10\x16', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xb7\x1f@\x10\x16', CAR.SUBARU_OUTBACK_PREGLOBAL
 
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xec\x1f@ \x04', CAR.SUBARU_LEGACY_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00c\xec\x1f@ \x04', CAR.SUBARU_OUTBACK_PREGLOBAL
Ecu.fwdCamera, 0x787, None, b'\x00\x00e\x80\x00\x1f@ \x19\x00', CAR.SUBARU_LEGACY
Ecu.fwdCamera, 0x787, None, b'\x00\x00e\x80\x00\x1f@ \x19\x00', CAR.SUBARU_OUTBACK
```

Reference:
https://github.com/commaai/openpilot/pull/33102
