### PR TITLE
Update fingerprints.py for 2024 Hyundai Tucson

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1024,6 +1024,7 @@ FW_VERSIONS = {
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9260 14Y',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9100 14A',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
+      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-CW020 14Z',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.00 1.00 99110-N9100         ',


### PR DESCRIPTION
Added " b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-CW020 14Z', "
   --> to " CAR.TUCSON_4TH_GEN: {
    (Ecu.fwdCamera, 0x7c4, None): [ "

Have updated this in my personnel pull and used this daily for more than 6 months. With the latest update, the file has been relocated making my device unusable. 

**Route**
662d2739183135b3|2024-01-13--06-07-06