### PR TITLE
Toyota: PERMIT_BRAKING shouldn't use rate limited decel

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -203,9 +203,10 @@ class CarController(CarControllerBase):
 
         # Along with rate limiting positive jerk above, this greatly improves gas response time
         # Consider the net acceleration request that the PCM should be applying (pitch included)
-        if net_acceleration_request < 0.1 or stopping or not CC.longActive:
+        net_acceleration_request_min = min(actuators.accel + accel_due_to_pitch, net_acceleration_request)
+        if net_acceleration_request_min < 0.1 or stopping or not CC.longActive:
           self.permit_braking = True
-        elif net_acceleration_request > 0.2:
+        elif net_acceleration_request_min > 0.2:
           self.permit_braking = False
 
         pcm_accel_cmd = clip(pcm_accel_cmd, self.params.ACCEL_MIN, self.params.ACCEL_MAX)


### PR DESCRIPTION
fixes some overshoot due to the [down rate limit](https://github.com/commaai/opendbc/pull/1481) we merged recently