### PR TITLE
Subaru: remove LKAS_ANGLE cars from dashcam only

### DIFF
--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -15,7 +15,7 @@ class CarInterface(CarInterfaceBase):
     # - replacement for ES_Distance so we can cancel the cruise control
     # - to find the Cruise_Activated bit from the car
     # - proper panda safety setup (use the correct cruise_activated bit, throttle from Throttle_Hybrid, etc)
-    ret.dashcamOnly = bool(ret.flags & (SubaruFlags.PREGLOBAL | SubaruFlags.LKAS_ANGLE | SubaruFlags.HYBRID))
+    ret.dashcamOnly = bool(ret.flags & (SubaruFlags.PREGLOBAL | SubaruFlags.HYBRID))
     ret.autoResumeSng = False
 
     # Detect infotainment message sent from the camera


### PR DESCRIPTION
This PR removes Subaru LKAS_ANGLE cars from dashcam only. Please let me know if anything is still missing before this can be done. I did not find anything missing during my initial review.

LKAS_ANGLE cars are currently:
- Subaru Forester 2022-24
- Subaru Outback 2023
- Subaru Ascent 2023