### PR TITLE
scons failure fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,7 @@ Everything you need to know to use, contribute, and extend opendbc are in these 
 ```bash
 git clone https://github.com/commaai/opendbc.git
 cd opendbc
-
-# you probably just want to use this. it's an all-in-one for dependency
-# installation, compiling, linting, and tests. it's also what runs in CI
-./test.sh
-
-# here are the individual commands it runs
-pip3 install -e .[testing,docs]  # install dependencies
-scons -j8                        # build with 8 cores
-pytest .                         # run the tests
-pre-commit run --all-files       # run the linter
+./test.sh # all-in-one dependency installation, compiling, linting, and tests. It's what runs in CI
 ```
 
 [`examples/`](examples/) contains small example programs that can read state from the car and control the steering, gas, and brakes.

--- a/SConstruct
+++ b/SConstruct
@@ -3,11 +3,13 @@ import subprocess
 import sysconfig
 import platform
 import numpy as np
+from pathlib import Path
 
 arch = subprocess.check_output(["uname", "-m"], encoding='utf8').rstrip()
 if platform.system() == "Darwin":
   arch = "Darwin"
 
+os.environ['PYTHONPATH'] = str(Path(sysconfig.get_paths()['data']).parent)
 python_path = sysconfig.get_paths()['include']
 cpppath = [
   '#',

--- a/test.sh
+++ b/test.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 set -e
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-cd $DIR
-
-# TODO: why doesn't uv do this?
-export PYTHONPATH=$DIR
-
 # *** dependencies install ***
 if ! command -v uv &>/dev/null; then
   echo "'uv' is not installed. Installing 'uv'..."
@@ -17,7 +11,7 @@ uv sync --all-extras
 source .venv/bin/activate
 
 # *** build ***
-uv run scons -j8
+uv run scons -j$(nproc)
 
 # *** lint ***
 # TODO: pre-commit is slow; replace it with openpilot's "op lint"
@@ -25,7 +19,7 @@ uv run scons -j8
 uv run ruff check .
 
 # *** test ***
-uv run pytest -n8
+uv run pytest -n$(nproc)
 
 # *** all done ***
 GREEN='\033[0;32m'

--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ uv sync --all-extras
 source .venv/bin/activate
 
 # *** build ***
-uv run scons -j$(nproc)
+uv run scons -j$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 
 # *** lint ***
 # TODO: pre-commit is slow; replace it with openpilot's "op lint"
@@ -19,7 +19,7 @@ uv run scons -j$(nproc)
 uv run ruff check .
 
 # *** test ***
-uv run pytest -n$(nproc)
+uv run pytest -n$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)
 
 # *** all done ***
 GREEN='\033[0;32m'


### PR DESCRIPTION
- building no longer fails
  - by setting `PYTHONPATH` env var within scons (where it matters)
- docs simplified

#### Bug Description:
```bash
$ scons                   # ❌ fails
$ PYTHONPATH=$(pwd) scons # ✅ succeeds
```
![image](https://github.com/user-attachments/assets/d92df023-70c4-462a-a3ae-a1ef1051fafc)
