### PR TITLE
VW PQ: Fix CarDocs year range for Jetta

### DIFF
--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -270,7 +270,7 @@ class CAR(Platforms):
     wmis={WMI.VOLKSWAGEN_MEXICO_CAR, WMI.VOLKSWAGEN_EUROPE_CAR},
   )
   VOLKSWAGEN_JETTA_MK6 = VolkswagenPQPlatformConfig(
-    [VWCarDocs("Volkswagen Jetta 2015-2018")],
+    [VWCarDocs("Volkswagen Jetta 2015-18")],
     VolkswagenCarSpecs(mass=1518, wheelbase=2.65, minSteerSpeed=50 * CV.KPH_TO_MS, minEnableSpeed=20 * CV.KPH_TO_MS),
     chassis_codes={"5K", "AJ"},
     wmis={WMI.VOLKSWAGEN_MEXICO_CAR},


### PR DESCRIPTION
Supported year range was improperly formatted. This was missed by tests in the past, because we don't currently generate CarDocs for cars in dashcam mode, but was exposed by #1286.