### PR TITLE
Remove STEER_MAX limit for Genesis G90

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -35,7 +35,7 @@ class CarControllerParams:
 
     # To determine the limit for your car, find the maximum value that the stock LKAS will request.
     # If the max stock LKAS request is <384, add your car to this list.
-    elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.GENESIS_G90, CAR.HYUNDAI_ELANTRA, CAR.HYUNDAI_ELANTRA_GT_I30, CAR.HYUNDAI_IONIQ,
+    elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.HYUNDAI_ELANTRA, CAR.HYUNDAI_ELANTRA_GT_I30, CAR.HYUNDAI_IONIQ,
                                CAR.HYUNDAI_IONIQ_EV_LTD, CAR.HYUNDAI_SANTA_FE_PHEV_2022, CAR.HYUNDAI_SONATA_LF, CAR.KIA_FORTE, CAR.KIA_NIRO_PHEV,
                                CAR.KIA_OPTIMA_H, CAR.KIA_OPTIMA_H_G4_FL, CAR.KIA_SORENTO):
       self.STEER_MAX = 255


### PR DESCRIPTION
The 2018 Genesis G90 should not be subject to the 255 steer max limit as it is fully capable of requesting the default 384 without error. I have been driving with this change since February with over 7k miles without issue. Attaching most recent route.

Car
2018 Genesis G90

Route
590a1a98ea35681c/2024-12-20--16-07-15/0

Including debug of car commanding and holding steer value of 384 without backing off in a tight freeway exit turn
![image](https://github.com/user-attachments/assets/22f9e386-5a13-4777-9375-144a4e195e76)
