### PR TITLE
remove cppcheck

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
     steps:
     - uses: commaai/timeout@v1
     - uses: actions/checkout@v4
-    - run: sudo apt install --no-install-recommends -y cppcheck
     - name: setup python
       run: |
         curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,20 +37,6 @@ repos:
         - --filter=-build,-legal,-readability,-runtime,-whitespace,+build/include_subdir,+build/forward_decl,+build/include_what_you_use,+build/deprecated,+whitespace/comma,+whitespace/line_length,+whitespace/empty_if_body,+whitespace/empty_loop_body,+whitespace/empty_conditional_body,+whitespace/forcolon,+whitespace/parens,+whitespace/semicolon,+whitespace/tab,+readability/braces
 -   repo: local
     hooks:
-    -   id: cppcheck
-        name: cppcheck
-        entry: cppcheck
-        language: system
-        types: [c++]
-        args:
-        - --error-exitcode=1
-        - --language=c++
-        - --inline-suppr
-        - --force
-        - --quiet
-        - -j4
--   repo: local
-    hooks:
     -   id: generator
         name: dbc generator
         entry: opendbc/dbc/generator/test_generator.py

--- a/opendbc/can/logger.h
+++ b/opendbc/can/logger.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #ifdef SWAGLOG
-// cppcheck-suppress preprocessorErrorDirective
 #include SWAGLOG
 #else
 


### PR DESCRIPTION
It's our one non-Python dependency, and it hasn't caught much. If we're missing it, we can add it back.