### PR TITLE
enhance CANPacker with efficient MessageData struct

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include <set>
 #include <string>
 #include <utility>
@@ -91,8 +90,16 @@ protected:
 class CANPacker {
 private:
   const DBC *dbc = NULL;
-  std::map<std::pair<uint32_t, std::string>, Signal> signal_lookup;
-  std::map<uint32_t, uint32_t> counters;
+
+  struct MessageData {
+    uint32_t msg_size = 0;
+    const Signal *counter_signal = nullptr;
+    const Signal *checksum_signal = nullptr;
+    uint32_t counter_value = 0;
+    std::unordered_map<std::string, const Signal *> signals;
+  };
+
+  std::unordered_map<uint32_t, MessageData> msg_lookup;
 
 public:
   CANPacker(const std::string& dbc_name);


### PR DESCRIPTION
This PR introduces a more efficient MessageData struct in the CANPacker class to significantly reduce map lookup overhead during CAN message packing. The original code performed excessive lookups, including inefficient searches using std::pair<address, string> keys. For example, the following code snippet includes five separate map lookups:
 ```
auto sig_it_counter = signal_lookup.find(std::make_pair(address, "COUNTER"));
  if (!counter_set && sig_it_counter != signal_lookup.end()) {
    const auto& sig = sig_it_counter->second;

    if (counters.find(address) == counters.end()) {
      counters[address] = 0;
    }
    set_value(ret, sig, counters[address]);
    counters[address] = (counters[address] + 1) % (1 << sig.size);
  }
```

By optimizing the way signals, counters, and checksums are accessed, the new structure improves performance and simplifies the code.

Key improvements:

- Introduced a MessageData struct for better organization and efficient management of signals, counters, and checksums.
- Kept pointers to signals in MessageData instead of copies, as these pointers are always valid in the dbc() instance—avoiding unnecessary data duplication.
- Minimized redundant lookups to significantly speed up the signal packing process.
- Cached counter and checksum signals directly in the MessageData struct to simplify counter and checksum handling.
- Optimized the pack method for faster processing of multiple signals, reducing overhead.

These enhancements lead to faster CAN message packing, particularly for larger datasets and frequent updates.