### PR TITLE
CANParser: expose `MessageState` to Cython to eliminate data copying

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -81,7 +81,7 @@ public:
             const std::vector<std::pair<uint32_t, int>> &messages);
   CANParser(int abus, const std::string& dbc_name, bool ignore_checksum, bool ignore_counter);
   std::set<uint32_t> update(const std::vector<CanData> &can_data);
-  MessageState *messageState(uint32_t address) { return &message_states.at(address); }
+  MessageState *getMessageState(uint32_t address) { return &message_states.at(address); }
 
 protected:
   void UpdateCans(const CanData &can, std::set<uint32_t> &updated_addresses);

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <map>
+#include <set>
 #include <string>
 #include <utility>
 #include <unordered_map>
@@ -72,7 +73,6 @@ public:
   bool can_valid = false;
   bool bus_timeout = false;
   uint64_t first_nanos = 0;
-  uint64_t last_nanos = 0;
   uint64_t last_nonempty_nanos = 0;
   uint64_t bus_timeout_threshold = 0;
   uint64_t can_invalid_cnt = CAN_INVALID_CNT;
@@ -80,11 +80,11 @@ public:
   CANParser(int abus, const std::string& dbc_name,
             const std::vector<std::pair<uint32_t, int>> &messages);
   CANParser(int abus, const std::string& dbc_name, bool ignore_checksum, bool ignore_counter);
-  void update(const std::vector<CanData> &can_data, std::vector<SignalValue> &vals);
-  void query_latest(std::vector<SignalValue> &vals, uint64_t last_ts = 0);
+  std::set<uint32_t> update(const std::vector<CanData> &can_data);
+  MessageState *messageState(uint32_t address) { return &message_states.at(address); }
 
 protected:
-  void UpdateCans(const CanData &can);
+  void UpdateCans(const CanData &can, std::set<uint32_t> &updated_addresses);
   void UpdateValid(uint64_t nanos);
 };
 

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -4,6 +4,7 @@
 from libc.stdint cimport uint8_t, uint32_t, uint64_t
 from libcpp cimport bool
 from libcpp.pair cimport pair
+from libcpp.set cimport set
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.unordered_map cimport unordered_map
@@ -53,13 +54,6 @@ cdef extern from "common_dbc.h":
     unordered_map[uint32_t, const Msg*] addr_to_msg
     unordered_map[string, const Msg*] name_to_msg
 
-  cdef struct SignalValue:
-    uint32_t address
-    uint64_t ts_nanos
-    string name
-    double value
-    vector[double] all_values
-
   cdef struct SignalPackValue:
     string name
     double value
@@ -67,6 +61,12 @@ cdef extern from "common_dbc.h":
 
 cdef extern from "common.h":
   cdef const DBC* dbc_lookup(const string) except +
+
+  cdef cppclass MessageState:
+    vector[Signal] parse_sigs
+    vector[double] vals
+    vector[vector[double]] all_vals
+    uint64_t last_seen_nanos
 
   cdef struct CanFrame:
     long src
@@ -81,7 +81,8 @@ cdef extern from "common.h":
     bool can_valid
     bool bus_timeout
     CANParser(int, string, vector[pair[uint32_t, int]]) except +
-    void update(vector[CanData]&, vector[SignalValue]&) except +
+    set[uint32_t] update(vector[CanData]&) except +
+    MessageState *messageState(uint32_t address)
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -82,7 +82,7 @@ cdef extern from "common.h":
     bool bus_timeout
     CANParser(int, string, vector[pair[uint32_t, int]]) except +
     set[uint32_t] update(vector[CanData]&) except +
-    MessageState *messageState(uint32_t address)
+    MessageState *getMessageState(uint32_t address)
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/opendbc/can/common_dbc.h
+++ b/opendbc/can/common_dbc.h
@@ -10,14 +10,6 @@ struct SignalPackValue {
   double value;
 };
 
-struct SignalValue {
-  uint32_t address;
-  uint64_t ts_nanos;
-  std::string name;
-  double value;  // latest value
-  std::vector<double> all_values;  // all values from this cycle
-};
-
 enum SignalType {
   DEFAULT,
   COUNTER,

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -5,11 +5,6 @@
 #include <stdexcept>
 #include <sstream>
 
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/mman.h>
-
 #include "opendbc/can/common.h"
 
 int64_t get_raw_value(const std::vector<uint8_t> &msg, const Signal &sig) {
@@ -157,8 +152,14 @@ CANParser::CANParser(int abus, const std::string& dbc_name, bool ignore_checksum
   }
 }
 
-void CANParser::update(const std::vector<CanData> &can_data, std::vector<SignalValue> &vals) {
+std::set<uint32_t> CANParser::update(const std::vector<CanData> &can_data) {
+  // Clear all_values
+  for (auto &state : message_states) {
+    for (auto &vals : state.second.all_vals) vals.clear();
+  }
+
   uint64_t current_nanos = 0;
+  std::set<uint32_t> updated_addresses;
   for (const auto &c : can_data) {
     if (first_nanos == 0) {
       first_nanos = c.nanos;
@@ -166,15 +167,13 @@ void CANParser::update(const std::vector<CanData> &can_data, std::vector<SignalV
     if (current_nanos == 0) {
       current_nanos = c.nanos;
     }
-    last_nanos = c.nanos;
-
-    UpdateCans(c);
-    UpdateValid(last_nanos);
+    UpdateCans(c, updated_addresses);
+    UpdateValid(c.nanos);
   }
-  query_latest(vals, current_nanos);
+  return updated_addresses;
 }
 
-void CANParser::UpdateCans(const CanData &can) {
+void CANParser::UpdateCans(const CanData &can, std::set<uint32_t> &updated_addresses) {
   //DEBUG("got %zu messages\n", can.frames.size());
 
   bool bus_empty = true;
@@ -202,7 +201,9 @@ void CANParser::UpdateCans(const CanData &can) {
     //  continue;
     //}
 
-    state_it->second.parse(can.nanos, frame.dat);
+    if (state_it->second.parse(can.nanos, frame.dat)) {
+      updated_addresses.insert(state_it->first);
+    }
   }
 
   // update bus timeout
@@ -239,27 +240,4 @@ void CANParser::UpdateValid(uint64_t nanos) {
   }
   can_invalid_cnt = _valid ? 0 : (can_invalid_cnt + 1);
   can_valid = (can_invalid_cnt < CAN_INVALID_CNT) && _counters_valid;
-}
-
-void CANParser::query_latest(std::vector<SignalValue> &vals, uint64_t last_ts) {
-  if (last_ts == 0) {
-    last_ts = last_nanos;
-  }
-  for (auto& kv : message_states) {
-    auto& state = kv.second;
-    if (last_ts != 0 && state.last_seen_nanos < last_ts) {
-      continue;
-    }
-
-    for (int i = 0; i < state.parse_sigs.size(); i++) {
-      const Signal &sig = state.parse_sigs[i];
-      SignalValue &v = vals.emplace_back();
-      v.address = state.address;
-      v.ts_nanos = state.last_seen_nanos;
-      v.name = sig.name;
-      v.value = state.vals[i];
-      v.all_values = state.all_vals[i];
-      state.all_vals[i].clear();
-    }
-  }
 }

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -153,8 +153,6 @@ CANParser::CANParser(int abus, const std::string& dbc_name, bool ignore_checksum
 }
 
 std::set<uint32_t> CANParser::update(const std::vector<CanData> &can_data) {
-  if (can_data.empty()) return;
-
   // Clear all_values
   for (auto &state : message_states) {
     for (auto &vals : state.second.all_vals) vals.clear();

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -158,15 +158,10 @@ std::set<uint32_t> CANParser::update(const std::vector<CanData> &can_data) {
     for (auto &vals : state.second.all_vals) vals.clear();
   }
 
-  // used to check for updated messages in earlier frames when we receive multiple at once
-  uint64_t current_nanos = 0;
   std::set<uint32_t> updated_addresses;
   for (const auto &c : can_data) {
     if (first_nanos == 0) {
       first_nanos = c.nanos;
-    }
-    if (current_nanos == 0) {
-      current_nanos = c.nanos;
     }
 
     UpdateCans(c, updated_addresses);

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -1,14 +1,13 @@
 # distutils: language = c++
 # cython: c_string_encoding=ascii, language_level=3
 
-from cython.operator cimport dereference as deref, preincrement as preinc
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libc.stdint cimport uint32_t
 
 from .common cimport CANParser as cpp_CANParser
-from .common cimport dbc_lookup, SignalValue, DBC, CanData, CanFrame
+from .common cimport dbc_lookup, Msg, DBC, CanData, CanFrame
 
 import numbers
 from collections import defaultdict
@@ -50,15 +49,16 @@ cdef class CANParser:
       self.addresses.push_back(address)
 
       name = m.name.decode("utf8")
-      self.vl[address] = {}
+      signal_names = [sig.name.decode("utf-8") for sig in (<Msg*>m).sigs]
+
+      self.vl[address] = {name : 0 for name in signal_names}
       self.vl[name] = self.vl[address]
       self.vl_all[address] = defaultdict(list)
       self.vl_all[name] = self.vl_all[address]
-      self.ts_nanos[address] = {}
+      self.ts_nanos[address] = {name : 0 for name in signal_names}
       self.ts_nanos[name] = self.ts_nanos[address]
 
     self.can = new cpp_CANParser(bus, dbc_name, message_v)
-    self.update_strings([])
 
   def __dealloc__(self):
     if self.can:
@@ -71,13 +71,6 @@ cdef class CANParser:
     for address in self.addresses:
       self.vl_all[address].clear()
 
-    cur_address = -1
-    vl = {}
-    vl_all = {}
-    ts_nanos = {}
-    updated_addrs = set()
-
-    cdef vector[SignalValue] new_vals
     cdef CanFrame* frame
     cdef CanData* can_data
     cdef vector[CanData] can_data_array
@@ -99,27 +92,18 @@ cdef class CANParser:
     except TypeError:
       raise RuntimeError("invalid parameter")
 
-    self.can.update(can_data_array, new_vals)
+    updated_addrs = self.can.update(can_data_array)
+    for addr in updated_addrs:
+      vl = self.vl[addr]
+      vl_all = self.vl_all[addr]
+      ts_nanos = self.ts_nanos[addr]
 
-    cdef vector[SignalValue].iterator it = new_vals.begin()
-    cdef SignalValue* cv
-    while it != new_vals.end():
-      cv = &deref(it)
-
-      # Check if the address has changed
-      if cv.address != cur_address:
-        cur_address = cv.address
-        vl = self.vl[cur_address]
-        vl_all = self.vl_all[cur_address]
-        ts_nanos = self.ts_nanos[cur_address]
-        updated_addrs.add(cur_address)
-
-      # Cast char * directly to unicode
-      cv_name = <unicode>cv.name
-      vl[cv_name] = cv.value
-      vl_all[cv_name] = cv.all_values
-      ts_nanos[cv_name] = cv.ts_nanos
-      preinc(it)
+      state = self.can.messageState(addr)
+      for i in range(state.parse_sigs.size()):
+        name = <unicode>state.parse_sigs[i].name
+        vl[name] = state.vals[i]
+        vl_all[name] = state.all_vals[i]
+        ts_nanos[name] = state.last_seen_nanos
 
     return updated_addrs
 

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -101,7 +101,7 @@ cdef class CANParser:
       vl_all = self.vl_all[addr]
       ts_nanos = self.ts_nanos[addr]
 
-      state = self.can.messageState(addr)
+      state = self.can.getMessageState(addr)
       for i in range(state.parse_sigs.size()):
         name = <unicode>state.parse_sigs[i].name
         vl[name] = state.vals[i]


### PR DESCRIPTION
This PR greatly simplifies the update logic, resulting in reduced code complexity and eliminating unnecessary data copying.

### Main Changes:
1. Removal of `SignalValue` Struct and `CANParser::query_latest` Function: These components, previously used for copying updated values to Cython, have been removed. This change streamlines the data flow between C++ and Cython.
2. Direct Exposure of `MessageState` to Cython: `MessageState` is now directly accessible from Cython, allowing values to be read straight from the C++ object. This eliminates the need for intermediate copying, optimizing performance and simplifying the overall code structure.

Additionally, this PR includes changes from #1381, where value dictionaries are now initialized directly from DBC messages, though it does not include the `test_parser_empty_list() `function.

Below are the performance benchmark results comparing this PR against the current master branch:

**Benchmark (PR):**

```
6000 CAN packets, 10 runs
272.64 mean ms, 278.98 max ms, 268.80 min ms, 2.98 std ms
0.0454 mean ms / CAN packet
```

**Benchmark (Master):**

```
6000 CAN packets, 10 runs
335.81 mean ms, 394.27 max ms, 312.58 min ms, 24.96 std ms
0.0560 mean ms / CAN packe
```

Most of the time is spent converting and copying messages from Python to C++. so while the current results don't show a massive improvement, after #1383 is merged, this PR could reduce the time per packet from **0.0318 ms** to under **0.02 ms**. I will run additional benchmarks to confirm once that change is integrated.