### PR TITLE
Synchronize gas and accel after accel was tweaked

### DIFF
--- a/opendbc/car/ford/carcontroller.py
+++ b/opendbc/car/ford/carcontroller.py
@@ -100,7 +100,6 @@ class CarController(CarControllerBase):
     # send acc msg at 50Hz
     if self.CP.openpilotLongitudinalControl and (self.frame % CarControllerParams.ACC_CONTROL_STEP) == 0:
       accel = actuators.accel
-      gas = accel
 
       if CC.longActive:
         # Compensate for engine creep at low speed.
@@ -115,6 +114,7 @@ class CarController(CarControllerBase):
       accel = clip(accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX)
 
       # Both gas and accel are in m/s^2, accel is used solely for braking
+      gas = accel
       if not CC.longActive or gas < CarControllerParams.MIN_GAS:
         gas = CarControllerParams.INACTIVE_GAS
 


### PR DESCRIPTION
Route: e36b272d5679115f/0000011d--ac087d2c7d/10:12

Every time when when slowing down to a stop and the speed was below 2-3mph, the ACC would inactivate itself.

Checking PJ, noticed that right before this happens, the gas would spike and become out of sync with accel. It seems that if gas is not inactive, it has to match accel.

Look after the green and red lines in the middle chart:
![image](https://github.com/user-attachments/assets/cc2a30f7-3b20-4260-bb56-e2fd06f54c19)
![image](https://github.com/user-attachments/assets/485d6c59-2a88-4191-97ec-39f8d1111cd3)

After the change:
Route: e36b272d5679115f/00000120--c793cf01c4/7:9

![image](https://github.com/user-attachments/assets/ada77357-8f5e-4c69-8715-f0590a934374)