### PR TITLE
Improve get_interface_attr speed through caching

### DIFF
--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -375,28 +375,42 @@ INTERFACE_ATTR_FILE = {
 
 # interface-specific helpers
 
+_brand_values = {}  # attr_file => brand_name => module
+_brand_names = None
 def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: bool = False) -> dict[str | StrEnum, Any]:
+  global _brand_names
   # read all the folders in opendbc/car and return a dict where:
   # - keys are all the car models or brand names
   # - values are attr values from all car folders
   result = {}
-  for car_folder in sorted([x[0] for x in os.walk(BASEDIR)]):
-    try:
-      brand_name = car_folder.split('/')[-1]
-      brand_values = __import__(f'opendbc.car.{brand_name}.{INTERFACE_ATTR_FILE.get(attr, "values")}', fromlist=[attr])
-      if hasattr(brand_values, attr) or not ignore_none:
-        attr_data = getattr(brand_values, attr, None)
-      else:
-        continue
+  attr_file = INTERFACE_ATTR_FILE.get(attr, "values")
+  if _brand_names is None:
+    _brand_names = [folder.split('/')[-1] for folder in sorted(x[0] for x in os.walk(BASEDIR))]
+  if attr_file not in _brand_values:
+    _brand_values[attr_file] = {}
+    for brand_name in _brand_names:
+      try:
+        brand_values = __import__(f'opendbc.car.{brand_name}.{attr_file}', fromlist=[attr])
+        _brand_values[attr_file][brand_name] = brand_values
+      except (ImportError, OSError):
+        pass
 
-      if combine_brands:
-        if isinstance(attr_data, dict):
-          for f, v in attr_data.items():
-            result[f] = v
-      else:
-        result[brand_name] = attr_data
-    except (ImportError, OSError):
-      pass
+  for brand_name in _brand_names:
+    brand_values = _brand_values[attr_file].get(brand_name)
+    if brand_values is None:
+      # This was an ImportError or OSError, so we skip it
+      continue
+    if hasattr(brand_values, attr) or not ignore_none:
+      attr_data = getattr(brand_values, attr, None)
+    else:
+      continue
+
+    if combine_brands:
+      if isinstance(attr_data, dict):
+        for f, v in attr_data.items():
+          result[f] = v
+    else:
+      result[brand_name] = attr_data
 
   return result
 


### PR DESCRIPTION
Inspired by https://github.com/commaai/opendbc/issues/1184 but only a small step.

To me, it looks like the car/ module does a lot of (potentially unnecessary) work at import time, such as defining dataclasses for documentation of a car. As a result, collecting the tests has to not only import class and function definitions, but also do real work.

In this case, `interfaces.get_interface_attr()` walks a folder structure ignoring some folders, dynamically imports modules, does some optional dict-merging, and returns. During test collection, it's called 3 times, each time walking the directory structure and importing the same module.

It seems to me that actually closing #1184 would entail a dozen or more of PRs like this: finding a small improvement to the import-time work or moving it either to runtime or maybe even "compilation".