### PR TITLE
Toyota TSS2: add longitudinal derivative

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -283,8 +283,8 @@ class CarController(CarControllerBase):
                                                  feedforward=pcm_accel_cmd)
           else:
             self.long_pid.reset()
-            self.prev_error = 0.0
             self.error_rate.x = 0.0
+            self.prev_error = 0.0
 
         # Along with rate limiting positive jerk above, this greatly improves gas response time
         # Consider the net acceleration request that the PCM should be applying (pitch included)

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -272,13 +272,12 @@ class CarController(CarControllerBase):
               a_ego_blended = CS.out.aEgo
 
             error = pcm_accel_cmd - a_ego_blended
-
             self.error_rate.update((error - self.prev_error) / (DT_CTRL * 3))
             self.prev_error = error
 
-            pcm_accel_cmd = self.long_pid.update(error, speed=CS.out.vEgo,
-                                                 feedforward=pcm_accel_cmd,
-                                                 error_rate=self.error_rate.x)
+            pcm_accel_cmd = self.long_pid.update(error, error_rate=self.error_rate.x,
+                                                 speed=CS.out.vEgo,
+                                                 feedforward=pcm_accel_cmd)
           else:
             self.long_pid.reset()
             self.prev_error = 0.0

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -42,7 +42,7 @@ def get_long_tune(CP, params):
   kdBP = [0.]
   kdV = [0.]
   if CP.carFingerprint in TSS2_CAR:
-    kiV = [0.5]
+    kiV = [0.25]
     kdV = [0.25 / 4]
 
     # Since we compensate for imprecise acceleration in carcontroller and error correct on aEgo, we can avoid using gains
@@ -74,6 +74,8 @@ class CarController(CarControllerBase):
 
     self.error_rate = FirstOrderFilter(0.0, 0.5, DT_CTRL * 3)
     self.prev_error = 0.0
+
+    self.aego = FirstOrderFilter(0.0, 0.25, DT_CTRL)
 
     # *** start PCM compensation state ***
     self.pitch = FirstOrderFilter(0, 0.5, DT_CTRL)
@@ -198,6 +200,18 @@ class CarController(CarControllerBase):
 
     # *** gas and brake ***
 
+    # GVC does not overshoot ego acceleration when starting from stop, but still has a similar delay
+    if not self.CP.flags & ToyotaFlags.SECOC.value:
+      a_ego_blended = interp(CS.out.vEgo, [1.0, 2.0], [CS.gvc, CS.out.aEgo])
+    else:
+      a_ego_blended = CS.out.aEgo
+
+    prev_aego = self.aego.x
+    self.aego.update(a_ego_blended)
+    jEgo = (self.aego.x - prev_aego) / DT_CTRL
+    # TODO: adjust for hybrid
+    future_aego = a_ego_blended + jEgo * 0.5
+
     # on entering standstill, send standstill request
     if CS.out.standstill and not self.last_standstill and (self.CP.carFingerprint not in NO_STOP_TIMER_CAR):
       self.standstill_req = True
@@ -268,16 +282,11 @@ class CarController(CarControllerBase):
 
         if not (self.CP.flags & ToyotaFlags.RAISED_ACCEL_LIMIT):
           if actuators.longControlState == LongCtrlState.pid:
-            # GVC does not overshoot ego acceleration when starting from stop, but still has a similar delay
-            if not self.CP.flags & ToyotaFlags.SECOC.value:
-              a_ego_blended = interp(CS.out.vEgo, [1.0, 2.0], [CS.gvc, CS.out.aEgo])
-            else:
-              a_ego_blended = CS.out.aEgo
-
             error = pcm_accel_cmd - a_ego_blended
             self.error_rate.update((error - self.prev_error) / (DT_CTRL * 3))
             self.prev_error = error
 
+            error = pcm_accel_cmd - future_aego
             pcm_accel_cmd = self.long_pid.update(error, error_rate=self.error_rate.x,
                                                  speed=CS.out.vEgo,
                                                  feedforward=pcm_accel_cmd)

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,8 +39,11 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 def get_long_tune(CP, params):
   kiBP = [0.]
+  kdBP = [0.]
+  kdV = [0.]
   if CP.carFingerprint in TSS2_CAR:
     kiV = [0.5]
+    kdV = [0.25 / 4]
 
     # Since we compensate for imprecise acceleration in carcontroller and error correct on aEgo, we can avoid using gains
     if CP.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
@@ -49,7 +52,7 @@ def get_long_tune(CP, params):
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]
 
-  return PIDController(0.0, (kiBP, kiV), k_f=1.0, k_d=0.25 / 4,
+  return PIDController(0.0, (kiBP, kiV), k_f=1.0, k_d=(kdBP, kdV),
                        pos_limit=params.ACCEL_MAX, neg_limit=params.ACCEL_MIN,
                        rate=1 / (DT_CTRL * 3))
 

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -40,7 +40,7 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 def get_long_tune(CP, params):
   kiBP = [0.]
   if CP.carFingerprint in TSS2_CAR:
-    kiV = [0.25]
+    kiV = [0.5]
 
     # Since we compensate for imprecise acceleration in carcontroller and error correct on aEgo, we can avoid using gains
     if CP.flags & ToyotaFlags.RAISED_ACCEL_LIMIT:
@@ -272,6 +272,7 @@ class CarController(CarControllerBase):
               a_ego_blended = CS.out.aEgo
 
             error = pcm_accel_cmd - a_ego_blended
+
             self.error_rate.update((error - self.prev_error) / (DT_CTRL * 3))
             self.prev_error = error
 

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -47,8 +47,8 @@ class CarInterface(CarInterfaceBase):
     found_ecus = [fw.ecu for fw in car_fw]
     ret.enableDsu = len(found_ecus) > 0 and Ecu.dsu not in found_ecus and candidate not in (NO_DSU_CAR | UNSUPPORTED_DSU_CAR)
 
-    #if candidate in (CAR.LEXUS_ES_TSS2, CAR.TOYOTA_COROLLA_TSS2) and Ecu.hybrid not in found_ecus:
-    #  ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
+    if candidate in (CAR.LEXUS_ES_TSS2,) and Ecu.hybrid not in found_ecus:
+     ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
 
     if candidate == CAR.TOYOTA_PRIUS:
       stop_and_go = True

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -47,8 +47,8 @@ class CarInterface(CarInterfaceBase):
     found_ecus = [fw.ecu for fw in car_fw]
     ret.enableDsu = len(found_ecus) > 0 and Ecu.dsu not in found_ecus and candidate not in (NO_DSU_CAR | UNSUPPORTED_DSU_CAR)
 
-    if candidate in (CAR.LEXUS_ES_TSS2, CAR.TOYOTA_COROLLA_TSS2) and Ecu.hybrid not in found_ecus:
-      ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
+    #if candidate in (CAR.LEXUS_ES_TSS2, CAR.TOYOTA_COROLLA_TSS2) and Ecu.hybrid not in found_ecus:
+    #  ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
 
     if candidate == CAR.TOYOTA_PRIUS:
       stop_and_go = True


### PR DESCRIPTION
Split from https://github.com/commaai/opendbc/pull/1522

This just mainly reduces integral windup during high jerk maneuvers.

You can see the braking overshoot decreases from ~-2.8 m/s^2 to ~-1.7 m/s^2 for a target of -1 m/s^2

(this is with ki=0.25 so that derivative can fully compensate, but ki will be left at 0.5 to start in this PR)

`a2bddce0b6747e10/000005be--78a61e8ab6`

![image](https://github.com/user-attachments/assets/1ebbbf36-7a0c-454f-afe7-42f7427b5e95)