### PR TITLE
CANParser: only filter bus

### DIFF
--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -87,7 +87,7 @@ cdef class CANParser:
         can_data.frames.reserve(len(s[1]))
         for address, dat, src in s[1]:
           source_bus = <uint32_t>src
-          if source_bus == self.bus and address in self.addresses:
+          if source_bus == self.bus:
             frame = &(can_data.frames.emplace_back())
             frame.address = address
             frame.dat = dat


### PR DESCRIPTION
Fixes a process replay diff introduced in https://github.com/commaai/opendbc/pull/1383. The bus timeout detection should still receive all messages to determine if the entire bus has dropped out.

https://github.com/commaai/openpilot/actions/runs/11640003241/job/32416858994?pr=33919