### PR TITLE
Ford: add long tuning back

### DIFF
--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -19,6 +19,9 @@ class CarInterface(CarInterfaceBase):
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0
 
+    ret.longitudinalTuning.kiBP = [0.]
+    ret.longitudinalTuning.kiV = [0.5]
+
     CAN = CanBus(fingerprint=fingerprint)
     cfgs = [get_safety_config(structs.CarParams.SafetyModel.ford)]
     if CAN.main >= 4:

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -14,7 +14,7 @@ class CarInterface(CarInterfaceBase):
     ret.carName = "ford"
     ret.dashcamOnly = bool(ret.flags & FordFlags.CANFD)
 
-    ret.radarUnavailable = True
+    ret.radarUnavailable = False
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -14,7 +14,7 @@ class CarInterface(CarInterfaceBase):
     ret.carName = "ford"
     ret.dashcamOnly = bool(ret.flags & FordFlags.CANFD)
 
-    ret.radarUnavailable = False
+    ret.radarUnavailable = True
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0


### PR DESCRIPTION
Restores similar closed loop control from before https://github.com/commaai/openpilot/pull/32706

Ford's ABS and PCM seem to have pitch compensation (or at the very least try to close the loop using the ego speed/accel), but it's very slow, this PR should mitigate that.

---

Here shows the ABS braking down a hill and then the PCM slowly applying gas when it goes up the next hill, all with small acceleration requests from the planner:

![image](https://github.com/user-attachments/assets/b1e2e779-8ba2-4784-bda0-96d1191691d2)

https://connect.comma.ai/b9d015f8ff659e1e/000004c5--5e22b30690/436/468