### PR TITLE
CANParser: filter CAN messages by bus and addresses

### DIFF
--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -8,7 +8,7 @@ from libcpp.vector cimport vector
 from libc.stdint cimport uint32_t
 
 from .common cimport CANParser as cpp_CANParser
-from .common cimport dbc_lookup, SignalValue, DBC, CanData, CanFrame
+from .common cimport dbc_lookup, SignalValue, DBC, CanData
 
 import numbers
 from collections import defaultdict
@@ -18,16 +18,18 @@ cdef class CANParser:
   cdef:
     cpp_CANParser *can
     const DBC *dbc
-    vector[uint32_t] addresses
+    set addresses
 
   cdef readonly:
     dict vl
     dict vl_all
     dict ts_nanos
     string dbc_name
+    uint32_t bus
 
   def __init__(self, dbc_name, messages, bus=0):
     self.dbc_name = dbc_name
+    self.bus = bus
     self.dbc = dbc_lookup(dbc_name)
     if not self.dbc:
       raise RuntimeError(f"Can't find DBC: {dbc_name}")
@@ -35,6 +37,7 @@ cdef class CANParser:
     self.vl = {}
     self.vl_all = {}
     self.ts_nanos = {}
+    self.addresses = set()
 
     # Convert message names into addresses and check existence in DBC
     cdef vector[pair[uint32_t, int]] message_v
@@ -47,7 +50,7 @@ cdef class CANParser:
 
       address = m.address
       message_v.push_back((address, c[1]))
-      self.addresses.push_back(address)
+      self.addresses.add(address)
 
       name = m.name.decode("utf8")
       self.vl[address] = {}
@@ -78,8 +81,6 @@ cdef class CANParser:
     updated_addrs = set()
 
     cdef vector[SignalValue] new_vals
-    cdef CanFrame* frame
-    cdef CanData* can_data
     cdef vector[CanData] can_data_array
 
     try:
@@ -91,11 +92,14 @@ cdef class CANParser:
         can_data = &(can_data_array.emplace_back())
         can_data.nanos = s[0]
         can_data.frames.reserve(len(s[1]))
-        for f in s[1]:
-          frame = &(can_data.frames.emplace_back())
-          frame.address = f[0]
-          frame.dat = f[1]
-          frame.src = f[2]
+        valid_addresses = self.addresses
+        for address, dat, src in s[1]:
+          source_bus = <uint32_t>src
+          if source_bus == self.bus and address in valid_addresses:
+            frame = &(can_data.frames.emplace_back())
+            frame.address = address
+            frame.dat = dat
+            frame.src = source_bus
     except TypeError:
       raise RuntimeError("invalid parameter")
 

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -92,10 +92,9 @@ cdef class CANParser:
         can_data = &(can_data_array.emplace_back())
         can_data.nanos = s[0]
         can_data.frames.reserve(len(s[1]))
-        valid_addresses = self.addresses
         for address, dat, src in s[1]:
           source_bus = <uint32_t>src
-          if source_bus == self.bus and address in valid_addresses:
+          if source_bus == self.bus and address in self.addresses:
             frame = &(can_data.frames.emplace_back())
             frame.address = address
             frame.dat = dat


### PR DESCRIPTION
This PR adds filtering for CAN messages  based on the bus and addresses that the CANParser specifically cares about.
Instead of converting and copying all incoming messages from Python to C++ , we now only parse and copy those with relevant addresses to the c++ `CanFrame` vector. This reduces the overhead from unnecessary message processing, lowering CPU and memory usage while enhancing overall performance and efficiency.

Below are the performance benchmark results comparing this PR against the current master branch:

**Benchmark (PR):**

```
6000 CAN packets, 10 runs
190.79 mean ms, 219.88 max ms, 180.86 min ms, 10.96 std ms
0.0318 mean ms / CAN packet

```

**Benchmark (Master):**

```
6000 CAN packets, 10 runs
335.81 mean ms, 394.27 max ms, 312.58 min ms, 24.96 std ms
0.0560 mean ms / CAN packe
```