### PR TITLE
Toyota: filter pitch for new tune

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -49,8 +49,8 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
-    self.pitch
-    
+    self.pitch = FirstOrderFilter(0, 2.0, DT_CTRL * 3)
+
     self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
 
     # the PCM's reported acceleration request can sometimes mismatch aEgo, close the loop
@@ -78,6 +78,9 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
     pcm_cancel_cmd = CC.cruiseControl.cancel
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
+
+    if len(CC.orientationNED) == 3:
+      self.pitch.update(CC.orientationNED[1])
 
     # *** control msgs ***
     can_sends = []
@@ -194,7 +197,7 @@ class CarController(CarControllerBase):
         self.prev_accel = pcm_accel_cmd
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch
-        accel_due_to_pitch = math.sin(CC.orientationNED[1]) * ACCELERATION_DUE_TO_GRAVITY if len(CC.orientationNED) == 3 else 0.0
+        accel_due_to_pitch = math.sin(self.pitch.x) * ACCELERATION_DUE_TO_GRAVITY
         net_acceleration_request = pcm_accel_cmd + accel_due_to_pitch
 
         # For cars where we allow a higher max acceleration of 2.0 m/s^2, compensate for PCM request overshoot and imprecise braking

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -49,6 +49,8 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
+    self.pitch
+    
     self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
 
     # the PCM's reported acceleration request can sometimes mismatch aEgo, close the loop

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -80,9 +80,7 @@ class CarController(CarControllerBase):
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
 
     if len(CC.orientationNED) == 3:
-      self.debug = CC.orientationNED[1]
       self.pitch.update(CC.orientationNED[1])
-      self.debug2 = self.pitch.x
 
     # *** control msgs ***
     can_sends = []
@@ -290,9 +288,6 @@ class CarController(CarControllerBase):
     new_actuators.steerOutputCan = apply_steer
     new_actuators.steeringAngleDeg = self.last_angle
     new_actuators.accel = self.accel
-
-    new_actuators.debug = self.debug
-    new_actuators.debug2 = self.debug2
 
     self.frame += 1
     return new_actuators, can_sends

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -49,7 +49,7 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
-    self.pitch = FirstOrderFilter(0, 1.5, DT_CTRL * 3)
+    self.pitch = FirstOrderFilter(0, 0.5, DT_CTRL)
 
     self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
 

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -49,7 +49,7 @@ class CarController(CarControllerBase):
     self.steer_rate_counter = 0
     self.distance_button = 0
 
-    self.pitch = FirstOrderFilter(0, 2.0, DT_CTRL * 3)
+    self.pitch = FirstOrderFilter(0, 1.5, DT_CTRL * 3)
 
     self.pcm_accel_compensation = FirstOrderFilter(0, 0.5, DT_CTRL * 3)
 
@@ -80,7 +80,9 @@ class CarController(CarControllerBase):
     lat_active = CC.latActive and abs(CS.out.steeringTorque) < MAX_USER_TORQUE
 
     if len(CC.orientationNED) == 3:
+      self.debug = CC.orientationNED[1]
       self.pitch.update(CC.orientationNED[1])
+      self.debug2 = self.pitch.x
 
     # *** control msgs ***
     can_sends = []
@@ -288,6 +290,9 @@ class CarController(CarControllerBase):
     new_actuators.steerOutputCan = apply_steer
     new_actuators.steeringAngleDeg = self.last_angle
     new_actuators.accel = self.accel
+
+    new_actuators.debug = self.debug
+    new_actuators.debug2 = self.debug2
 
     self.frame += 1
     return new_actuators, can_sends


### PR DESCRIPTION
Here the Corolla hit a bump which caused the localizer pitch to oscillate rapidly, we should filter the signal a bit to prevent overreaction: https://connect.comma.ai/a2bddce0b6747e10/000003fa--6edfaa70be/900/960

Slower pitch updates also allows the aEgo error-corrector to compensate for incorrect pitch faster

middle is old vs. new actuators output accel on https://github.com/commaai/opendbc/pull/1499, bottom is pitch

![image](https://github.com/user-attachments/assets/1a6187ee-6490-4858-8c85-bc234b3fb07b)
