### PR TITLE
Hyundai: Fix docs for Ioniq 5 Southeast Asia and Europe

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -103,7 +103,7 @@
 |Hyundai|Elantra Hybrid 2021-23|Smart Cruise Control (SCC)|[Upstream](#upstream)|
 |Hyundai|Genesis 2015-16|Smart Cruise Control (SCC)|[Upstream](#upstream)|
 |Hyundai|i30 2017-19|Smart Cruise Control (SCC)|[Upstream](#upstream)|
-|Hyundai|Ioniq 5 (Non-US only) 2022-24|All|[Upstream](#upstream)|
+|Hyundai|Ioniq 5 (Southeast Asia and Europe only) 2022-24|All|[Upstream](#upstream)|
 |Hyundai|Ioniq 5 (with HDA II) 2022-24|Highway Driving Assist II|[Upstream](#upstream)|
 |Hyundai|Ioniq 5 (without HDA II) 2022-24|Highway Driving Assist|[Upstream](#upstream)|
 |Hyundai|Ioniq 6 (with HDA II) 2023-24|Highway Driving Assist II|[Upstream](#upstream)|

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -309,7 +309,7 @@ class CAR(Platforms):
   )
   HYUNDAI_IONIQ_5 = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Hyundai Ioniq 5 (Non-US only) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_q])),
+      HyundaiCarDocs("Hyundai Ioniq 5 (Southeast Asia and Europe only) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_q])),
       HyundaiCarDocs("Hyundai Ioniq 5 (without HDA II) 2022-24", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_k])),
       HyundaiCarDocs("Hyundai Ioniq 5 (with HDA II) 2022-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q])),
     ],


### PR DESCRIPTION
**Description**

This PR updates the regional labeling and hardware information for the Hyundai Ioniq 5.
- The description shifts from "Non-US only" to "Southeast Asia and Europe only" (introduced in https://github.com/commaai/openpilot/pull/32701) to reflect regional specificity.
- The Hyundai Q harness is now exclusively assigned to Southeast Asia and Europe specs, as confirmed by user feedback on a 2024 Hyundai Ioniq 5 sold in India that required the Hyundai K harness instead.
- This clarification ensures the correct harness is associated with the regional configurations of the Ioniq 5 across supported platforms.