### PR TITLE
Toyota: DBC message for SecOC longitudinal control

### DIFF
--- a/opendbc/dbc/generator/toyota/toyota_rav4_prime.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_rav4_prime.dbc
@@ -84,7 +84,7 @@ BO_ 374 PCM_CRUISE: 8 XXX
  SG_ CRUISE_STATE : 31|4@0+ (1,0) [0|1] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 375 ACC_CONTROL_2: 8 XXX
+BO_ 375 PCM_CRUISE_3: 8 XXX
  SG_ NEW_SIGNAL_1 : 7|16@0- (1,0) [0|65535] "" XXX
  SG_ NEW_SIGNAL_4 : 16|1@0+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_6 : 19|1@0+ (1,0) [0|1] "" XXX
@@ -92,6 +92,12 @@ BO_ 375 ACC_CONTROL_2: 8 XXX
  SG_ NEW_SIGNAL_5 : 22|1@0+ (1,0) [0|1] "" XXX
  SG_ GAS_RELEASED : 30|1@0+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_2 : 31|1@0+ (1,0) [0|1] "" XXX
+ SG_ AUTHENTICATOR : 35|28@0+ (1,0) [0|268435455] "" XXX
+ SG_ RESET_FLAG : 37|2@0+ (1,0) [0|3] "" XXX
+ SG_ MSG_CNT_LOWER : 39|2@0+ (1,0) [0|3] "" XXX
+
+BO_ 387 ACC_CONTROL_2: 8 XXX
+ SG_ ACCEL_CMD : 7|16@0- (1,0) [0|65535] "" XXX
  SG_ AUTHENTICATOR : 35|28@0+ (1,0) [0|268435455] "" XXX
  SG_ RESET_FLAG : 37|2@0+ (1,0) [0|3] "" XXX
  SG_ MSG_CNT_LOWER : 39|2@0+ (1,0) [0|3] "" XXX
@@ -345,6 +351,8 @@ BO_ 1592 DOOR_LOCKS: 8 XXX
 
 CM_ SG_ 37 STEER_RATE "factor is tbd";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
+CM_ SG_ 305 STEER_ANGLE_CMD "Used in place of STEERING_LTA.STEER_ANGLE_CMD on SecOC cars";
+CM_ SG_ 387 ACCEL_CMD "Used in place of ACC_CONTROL.ACCEL_CMD on SecOC cars";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 SETME_X1 "usually 1, seen at 0 on some South American Corollas indicating lack of stock Lane Tracing Assist";
 CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";

--- a/opendbc/dbc/toyota_rav4_prime_generated.dbc
+++ b/opendbc/dbc/toyota_rav4_prime_generated.dbc
@@ -87,7 +87,7 @@ BO_ 374 PCM_CRUISE: 8 XXX
  SG_ CRUISE_STATE : 31|4@0+ (1,0) [0|1] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 375 ACC_CONTROL_2: 8 XXX
+BO_ 375 PCM_CRUISE_3: 8 XXX
  SG_ NEW_SIGNAL_1 : 7|16@0- (1,0) [0|65535] "" XXX
  SG_ NEW_SIGNAL_4 : 16|1@0+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_6 : 19|1@0+ (1,0) [0|1] "" XXX
@@ -95,6 +95,12 @@ BO_ 375 ACC_CONTROL_2: 8 XXX
  SG_ NEW_SIGNAL_5 : 22|1@0+ (1,0) [0|1] "" XXX
  SG_ GAS_RELEASED : 30|1@0+ (1,0) [0|1] "" XXX
  SG_ NEW_SIGNAL_2 : 31|1@0+ (1,0) [0|1] "" XXX
+ SG_ AUTHENTICATOR : 35|28@0+ (1,0) [0|268435455] "" XXX
+ SG_ RESET_FLAG : 37|2@0+ (1,0) [0|3] "" XXX
+ SG_ MSG_CNT_LOWER : 39|2@0+ (1,0) [0|3] "" XXX
+
+BO_ 387 ACC_CONTROL_2: 8 XXX
+ SG_ ACCEL_CMD : 7|16@0- (1,0) [0|65535] "" XXX
  SG_ AUTHENTICATOR : 35|28@0+ (1,0) [0|268435455] "" XXX
  SG_ RESET_FLAG : 37|2@0+ (1,0) [0|3] "" XXX
  SG_ MSG_CNT_LOWER : 39|2@0+ (1,0) [0|3] "" XXX
@@ -348,6 +354,8 @@ BO_ 1592 DOOR_LOCKS: 8 XXX
 
 CM_ SG_ 37 STEER_RATE "factor is tbd";
 CM_ SG_ 37 STEER_FRACTION "1/15th of the signal STEER_ANGLE, which is 1.5 deg; note that 0x8 is never set";
+CM_ SG_ 305 STEER_ANGLE_CMD "Used in place of STEERING_LTA.STEER_ANGLE_CMD on SecOC cars";
+CM_ SG_ 387 ACCEL_CMD "Used in place of ACC_CONTROL.ACCEL_CMD on SecOC cars";
 CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
 CM_ SG_ 401 SETME_X1 "usually 1, seen at 0 on some South American Corollas indicating lack of stock Lane Tracing Assist";
 CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";


### PR DESCRIPTION
Long control is out of scope for initial RAV4 Prime support in #1287, but in the course of validation, we identified the new ACC control message.

Much like STEERING_LTA now has a SecOC-signed companion STEERING_LTA_2 with mostly just the actuation commands moved, ACC_CONTROL now has a SecOC-signed companion ACC_CONTROL_2 with just the acceleration value moved.

The message comes in from the bus 2 side, just like ACC_CONTROL, and the SecOC solve should be generally applicable. Long control is almost certainly possible with a few hours spent on control and Panda safety.