### PR TITLE
HKG: Cleanup EV and HYBRID flag setting

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -2,7 +2,7 @@ from panda import Panda
 from opendbc.car import get_safety_config, structs
 from opendbc.car.hyundai.hyundaicanfd import CanBus
 from opendbc.car.hyundai.values import HyundaiFlags, CAR, DBC, CANFD_CAR, CAMERA_SCC_CAR, CANFD_RADAR_SCC_CAR, \
-                                                   CANFD_UNSUPPORTED_LONGITUDINAL_CAR, EV_CAR, HYBRID_CAR, LEGACY_SAFETY_MODE_CAR, \
+                                                   CANFD_UNSUPPORTED_LONGITUDINAL_CAR, LEGACY_SAFETY_MODE_CAR, \
                                                    UNSUPPORTED_LONGITUDINAL_CAR, Buttons
 from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
 from opendbc.car.interfaces import CarInterfaceBase

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -32,8 +32,6 @@ class CarInterface(CarInterfaceBase):
       # detect if car is hybrid
       if 0x105 in fingerprint[CAN.ECAN]:
         ret.flags |= HyundaiFlags.HYBRID.value
-      elif candidate in EV_CAR:
-        ret.flags |= HyundaiFlags.EV.value
 
       # detect HDA2 with ADAS Driving ECU
       if hda2:
@@ -53,12 +51,6 @@ class CarInterface(CarInterfaceBase):
         if candidate not in CANFD_RADAR_SCC_CAR:
           ret.flags |= HyundaiFlags.CANFD_CAMERA_SCC.value
     else:
-      # TODO: detect EV and hybrid
-      if candidate in HYBRID_CAR:
-        ret.flags |= HyundaiFlags.HYBRID.value
-      elif candidate in EV_CAR:
-        ret.flags |= HyundaiFlags.EV.value
-
       # Send LFA message on cars with HDA
       if 0x485 in fingerprint[2]:
         ret.flags |= HyundaiFlags.SEND_LFA.value


### PR DESCRIPTION
Remove no-op code: set flags if in relevant group, but only in that group because the flags are already set.

Offline validation:

* `pytest opendbc` passes
* `pytest selfdrive/car/tests` passes
* `selfdrive/test/process_replay/test_processes.py` just in case I'm blind, no change to carParams