### PR TITLE
Tesla: allow Steering below 18mph

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -36,6 +36,9 @@ class CarController(CarControllerBase):
       self.apply_angle_last = apply_angle
       can_sends.append(self.tesla_can.create_steering_control(apply_angle, lkas_enabled, (self.frame // 2) % 16))
 
+    if self.frame % 10 == 0:
+      can_sends.append(self.tesla_can.create_steering_allowed((self.frame // 10) % 16))
+
     # Longitudinal control
     if self.CP.openpilotLongitudinalControl and self.frame % 4 == 0:
       state = CS.das_control["DAS_accState"]

--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -39,3 +39,13 @@ class TeslaCAN:
     data = self.packer.make_can_msg("DAS_control", CANBUS.party, values)[1]
     values["DAS_controlChecksum"] = self.checksum(0x2b9, data[:7])
     return self.packer.make_can_msg("DAS_control", CANBUS.party, values)
+
+  def create_steering_allowed(self, counter):
+    values = {
+      "APS_eacAllow": 1,
+      "APS_eacMonitorCounter": counter,
+    }
+
+    data = self.packer.make_can_msg("APS_eacMonitor", CANBUS.party, values)[1]
+    values["APS_eacMonitorChecksum"] = self.checksum(0x27d, data[:2])
+    return self.packer.make_can_msg("APS_eacMonitor", CANBUS.party, values)


### PR DESCRIPTION
The APS_eacMonitor message, sent by the Autopilot computer, tells the EPAS if steering commands are allowed. 
Setting APS_eacAllow to 1 always lets us engage steering.