### PR TITLE
Toyota: enable new long tune for Corolla TSS2

### DIFF
--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -45,7 +45,7 @@ class CarInterface(CarInterfaceBase):
     found_ecus = [fw.ecu for fw in car_fw]
     ret.enableDsu = len(found_ecus) > 0 and Ecu.dsu not in found_ecus and candidate not in (NO_DSU_CAR | UNSUPPORTED_DSU_CAR)
 
-    if candidate == CAR.LEXUS_ES_TSS2 and Ecu.hybrid not in found_ecus:
+    if candidate in (CAR.LEXUS_ES_TSS2, CAR.TOYOTA_COROLLA_TSS2) and Ecu.hybrid not in found_ecus:
       ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
 
     if candidate == CAR.TOYOTA_PRIUS:


### PR DESCRIPTION
High speed is largely unaffected, but low speed reaches the target acceleration faster.

master Corolla route: a2bddce0b6747e10/0000025b--a32628ab6b

PCM comp Corolla route: a2bddce0b6747e10/0000025a--bd4dcd6aec

Summary:

<details><summary>master</summary>

```
Summary
start from stop
Target crossed 4 out of 4 runs

Mean time to cross: 3.663s, min: 3.251s, max: 4.153s

creep: alternate between +1m/s^2 and -1m/s^2
Target crossed 2 out of 2 runs

Mean time to cross: 2.553s, min: 2.399s, max: 2.707s

brake step response: -1m/s^2 from 20mph
Target crossed 3 out of 3 runs

Mean time to cross: 1.066s, min: 0.901s, max: 1.198s

brake step response: -4m/s^2 from 20mph
Target crossed 3 out of 3 runs

Mean time to cross: 2.132s, min: 2.099s, max: 2.149s

gas step response: +1m/s^2 from 20mph
Target crossed 3 out of 3 runs

Mean time to cross: 0.933s, min: 0.750s, max: 1.151s

gas step response: +4m/s^2 from 20mph
Target crossed 0 out of 3 runs
```

</details>

<details><summary>PCM compensation</summary>

```
Summary
start from stop
Target crossed 4 out of 4 runs

Mean time to cross: 2.513s, min: 1.802s, max: 2.900s

creep: alternate between +1m/s^2 and -1m/s^2
Target crossed 2 out of 2 runs

Mean time to cross: 1.925s, min: 1.901s, max: 1.950s

brake step response: -1m/s^2 from 20mph
Target crossed 3 out of 3 runs

Mean time to cross: 1.066s, min: 1.000s, max: 1.100s

brake step response: -4m/s^2 from 20mph
Target crossed 3 out of 3 runs

Mean time to cross: 2.102s, min: 2.051s, max: 2.154s

gas step response: +1m/s^2 from 20mph
Target crossed 3 out of 3 runs

Mean time to cross: 0.900s, min: 0.702s, max: 1.249s

gas step response: +4m/s^2 from 20mph
Target crossed 0 out of 3 runs
```

</details>

---

Some plots:

Left is master, right is this branch:

![image](https://github.com/user-attachments/assets/63b8f991-ef1f-4317-aec2-33e616770e45)

![image](https://github.com/user-attachments/assets/ecef2da8-0226-4e23-bdde-b4cfbfbad343)

![image](https://github.com/user-attachments/assets/d0a512c1-59f9-41c2-b272-03894983dfa6)
