### PR TITLE
Subaru: add fwdCamera to non_essential for ANGLE_LKAS cars

### DIFF
--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -266,9 +266,11 @@ FW_QUERY_CONFIG = FwQueryConfig(
       obd_multiplexing=False,
     ),
   ],
-  # We don't get the EPS from non-OBD queries on GEN2 cars. Note that we still attempt to match when it exists
+  # We don't get the EPS from non-OBD queries on GEN2 and sometimes fwdCamera on LKAS_ANGLE cars.
+  # Note that we still attempt to match when it exists
   non_essential_ecus={
     Ecu.eps: list(CAR.with_flags(SubaruFlags.GLOBAL_GEN2)),
+    Ecu.fwdCamera: list(CAR.with_flags(SubaruFlags.LKAS_ANGLE)),
   }
 )
 


### PR DESCRIPTION
Possible solution for https://github.com/commaai/opendbc/issues/1153
The remaining ecu fw versions for ANGLE_LKAS cars are unique enough for fingerprinting.

IIRC, SSM4 just retried the fw query on startup on all known ecu addresses for a few minutes until it got response. I can provide logs if you need.

if we must know fwdCamera fw version for logging or verification purposes, could it be run in the background after fingerprinting a few times to see if the fw version has changed?