### PR TITLE
Toyota: prevent lagged gas after heavy braking

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -14,7 +14,9 @@ LongCtrlState = structs.CarControl.Actuators.LongControlState
 SteerControlType = structs.CarParams.SteerControlType
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
 
-ACCELERATION_DUE_TO_GRAVITY = 9.81
+ACCELERATION_DUE_TO_GRAVITY = 9.81  # m/s^2
+
+ACCEL_WINDUP_LIMIT = 0.5  # m/s^2 / frame
 
 # LKA limits
 # EPS faults if you apply torque while the steering rate is above 100 deg/s for too long
@@ -158,6 +160,9 @@ class CarController(CarControllerBase):
       if pcm_cancel_cmd and self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
         can_sends.append(toyotacan.create_acc_cancel_command(self.packer))
       elif self.CP.openpilotLongitudinalControl:
+        # internal PCM gas command can get stuck unwinding from negative accel so we apply a generous rate limit
+        pcm_accel_cmd = min(pcm_accel_cmd, self.accel + ACCEL_WINDUP_LIMIT) if CC.longActive else 0.0
+
         can_sends.append(toyotacan.create_accel_command(self.packer, pcm_accel_cmd, pcm_cancel_cmd, self.standstill_req, lead, CS.acc_type, fcw_alert,
                                                         self.distance_button))
         self.accel = pcm_accel_cmd


### PR DESCRIPTION
Try 2 of https://github.com/commaai/opendbc/pull/1266. Applies to all of Toyota, but only tested on Lexus. This is a safe change regardless.

When `CLUTCH->ACCEL_NET` is positive, it describes the acceleration the engine is actually applying. When you go from a negative to a positive acceleration request with a high delta, this `CLUTCH` signal sometimes unwinds from the negative request, even though it has no meaning under 0 m/s^2. You essentially are doing nothing for this time causing a delayed gas response. Here is a screenshot explaining this visually:

Route: 57048cfce01d9625/0000018e--0c9e84091e

<details><summary>View image</summary>

![image](https://github.com/user-attachments/assets/8c9f7984-07a7-41df-b6b1-bd4340a84bc5)

</details>

This does not seem to affect start from stop events, in the maneuver test at least.

---

Here is what it looks like when you rate limit your request, or don't jump too abruptly between frames:

Route: 57048cfce01d9625/0000018f--48b7269868

<details><summary>View image</summary>

![image](https://github.com/user-attachments/assets/939d6ed3-091e-48ae-bcd1-ce6508045d8d)

</details>

---

Creep test looks good, does not overshoot on any run:

<details><summary>View images</summary>

| creep: alternate between +1m/s^2 and -1m/s^2   |
| -------- |
| ![image](https://github.com/user-attachments/assets/f3e0f2dc-3c8b-4521-99bb-eeb1b16a4bcc)  | 
| ![image](https://github.com/user-attachments/assets/9a8dc808-30c4-41e0-9d57-46a002aacf1e)  |
|  ![image](https://github.com/user-attachments/assets/072dfe98-f340-4284-ad14-ae84c3e7a961) |
| ![image](https://github.com/user-attachments/assets/151c7599-6ae1-4970-a8f8-711b602e98c5)     |

</details>

---

20 mph brake response is the same as it's only a positive rate limit. 20 mph gas response seems to have no discernible difference:

<details><summary>View image</summary>

![image](https://github.com/user-attachments/assets/b949c718-a9e2-4273-afc8-a51bc9eec1df)

</details>

---

Full reports: [LEXUS_ES_TSS2_57048cfce01d9625_0000018.zip](https://github.com/user-attachments/files/17122673/LEXUS_ES_TSS2_57048cfce01d9625_0000018.zip)