### PR TITLE
Tesla: setSpeed to 0 if not active

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -43,7 +43,7 @@ class CarController(CarControllerBase):
         state = 13  # "ACC_CANCEL_GENERIC_SILENT"
       accel = clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
       cntr =  (self.frame // 4) % 8
-      can_sends.append(self.tesla_can.create_longitudinal_command(state, accel, cntr))
+      can_sends.append(self.tesla_can.create_longitudinal_command(state, accel, cntr, CC.longActive))
 
     # Increment counter so cancel is prioritized even without openpilot longitudinal
     if hands_on_fault and not self.CP.openpilotLongitudinalControl:

--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -24,9 +24,9 @@ class TeslaCAN:
     values["DAS_steeringControlChecksum"] = self.checksum(0x488, data[:3])
     return self.packer.make_can_msg("DAS_steeringControl", CANBUS.party, values)
 
-  def create_longitudinal_command(self, acc_state, accel, cntr):
+  def create_longitudinal_command(self, acc_state, accel, cntr, active):
     values = {
-      "DAS_setSpeed": 0 if accel <= 0 else V_CRUISE_MAX,
+      "DAS_setSpeed": 0 if (accel < 0 or not active) else V_CRUISE_MAX,
       "DAS_accState": acc_state,
       "DAS_aebEvent": 0,
       "DAS_jerkMin": CarControllerParams.JERK_LIMIT_MIN,

--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -26,7 +26,7 @@ class TeslaCAN:
 
   def create_longitudinal_command(self, acc_state, accel, cntr):
     values = {
-      "DAS_setSpeed": 0 if accel < 0 else V_CRUISE_MAX,
+      "DAS_setSpeed": 0 if accel <= 0 else V_CRUISE_MAX,
       "DAS_accState": acc_state,
       "DAS_aebEvent": 0,
       "DAS_jerkMin": CarControllerParams.JERK_LIMIT_MIN,


### PR DESCRIPTION
Setting the speed to anything other than 0 when we are not engaged puts the Driver Interface (DI_cruiseState) in the UNAVAILABLE state. This stops us from engaging while the car is at a standstill.