### PR TITLE
optimize CANParser with ParsedCanData for faster updates

### DIFF
--- a/opendbc/can/parser.py
+++ b/opendbc/can/parser.py
@@ -1,2 +1,2 @@
-from opendbc.can.parser_pyx import CANParser, CANDefine  # pylint: disable=no-name-in-module, import-error
-assert CANParser, CANDefine
+from opendbc.can.parser_pyx import CANParser, CANDefine, ParsedCanData  # pylint: disable=no-name-in-module, import-error
+assert all([CANParser, CANDefine, ParsedCanData])

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -9,6 +9,7 @@ from typing import Any, NamedTuple
 from collections.abc import Callable
 from functools import cache
 
+from opendbc.can.parser import ParsedCanData
 from opendbc.car import DT_CTRL, apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, get_friction, STD_CARGO_KG
 from opendbc.car import structs
 from opendbc.car.can_definitions import CanData, CanRecvCallable, CanSendCallable
@@ -225,9 +226,10 @@ class CarInterfaceBase(ABC):
 
   def update(self, can_packets: list[tuple[int, list[CanData]]]) -> structs.CarState:
     # parse can
+    parsed_can_data = ParsedCanData(can_packets)
     for cp in self.can_parsers:
       if cp is not None:
-        cp.update_strings(can_packets)
+        cp.update_from_parsed(parsed_can_data)
 
     # get CarState
     ret = self._update()


### PR DESCRIPTION
This PR introduces performance optimizations to the `CANParser` by adding a new `ParsedCanData` class and a new `update_from_parsed` method. These changes reduce the overhead of repeatedly parsing the same string inputs in the update process, resulting in faster updates.