### PR TITLE
HKG: ALT_LAMPS support

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -224,10 +224,11 @@ class CarState(CarStateBase):
     ret.steeringPressed = self.update_steering_pressed(abs(ret.steeringTorque) > self.params.STEER_THRESHOLD, 5)
     ret.steerFaultTemporary = cp.vl["MDPS"]["LKA_FAULT"] != 0
 
-    # TODO: alt signal usage may be described by cp.vl['BLINKERS']['USE_ALT_LAMP']
-    left_blinker_sig, right_blinker_sig = "LEFT_LAMP", "RIGHT_LAMP"
-    if self.CP.carFingerprint == CAR.HYUNDAI_KONA_EV_2ND_GEN:
-      left_blinker_sig, right_blinker_sig = "LEFT_LAMP_ALT", "RIGHT_LAMP_ALT"
+    left_blinker_sig, right_blinker_sig = (
+      ("LEFT_LAMP_ALT", "RIGHT_LAMP_ALT")
+      if cp.vl['BLINKERS']['USE_ALT_LAMP']
+      else ("LEFT_LAMP", "RIGHT_LAMP")
+    )
     ret.leftBlinker, ret.rightBlinker = self.update_blinker_from_lamp(50, cp.vl["BLINKERS"][left_blinker_sig],
                                                                       cp.vl["BLINKERS"][right_blinker_sig])
     if self.CP.enableBsm:


### PR DESCRIPTION
Without this, turn signals aren't detected for a number of new cars.

Related:
- https://github.com/commaai/opendbc/pull/1580
- https://github.com/commaai/opendbc/pull/1558
- https://github.com/commaai/opendbc/pull/1575

TODO:
- make it consistent with codebase conventions
  - too pythonic
- discuss whether we want the flag to be purely dynamic.
  - if yes, verify expected behavior on existing cars e.g. all test routes (w/ and w/o ALT_LAMP)
  - if no, add static flag to gate feature