### PR TITLE
tesla: fix standstill

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -22,7 +22,6 @@ class CarState(CarStateBase):
     # Vehicle speed
     ret.vEgoRaw = cp.vl["DI_speed"]["DI_vehicleSpeed"] * CV.KPH_TO_MS
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
-    ret.standstill = cp.vl["DI_state"]["DI_vehicleHoldState"] == 3
 
     # Gas pedal
     pedal_status = cp.vl["DI_systemStatus"]["DI_accelPedalPos"]
@@ -56,6 +55,7 @@ class CarState(CarStateBase):
       ret.cruiseState.speed = cp.vl["DI_state"]["DI_digitalSpeed"] * CV.MPH_TO_MS
     ret.cruiseState.available = cruise_state == "STANDBY" or ret.cruiseState.enabled
     ret.cruiseState.standstill = False  # This needs to be false, since we can resume from stop without sending anything special
+    ret.standstill = cruise_state == "STANDSTILL"
 
     # Gear
     ret.gearShifter = GEAR_MAP[self.can_define.dv["DI_systemStatus"]["DI_gear"].get(int(cp.vl["DI_systemStatus"]["DI_gear"]), "DI_GEAR_INVALID")]


### PR DESCRIPTION
The latest version of autopilot changes the meaning of most of the values for `DI_vehicleHoldState`.  Switching to `DI_cruiseState` should reduce our exposure to changes like this by decreasing the number of signals used.

I don't like using a constant speed threshold because we used to do that and I have seen it bounce in and out of the standstill state quickly/repeatedly causing the wheel to jerk back and forth rapidly.  I suppose we could address this with a hysteresis when entering the standstill state, but the signal I am changing it to seems to do that for us.