### PR TITLE
Toyota: lower accel down rate limit

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -17,9 +17,9 @@ SteerControlType = structs.CarParams.SteerControlType
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
 
 # The up limit allows the brakes/gas to unwind quickly leaving a stop,
-# the down limit matches the rate of ACCEL_NET, reducing PCM compensation windup
+# the down limit roughly matches the rate of ACCEL_NET, reducing PCM compensation windup
 ACCEL_WINDUP_LIMIT = 0.5  # m/s^2 / frame
-ACCEL_WINDDOWN_LIMIT = -5.0 * DT_CTRL * 3  # m/s^2 / frame
+ACCEL_WINDDOWN_LIMIT = -4.0 * DT_CTRL * 3  # m/s^2 / frame
 
 # LKA limits
 # EPS faults if you apply torque while the steering rate is above 100 deg/s for too long


### PR DESCRIPTION
To be clear, I am measuring the `PCM_CRUISE->ACCEL_NET` brake accel readback signal. I've observed down rates when requesting -3.5 m/s^2 of anywhere from -3.5 m/s^3  to -4.8 m/s^3 across Corolla, Lexus, Camry Hybrid, but the Camry Hybrid (and most other hybrids) is the only one able to actually achieve that jerk (seen -4.5 m/s^3). The other two ICE cars are 2x to 4x slower.

So limiting to -4 m/s^3 doesn't degrade performance that much in terms of realized jerk and allows us to better control for brake overshoot when we merge aEgo error correction.

Follow up to https://github.com/commaai/opendbc/pull/1481