### PR TITLE
Lexus ES TSS2: fix brake undershooting

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -112,10 +112,7 @@ class CarController(CarControllerBase):
     # TODO: sometimes when switching from brake to gas quickly, CLUTCH->ACCEL_NET shows a slow unwind. make it go to 0 immediately
     if self.CP.flags & ToyotaFlags.RAISED_ACCEL_LIMIT and CC.longActive and not CS.out.cruiseState.standstill:
       # calculate amount of acceleration PCM should apply to reach target, given pitch
-      # pitch has less of an effect
       accel_due_to_pitch = math.sin(CS.slope_angle) * ACCELERATION_DUE_TO_GRAVITY
-      accel_due_to_pitch = interp(actuators.accel, [self.params.ACCEL_MIN, self.params.ACCEL_MIN / 2], [0, accel_due_to_pitch])
-
       net_acceleration_request = actuators.accel + accel_due_to_pitch
 
       # let PCM handle stopping for now
@@ -137,8 +134,6 @@ class CarController(CarControllerBase):
 
       # Along with rate limiting positive jerk below, this greatly improves gas response time
       # Consider the net acceleration request that the PCM should be applying (pitch included)
-      # what about low speed where 0.3 might still be braking due to engine neutral force?
-      # TODO: what if neutral accel matters?
       if net_acceleration_request < 0.1:
         self.permit_braking = True
       elif net_acceleration_request > 0.2:


### PR DESCRIPTION
- [ ] Find a signal that describes why sometimes it overreports aEgo on flat ground
- [ ] Or model the PCM compensation response and implement a feedforward solution using no PCM feedback
- [ ] Or just disable PCM compensation for (heavy) braking

Sometimes this happens below. The pitch was just 2 degrees, but that would actually cause more braking than necessary, this is less braking than necessary by almost 1 m/s^2.

![image](https://github.com/user-attachments/assets/b8bc4512-7385-4d5c-9ab6-7dd3916f8e6e)

![image](https://github.com/user-attachments/assets/cd8a43e1-c96d-418e-b4f6-fa864fae16cd)