### PR TITLE
car.capnp: LongitudinalPIDTuning kd derivative term

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -553,6 +553,8 @@ struct CarParams {
     kpV @1 :List(Float32);
     kiBP @2 :List(Float32);
     kiV @3 :List(Float32);
+    kdBP @7 :List(Float32);
+    kdV @8 :List(Float32);
     kf @6 :Float32;
     deadzoneBPDEPRECATED @4 :List(Float32);
     deadzoneVDEPRECATED @5 :List(Float32);


### PR DESCRIPTION
Allow for cars that utilize the derivative term in longitudinal PID tuning
to log the derivative term along with the rest.