### PR TITLE
Toyota: add brake force signal for hybrids

### DIFF
--- a/opendbc/dbc/generator/toyota/_toyota_2017.dbc
+++ b/opendbc/dbc/generator/toyota/_toyota_2017.dbc
@@ -62,7 +62,7 @@ BO_ 120 ENG2F42: 4 CGW
 
 BO_ 166 BRAKE: 8 XXX
  SG_ BRAKE_AMOUNT : 7|8@0+ (1,0) [0|255] "" XXX
- SG_ BRAKE_PEDAL : 23|8@0+ (1,0) [0|255] "" XXX
+ SG_ BRAKE_FORCE : 23|8@0+ (40,0) [0|10200] "N" XXX
 
 BO_ 170 WHEEL_SPEEDS: 8 XXX
  SG_ WHEEL_SPEED_FR : 7|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
@@ -463,6 +463,7 @@ CM_ SG_ 36 ACCEL_X "x-axis accel";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
 CM_ SG_ 37 STEER_RATE "factor is tbd";
 CM_ SG_ 119 FDRVREAL "ICE only: force applied by wheels from the engine. includes creeping force, regen, and engine braking";
+CM_ SG_ 166 BRAKE_FORCE "hybrid only: force applied by friction brakes from user or ACC command";
 CM_ SG_ 295 FDRVREAL "hybrid only: force applied by wheels from the engine and/or electric motors. includes creeping force, regen, and engine braking";
 CM_ SG_ 466 NEUTRAL_FORCE "force in newtons the engine/electric motors are applying without any acceleration commands or user input";
 CM_ SG_ 466 ACC_BRAKING "whether brakes are being actuated from ACC command";

--- a/opendbc/dbc/toyota_new_mc_pt_generated.dbc
+++ b/opendbc/dbc/toyota_new_mc_pt_generated.dbc
@@ -66,7 +66,7 @@ BO_ 120 ENG2F42: 4 CGW
 
 BO_ 166 BRAKE: 8 XXX
  SG_ BRAKE_AMOUNT : 7|8@0+ (1,0) [0|255] "" XXX
- SG_ BRAKE_PEDAL : 23|8@0+ (1,0) [0|255] "" XXX
+ SG_ BRAKE_FORCE : 23|8@0+ (40,0) [0|10200] "N" XXX
 
 BO_ 170 WHEEL_SPEEDS: 8 XXX
  SG_ WHEEL_SPEED_FR : 7|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
@@ -467,6 +467,7 @@ CM_ SG_ 36 ACCEL_X "x-axis accel";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
 CM_ SG_ 37 STEER_RATE "factor is tbd";
 CM_ SG_ 119 FDRVREAL "ICE only: force applied by wheels from the engine. includes creeping force, regen, and engine braking";
+CM_ SG_ 166 BRAKE_FORCE "hybrid only: force applied by friction brakes from user or ACC command";
 CM_ SG_ 295 FDRVREAL "hybrid only: force applied by wheels from the engine and/or electric motors. includes creeping force, regen, and engine braking";
 CM_ SG_ 466 NEUTRAL_FORCE "force in newtons the engine/electric motors are applying without any acceleration commands or user input";
 CM_ SG_ 466 ACC_BRAKING "whether brakes are being actuated from ACC command";

--- a/opendbc/dbc/toyota_nodsu_pt_generated.dbc
+++ b/opendbc/dbc/toyota_nodsu_pt_generated.dbc
@@ -66,7 +66,7 @@ BO_ 120 ENG2F42: 4 CGW
 
 BO_ 166 BRAKE: 8 XXX
  SG_ BRAKE_AMOUNT : 7|8@0+ (1,0) [0|255] "" XXX
- SG_ BRAKE_PEDAL : 23|8@0+ (1,0) [0|255] "" XXX
+ SG_ BRAKE_FORCE : 23|8@0+ (40,0) [0|10200] "N" XXX
 
 BO_ 170 WHEEL_SPEEDS: 8 XXX
  SG_ WHEEL_SPEED_FR : 7|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
@@ -467,6 +467,7 @@ CM_ SG_ 36 ACCEL_X "x-axis accel";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
 CM_ SG_ 37 STEER_RATE "factor is tbd";
 CM_ SG_ 119 FDRVREAL "ICE only: force applied by wheels from the engine. includes creeping force, regen, and engine braking";
+CM_ SG_ 166 BRAKE_FORCE "hybrid only: force applied by friction brakes from user or ACC command";
 CM_ SG_ 295 FDRVREAL "hybrid only: force applied by wheels from the engine and/or electric motors. includes creeping force, regen, and engine braking";
 CM_ SG_ 466 NEUTRAL_FORCE "force in newtons the engine/electric motors are applying without any acceleration commands or user input";
 CM_ SG_ 466 ACC_BRAKING "whether brakes are being actuated from ACC command";

--- a/opendbc/dbc/toyota_tnga_k_pt_generated.dbc
+++ b/opendbc/dbc/toyota_tnga_k_pt_generated.dbc
@@ -66,7 +66,7 @@ BO_ 120 ENG2F42: 4 CGW
 
 BO_ 166 BRAKE: 8 XXX
  SG_ BRAKE_AMOUNT : 7|8@0+ (1,0) [0|255] "" XXX
- SG_ BRAKE_PEDAL : 23|8@0+ (1,0) [0|255] "" XXX
+ SG_ BRAKE_FORCE : 23|8@0+ (40,0) [0|10200] "N" XXX
 
 BO_ 170 WHEEL_SPEEDS: 8 XXX
  SG_ WHEEL_SPEED_FR : 7|16@0+ (0.01,-67.67) [0|250] "km/h" XXX
@@ -467,6 +467,7 @@ CM_ SG_ 36 ACCEL_X "x-axis accel";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
 CM_ SG_ 37 STEER_RATE "factor is tbd";
 CM_ SG_ 119 FDRVREAL "ICE only: force applied by wheels from the engine. includes creeping force, regen, and engine braking";
+CM_ SG_ 166 BRAKE_FORCE "hybrid only: force applied by friction brakes from user or ACC command";
 CM_ SG_ 295 FDRVREAL "hybrid only: force applied by wheels from the engine and/or electric motors. includes creeping force, regen, and engine braking";
 CM_ SG_ 466 NEUTRAL_FORCE "force in newtons the engine/electric motors are applying without any acceleration commands or user input";
 CM_ SG_ 466 ACC_BRAKING "whether brakes are being actuated from ACC command";


### PR DESCRIPTION
Same as drive force (https://github.com/commaai/opendbc/pull/1246) but only for friction brakes. Now to find for Lexus!

You can see it mostly matches `PCM_CRUISE->ACCEL_NET` using the mass we have in CarParams, but in some cases it shows `ACCEL_NET` doesn't always capture every brake usage (it *did* brake here):

08e4c2a99df165b1/0000027e--b51d0c81a8/31:36

![image](https://github.com/user-attachments/assets/792c4f66-95fa-44c1-865e-dca96a962447)
