### PR TITLE
CANParser: optimize data handling by eliminating data copy after Update()

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -40,6 +40,12 @@ struct CanData {
   std::vector<CanFrame> frames;
 };
 
+struct SignalValue {
+  uint64_t ts_nanos;
+  double value;
+  std::vector<double> all_values;
+};
+
 class MessageState {
 public:
   std::string name;
@@ -47,8 +53,7 @@ public:
   unsigned int size;
 
   std::vector<Signal> parse_sigs;
-  std::vector<double> vals;
-  std::vector<std::vector<double>> all_vals;
+  std::unordered_map<std::string, SignalValue> signal_values;
 
   uint64_t last_seen_nanos;
   uint64_t check_threshold;

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -62,11 +62,14 @@ cdef extern from "common_dbc.h":
 cdef extern from "common.h":
   cdef const DBC* dbc_lookup(const string) except +
 
+  cdef struct SignalValue:
+    uint64_t ts_nanos
+    double value
+    vector[double] all_values
+
   cdef cppclass MessageState:
     vector[Signal] parse_sigs
-    vector[double] vals
-    vector[vector[double]] all_vals
-    uint64_t last_seen_nanos
+    unordered_map[string, SignalValue] signal_values
 
   cdef struct CanFrame:
     long src

--- a/opendbc/can/tests/test_checksums.py
+++ b/opendbc/can/tests/test_checksums.py
@@ -17,7 +17,7 @@ class TestCanChecksums:
     for data in test_messages:
       expected_msg = (msg_addr, data, 0)
       parser.update_strings([0, [expected_msg]])
-      expected = copy.deepcopy(parser.vl[msg_name])
+      expected = {key: parser.vl[msg_name][key] for key in parser.vl[msg_name]}
 
       modified = copy.deepcopy(expected)
       modified.pop(checksum_field, None)


### PR DESCRIPTION
This pull request removes unnecessary data copying from MessageState to dictionaries following update() calls. By encapsulating MessageState within a Cython object and implementing a read-only dictionary for direct access to the signal data, we eliminate the need to clear `vl_all` and copy updated data to `vl`, `vl_all` and `ts_nanos`. This optimization yields approximately a 1x performance improvement on the 3X device.

With this refactor, the impact on dictionary read performance is negligible, as the read-only dictionary is a minimal wrapper around the C++ MessageState, allowing direct access to data from the C++ `unordered_map` without additional overhead.

Passes tests on the device and OpenPilot branch [#33926](https://github.com/commaai/openpilot/pull/33926).

**Key Changes:**
1. **Encapsulated MessageState in a Cython Class:** Enables direct access to signal data from the C++ MessageState, eliminating the need for data copying after `update()`.
2. **Implemented a Custom ReadOnlyDict:** Overrides `__getitem__` to retrieve data from C++ MessageState, ensuring read-only access.
3. **Adjusted `test_checksum.py`:** Removed deep copy requirements as the new implementation is read-only.

Below is the benchmark comparison on the 3X device:

**Benchmark (PR):**
```

6000 CAN packets, 10 runs
265.55 mean ms, 267.66 max ms, 264.63 min ms, 0.86 std ms
0.0443 mean ms / CAN packet
```

**Benchmark (Master):**

```
6000 CAN packets, 10 runs
491.51 mean ms, 492.63 max ms, 490.43 min ms, 0.71 std ms
0.0819 mean ms / CAN packet
```
-------------------
This PR is an improved version of https://github.com/commaai/opendbc/pull/1046