### PR TITLE
Toyota: use a PID for PCM compensation

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -48,7 +48,7 @@ class CarController(CarControllerBase):
     self.permit_braking = True
     self.steer_rate_counter = 0
     self.distance_button = 0
-
+k
     self.pitch = FirstOrderFilter(0, 0.5, DT_CTRL)
     self.net_acceleration_request = FirstOrderFilter(0, 0.15, DT_CTRL * 3)
 


### PR DESCRIPTION
Split from https://github.com/commaai/opendbc/pull/1513. Useful to avoid persistent errors which is more common on the Corolla.

Comparing a new long report on the Lexus ES vs. the one in https://github.com/commaai/opendbc/pull/1515:

come to stop is the same

start from stop is the same

creep is the same

![image](https://github.com/user-attachments/assets/99f6643a-4920-4646-84a5-f0e3ed7a73d1)

