### PR TITLE
Ford: add override signal

### DIFF
--- a/opendbc/car/ford/carcontroller.py
+++ b/opendbc/car/ford/carcontroller.py
@@ -95,7 +95,7 @@ class CarController(CarControllerBase):
         gas = CarControllerParams.INACTIVE_GAS
       stopping = CC.actuators.longControlState == LongCtrlState.stopping
       # TODO: look into using the actuators packet to send the desired speed
-      can_sends.append(fordcan.create_acc_msg(self.packer, self.CAN, CC.longActive, gas, accel, stopping, v_ego_kph=V_CRUISE_MAX))
+      can_sends.append(fordcan.create_acc_msg(self.packer, self.CAN, CC.longActive, CS.out.gasPressed, gas, accel, stopping, v_ego_kph=V_CRUISE_MAX))
 
     ### ui ###
     send_ui = (self.main_on_last != main_on) or (self.lkas_enabled_last != CC.latActive) or (self.steer_alert_last != steer_alert)

--- a/opendbc/car/ford/fordcan.py
+++ b/opendbc/car/ford/fordcan.py
@@ -117,7 +117,7 @@ def create_lat_ctl2_msg(packer, CAN: CanBus, mode: int, path_offset: float, path
   return packer.make_can_msg("LateralMotionControl2", CAN.main, values)
 
 
-def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: float, stopping: bool, v_ego_kph: float):
+def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas_pressed: bool, gas: float, accel: float, stopping: bool, v_ego_kph: float):
   """
   Creates a CAN message for the Ford ACC Command.
 
@@ -141,6 +141,7 @@ def create_acc_msg(packer, CAN: CanBus, long_active: bool, gas: float, accel: fl
     "AccBrkPrchg_B_Rq": 1 if decel else 0,            # Pre-charge brake request: 0=No, 1=Yes
     "AccBrkDecel_B_Rq": 1 if decel else 0,            # Deceleration request: 0=Inactive, 1=Active
     "AccStopStat_B_Rq": 1 if stopping else 0,
+    "CmbbOvrrd_B_RqDrv": 1 if gas_pressed and long_active else 0,  # TODO: does this prevent brake windup when gas is pressed?
   }
   return packer.make_can_msg("ACCDATA", CAN.main, values)
 


### PR DESCRIPTION
May prevent brake wind up when overriding while it wants to brake. The stock system even starts the brake request from aEgo which further reduces the jerk:

![image](https://github.com/user-attachments/assets/801c0ef9-8c32-4b6c-92fb-2245c09e6b1d)
