### PR TITLE
Hide FCA Errors 

### DIFF
--- a/opendbc/car/hyundai/hyundaican.py
+++ b/opendbc/car/hyundai/hyundaican.py
@@ -42,6 +42,9 @@ def create_lkas11(packer, frame, CP, apply_steer, steer_req,
     values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)
     values["CF_Lkas_LdwsOpt_USM"] = 2
 
+    # Some cars show an FCA fault when forwarding CF_Lkas_FusionState. Hide FCA Fault:
+    values["CF_Lkas_FusionState"] = 0
+                             
     # FcwOpt_USM 5 = Orange blinking car + lanes
     # FcwOpt_USM 4 = Orange car + lanes
     # FcwOpt_USM 3 = Green blinking car + lanes

--- a/opendbc/car/hyundai/hyundaican.py
+++ b/opendbc/car/hyundai/hyundaican.py
@@ -41,7 +41,7 @@ def create_lkas11(packer, frame, CP, apply_steer, steer_req,
                            CAR.HYUNDAI_AZERA_6TH_GEN, CAR.HYUNDAI_AZERA_HEV_6TH_GEN, CAR.HYUNDAI_CUSTIN_1ST_GEN):
     values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)
     values["CF_Lkas_LdwsOpt_USM"] = 2
-
+                             
     # Some cars show an FCA fault when forwarding CF_Lkas_FusionState. Hide FCA Fault:
     values["CF_Lkas_FusionState"] = 0
                              

--- a/opendbc/car/hyundai/hyundaican.py
+++ b/opendbc/car/hyundai/hyundaican.py
@@ -41,10 +41,10 @@ def create_lkas11(packer, frame, CP, apply_steer, steer_req,
                            CAR.HYUNDAI_AZERA_6TH_GEN, CAR.HYUNDAI_AZERA_HEV_6TH_GEN, CAR.HYUNDAI_CUSTIN_1ST_GEN):
     values["CF_Lkas_LdwsActivemode"] = int(left_lane) + (int(right_lane) << 1)
     values["CF_Lkas_LdwsOpt_USM"] = 2
-                             
+
     # Some cars show an FCA fault when forwarding CF_Lkas_FusionState. Hide FCA Fault:
     values["CF_Lkas_FusionState"] = 0
-                             
+    
     # FcwOpt_USM 5 = Orange blinking car + lanes
     # FcwOpt_USM 4 = Orange car + lanes
     # FcwOpt_USM 3 = Green blinking car + lanes


### PR DESCRIPTION
Some cars show an FCA fault when forwarding CF_Lkas_FusionState. 
Especially with Kia Niro MY19