### PR TITLE
Toyota: use a filter for PCM compensation

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -44,7 +44,6 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
-    self.pitch = FirstOrderFilter(0, 2, DT_CTRL)
     self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
     self.permit_braking = True
 
@@ -62,10 +61,6 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
     pcm_cancel_cmd = CC.cruiseControl.cancel
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
-
-    # update pitch within sane bounds
-    if abs(CS.out.aEgo) < 0.5 and abs(CS.out.vEgo) > 0.2 and len(CC.orientationNED) == 3:
-      self.pitch.update(CC.orientationNED[1])
 
     # *** control msgs ***
     can_sends = []
@@ -176,7 +171,7 @@ class CarController(CarControllerBase):
             self.distance_button = 0
 
         # internal PCM gas command can get stuck unwinding from negative accel so we apply a generous rate limit
-        pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT / 3) if CC.longActive else 0.0
+        pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT) if CC.longActive else 0.0
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch
         accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY if len(CC.orientationNED) == 3 else 0.0

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -1,6 +1,6 @@
 import math
 from opendbc.car import carlog, apply_meas_steer_torque_limits, apply_std_steer_angle_limits, common_fault_avoidance, \
-                        make_tester_present_msg, rate_limit, structs, ACCELERATION_DUE_TO_GRAVITY, DT_CTRL
+                        make_tester_present_msg, structs, ACCELERATION_DUE_TO_GRAVITY, DT_CTRL
 from opendbc.car.can_definitions import CanData
 from opendbc.car.common.filter_simple import FirstOrderFilter
 from opendbc.car.common.numpy_fast import clip

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -64,7 +64,7 @@ class CarController(CarControllerBase):
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
 
     # update pitch within sane bounds
-    if abs(CS.out.aEgo) < 0.5 and not CS.out.standstill and len(CC.orientationNED) == 3:
+    if abs(CS.out.aEgo) < 0.5 and abs(CS.out.vEgo) > 0.2 and len(CC.orientationNED) == 3:
       self.pitch.update(CC.orientationNED[1])
 
     # *** control msgs ***
@@ -179,7 +179,7 @@ class CarController(CarControllerBase):
         pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT / 3) if CC.longActive else 0.0
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch
-        accel_due_to_pitch = math.sin(self.pitch.x) * ACCELERATION_DUE_TO_GRAVITY
+        accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY if len(CC.orientationNED) == 3 else 0.0
         net_acceleration_request = pcm_accel_cmd + accel_due_to_pitch
 
         # For cars where we allow a higher max acceleration of 2.0 m/s^2, compensate for PCM request overshoot and imprecise braking
@@ -200,11 +200,10 @@ class CarController(CarControllerBase):
           self.permit_braking = True
 
         # Along with rate limiting positive jerk above, this greatly improves gas response time
-        # Consider the net acceleration request that the PCM should be applying before rate limiting (pitch included)
-        net_acceleration_request_raw = actuators.accel + accel_due_to_pitch
-        if net_acceleration_request_raw < 0.1 or stopping or not CC.longActive:
+        # Consider the net acceleration request that the PCM should be applying (pitch included)
+        if net_acceleration_request < 0.1 or stopping or not CC.longActive:
           self.permit_braking = True
-        elif net_acceleration_request_raw > 0.2:
+        elif net_acceleration_request > 0.2:
           self.permit_braking = False
 
         pcm_accel_cmd = clip(pcm_accel_cmd, self.params.ACCEL_MIN, self.params.ACCEL_MAX)

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -64,7 +64,7 @@ class CarController(CarControllerBase):
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
 
     # update pitch within sane bounds
-    if abs(CS.out.aEgo) < 0.5 and abs(CS.out.vEgo) > 0.2 and len(CC.orientationNED) == 3:
+    if abs(CS.out.aEgo) < 0.5 and not CS.out.standstill and len(CC.orientationNED) == 3:
       self.pitch.update(CC.orientationNED[1])
 
     # *** control msgs ***
@@ -179,7 +179,7 @@ class CarController(CarControllerBase):
         pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT / 3) if CC.longActive else 0.0
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch
-        accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY if len(CC.orientationNED) == 3 else 0.0
+        accel_due_to_pitch = math.sin(self.pitch.x) * ACCELERATION_DUE_TO_GRAVITY
         net_acceleration_request = pcm_accel_cmd + accel_due_to_pitch
 
         # For cars where we allow a higher max acceleration of 2.0 m/s^2, compensate for PCM request overshoot and imprecise braking
@@ -200,10 +200,11 @@ class CarController(CarControllerBase):
           self.permit_braking = True
 
         # Along with rate limiting positive jerk above, this greatly improves gas response time
-        # Consider the net acceleration request that the PCM should be applying (pitch included)
-        if net_acceleration_request < 0.1 or stopping or not CC.longActive:
+        # Consider the net acceleration request that the PCM should be applying before rate limiting (pitch included)
+        net_acceleration_request_raw = actuators.accel + accel_due_to_pitch
+        if net_acceleration_request_raw < 0.1 or stopping or not CC.longActive:
           self.permit_braking = True
-        elif net_acceleration_request > 0.2:
+        elif net_acceleration_request_raw > 0.2:
           self.permit_braking = False
 
         pcm_accel_cmd = clip(pcm_accel_cmd, self.params.ACCEL_MIN, self.params.ACCEL_MAX)

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -44,6 +44,7 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
+    self.pitch = FirstOrderFilter(0, 2, DT_CTRL)
     self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
     self.permit_braking = True
 
@@ -61,6 +62,10 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
     pcm_cancel_cmd = CC.cruiseControl.cancel
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
+
+    # update pitch within sane bounds
+    if abs(CS.out.aEgo) < 0.5 and abs(CS.out.vEgo) > 0.2 and len(CC.orientationNED) == 3:
+      self.pitch.update(CC.orientationNED[1])
 
     # *** control msgs ***
     can_sends = []
@@ -171,7 +176,7 @@ class CarController(CarControllerBase):
             self.distance_button = 0
 
         # internal PCM gas command can get stuck unwinding from negative accel so we apply a generous rate limit
-        pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT) if CC.longActive else 0.0
+        pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT / 3) if CC.longActive else 0.0
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch
         accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY if len(CC.orientationNED) == 3 else 0.0

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -1,6 +1,6 @@
 import math
 from opendbc.car import carlog, apply_meas_steer_torque_limits, apply_std_steer_angle_limits, common_fault_avoidance, \
-                        make_tester_present_msg, structs, ACCELERATION_DUE_TO_GRAVITY, DT_CTRL
+                        make_tester_present_msg, rate_limit, structs, ACCELERATION_DUE_TO_GRAVITY, DT_CTRL
 from opendbc.car.can_definitions import CanData
 from opendbc.car.common.filter_simple import FirstOrderFilter
 from opendbc.car.common.numpy_fast import clip
@@ -44,8 +44,13 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
+    self.debug = 0
+    self.debug2 = 0
+    self.debug3 = 0
+
     self.pitch = FirstOrderFilter(0, 2, DT_CTRL)
-    self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
+    self.pcm_accel_compensation = 0.0
+    self.pcm_accel_compensation2 = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
     self.permit_braking = True
 
     self.packer = CANPacker(dbc_name)
@@ -179,11 +184,13 @@ class CarController(CarControllerBase):
         pcm_accel_cmd = min(actuators.accel, self.accel + ACCEL_WINDUP_LIMIT / 3) if CC.longActive else 0.0
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch
-        accel_due_to_pitch = math.sin(self.pitch.x) * ACCELERATION_DUE_TO_GRAVITY
+        # accel_due_to_pitch = math.sin(self.pitch.x) * ACCELERATION_DUE_TO_GRAVITY
+        # accel_due_to_pitch = math.sin(math.radians(CS.aslp)) * ACCELERATION_DUE_TO_GRAVITY
+        accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY
         net_acceleration_request = pcm_accel_cmd + accel_due_to_pitch
 
         # For cars where we allow a higher max acceleration of 2.0 m/s^2, compensate for PCM request overshoot and imprecise braking
-        if self.CP.flags & ToyotaFlags.RAISED_ACCEL_LIMIT and CC.longActive and not CS.out.cruiseState.standstill:
+        if CC.longActive and not CS.out.cruiseState.standstill:
           # let PCM handle stopping for now
           pcm_accel_compensation = 0.0
           if not stopping:
@@ -193,10 +200,16 @@ class CarController(CarControllerBase):
           pcm_accel_compensation = clip(pcm_accel_compensation, pcm_accel_cmd - self.params.ACCEL_MAX,
                                         pcm_accel_cmd - self.params.ACCEL_MIN)
 
-          pcm_accel_cmd = pcm_accel_cmd - self.pcm_accel_compensation.update(pcm_accel_compensation)
+          self.pcm_accel_compensation = rate_limit(pcm_accel_compensation, self.pcm_accel_compensation, -0.03, 0.03)
+          self.debug = self.pcm_accel_compensation
+          pcm_accel_cmd = pcm_accel_cmd - self.pcm_accel_compensation
+
+          # pcm_accel_cmd = pcm_accel_cmd - self.pcm_accel_compensation2.update(pcm_accel_compensation)
+          # self.debug2 = self.pcm_accel_compensation2.x
 
         else:
-          self.pcm_accel_compensation.x = 0.0
+          self.pcm_accel_compensation2.x = 0.0
+          self.pcm_accel_compensation = 0.0
           self.permit_braking = True
 
         # Along with rate limiting positive jerk above, this greatly improves gas response time
@@ -257,6 +270,10 @@ class CarController(CarControllerBase):
     new_actuators.steerOutputCan = apply_steer
     new_actuators.steeringAngleDeg = self.last_angle
     new_actuators.accel = self.accel
+
+    new_actuators.debug = self.debug
+    new_actuators.debug2 = self.debug2
+    new_actuators.debug3 = self.debug3
 
     self.frame += 1
     return new_actuators, can_sends

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -61,6 +61,7 @@ class CarState(CarStateBase):
     # CLUTCH->ACCEL_NET is only accurate for gas, PCM_CRUISE->ACCEL_NET is only accurate for brake
     # These signals only have meaning when ACC is active
     if "CLUTCH" in cp.vl:
+      self.aslp = cp.vl["VSC1S07"]["ASLP"]
       self.pcm_accel_net = max(cp.vl["CLUTCH"]["ACCEL_NET"], 0.0)
 
       # Sometimes ACC_BRAKING can be 1 while showing we're applying gas already
@@ -234,6 +235,7 @@ class CarState(CarStateBase):
 
     if CP.carFingerprint in (TSS2_CAR - SECOC_CAR - {CAR.LEXUS_NX_TSS2, CAR.TOYOTA_ALPHARD_TSS2, CAR.LEXUS_IS_TSS2}):
       messages.append(("CLUTCH", 15))
+      messages.append(("VSC1S07", 15))
 
     if CP.carFingerprint in UNSUPPORTED_DSU_CAR:
       messages.append(("DSU_CRUISE", 5))

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -61,7 +61,6 @@ class CarState(CarStateBase):
     # CLUTCH->ACCEL_NET is only accurate for gas, PCM_CRUISE->ACCEL_NET is only accurate for brake
     # These signals only have meaning when ACC is active
     if "CLUTCH" in cp.vl:
-      self.aslp = cp.vl["VSC1S07"]["ASLP"]
       self.pcm_accel_net = max(cp.vl["CLUTCH"]["ACCEL_NET"], 0.0)
 
       # Sometimes ACC_BRAKING can be 1 while showing we're applying gas already
@@ -235,7 +234,6 @@ class CarState(CarStateBase):
 
     if CP.carFingerprint in (TSS2_CAR - SECOC_CAR - {CAR.LEXUS_NX_TSS2, CAR.TOYOTA_ALPHARD_TSS2, CAR.LEXUS_IS_TSS2}):
       messages.append(("CLUTCH", 15))
-      messages.append(("VSC1S07", 15))
 
     if CP.carFingerprint in UNSUPPORTED_DSU_CAR:
       messages.append(("DSU_CRUISE", 5))


### PR DESCRIPTION
We mainly want to reduce the high frequency oscillations and feedback from the PCM signals, not restrict the rate. This should do that. Split from https://github.com/commaai/opendbc/pull/1475