### PR TITLE
Ford: trigger radar update on header message

### DIFF
--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -21,7 +21,7 @@ def _create_delphi_esr_radar_can_parser(CP) -> CANParser:
 
 
 def _create_delphi_mrr_radar_can_parser(CP) -> CANParser:
-  messages = [('MRR_Header_InformationDetections', 33)]
+  messages = [("MRR_Header_InformationDetections", 33)]
 
   for i in range(1, DELPHI_MRR_RADAR_MSG_COUNT + 1):
     msg = f"MRR_Detection_{i:03d}"


### PR DESCRIPTION
Split from https://github.com/commaai/opendbc/pull/1408

- Each track message's `CAN_SCAN_INDEX_2LSB_xx` signal matches the header's when triggered on the header message
- Every cycle we now receive exactly 65 track updates when triggered on the header message