### PR TITLE
Honda: adjust longitudinal wind_brake

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -170,7 +170,7 @@ class CarController(CarControllerBase):
                                                       CS.CP.openpilotLongitudinalControl))
 
     # wind brake from air resistance decel at high speed
-    wind_brake = interp(CS.out.vEgo, [0.0, 2.3, 35.0], [0.001, 0.002, 0.15])
+    wind_brake = interp(CS.out.vEgo, [0.0, 2.3, 10.0, 35.0], [0.001, 0.005, 0.1, 0.15])
     # all of this is only relevant for HONDA NIDEC
     max_accel = interp(CS.out.vEgo, self.params.NIDEC_MAX_ACCEL_BP, self.params.NIDEC_MAX_ACCEL_V)
     # TODO this 1.44 is just to maintain previous behavior

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -170,7 +170,7 @@ class CarController(CarControllerBase):
                                                       CS.CP.openpilotLongitudinalControl))
 
     # wind brake from air resistance decel at high speed
-    wind_brake = interp(CS.out.vEgo, [0.0, 2.3, 10.0, 35.0], [0.001, 0.005, 0.1, 0.15])
+    wind_brake = interp(CS.out.vEgo, [0.0, 2.3, 10.0, 35.0], [0.001, 0.002, 0.1, 0.15])
     # all of this is only relevant for HONDA NIDEC
     max_accel = interp(CS.out.vEgo, self.params.NIDEC_MAX_ACCEL_BP, self.params.NIDEC_MAX_ACCEL_V)
     # TODO this 1.44 is just to maintain previous behavior


### PR DESCRIPTION
On a 2 degree downhill, the decel was already ~-0.3 m/s^2 at 10 m/s. 96850532278bae3b/00000104--77fe0d07d3

The interp currently assumes 0.15 m/s^2 at this speed which might lead to overshooting on braking.

![image](https://github.com/user-attachments/assets/fa7d679f-cf51-434a-ba1a-d7abee993153)
