### PR TITLE
Fix bug of PandaRunner

### DIFF
--- a/opendbc/car/panda_runner.py
+++ b/opendbc/car/panda_runner.py
@@ -15,7 +15,7 @@ class PandaRunner(AbstractContextManager):
     self.p.set_safety_mode(Panda.SAFETY_ELM327, 1)
     self.CI = get_car(self._can_recv, self.p.can_send_many, self.p.set_obd, True)
     assert self.CI.CP.carFingerprint.lower() != "mock", "Unable to identify car. Check connections and ensure car is supported."
-    
+
     safety_model = CarParams.SafetyModel.schema.enumerants[self.CI.CP.safetyConfigs[0].safetyModel]
     self.p.set_safety_mode(Panda.SAFETY_ELM327, 1)
     self.CI.init(self.CI.CP, self._can_recv, self.p.can_send_many)


### PR DESCRIPTION
Basically "CarParams.SafetyModel" is a DynamycEnum which can't be converted to list. I just modified the line to access the enumerants of CarParams.SafetyModel from the dictionary of enumerants.