### PR TITLE
Hyundai: Cleanup unused parameter in `create_lfahda_mfc`

### DIFF
--- a/opendbc/car/hyundai/hyundaican.py
+++ b/opendbc/car/hyundai/hyundaican.py
@@ -120,9 +120,6 @@ def create_clu11(packer, frame, clu11, button, CP):
 def create_lfahda_mfc(packer, enabled):
   values = {
     "LFA_Icon_State": 2 if enabled else 0,
-    "HDA_Active": 0,
-    "HDA_Icon_State": 0,
-    "HDA_VSetReq": 0,
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 

--- a/opendbc/car/hyundai/hyundaican.py
+++ b/opendbc/car/hyundai/hyundaican.py
@@ -117,12 +117,12 @@ def create_clu11(packer, frame, clu11, button, CP):
   return packer.make_can_msg("CLU11", bus, values)
 
 
-def create_lfahda_mfc(packer, enabled, hda_set_speed=0):
+def create_lfahda_mfc(packer, enabled):
   values = {
     "LFA_Icon_State": 2 if enabled else 0,
-    "HDA_Active": 1 if hda_set_speed else 0,
-    "HDA_Icon_State": 2 if hda_set_speed else 0,
-    "HDA_VSetReq": hda_set_speed,
+    "HDA_Active": 0,
+    "HDA_Icon_State": 0,
+    "HDA_VSetReq": 0,
   }
   return packer.make_can_msg("LFAHDA_MFC", 0, values)
 


### PR DESCRIPTION
**Description**

`hda_set_speed` has not been used since the first Hyundai was supported. The other values are not required for opnepilot lateral and longitudinal control.

**Offline Validation**
- [x] `pytest opendbc`
- [x] `pytest selfdrive/car/tests`
- [x] `selfdrive/test/process_replay/test_processes.py`