### PR TITLE
Toyota: more responsive start from stop

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -172,16 +172,12 @@ class CarController(CarControllerBase):
         # internal PCM gas command can get stuck unwinding from negative accel so we apply a generous rate limit
         pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT) if CC.longActive else 0.0
 
+        # calculate amount of acceleration PCM should apply to reach target, given pitch
+        accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY if len(CC.orientationNED) == 3 else 0.0
+        net_acceleration_request = pcm_accel_cmd + accel_due_to_pitch
+
         # For cars where we allow a higher max acceleration of 2.0 m/s^2, compensate for PCM request overshoot and imprecise braking
         if self.CP.flags & ToyotaFlags.RAISED_ACCEL_LIMIT and CC.longActive and not CS.out.cruiseState.standstill:
-          # calculate amount of acceleration PCM should apply to reach target, given pitch
-          if len(CC.orientationNED) == 3:
-            accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY
-          else:
-            accel_due_to_pitch = 0.0
-
-          net_acceleration_request = pcm_accel_cmd + accel_due_to_pitch
-
           # let PCM handle stopping for now
           pcm_accel_compensation = 0.0
           if not stopping:
@@ -194,15 +190,16 @@ class CarController(CarControllerBase):
           self.pcm_accel_compensation = rate_limit(pcm_accel_compensation, self.pcm_accel_compensation, -0.03, 0.03)
           pcm_accel_cmd = pcm_accel_cmd - self.pcm_accel_compensation
 
-          # Along with rate limiting positive jerk above, this greatly improves gas response time
-          # Consider the net acceleration request that the PCM should be applying (pitch included)
-          if net_acceleration_request < 0.1 or stopping:
-            self.permit_braking = True
-          elif net_acceleration_request > 0.2:
-            self.permit_braking = False
         else:
           self.pcm_accel_compensation = 0.0
           self.permit_braking = True
+
+        # Along with rate limiting positive jerk above, this greatly improves gas response time
+        # Consider the net acceleration request that the PCM should be applying (pitch included)
+        if net_acceleration_request < 0.1 or stopping or not CC.longActive:
+          self.permit_braking = True
+        elif net_acceleration_request > 0.2:
+          self.permit_braking = False
 
         pcm_accel_cmd = clip(pcm_accel_cmd, self.params.ACCEL_MIN, self.params.ACCEL_MAX)
 


### PR DESCRIPTION
- Fixes case where PCM can be stuck applying brakes while we request 1.5 m/s^2 (e.g. Corolla) after coming to a quick stop
- Improves gas responsiveness in start from stop situations, PCM's acceleration request is closer to our request

Looks like there's almost no difference in the report for start from stop in regards to overshooting/reaching target:

master report: https://commaai.github.io/opendbc-data/longitudinal_reports/TOYOTA_CAMRY_TSS2_6483a59cd49b6650_00000068--f3684c0b08.html
this PR report: https://commaai.github.io/opendbc-data/longitudinal_reports/TOYOTA_CAMRY_TSS2_6483a59cd49b6650_00000062--f6537659bd.html

However in actual driving, this leads to clear improvements for start from stop, perhaps the step change elicits a different response than a ramp:

Camry Hybrid:

- uphill section of road start from stop behind lead:
  - You can see how this PR starts in ~1s, but master never starts in ~2s, and I end up overriding: ![image](https://github.com/user-attachments/assets/7b57cbdc-c6fa-412d-8e2b-dd53a1ab967d)
  - master: https://connect.comma.ai/6483a59cd49b6650/00000069--d5a622ece5/227/241
  - this PR: https://connect.comma.ai/6483a59cd49b6650/00000063--9c50578243/333/347

- another uphill start from stop:
  - both started within 1.25-1.35s, not too different
  - master: https://connect.comma.ai/6483a59cd49b6650/00000069--d5a622ece5/275/287
this PR: https://connect.comma.ai/6483a59cd49b6650/00000063--9c50578243/533/549

- another uphill start from stop:
  - ![image](https://github.com/user-attachments/assets/ef10f243-6b85-45d0-bc34-73097f794cec)
  - master: https://connect.comma.ai/6483a59cd49b6650/00000069--d5a622ece5/376/400
  - this PR: https://connect.comma.ai/6483a59cd49b6650/00000064--4a6c4c8bbd/29/45