### PR TITLE
Add speed limit control signals for Ioniq PHEV 2020

### DIFF
--- a/opendbc/dbc/hyundai_kia_generic.dbc
+++ b/opendbc/dbc/hyundai_kia_generic.dbc
@@ -1520,7 +1520,9 @@ BO_ 865 ADAS_PRK_11: 8 ADAS_PRK
  SG_ PCA_CHECK_SUM : 48|8@1+ (1,0) [0|0] "" Vector__XXX
 
 BO_ 882 ELECT_GEAR: 8 XXX
- SG_ Elect_Gear_Shifter : 16|4@1+ (1,0) [0|7] ""  CLU
+ SG_ Elect_Gear_Shifter : 16|4@1+ (1,0) [0|7] "" CLU
+ SG_ SLC_ON : 31|1@0+ (1,0) [0|1] "" CLU
+ SG_ SLC_SET_SPEED : 32|8@1+ (1,0) [0|255] "" CLU
 
 BO_ 881 E_EMS11: 8 XXX
  SG_ Brake_Pedal_Pos : 0|8@1+ (1,0) [0|127] "" XXX


### PR DESCRIPTION
Added `SLC_ON` and `SLC_SET_SPEED` signals to the ELECT_GEAR message.

Route: `e1107f9d04dfb1e2/00000179--d93c2e7bc1`

On my car, 
* `CF_Clu_SldMainSW` is used for enabling speed limit mode. 
* `CF_Clu_SldMainSW` is the same physical button as `CF_Clu_CruiseMainSW`, but goes rising edge on the second press of it
* When `CF_Clu_SldMainSW` goes rising edge, `MainMode_ACC` goes Falling Edge and `SLC_ON` (new) goes Rising Edge and stays like that until `CF_Clu_SldMainSW` is pressed once more. 
* The `SLC_SET_SPEED` is the limit speed chosen on the dash. It was displayed in km/h for me but my car is EU. Not sure how it would look on American cars.
* The speed is controlled via the known set and res buttons

<img width="877" alt="image" src="https://github.com/user-attachments/assets/94c850ef-67cf-4f9f-aa03-b8ae30824742" />

![image](https://github.com/user-attachments/assets/cfda5a02-ad9e-4830-a0e1-620974250c52)

## Footnote
Because this signal was missing, it causes a bad behavior with OP long control. 
<img width="1098" alt="image" src="https://github.com/user-attachments/assets/2a4cf421-7922-46d9-b279-a4952bd8c32c" />
<img width="1030" alt="image" src="https://github.com/user-attachments/assets/c933aea6-5ca9-4849-a29b-115cbc5ff3b0" />
More about that https://discord.com/channels/469524606043160576/524611978208215070/1159242110281719859
