### PR TITLE
Lexus: prevent lagged gas after heavy braking

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -43,6 +43,7 @@ class CarController(CarControllerBase):
     self.distance_button = 0
 
     self.pcm_accel_compensation = 0.0
+    self.last_accel = 0.0
 
     self.packer = CANPacker(dbc_name)
     self.accel = 0
@@ -126,6 +127,10 @@ class CarController(CarControllerBase):
     else:
       self.pcm_accel_compensation = 0.0
       pcm_accel_cmd = actuators.accel
+
+    if CC.longActive:
+      pcm_accel_cmd = rate_limit(pcm_accel_cmd, self.last_accel, -0.45 / 3, 0.45 / 3)
+    self.last_accel = pcm_accel_cmd
 
     pcm_accel_cmd = clip(pcm_accel_cmd, self.params.ACCEL_MIN, self.params.ACCEL_MAX)
 

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -158,7 +158,7 @@ class CarController(CarControllerBase):
       if pcm_cancel_cmd and self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
         can_sends.append(toyotacan.create_acc_cancel_command(self.packer))
       elif self.CP.openpilotLongitudinalControl:
-        # on transition from negative to positive accel, send one frame of zero to ensure gas starts at zero
+        # internal PCM gas command can get stuck at high negative values. send one frame of zero when transitioning from braking to gas
         if pcm_accel_cmd > 0 > self.accel and abs(pcm_accel_cmd - self.accel) > 0.5:
           pcm_accel_cmd = 0
 

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -158,7 +158,7 @@ class CarController(CarControllerBase):
       if pcm_cancel_cmd and self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
         can_sends.append(toyotacan.create_acc_cancel_command(self.packer))
       elif self.CP.openpilotLongitudinalControl:
-        # internal PCM gas command can get stuck at high negative values. send one frame of zero when transitioning from braking to gas
+        # internal PCM gas command can get stuck unwinding from negative accel. send one frame of zero when transitioning from braking to gas
         if pcm_accel_cmd > 0 > self.accel and abs(pcm_accel_cmd - self.accel) > 0.5:
           pcm_accel_cmd = 0
 


### PR DESCRIPTION
If you switch from a high negative aceleration request to a positive one, sometimes the gas has to "unwind" from the negative acceleration value. Which doesn't make sense, but is what happens.

If you rate limit your request or send zero for one frame, then it is fine and the gas starts from 0 immediately.
