### PR TITLE
Tesla: don't copy DAS_accState

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -38,9 +38,7 @@ class CarController(CarControllerBase):
 
     # Longitudinal control
     if self.CP.openpilotLongitudinalControl and self.frame % 4 == 0:
-      state = CS.das_control["DAS_accState"]
-      if hands_on_fault:
-        state = 13  # "ACC_CANCEL_GENERIC_SILENT"
+      state = 4 if not hands_on_fault else 13  # 4=ACC_ON, 13=ACC_CANCEL_GENERIC_SILENT
       accel = clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
       cntr =  (self.frame // 4) % 8
       can_sends.append(self.tesla_can.create_longitudinal_command(state, accel, cntr))


### PR DESCRIPTION
The Autopilot computer sends the `ACC_ON` state to the Drive Interface (DI). The DI then manages the actual ACC state.

`ACC_ON` simply indicates that ACC is ready to engage, but not yet active. 
In the example from the stock route `35f334fe58c5cdc5/00000001--d8d176b1af`, the `ACC_ON` state is active even though the DI_cruiseState is not set to "ENABLED". It's the action of pressing "Resume" on the stalk that actually activates ACC.

With this change, we no longer have to adhere to the Autopilot computer's restrictions to enable ACC.