### PR TITLE
Subaru: driver torque sensor Nm scaling factor and unit

### DIFF
--- a/opendbc/car/subaru/carstate.py
+++ b/opendbc/car/subaru/carstate.py
@@ -68,7 +68,7 @@ class CarState(CarStateBase):
       # ideally we get this from the car, but unclear if it exists. diagnostic software doesn't even have it
       ret.steeringRateDeg = self.angle_rate_calulator.update(ret.steeringAngleDeg, cp.vl["Steering_Torque"]["COUNTER"])
 
-    ret.steeringTorque = cp.vl["Steering_Torque"]["Steer_Torque_Sensor"]
+    ret.steeringTorque = cp.vl["Steering_Torque_2"]["Steer_Torque_Sensor"]
     ret.steeringTorqueEps = cp.vl["Steering_Torque"]["Steer_Torque_Output"]
 
     steer_threshold = 75 if self.CP.flags & SubaruFlags.PREGLOBAL else 80

--- a/opendbc/car/subaru/carstate.py
+++ b/opendbc/car/subaru/carstate.py
@@ -169,6 +169,7 @@ class CarState(CarStateBase):
       # sig_address, frequency
       ("Dashlights", 10),
       ("Steering_Torque", 50),
+      ("Steering_Torque_2", 50),
       ("BodyInfo", 1),
       ("Brake_Pedal", 50),
     ]

--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -17,7 +17,7 @@ class CarControllerParams:
     self.STEER_DELTA_DOWN = 70         # torque decrease per refresh
     self.STEER_DRIVER_ALLOWANCE = 60   # allowed driver torque before start limiting
     self.STEER_DRIVER_MULTIPLIER = 50  # weight driver torque heavily
-    self.STEER_DRIVER_FACTOR = 1       # from dbc
+    self.STEER_DRIVER_FACTOR = 0.012   # from dbc
 
     if CP.flags & SubaruFlags.GLOBAL_GEN2:
       self.STEER_MAX = 1000

--- a/opendbc/dbc/generator/subaru/_subaru_global.dbc
+++ b/opendbc/dbc/generator/subaru/_subaru_global.dbc
@@ -88,7 +88,7 @@ BO_ 280 Steering_Torque_2: 8 XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Steer_Torque_Output : 13|11@1- (-10,0) [0|255] "" XXX
  SG_ Signal1 : 24|8@1+ (1,0) [0|511] "" XXX
- SG_ Steer_Torque_Sensor : 45|11@1- (-1,0) [0|255] "" XXX
+ SG_ Steer_Torque_Sensor : 45|11@1- (-0.012,0) [0|255] "Nm" XXX
  SG_ Steering_Active : 61|1@0+ (1,0) [0|1] "" XXX
  SG_ Steering_Disabled : 63|1@1+ (1,0) [0|1] "" XXX
 

--- a/opendbc/dbc/subaru_global_2017_generated.dbc
+++ b/opendbc/dbc/subaru_global_2017_generated.dbc
@@ -92,7 +92,7 @@ BO_ 280 Steering_Torque_2: 8 XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Steer_Torque_Output : 13|11@1- (-10,0) [0|255] "" XXX
  SG_ Signal1 : 24|8@1+ (1,0) [0|511] "" XXX
- SG_ Steer_Torque_Sensor : 45|11@1- (-1,0) [0|255] "" XXX
+ SG_ Steer_Torque_Sensor : 45|11@1- (-0.012,0) [0|255] "Nm" XXX
  SG_ Steering_Active : 61|1@0+ (1,0) [0|1] "" XXX
  SG_ Steering_Disabled : 63|1@1+ (1,0) [0|1] "" XXX
 

--- a/opendbc/dbc/subaru_global_2020_hybrid_generated.dbc
+++ b/opendbc/dbc/subaru_global_2020_hybrid_generated.dbc
@@ -92,7 +92,7 @@ BO_ 280 Steering_Torque_2: 8 XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Steer_Torque_Output : 13|11@1- (-10,0) [0|255] "" XXX
  SG_ Signal1 : 24|8@1+ (1,0) [0|511] "" XXX
- SG_ Steer_Torque_Sensor : 45|11@1- (-1,0) [0|255] "" XXX
+ SG_ Steer_Torque_Sensor : 45|11@1- (-0.012,0) [0|255] "Nm" XXX
  SG_ Steering_Active : 61|1@0+ (1,0) [0|1] "" XXX
  SG_ Steering_Disabled : 63|1@1+ (1,0) [0|1] "" XXX
 


### PR DESCRIPTION
This PR adds Nm unit for Subaru driver torque sensor signal for gen1 and gen2 and updates carstate to use new signal. Matched with SSM4 signal output by to jnewb1 at https://github.com/martinl/openpilot/issues/80