### PR TITLE
Hyundai: Add latest 2024 Ioniq 6 fingerprints

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1005,12 +1005,14 @@ FW_VERSIONS = {
   CAR.HYUNDAI_IONIQ_6: {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00CE__ RDR -----      1.00 1.01 99110-KL000         ',
+      b'\xf1\x00CE__ RDR -----      1.00 1.02 99110-KL000         ',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00CE  MFC  AT CAN LHD 1.00 1.04 99211-KL000 221213',
       b'\xf1\x00CE  MFC  AT EUR LHD 1.00 1.03 99211-KL000 221011',
       b'\xf1\x00CE  MFC  AT EUR LHD 1.00 1.04 99211-KL000 221213',
       b'\xf1\x00CE  MFC  AT USA LHD 1.00 1.04 99211-KL000 221213',
+      b'\xf1\x00CE  MFC  AT USA LHD 1.00 1.06 99211-KL000 230915',
     ],
   },
   CAR.HYUNDAI_TUCSON_4TH_GEN: {


### PR DESCRIPTION
Adds fingerprints from a 2024 Hyundai Ioniq 6 Limited.

Route: e427c77ff2e36741/00000000--eeded7fe50