### PR TITLE
Set Ford CAN radar timestep

### DIFF
--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -2,7 +2,7 @@ from panda import Panda
 from opendbc.car import get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.ford.fordcan import CanBus
-from opendbc.car.ford.values import Ecu, FordFlags
+from opendbc.car.ford.values import DBC, Ecu, FordFlags, RADAR
 from opendbc.car.interfaces import CarInterfaceBase
 
 TransmissionType = structs.CarParams.TransmissionType
@@ -15,6 +15,9 @@ class CarInterface(CarInterfaceBase):
     ret.dashcamOnly = bool(ret.flags & FordFlags.CANFD)
 
     ret.radarUnavailable = True
+    if DBC[candidate]['radar'] == RADAR.DELPHI_MRR:
+      ret.radarTimeStep = 0.03  # 33.3 Hz
+
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -24,7 +24,7 @@ def _create_delphi_mrr_radar_can_parser(CP) -> CANParser:
 
   for i in range(1, DELPHI_MRR_RADAR_MSG_COUNT + 1):
     msg = f"MRR_Detection_{i:03d}"
-    messages += [(msg, 20)]
+    messages += [(msg, 33)]
 
   return CANParser(RADAR.DELPHI_MRR, messages, CanBus(CP).radar)
 
@@ -36,7 +36,7 @@ class RadarInterface(RadarInterfaceBase):
     self.updated_messages = set()
     self.track_id = 0
     self.radar = DBC[CP.carFingerprint]['radar']
-    if self.radar is None or CP.radarUnavailable:
+    if CP.radarUnavailable:
       self.rcp = None
     elif self.radar == RADAR.DELPHI_ESR:
       self.rcp = _create_delphi_esr_radar_can_parser(CP)


### PR DESCRIPTION
For https://github.com/commaai/opendbc/pull/1363

Verified with this code in the `test_radar_interface` test_models function:

```
    if self.CP.flags & 1:  # CAN FD
      assert abs(msgs - 1200) < 50  # 20 Hz
    else:
      assert abs(msgs - 2000) < 50  # 33.3 Hz
```