### PR TITLE
Ford: fix unnecessary radar point creation and deletion

### DIFF
--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -14,7 +14,7 @@ class CarInterface(CarInterfaceBase):
     ret.carName = "ford"
     ret.dashcamOnly = bool(ret.flags & FordFlags.CANFD)
 
-    ret.radarUnavailable = True
+    ret.radarUnavailable = False
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -14,7 +14,7 @@ class CarInterface(CarInterfaceBase):
     ret.carName = "ford"
     ret.dashcamOnly = bool(ret.flags & FordFlags.CANFD)
 
-    ret.radarUnavailable = False
+    ret.radarUnavailable = True
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -153,7 +153,6 @@ class RadarInterface(RadarInterfaceBase):
         elif abs(self.pts[i].vRel - distRate) > 2 or abs(self.pts[i].dRel - dRel) > 5:
           # delphi doesn't notify of track switches, so do it manually
           # TODO: refactor this to radard if more radars behave this way
-
           self.pts[i].trackId = self.track_id
           self.track_id += 1
 

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -130,13 +130,6 @@ class RadarInterface(RadarInterfaceBase):
       if scanIndex != headerScanIndex:
         continue
 
-      if i not in self.pts:
-        self.pts[i] = structs.RadarData.RadarPoint()
-        self.pts[i].trackId = self.track_id
-        self.pts[i].aRel = float('nan')
-        self.pts[i].yvRel = float('nan')
-        self.track_id += 1
-
       valid = bool(msg[f"CAN_DET_VALID_LEVEL_{ii:02d}"])
 
       # Long range measurement mode is more sensitive and can detect the road surface
@@ -150,9 +143,17 @@ class RadarInterface(RadarInterfaceBase):
         dRel = cos(azimuth) * dist                              # m from front of car
         yRel = -sin(azimuth) * dist                             # in car frame's y axis, left is positive
 
-        # delphi doesn't notify of track switches, so do it manually
-        # TODO: refactor this to radard if more radars behave this way
-        if abs(self.pts[i].vRel - distRate) > 2 or abs(self.pts[i].dRel - dRel) > 5:
+        if i not in self.pts:
+          self.pts[i] = structs.RadarData.RadarPoint()
+          self.pts[i].trackId = self.track_id
+          self.pts[i].aRel = float('nan')
+          self.pts[i].yvRel = float('nan')
+          self.track_id += 1
+
+        elif abs(self.pts[i].vRel - distRate) > 2 or abs(self.pts[i].dRel - dRel) > 5:
+          # delphi doesn't notify of track switches, so do it manually
+          # TODO: refactor this to radard if more radars behave this way
+
           self.pts[i].trackId = self.track_id
           self.track_id += 1
 
@@ -163,6 +164,7 @@ class RadarInterface(RadarInterfaceBase):
         self.pts[i].measured = True
 
       else:
-        del self.pts[i]
+        if i in self.pts:
+          del self.pts[i]
 
     return errors


### PR DESCRIPTION
track ID goes from 100k to 30k for `./regen.py 'b9d015f8ff659e1e/000004b6--2657291be4' 7 --whitelist-procs card`, saves 1-2% CPU

- fixes creating capnp radar point object only to delete it if it's not valid (this is the big CPU savings contributor)
- if newly valid point, fixes comparing it with empty radar point, double incrementing its track id