### PR TITLE
Lexus ES TSS2: improve start from stop response time

### DIFF
--- a/opendbc/car/toyota/toyotacan.py
+++ b/opendbc/car/toyota/toyotacan.py
@@ -33,15 +33,14 @@ def create_lta_steer_command(packer, steer_control_type, steer_angle, steer_req,
   return packer.make_can_msg("STEERING_LTA", 0, values)
 
 
-def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_type, fcw_alert, distance):
+def create_accel_command(packer, accel, pcm_cancel, permit_braking, standstill_req, lead, acc_type, fcw_alert, distance):
   # TODO: find the exact canceling bit that does not create a chime
   values = {
     "ACCEL_CMD": accel,
     "ACC_TYPE": acc_type,
     "DISTANCE": distance,
     "MINI_CAR": lead,
-    # TODO: consider pitch and a safe threshold
-    "PERMIT_BRAKING": 1 if accel < 0.1 else 0,
+    "PERMIT_BRAKING": permit_braking,
     "RELEASE_STANDSTILL": not standstill_req,
     "CANCEL_REQ": pcm_cancel,
     "ALLOW_LONG_PRESS": 1,

--- a/opendbc/car/toyota/toyotacan.py
+++ b/opendbc/car/toyota/toyotacan.py
@@ -40,7 +40,8 @@ def create_accel_command(packer, accel, pcm_cancel, standstill_req, lead, acc_ty
     "ACC_TYPE": acc_type,
     "DISTANCE": distance,
     "MINI_CAR": lead,
-    "PERMIT_BRAKING": 1,
+    # TODO: consider pitch and a safe threshold
+    "PERMIT_BRAKING": 1 if accel < 0.1 else 0,
     "RELEASE_STANDSTILL": not standstill_req,
     "CANCEL_REQ": pcm_cancel,
     "ALLOW_LONG_PRESS": 1,


### PR DESCRIPTION
Before PCM accel compensation, we couldn't ship 2 m/s^2 because of the overshooting, but that's fixed with PCM compensation. A similar overshooting problem with `PERMIT_BRAKING` occurs, but our compensation should counteract that now.

We just need to be careful about not braking when we really should, but we do pitch compensation now so that should be fine as well. The stock system uses this bit often when accelerating, so it's not some unused API.

---

Start from stop shows almost instant acceleration from a stop, which is also clearly visible in the speed plot as being more linear:

![image](https://github.com/user-attachments/assets/ca95a1fc-7a8a-47b0-a157-9ee414952573)

`come to stop` maneuver is the same.

`start from stop` maneuver is greatly improved:

![image](https://github.com/user-attachments/assets/68fa9cfd-e68a-4f02-adc6-e4841b701792)

![image](https://github.com/user-attachments/assets/9bfa330d-9038-4e67-a980-3bde22288fb1)

Creep test is also a bit better:

![image](https://github.com/user-attachments/assets/4c39469d-abde-47d4-bdb0-9d3549554d35)

brake step response also looks the same, as does gas step response at high speed.

---

Full reports: [LEXUS_ES_TSS2_57048cfce01d9625_00000.zip](https://github.com/user-attachments/files/17172198/LEXUS_ES_TSS2_57048cfce01d9625_00000.zip)