### PR TITLE
Toyota: remove accel down rate limit

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -1,6 +1,6 @@
 import math
 from opendbc.car import Bus, carlog, apply_meas_steer_torque_limits, apply_std_steer_angle_limits, common_fault_avoidance, \
-                        make_tester_present_msg, rate_limit, structs, ACCELERATION_DUE_TO_GRAVITY, DT_CTRL
+                        make_tester_present_msg, structs, ACCELERATION_DUE_TO_GRAVITY, DT_CTRL
 from opendbc.car.can_definitions import CanData
 from opendbc.car.common.filter_simple import FirstOrderFilter
 from opendbc.car.common.numpy_fast import clip, interp
@@ -225,7 +225,6 @@ class CarController(CarControllerBase):
         # internal PCM gas command can get stuck unwinding from negative accel so we apply a generous rate limit
         pcm_accel_cmd = actuators.accel
         if CC.longActive:
-          # pcm_accel_cmd = rate_limit(pcm_accel_cmd, self.prev_accel, ACCEL_WINDDOWN_LIMIT, ACCEL_WINDUP_LIMIT)
           pcm_accel_cmd = min(pcm_accel_cmd, self.prev_accel + ACCEL_WINDUP_LIMIT)
         self.prev_accel = pcm_accel_cmd
 

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -225,7 +225,8 @@ class CarController(CarControllerBase):
         # internal PCM gas command can get stuck unwinding from negative accel so we apply a generous rate limit
         pcm_accel_cmd = actuators.accel
         if CC.longActive:
-          pcm_accel_cmd = rate_limit(pcm_accel_cmd, self.prev_accel, ACCEL_WINDDOWN_LIMIT, ACCEL_WINDUP_LIMIT)
+          # pcm_accel_cmd = rate_limit(pcm_accel_cmd, self.prev_accel, ACCEL_WINDDOWN_LIMIT, ACCEL_WINDUP_LIMIT)
+          pcm_accel_cmd = min(pcm_accel_cmd, self.prev_accel + ACCEL_WINDUP_LIMIT)
         self.prev_accel = pcm_accel_cmd
 
         # calculate amount of acceleration PCM should apply to reach target, given pitch


### PR DESCRIPTION
Could potentially reduce the lag in the step response. Here it took 0.2s before FDRV (force from engine/motors) started to wind down. Now we will wind up integral much more in the controller since it will be comparing against the -1 m/s^2 request during the entire maneuver, but with our derivative or https://github.com/commaai/opendbc/pull/1536 we should be able to lessen that issue. Letting derivative and the controller w/ future aEgo be aware of the final accel in the step response should also let it be more effective.

Camry Hybrid:

![image](https://github.com/user-attachments/assets/3207be1a-5a48-4ba7-b1d2-97175af17b82)