### PR TITLE
Toyota: lower long integral for new tune

### DIFF
--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -131,6 +131,11 @@ class CarInterface(CarInterfaceBase):
       ret.vEgoStopping = 0.25
       ret.vEgoStarting = 0.25
       ret.stoppingDecelRate = 0.3  # reach stopping target smoothly
+
+      # Since we compensate for imprecise acceleration in carcontroller, we can be less aggressive with tuning
+      # This also prevents unnecessary windup due to internal car jerk limits
+      if ret.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
+        tune.kiV = [0.25]
     else:
       tune.kiBP = [0., 5., 35.]
       tune.kiV = [3.6, 2.4, 1.5]

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -133,7 +133,7 @@ class CarInterface(CarInterfaceBase):
       ret.stoppingDecelRate = 0.3  # reach stopping target smoothly
 
       # Since we compensate for imprecise acceleration in carcontroller, we can be less aggressive with tuning
-      # This also prevents unnecessary windup due to internal car jerk limits
+      # This also prevents unnecessary request windup due to internal car jerk limits
       if ret.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
         tune.kiV = [0.25]
     else:


### PR DESCRIPTION
Lexus ES route on this branch: https://connect.comma.ai/57048cfce01d9625/00000130--7556579cf1

Less start from stop windup:

This branch is on the right.

![image](https://github.com/user-attachments/assets/21a972c1-e63d-4a43-86e9-772e99659104)

Much less windup and request overshoot in creep tests:

![image](https://github.com/user-attachments/assets/b12e08d9-0314-4174-817b-361e89be59f4)

---

Report: [LEXUS_ES_TSS2_57048cfce01d9625_00000130--7556579cf1.zip](https://github.com/user-attachments/files/17081341/LEXUS_ES_TSS2_57048cfce01d9625_00000130--7556579cf1.zip)

