### PR TITLE
Ford: limit acceleration near PCM set speed

### DIFF
--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -15,7 +15,7 @@ class CarInterface(CarInterfaceBase):
     # PCM doesn't allow acceleration near cruise_speed,
     # so limit limits of pid to prevent windup
     ACCEL_MAX_VALS = [CarControllerParams.ACCEL_MAX, 0.2]
-    ACCEL_MAX_BP = [cruise_speed - 2., cruise_speed - .2]
+    ACCEL_MAX_BP = [cruise_speed - 2., cruise_speed - .4]
     return CarControllerParams.ACCEL_MIN, interp(current_speed, ACCEL_MAX_BP, ACCEL_MAX_VALS)
 
   @staticmethod

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -1,14 +1,23 @@
 from panda import Panda
+from opendbc.car.common.numpy_fast import interp
 from opendbc.car import get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.ford.fordcan import CanBus
-from opendbc.car.ford.values import DBC, Ecu, FordFlags, RADAR
+from opendbc.car.ford.values import CarControllerParams, DBC, Ecu, FordFlags, RADAR
 from opendbc.car.interfaces import CarInterfaceBase
 
 TransmissionType = structs.CarParams.TransmissionType
 
 
 class CarInterface(CarInterfaceBase):
+  @staticmethod
+  def get_pid_accel_limits(CP, current_speed, cruise_speed):
+    # PCM doesn't allow acceleration near cruise_speed,
+    # so limit limits of pid to prevent windup
+    ACCEL_MAX_VALS = [CarControllerParams.ACCEL_MAX, 0.2]
+    ACCEL_MAX_BP = [cruise_speed - 2., cruise_speed - .2]
+    return CarControllerParams.ACCEL_MIN, interp(current_speed, ACCEL_MAX_BP, ACCEL_MAX_VALS)
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.carName = "ford"


### PR DESCRIPTION
Looks like the diff between PCM set speed and vEgo can be as high as 0.6 m/s, going to choose 0.4 m/s as the final breakpoint as a good middle ground:

![image](https://github.com/user-attachments/assets/32a88240-5d5a-4787-b272-b94748d61b21)

![image](https://github.com/user-attachments/assets/bef0bb12-cef7-40ba-a907-fafb0e207fec)

---

Before/after:

![image](https://github.com/user-attachments/assets/a2b2612f-c369-4d1e-895a-e48c43109adb)

![image](https://github.com/user-attachments/assets/45225569-db77-468a-aa8a-69005218e085)