### PR TITLE
Lexus ES TSS2: switch braking signal

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -164,6 +164,9 @@ class CarController(CarControllerBase):
       self.pcm_accel_compensation = rate_limit(pcm_accel_compensation, self.pcm_accel_compensation, -0.01, 0.01)
       pcm_accel_cmd = actuators.accel - self.pcm_accel_compensation
 
+      # prevent request from deviating too far from current pcm accel net
+      pcm_accel_cmd = max(pcm_accel_cmd, CS.pcm_accel_net - 0.5)
+
       # Along with rate limiting positive jerk below, this greatly improves gas response time
       # Consider the net acceleration request that the PCM should be applying (pitch included)
       if net_acceleration_request < 0.1:

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -165,7 +165,8 @@ class CarController(CarControllerBase):
       pcm_accel_cmd = actuators.accel - self.pcm_accel_compensation
 
       # prevent request from deviating too far from current pcm accel net
-      pcm_accel_cmd = max(pcm_accel_cmd, CS.pcm_accel_net - 0.5)
+      if pcm_accel_cmd < 0:
+        pcm_accel_cmd = max(pcm_accel_cmd, min(CS.pcm_accel_net - 0.5, 0))
 
       # Along with rate limiting positive jerk below, this greatly improves gas response time
       # Consider the net acceleration request that the PCM should be applying (pitch included)

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -76,8 +76,8 @@ class CarState(CarStateBase):
 
       # add creeping force at low speeds only for braking, CLUTCH->ACCEL_NET already shows this
       # TODO: with ICBACT maybe we can always add neutral force for engine braking at high speed now!
-      neutral_accel = max(cp.vl["PCM_CRUISE"]["NEUTRAL_FORCE"] / self.CP.mass, 0.0)
-      if self.pcm_accel_net + neutral_accel < 0.0:
+        neutral_accel = max(cp.vl["PCM_CRUISE"]["NEUTRAL_FORCE"] / self.CP.mass, 0.0)
+        # if self.pcm_accel_net + neutral_accel < 0.0:
         self.pcm_accel_net += neutral_accel
 
     ret.doorOpen = any([cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_FL"], cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_FR"],

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -66,9 +66,12 @@ class CarState(CarStateBase):
 
       # Sometimes ACC_BRAKING can be 1 while showing we're applying gas already
       # TODO: is ACC_BRAKING actually just the brake lights? ICBACT goes high much later/with lower decel requests
-      # if cp.vl["PCM_CRUISE"]["ACC_BRAKING"]:
-      if cp.vl["VSC1S29"]["ICBACT"]:
+      if cp.vl["PCM_CRUISE"]["ACC_BRAKING"]:
         self.pcm_accel_net += min(cp.vl["PCM_CRUISE"]["ACCEL_NET"], 0.0)
+
+        # this 0.8x seems consistent with the pitch compensated accel net, TODO: figure out what this is
+        if cp.vl["VSC1S29"]["ICBACT"]:
+          self.pcm_accel_net *= 0.8
 
       # add creeping force at low speeds only for braking, CLUTCH->ACCEL_NET already shows this
       # TODO: with ICBACT maybe we can always add neutral force for engine braking at high speed now!

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -65,10 +65,13 @@ class CarState(CarStateBase):
       self.pcm_accel_net = max(cp.vl["CLUTCH"]["ACCEL_NET"], 0.0)
 
       # Sometimes ACC_BRAKING can be 1 while showing we're applying gas already
-      if cp.vl["PCM_CRUISE"]["ACC_BRAKING"]:
+      # TODO: is ACC_BRAKING actually just the brake lights? ICBACT goes high much later/with lower decel requests
+      # if cp.vl["PCM_CRUISE"]["ACC_BRAKING"]:
+      if cp.vl["VSC1S29"]["ICBACT"]:
         self.pcm_accel_net += min(cp.vl["PCM_CRUISE"]["ACCEL_NET"], 0.0)
 
       # add creeping force at low speeds only for braking, CLUTCH->ACCEL_NET already shows this
+      # TODO: with ICBACT maybe we can always add neutral force for engine braking at high speed now!
       neutral_accel = max(cp.vl["PCM_CRUISE"]["NEUTRAL_FORCE"] / self.CP.mass, 0.0)
       if self.pcm_accel_net + neutral_accel < 0.0:
         self.pcm_accel_net += neutral_accel
@@ -217,6 +220,7 @@ class CarState(CarStateBase):
       ("STEER_ANGLE_SENSOR", 80),
       ("PCM_CRUISE", 33),
       ("PCM_CRUISE_SM", 1),
+      ("VSC1S29", 50),
       ("STEER_TORQUE_SENSOR", 50),
     ]
 

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -69,9 +69,10 @@ class CarState(CarStateBase):
       if cp.vl["PCM_CRUISE"]["ACC_BRAKING"]:
         self.pcm_accel_net += min(cp.vl["PCM_CRUISE"]["ACCEL_NET"], 0.0)
 
-        # this 0.8x seems consistent with the pitch compensated accel net, TODO: figure out what this is
-        if cp.vl["VSC1S29"]["ICBACT"]:
-          self.pcm_accel_net *= 0.8
+        # # this 0.8x seems consistent with the pitch compensated accel net, TODO: figure out what this is
+        # TODO: no it doesn't, is it request rate based?
+        # if cp.vl["VSC1S29"]["ICBACT"]:
+        #   self.pcm_accel_net *= 0.8
 
       # add creeping force at low speeds only for braking, CLUTCH->ACCEL_NET already shows this
       # TODO: with ICBACT maybe we can always add neutral force for engine braking at high speed now!


### PR DESCRIPTION
So far my theory is ACC_BRAKING describes the brake lights and activates for engine braking, and ICBACT is friction brakes actuation. How the car gets to more than 0.5 m/s^2 of deceleration with a NEUTRAL_FORCE that says it can only engine brake ~0.1 m/s^2 is a mystery though.

If this new signal is truly when the friction brakes are being actuated, then NEUTRAL_FORCE might not be correct, or depends on the gear possibly.

There is also a weird descrepency of aEgo undershooting the ACCEL_NET brake request from the PCM, that starts only when ICBACT goes high:

![image](https://github.com/user-attachments/assets/a27aaded-5f60-483b-b3e6-a02f63283917)