### PR TITLE
Subaru: add brake_status message generation for long

### DIFF
--- a/opendbc/car/subaru/carcontroller.py
+++ b/opendbc/car/subaru/carcontroller.py
@@ -115,6 +115,8 @@ class CarController(CarControllerBase):
 
           can_sends.append(subarucan.create_es_distance(self.packer, self.frame // 5, CS.es_distance_msg, 0, pcm_cancel_cmd,
                                                         self.CP.openpilotLongitudinalControl, cruise_brake > 0, cruise_throttle))
+
+          can_sends.append(subarucan.create_brake_status(self.packer, CS.brake_status_msg, CS.es_brake_msg))
       else:
         if pcm_cancel_cmd:
           if not (self.CP.flags & SubaruFlags.HYBRID):

--- a/opendbc/car/subaru/carstate.py
+++ b/opendbc/car/subaru/carstate.py
@@ -117,6 +117,7 @@ class CarState(CarStateBase):
 
         self.es_status_msg = copy.copy(cp_es_status.vl["ES_Status"])
         self.cruise_control_msg = copy.copy(cp_cruise.vl["CruiseControl"])
+      self.brake_status_msg = copy.copy(cp_brakes.vl["Brake_Status"])
 
     if not (self.CP.flags & SubaruFlags.HYBRID):
       self.es_distance_msg = copy.copy(cp_es_distance.vl["ES_Distance"])

--- a/opendbc/car/subaru/subarucan.py
+++ b/opendbc/car/subaru/subarucan.py
@@ -276,6 +276,21 @@ def create_es_static_2(packer):
   return packer.make_can_msg("ES_STATIC_2", CanBus.main, values)
 
 
+def create_brake_status(packer, brake_status_msg, es_brake_msg):
+  values = {s: brake_status_msg[s] for s in [
+    "CHECKSUM",
+    "Signal1",
+    "ES_Brake",
+    "Signal2",
+    "Brake",
+    "Signal3",
+  ]}
+
+  values["ES_Brake"] = es_brake_msg["Brake_Pressure"] > 0
+
+  return packer.make_can_msg("Brake_Status", CanBus.camera, values)
+
+
 # *** Subaru Pre-global ***
 
 def subaru_preglobal_checksum(packer, values, addr, checksum_byte=7):


### PR DESCRIPTION
This PR fixes lanelines and car in front in dash/hud when Subaru long is enabled and Eyesight ecu is disabled