### PR TITLE
Toyota: don't apply PCM compensation in the stopping state

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -10,6 +10,7 @@ from opendbc.car.toyota.values import CAR, STATIC_DSU_MSGS, NO_STOP_TIMER_CAR, T
                                         UNSUPPORTED_DSU_CAR
 from opendbc.can.packer import CANPacker
 
+LongCtrlState = structs.CarControl.Actuators.LongControlState
 SteerControlType = structs.CarParams.SteerControlType
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
 
@@ -111,7 +112,10 @@ class CarController(CarControllerBase):
       accel_due_to_pitch = math.sin(CS.slope_angle) * ACCELERATION_DUE_TO_GRAVITY
       net_acceleration_request = actuators.accel + accel_due_to_pitch
 
-      pcm_accel_compensation = 2.0 * (CS.pcm_accel_net - net_acceleration_request) if net_acceleration_request > 0 else 0.0
+      # let PCM handle stopping and braking for now
+      pcm_accel_compensation = 0.0
+      if net_acceleration_request > 0.0 and actuators.longControlState != LongCtrlState.stopping:
+        pcm_accel_compensation = 2.0 * (CS.pcm_accel_net - net_acceleration_request)
 
       # prevent compensation windup
       if actuators.accel - pcm_accel_compensation > self.params.ACCEL_MAX:


### PR DESCRIPTION
The biggest innacuracy was coming to a final stop, we were not braking enough; probably due to lack of integral on compensation:

https://connect.comma.ai/57048cfce01d9625/00000137--ab0a0ba374

![image](https://github.com/user-attachments/assets/cd002e9c-c9cd-4451-9134-ff5b8f95417f)
