### PR TITLE
2024 Kia EV9

### DIFF
--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -133,7 +133,7 @@ class CarController(CarControllerBase):
     # CAN-FD platforms
     if self.CP.carFingerprint in CANFD_CAR:
       hda2 = self.CP.flags & HyundaiFlags.CANFD_HDA2
-      #hda2_long = hda2 and self.CP.openpilotLongitudinalControl
+      hda2_long = hda2 and self.CP.openpilotLongitudinalControl
 
       # steering control
       can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled,
@@ -146,7 +146,7 @@ class CarController(CarControllerBase):
                                                           self.CP.flags & HyundaiFlags.CANFD_HDA2_ALT_STEERING))
 
       # LFA and HDA icons
-      updateLfaHdaIcons = (not hda2) or self.CP.carFingerprint == CAR.KIA_EV9
+      updateLfaHdaIcons = (not hda2 or hda2_long) or self.CP.carFingerprint == CAR.KIA_EV9
       if self.frame % 5 == 0 and updateLfaHdaIcons:
         can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
 

--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -217,13 +217,17 @@ class CarState(CarStateBase):
 
     # TODO: alt signal usage may be described by cp.vl['BLINKERS']['USE_ALT_LAMP']
     left_blinker_sig, right_blinker_sig = "LEFT_LAMP", "RIGHT_LAMP"
-    if self.CP.carFingerprint == CAR.HYUNDAI_KONA_EV_2ND_GEN:
+    if self.CP.carFingerprint in (CAR.HYUNDAI_KONA_EV_2ND_GEN, CAR.KIA_EV9):
       left_blinker_sig, right_blinker_sig = "LEFT_LAMP_ALT", "RIGHT_LAMP_ALT"
     ret.leftBlinker, ret.rightBlinker = self.update_blinker_from_lamp(50, cp.vl["BLINKERS"][left_blinker_sig],
                                                                       cp.vl["BLINKERS"][right_blinker_sig])
     if self.CP.enableBsm:
-      ret.leftBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["FL_INDICATOR"] != 0
-      ret.rightBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["FR_INDICATOR"] != 0
+      if self.CP.carFingerprint == CAR.KIA_EV9:
+        ret.leftBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["INDICATOR_LEFT_FOUR"] != 0
+        ret.rightBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["INDICATOR_RIGHT_FOUR"] != 0
+      else:
+        ret.leftBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["FL_INDICATOR"] != 0
+        ret.rightBlindspot = cp.vl["BLINDSPOTS_REAR_CORNERS"]["FR_INDICATOR"] != 0
 
     # cruise state
     # CAN FD cars enable on main button press, set available if no TCS faults preventing engagement

--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1139,4 +1139,15 @@ FW_VERSIONS = {
       b'\xf1\x00US4_ RDR -----      1.00 1.00 99110-CG000         ',
     ],
   },
+ CAR.KIA_EV9: {
+    (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO700         ',
+      b'\xf1\x00MV__ RDR -----      1.00 1.02 99110-DO000         '
+    ],
+    (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00MV  MFC  AT KOR LHD 1.00 1.01 99211-DO000 230419',
+      b'\xf1\x00MV  MFC  AT USA LHD 1.00 1.02 99211-DO000 230616',
+      b'\xf1\x00MV  MFC  AT EUR LHD 1.00 1.02 99211-DO000 230616'
+    ],
+  },
 }

--- a/opendbc/car/hyundai/hyundaicanfd.py
+++ b/opendbc/car/hyundai/hyundaicanfd.py
@@ -35,20 +35,25 @@ class CanBus(CanBusBase):
     return self._cam
 
 
-def create_steering_messages(packer, CP, CAN, enabled, lat_active, apply_steer):
+def create_steering_messages(packer, CP, CAN, enabled, lat_active, steering_pressed, apply_steer, apply_angle, max_torque):
 
   ret = []
 
   values = {
-    "LKA_MODE": 2,
+    "LKA_MODE": 0,
     "LKA_ICON": 2 if enabled else 1,
-    "TORQUE_REQUEST": apply_steer,
+    "TORQUE_REQUEST": 0, #apply_steer,
     "LKA_ASSIST": 0,
-    "STEER_REQ": 1 if lat_active else 0,
+    "STEER_REQ": 0,  # 1 if lat_active else 0,
     "STEER_MODE": 0,
     "HAS_LANE_SAFETY": 0,  # hide LKAS settings
-    "NEW_SIGNAL_1": 0,
+    "NEW_SIGNAL_1": 3 if lat_active else 0,  # this changes sometimes, 3 seems to indicate engaged
     "NEW_SIGNAL_2": 0,
+    "LKAS_ANGLE_CMD": -apply_angle,
+    "LKAS_ANGLE_ACTIVE": 2 if lat_active else 1,
+    # a torque scale value? ramps up when steering, highest seen is 234
+    # "UNKNOWN": 50 if lat_active and not steering_pressed else 0,
+    "UNKNOWN": max_torque if lat_active else 0,
   }
 
   if CP.flags & HyundaiFlags.CANFD_HDA2:

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -18,6 +18,8 @@ class CarInterface(CarInterfaceBase):
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.carName = "hyundai"
     ret.radarUnavailable = RADAR_START_ADDR not in fingerprint[1] or DBC[ret.carFingerprint]["radar"] is None
+    if candidate == CAR.KIA_EV9:
+      ret.steerControlType = structs.CarParams.SteerControlType.angle
 
     # These cars have been put into dashcam only due to both a lack of users and test coverage.
     # These cars likely still work fine. Once a user confirms each car works and a test route is
@@ -74,6 +76,8 @@ class CarInterface(CarInterfaceBase):
     if candidate == CAR.KIA_OPTIMA_G4_FL:
       ret.steerActuatorDelay = 0.2
 
+    if candidate == CAR.KIA_EV9:
+      ret.steerControlType = structs.CarControl.SteerControlType.angle
     # *** longitudinal control ***
     if candidate in CANFD_CAR:
       ret.experimentalLongitudinalAvailable = candidate not in (CANFD_UNSUPPORTED_LONGITUDINAL_CAR | CANFD_RADAR_SCC_CAR)

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from enum import Enum, IntFlag
 
 from panda import uds
-from opendbc.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict
+from opendbc.car import CarSpecs, DbcDict, PlatformConfig, Platforms, dbc_dict, AngleRateLimit
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.structs import CarParams
 from opendbc.car.docs_definitions import CarFootnote, CarHarness, CarDocs, CarParts, Column
@@ -15,6 +15,10 @@ Ecu = CarParams.Ecu
 class CarControllerParams:
   ACCEL_MIN = -3.5 # m/s
   ACCEL_MAX = 2.0 # m/s
+
+  # seen changing at 0.2 deg/frame down, 0.1 deg/frame up at 100Hz
+  ANGLE_RATE_LIMIT_UP = AngleRateLimit(speed_bp=[0., 5., 15.], angle_v=[5., .8, .15])
+  ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[0., 5., 15.], angle_v=[5., 3.5, 0.4])
 
   def __init__(self, CP):
     self.STEER_DELTA_UP = 3
@@ -492,6 +496,14 @@ class CAR(Platforms):
     ],
     CarSpecs(mass=2087, wheelbase=3.09, steerRatio=14.23),
     flags=HyundaiFlags.RADAR_SCC,
+  )
+  KIA_EV9 = HyundaiCanFDPlatformConfig(
+    "KIA EV9 2024",
+    [
+      HyundaiCarDocs("Kia EV9 2024", car_parts=CarParts.common([CarHarness.hyundai_r]))
+    ],
+    CarSpecs(mass=2625, wheelbase=3.1, steerRatio=16.02),
+    flags=HyundaiFlags.EV,
   )
 
   # Genesis

--- a/opendbc/car/torque_data/override.toml
+++ b/opendbc/car/torque_data/override.toml
@@ -65,6 +65,7 @@ legend = ["LAT_ACCEL_FACTOR", "MAX_LAT_ACCEL_MEASURED", "FRICTION"]
 "HYUNDAI_CUSTIN_1ST_GEN" = [2.5, 2.5, 0.1]
 "LEXUS_GS_F" = [2.5, 2.5, 0.08]
 "HYUNDAI_STARIA_4TH_GEN" = [1.8, 2.0, 0.15]
+"KIA_EV9" = [1.75, 1.75, 0.15]
 
 # Dashcam or fallback configured as ideal car
 "MOCK" = [10.0, 10, 0.0]

--- a/opendbc/dbc/hyundai_canfd.dbc
+++ b/opendbc/dbc/hyundai_canfd.dbc
@@ -68,6 +68,9 @@ BO_ 80 LKAS: 16 XXX
  SG_ HAS_LANE_SAFETY : 80|1@0+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_3 : 111|8@0+ (1,0) [0|255] "" XXX
  SG_ FCA_SYSWARN : 40|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKAS_ANGLE_ACTIVE : 77|2@0+ (1,0) [0|3] "" XXX
+ SG_ LKAS_ANGLE_CMD : 82|14@1- (-0.1,0) [0|511] "" XXX
+ SG_ UNKNOWN : 96|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 81 ADRV_0x51: 32 ADRV
  SG_ COUNTER : 16|8@1+ (1,0) [0|255] "" XXX
@@ -595,7 +598,12 @@ BO_ 442 BLINDSPOTS_REAR_CORNERS: 24 XXX
  SG_ COLLISION_AVOIDANCE_ACTIVE : 68|1@0+ (1,0) [0|1] "" XXX
  SG_ LEFT_MB : 30|1@0+ (1,0) [0|3] "" XXX
  SG_ LEFT_BLOCKED : 24|1@0+ (1,0) [0|1] "" XXX
- SG_ MORE_LEFT_PROB : 32|1@1+ (1,0) [0|3] "" XXX
+ SG_ INDICATOR_LEFT_TWO : 30|1@0+ (1,0) [0|3] "" XXX
+ SG_ INDICATOR_RIGHT_TWO : 32|1@1+ (1,0) [0|3] "" XXX
+ SG_ INDICATOR_LEFT_THREE : 128|1@0+ (1,0) [0|1] "" XXX
+ SG_ INDICATOR_RIGHT_THREE : 130|1@0+ (1,0) [0|1] "" XXX
+ SG_ INDICATOR_LEFT_FOUR : 138|1@0+ (1,0) [0|1] "" XXX
+ SG_ INDICATOR_RIGHT_FOUR : 141|1@0+ (1,0) [0|1] "" XXX
  SG_ FL_INDICATOR : 46|6@0+ (1,0) [0|1] "" XXX
  SG_ FR_INDICATOR : 54|6@0+ (1,0) [0|63] "" XXX
  SG_ RIGHT_BLOCKED : 64|1@0+ (1,0) [0|1] "" XXX
@@ -666,6 +674,7 @@ CM_ 1043 "Lamp signals do not seem universal on cars that use LKAS_ALT, but stal
 CM_ SG_ 80 HAS_LANE_SAFETY "If 0, hides LKAS 'Lane Safety' menu from vehicle settings";
 CM_ SG_ 96 BRAKE_PRESSURE "User applied brake pedal pressure. Ramps from computer applied pressure on falling edge of cruise. Cruise cancels if !=0";
 CM_ SG_ 101 BRAKE_POSITION "User applied brake pedal position, max is ~700. Signed on some vehicles";
+CM_ SG_ 272 LKAS_ANGLE_CMD "tracks MDPS->STEERING_ANGLE when not engaged, not STEERING_SENSORS->STEERING_ANGLE";
 CM_ SG_ 373 PROBABLY_EQUIP "aeb equip?";
 CM_ SG_ 373 ACCEnable "Likely a copy of CAN's TCS13->ACCEnable";
 CM_ SG_ 373 DriverBraking "Likely derived from BRAKE->BRAKE_POSITION";
@@ -689,6 +698,7 @@ VAL_ 80 LKA_ICON 0 "hidden" 1 "grey" 2 "green" 3 "flashing green" ;
 VAL_ 80 LKA_MODE 1 "warning only" 2 "assist" 6 "off" ;
 VAL_ 96 TRACTION_AND_STABILITY_CONTROL 0 "On" 5 "Limited" 1 "Off";
 VAL_ 234 LKA_FAULT 0 "ok" 1 "lka fault" ;
+VAL_ 272 LKAS_ANGLE_ACTIVE 1 "not active" 2 "active";
 VAL_ 272 LKA_ICON 0 "hidden" 1 "grey" 2 "green" 3 "flashing green" ;
 VAL_ 272 LKA_MODE 1 "warning only" 2 "assist" 6 "off" ;
 VAL_ 298 LKA_ICON 0 "hidden" 1 "grey" 2 "green" 3 "flashing green" ;


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is still a WIP.  Lateral control has initial support, long control is not supported yet.

> [!WARNING]
> **This has not been tested yet.  This is just attempting to port the old EV9 PR into the new repo structure**

**Car**
2024 Kia EV9

**Route**
Need to get one of these yet

**Checklist**

- [X] added entry to CarInfo in selfdrive/car/*/values.py and ran `selfdrive/car/docs.py` to generate new docs
- [ ] test route added to [routes.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/tests/routes.py)
- [ ] route with openpilot:
- [ ] route with stock system: 
- [X] car harness used (if comma doesn't sell it, put N/A): Hyundai R
