### PR TITLE
VW MQB: Temporarily remove 2024 Volkswagen Jetta

### DIFF
--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -277,8 +277,8 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_JETTA_MK7 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Volkswagen Jetta 2018-24"),
-      VWCarDocs("Volkswagen Jetta GLI 2021-24"),
+      VWCarDocs("Volkswagen Jetta 2018-23"),
+      VWCarDocs("Volkswagen Jetta GLI 2021-23"),
     ],
     VolkswagenCarSpecs(mass=1328, wheelbase=2.71),
     chassis_codes={"BU"},


### PR DESCRIPTION
Temporarily revoking official support for the 2024 Volkswagen Jetta. CARS.md will be regenerated when openpilot bumps opendbc. The process for doing that is in flux.

**Background**

We added support for the 2024 Volkswagen Jetta in commaai/openpilot#30979. It was valid at the time, but it turns out MY2024 Jetta has an annoying  mid-year production split.

Cars produced starting February 19 switched to a new gateway. It's still ostensibly in the 3Q0 family, but uses the new MQBevo style connector, for which we don't have a harness.

We can re-add all MY 2024 Jetta when commaai/openpilot#33380 is available and we start converting most VW default installs back to using a camera harness.

**Split:**

![image](https://github.com/user-attachments/assets/99df68cc-94b6-4f4e-8b08-a68331fe62cf)

**Early MY 2024 gateway**

![image](https://github.com/user-attachments/assets/293c6fdf-e9ab-4823-97d6-76cc72898456)

**Late MY 2024 gateway**

![image](https://github.com/user-attachments/assets/7c6c39fe-7fd4-4944-8403-acc1349ba71b)
