### PR TITLE
Ford: enable radar

### DIFF
--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -14,7 +14,7 @@ class CarInterface(CarInterfaceBase):
     ret.carName = "ford"
     ret.dashcamOnly = bool(ret.flags & FordFlags.CANFD)
 
-    ret.radarUnavailable = True
+    ret.radarUnavailable = False
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2
     ret.steerLimitTimer = 1.0


### PR DESCRIPTION
FYI, CAN parsing and accessing the messages and signals from the CANParser dicts is mostly the slowest part, clustering takes only ~10-20% of the time.

@deanlee I see you have some optimization PRs, do they make a significant difference? Please post time differences using the [debug script](https://github.com/commaai/openpilot/blob/master/selfdrive/debug/check_can_parser_performance.py) if you haven't and I'll check it out soon!