### PR TITLE
Toyota: learn PCM accel request

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -175,6 +175,7 @@ class CarController(CarControllerBase):
         accel_due_to_pitch = 0.0
 
       net_acceleration_request = actuators_accel + accel_due_to_pitch
+      net_acceleration_request2 = actuators.accel + accel_due_to_pitch
 
       # Corolla (and others?) have accel net signals that somewhat describe the acceleration request and future aEgo, but exhibit unexplainable offsets
       # that we haven't been able to model correctly yet. For now, learn the offset and error correct on it, as that is better than error correcting on aEgo
@@ -238,9 +239,9 @@ class CarController(CarControllerBase):
 
       # Along with rate limiting positive jerk below, this greatly improves gas response time
       # Consider the net acceleration request that the PCM should be applying (pitch included)
-      if net_acceleration_request < 0.1 or stopping:
+      if net_acceleration_request2 < 0.1 or stopping:
         self.permit_braking = True
-      elif net_acceleration_request > 0.2:
+      elif net_acceleration_request2 > 0.2:
         self.permit_braking = False
     else:
       self.pcm_accel_net_filter.x = 0.0

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -218,14 +218,13 @@ class CarController(CarControllerBase):
       pcm_accel_compensation = 0.0
       if not stopping:
         # pcm_accel_compensation = 2.0 * (CS.pcm_accel_net - net_acceleration_request)
-        #pcm_accel_compensation = 2.0 * (new_pcm_accel_net - net_acceleration_request)
-        # pcm_accel_compensation = 2.0 * (new_pcm_accel_net - net_acceleration_request)
+        pcm_accel_compensation = 2.0 * (new_pcm_accel_net - net_acceleration_request)
 
         # TODO: test this in the car on the start from stop maneuver
         self.pid.pos_limit = actuators_accel - self.params.ACCEL_MIN
         self.pid.neg_limit = actuators_accel - self.params.ACCEL_MAX
         # TODO: freeze integrator needed?
-        pcm_accel_compensation = self.pid.update(new_pcm_accel_net - net_acceleration_request)  # , freeze_integrator=CS.out.standstill)
+        # pcm_accel_compensation = self.pid.update(new_pcm_accel_net - net_acceleration_request)  # , freeze_integrator=CS.out.standstill)
 
       # prevent compensation windup
       pcm_accel_compensation = clip(pcm_accel_compensation, actuators_accel - self.params.ACCEL_MAX,

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -181,9 +181,9 @@ class CarController(CarControllerBase):
       # TODO: error correct on acceleration request 0.5s in past
       # TODO: don't error correct when jerk is high
       # TODO: don't error correct near a stop (instead of resetting)? think resetting is fine since brake offset != gas offset when starting
-      offset = self.pcm_accel_net_filter.update((self.deque[-40] - accel_due_to_pitch) - CS.out.aEgo)
-      new_pcm_accel_net = CS.pcm_accel_net - offset
-      print(CS.pcm_accel_net, CS.out.aEgo, offset, new_pcm_accel_net)
+      # offset = self.pcm_accel_net_filter.update((self.deque[-40] - accel_due_to_pitch) - CS.out.aEgo)
+      # new_pcm_accel_net = CS.pcm_accel_net - offset
+      # print(CS.pcm_accel_net, CS.out.aEgo, offset, new_pcm_accel_net)
       self.deque.append(CS.pcm_accel_net)
       if PLOT:
         self.offsets.append(offset)
@@ -203,17 +203,15 @@ class CarController(CarControllerBase):
           plt.show()
           plt.pause(1000)
 
-      if CS.out.standstill or stopping:
-        self.pcm_accel_net_filter.x = 0
-        self.pid.reset()
-        new_pcm_accel_net = CS.pcm_accel_net
-
       # Our model of the PCM's acceleration request isn't perfect, so we learn the offset when moving
       # TODO: unwind during high jerk events
       new_pcm_accel_net = CS.pcm_accel_net
       if CS.out.standstill or stopping:
+        self.pid.reset()
         self.pcm_accel_net_filter.x = 0.0
       else:
+        # TODO: try both
+        # new_pcm_accel_net -= self.pcm_accel_net_filter.update((self.deque[-40] - accel_due_to_pitch) - CS.out.aEgo)
         new_pcm_accel_net -= self.pcm_accel_net_filter.update((CS.pcm_accel_net - accel_due_to_pitch) - CS.out.aEgo)
 
       # let PCM handle stopping for now

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -173,7 +173,7 @@ class CarController(CarControllerBase):
       else:
         accel_due_to_pitch = 0.0
 
-      net_acceleration_request = actuators.accel + accel_due_to_pitch
+      net_acceleration_request = actuators_accel + accel_due_to_pitch
 
       # Corolla (and others?) have accel net signals that somewhat describe the acceleration request and future aEgo, but exhibit unexplainable offsets
       # that we haven't been able to model correctly yet. For now, learn the offset and error correct on it, as that is better than error correcting on aEgo

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -226,7 +226,8 @@ class CarController(CarControllerBase):
         # TODO: test this in the car on the start from stop maneuver
         self.pid.pos_limit = actuators_accel - self.params.ACCEL_MIN
         self.pid.neg_limit = actuators_accel - self.params.ACCEL_MAX
-        pcm_accel_compensation = self.pid.update(new_pcm_accel_net - net_acceleration_request, freeze_integrator=CS.out.standstill)
+        # TODO: freeze integrator needed?
+        pcm_accel_compensation = self.pid.update(new_pcm_accel_net - net_acceleration_request)  # , freeze_integrator=CS.out.standstill)
 
       # prevent compensation windup
       pcm_accel_compensation = clip(pcm_accel_compensation, actuators_accel - self.params.ACCEL_MAX,

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -213,12 +213,12 @@ class CarController(CarControllerBase):
       if not stopping:
         # pcm_accel_compensation = 2.0 * (CS.pcm_accel_net - net_acceleration_request)
         #pcm_accel_compensation = 2.0 * (new_pcm_accel_net - net_acceleration_request)
-        pcm_accel_compensation = 2.0 * (new_pcm_accel_net - net_acceleration_request)
+        # pcm_accel_compensation = 2.0 * (new_pcm_accel_net - net_acceleration_request)
 
         # TODO: test this in the car on the start from stop maneuver
         self.pid.pos_limit = actuators_accel - self.params.ACCEL_MIN
         self.pid.neg_limit = actuators_accel - self.params.ACCEL_MAX
-        # pcm_accel_compensation = self.pid.update(new_pcm_accel_net - net_acceleration_request, freeze_integrator=CS.out.standstill)
+        pcm_accel_compensation = self.pid.update(new_pcm_accel_net - net_acceleration_request, freeze_integrator=CS.out.standstill)
 
       # prevent compensation windup
       pcm_accel_compensation = clip(pcm_accel_compensation, actuators_accel - self.params.ACCEL_MAX,

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -67,6 +67,8 @@ class CarState(CarStateBase):
       if cp.vl["PCM_CRUISE"]["ACC_BRAKING"]:
         self.pcm_accel_net += min(cp.vl["PCM_CRUISE"]["ACCEL_NET"], 0.0)
 
+      # TODO: re-evaluate this, on the Corolla it goes negative instantly after taking off from a stop,
+      #  but the positive offset seen at a standstill still exists for a few m/s
       # add creeping force at low speeds only for braking, CLUTCH->ACCEL_NET already shows this
       neutral_accel = max(cp.vl["PCM_CRUISE"]["NEUTRAL_FORCE"] / self.CP.mass, 0.0)
       if self.pcm_accel_net + neutral_accel < 0.0:

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -70,9 +70,9 @@ class CarState(CarStateBase):
       # TODO: re-evaluate this, on the Corolla it goes negative instantly after taking off from a stop,
       #  but the positive offset seen at a standstill still exists for a few m/s
       # add creeping force at low speeds only for braking, CLUTCH->ACCEL_NET already shows this
-      neutral_accel = max(cp.vl["PCM_CRUISE"]["NEUTRAL_FORCE"] / self.CP.mass, 0.0)
-      if self.pcm_accel_net + neutral_accel < 0.0:
-        self.pcm_accel_net += neutral_accel
+      #neutral_accel = max(cp.vl["PCM_CRUISE"]["NEUTRAL_FORCE"] / self.CP.mass, 0.0)
+      #if self.pcm_accel_net + neutral_accel < 0.0:
+      #  self.pcm_accel_net += neutral_accel
 
     ret.doorOpen = any([cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_FL"], cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_FR"],
                         cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_RL"], cp.vl["BODY_CONTROL_STATE"]["DOOR_OPEN_RR"]])

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -47,7 +47,7 @@ class CarInterface(CarInterfaceBase):
     found_ecus = [fw.ecu for fw in car_fw]
     ret.enableDsu = len(found_ecus) > 0 and Ecu.dsu not in found_ecus and candidate not in (NO_DSU_CAR | UNSUPPORTED_DSU_CAR)
 
-    if candidate == CAR.LEXUS_ES_TSS2 and Ecu.hybrid not in found_ecus:
+    if candidate in (CAR.LEXUS_ES_TSS2, CAR.TOYOTA_COROLLA_TSS2) and Ecu.hybrid not in found_ecus:
       ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
 
     if candidate == CAR.TOYOTA_PRIUS:
@@ -143,8 +143,8 @@ class CarInterface(CarInterfaceBase):
 
       # Since we compensate for imprecise acceleration in carcontroller, we can be less aggressive with tuning
       # This also prevents unnecessary request windup due to internal car jerk limits
-      if ret.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
-        tune.kiV = [0.25]
+      # if ret.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
+      #   tune.kiV = [0.25]
     else:
       tune.kiBP = [0., 5., 35.]
       tune.kiV = [3.6, 2.4, 1.5]

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -143,8 +143,8 @@ class CarInterface(CarInterfaceBase):
 
       # Since we compensate for imprecise acceleration in carcontroller, we can be less aggressive with tuning
       # This also prevents unnecessary request windup due to internal car jerk limits
-      # if ret.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
-      #   tune.kiV = [0.25]
+      if ret.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
+        tune.kiV = [0.0]
     else:
       tune.kiBP = [0., 5., 35.]
       tune.kiV = [3.6, 2.4, 1.5]

--- a/opendbc/compare_toyota_pcm_comp.py
+++ b/opendbc/compare_toyota_pcm_comp.py
@@ -1,0 +1,47 @@
+import os
+import matplotlib.pyplot as plt
+from tools.lib.logreader import LogReader
+
+os.chdir('/home/batman/openpilot/selfdrive/debug')
+
+# lr = LogReader('a2bddce0b6747e10/0000033f--bc20a12d8b/:2')
+# lr_regen = LogReader('a2bddce0b6747e10_0000033f--bc20a12d8b_:2_card.zst')
+
+lr = LogReader('a2bddce0b6747e10/00000379--298edb2ca7/6:8')
+lr_regen = LogReader('a2bddce0b6747e10_00000379--298edb2ca7_6:8_card.zst')
+
+accels = []
+accels_out = []
+aegos = []
+
+accels_regen = []
+accels_out_regen = []
+
+for msg in lr:
+  if msg.which() == 'carState':
+    aegos.append(msg.carState.aEgo)
+  elif msg.which() == 'carControl':
+    accels.append(msg.carControl.actuators.accel)
+  elif msg.which() == 'carOutput':
+    accels_out.append(msg.carOutput.actuatorsOutput.accel)
+
+for msg in lr_regen:
+  if msg.which() == 'carControl':
+    accels_regen.append(msg.carControl.actuators.accel)
+  elif msg.which() == 'carOutput':
+    accels_out_regen.append(msg.carOutput.actuatorsOutput.accel)
+
+fig, ax = plt.subplots(2, sharex=True)
+
+ax[0].plot(accels, label='accels')
+ax[0].plot(accels_regen, label='accels_regen')
+ax[0].plot(aegos, label='aegos')
+ax[0].legend()
+
+ax[1].plot(accels, label='accels')
+ax[1].plot(accels_out_regen, label='accels_out_regen')
+ax[1].plot(accels_out, label='accels_out')
+# ax[1].plot(aegos, label='aegos')
+ax[1].legend()
+
+plt.show()


### PR DESCRIPTION
The internal PCM acceleration request that tells us what it's going to apply is mostly correct, but has some persistent offsets we don't fully account for (due to engine creep force, road pitch, friction, general inaccuracies) and causes acceleration over/undershoot which can be really bad since we're currently not error correcting on aEgo.

This PR grounds the internal PCM acceleration request using aEgo. It's sort of like using the shape of the internal value and the magnitude of aEgo, so that it matches what we're achieving, but shows us the future state of the vehicle as well to error correct in time!

With this, we can use a PI controller for the PCM compensation without any worry of under/overshoot error as well as remove the conventional feedback control.

Corolla (a2bddce0b6747e10/0000033f--bc20a12d8b):

![image](https://github.com/user-attachments/assets/2916d620-9887-4b3c-a5d5-10d6977fbee8)
