### PR TITLE
Toyota: Separate DBC generator include for certain ADAS messages

### DIFF
--- a/opendbc/dbc/generator/toyota/_toyota_2017.dbc
+++ b/opendbc/dbc/generator/toyota/_toyota_2017.dbc
@@ -136,17 +136,6 @@ BO_ 614 STEERING_IPAS: 8 IPAS
  SG_ SET_ME_X00_1 : 55|8@0+ (1,0) [0|255] "" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
 
-BO_ 643 PRE_COLLISION: 7 DSU
- SG_ _COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X00 : 15|8@0+ (1,0) [0|255] "" XXX
- SG_ FORCE : 23|16@0- (2,0) [0|255] "N" XXX
- SG_ SET_ME_X002 : 33|8@0+ (1,0) [0|3] "" XXX
- SG_ BRAKE_STATUS : 39|3@0+ (1,0) [0|255] "" XXX
- SG_ STATE : 36|3@0+ (1,0) [0|255] "" XXX
- SG_ SET_ME_X003 : 40|1@0+ (1,0) [0|1] "" XXX
- SG_ PRECOLLISION_ACTIVE : 41|1@0+ (1,0) [0|255] "" XXX
- SG_ CHECKSUM : 55|8@0+ (1,0) [0|255] "" XXX
-
 BO_ 705 GAS_PEDAL: 8 XXX
  SG_ GAS_RELEASED : 3|1@0+ (1,0) [0|1] "" XXX
  SG_ ETQLVSC : 15|16@0- (0.03125,0) [0|0] "Nm" XXX
@@ -154,14 +143,6 @@ BO_ 705 GAS_PEDAL: 8 XXX
  SG_ ETQISC : 47|8@0+ (1,-192) [0|0] "Nm" XXX
  SG_ GAS_PEDAL : 55|8@0+ (0.5,0) [0|0] "%" DS1,FCM
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" DS1,FCM
-
-BO_ 740 STEERING_LKA: 5 XXX
- SG_ LKA_STATE : 31|8@0+ (1,0) [0|255] "" XXX
- SG_ STEER_REQUEST : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 6|6@0+ (1,0) [0|63] "" XXX
- SG_ SET_ME_1 : 7|1@0+ (1,0) [0|1] "" XXX
- SG_ STEER_TORQUE_CMD : 15|16@0- (1,0) [0|65535] "" XXX
- SG_ CHECKSUM : 39|8@0+ (1,0) [0|255] "" XXX
 
 BO_ 742 LEAD_INFO: 8 DSU
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" HCU
@@ -209,15 +190,6 @@ BO_ 835 ACC_CONTROL: 8 DSU
  SG_ ITS_CONNECT_LEAD : 39|8@0+ (1,0) [0|1] "" Vector__XXX
  SG_ ACCEL_CMD_ALT : 47|8@0- (0.05,0) [0|0] "m/s^2" XXX
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
-
-BO_ 836 PRE_COLLISION_2: 8 DSU
- SG_ DSS1GDRV : 7|10@0- (0.1,0) [0|0] "m/s^2" Vector__XXX
- SG_ PCSALM : 17|1@0+ (1,0) [0|0] "" FCM
- SG_ IBTRGR : 27|1@0+ (1,0) [0|0] "" FCM
- SG_ PBATRGR : 30|2@0+ (1,0) [0|0] "" Vector__XXX
- SG_ PREFILL : 33|1@0+ (1,0) [0|0] "" Vector__XXX
- SG_ AVSTRGR : 36|1@0+ (1,0) [0|0] "" SCS
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
 
 BO_ 865 CLUTCH: 8 XXX
  SG_ ACC_FAULTED : 32|1@0+ (1,0) [0|1] "" XXX
@@ -481,9 +453,6 @@ CM_ SG_ 581 GAS_PEDAL "it seems slightly filtered";
 CM_ SG_ 608 STEER_TORQUE_DRIVER "driver torque";
 CM_ SG_ 608 STEER_OVERRIDE "set when driver torque exceeds a certain value";
 CM_ SG_ 614 ANGLE "set to measured angle when ipas control isn't active";
-CM_ SG_ 643 _COUNTER "only used on cars that use this msg for cruise control";
-CM_ SG_ 643 BRAKE_STATUS "only used on cars that use this msg for cruise control";
-CM_ SG_ 643 PRECOLLISION_ACTIVE "set 0.5s before any braking";
 CM_ SG_ 800 SLOPE_ANGLE "potentially used by the PCM to compensate for road pitch";
 CM_ SG_ 800 ACCEL "filtered ego acceleration";
 CM_ SG_ 835 ACC_TYPE "if 2, car is likely to have a permanent low speed lockout. 1 is ok";
@@ -557,7 +526,6 @@ VAL_ 467 LOW_SPEED_LOCKOUT 2 "low speed locked" 1 "ok";
 VAL_ 467 PCM_FOLLOW_DISTANCE 1 "far" 2 "medium" 3 "close";
 VAL_ 614 STATE 3 "enabled" 1 "disabled";
 VAL_ 614 DIRECTION_CMD 3 "right" 2 "center" 1 "left";
-VAL_ 643 STATE 0 "normal" 1 "adaptive_cruise_control" 3 "emergency_braking";
 VAL_ 835 ACC_TYPE 2 "permanent low speed lockout" 1 "ok";
 VAL_ 835 ACC_MALFUNCTION 1 "faulted" 0 "ok";
 VAL_ 835 ACC_CUT_IN 1 "CUT-IN Detected" 0 "clear";

--- a/opendbc/dbc/generator/toyota/_toyota_adas_standard.dbc
+++ b/opendbc/dbc/generator/toyota/_toyota_adas_standard.dbc
@@ -1,17 +1,3 @@
-BO_ 401 STEERING_LTA: 8 XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ SETME_X3 : 29|2@0+ (1,0) [0|3] "" XXX
- SG_ PERCENTAGE : 39|8@0+ (1,0) [0|255] "" XXX
- SG_ TORQUE_WIND_DOWN : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ ANGLE : 55|8@0- (0.5,0) [0|255] "" XXX
- SG_ STEER_ANGLE_CMD : 15|16@0- (0.0573,0) [-540|540] "" XXX
- SG_ STEER_REQUEST_2 : 25|1@0+ (1,0) [0|1] "" XXX
- SG_ LKA_ACTIVE : 26|1@0+ (1,0) [0|1] "" XXX
- SG_ CLEAR_HOLD_STEERING_ALERT : 30|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 6|6@0+ (1,0) [0|255] "" XXX
- SG_ STEER_REQUEST : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 643 PRE_COLLISION: 7 DSU
  SG_ _COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ SET_ME_X00 : 15|8@0+ (1,0) [0|255] "" XXX
@@ -40,19 +26,8 @@ BO_ 836 PRE_COLLISION_2: 8 DSU
  SG_ AVSTRGR : 36|1@0+ (1,0) [0|0] "" SCS
  SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
 
-CM_ SG_ 401 PERCENTAGE "driver override percentage (0-100), very close to steeringPressed in OP";
-CM_ SG_ 401 TORQUE_WIND_DOWN "used to wind down torque on user override";
-CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
-CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
-CM_ SG_ 401 CLEAR_HOLD_STEERING_ALERT "set to 1 when user clears LKAS_HUD->LDA_ALERT ('Hold Steering') by applying torque to steering wheel";
-CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
-CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
-CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
-CM_ SG_ 401 SETME_X1 "usually 1, seen at 0 on some South American Corollas indicating lack of stock Lane Tracing Assist";
-CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, but may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 643 _COUNTER "only used on cars that use this msg for cruise control";
 CM_ SG_ 643 BRAKE_STATUS "only used on cars that use this msg for cruise control";
 CM_ SG_ 643 PRECOLLISION_ACTIVE "set 0.5s before any braking";
 
-VAL_ 401 SETME_X3 3 "TSS 2.0" 1 "TSS 2.5 or 2022 RAV4" 0 "TSS 2.0 on Alphard, Highlander, NX";
 VAL_ 643 STATE 0 "normal" 1 "adaptive_cruise_control" 3 "emergency_braking";

--- a/opendbc/dbc/generator/toyota/_toyota_adas_standard.dbc
+++ b/opendbc/dbc/generator/toyota/_toyota_adas_standard.dbc
@@ -1,0 +1,58 @@
+BO_ 401 STEERING_LTA: 8 XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ SETME_X3 : 29|2@0+ (1,0) [0|3] "" XXX
+ SG_ PERCENTAGE : 39|8@0+ (1,0) [0|255] "" XXX
+ SG_ TORQUE_WIND_DOWN : 47|8@0+ (1,0) [0|255] "" XXX
+ SG_ ANGLE : 55|8@0- (0.5,0) [0|255] "" XXX
+ SG_ STEER_ANGLE_CMD : 15|16@0- (0.0573,0) [-540|540] "" XXX
+ SG_ STEER_REQUEST_2 : 25|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKA_ACTIVE : 26|1@0+ (1,0) [0|1] "" XXX
+ SG_ CLEAR_HOLD_STEERING_ALERT : 30|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 6|6@0+ (1,0) [0|255] "" XXX
+ SG_ STEER_REQUEST : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
+
+BO_ 643 PRE_COLLISION: 7 DSU
+ SG_ _COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X00 : 15|8@0+ (1,0) [0|255] "" XXX
+ SG_ FORCE : 23|16@0- (2,0) [0|255] "N" XXX
+ SG_ SET_ME_X002 : 33|8@0+ (1,0) [0|3] "" XXX
+ SG_ BRAKE_STATUS : 39|3@0+ (1,0) [0|255] "" XXX
+ SG_ STATE : 36|3@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X003 : 40|1@0+ (1,0) [0|1] "" XXX
+ SG_ PRECOLLISION_ACTIVE : 41|1@0+ (1,0) [0|255] "" XXX
+ SG_ CHECKSUM : 55|8@0+ (1,0) [0|255] "" XXX
+
+BO_ 740 STEERING_LKA: 5 XXX
+ SG_ LKA_STATE : 31|8@0+ (1,0) [0|255] "" XXX
+ SG_ STEER_REQUEST : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 6|6@0+ (1,0) [0|63] "" XXX
+ SG_ SET_ME_1 : 7|1@0+ (1,0) [0|1] "" XXX
+ SG_ STEER_TORQUE_CMD : 15|16@0- (1,0) [0|65535] "" XXX
+ SG_ CHECKSUM : 39|8@0+ (1,0) [0|255] "" XXX
+
+BO_ 836 PRE_COLLISION_2: 8 DSU
+ SG_ DSS1GDRV : 7|10@0- (0.1,0) [0|0] "m/s^2" Vector__XXX
+ SG_ PCSALM : 17|1@0+ (1,0) [0|0] "" FCM
+ SG_ IBTRGR : 27|1@0+ (1,0) [0|0] "" FCM
+ SG_ PBATRGR : 30|2@0+ (1,0) [0|0] "" Vector__XXX
+ SG_ PREFILL : 33|1@0+ (1,0) [0|0] "" Vector__XXX
+ SG_ AVSTRGR : 36|1@0+ (1,0) [0|0] "" SCS
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|0] "" XXX
+
+CM_ SG_ 401 PERCENTAGE "driver override percentage (0-100), very close to steeringPressed in OP";
+CM_ SG_ 401 TORQUE_WIND_DOWN "used to wind down torque on user override";
+CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
+CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
+CM_ SG_ 401 CLEAR_HOLD_STEERING_ALERT "set to 1 when user clears LKAS_HUD->LDA_ALERT ('Hold Steering') by applying torque to steering wheel";
+CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
+CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
+CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
+CM_ SG_ 401 SETME_X1 "usually 1, seen at 0 on some South American Corollas indicating lack of stock Lane Tracing Assist";
+CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, but may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
+CM_ SG_ 643 _COUNTER "only used on cars that use this msg for cruise control";
+CM_ SG_ 643 BRAKE_STATUS "only used on cars that use this msg for cruise control";
+CM_ SG_ 643 PRECOLLISION_ACTIVE "set 0.5s before any braking";
+
+VAL_ 401 SETME_X3 3 "TSS 2.0" 1 "TSS 2.5 or 2022 RAV4" 0 "TSS 2.0 on Alphard, Highlander, NX";
+VAL_ 643 STATE 0 "normal" 1 "adaptive_cruise_control" 3 "emergency_braking";

--- a/opendbc/dbc/generator/toyota/toyota_new_mc_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_new_mc_pt.dbc
@@ -1,4 +1,5 @@
 CM_ "IMPORT _toyota_2017.dbc";
+CM_ "IMPORT _toyota_adas_standard.dbc";
 
 BO_ 548 BRAKE_MODULE: 8 XXX
  SG_ BRAKE_PRESSURE : 43|12@0+ (1,0) [0|4047] "" XXX

--- a/opendbc/dbc/generator/toyota/toyota_nodsu_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_nodsu_pt.dbc
@@ -1,18 +1,5 @@
 CM_ "IMPORT _toyota_2017.dbc";
-
-BO_ 401 STEERING_LTA: 8 XXX
- SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
- SG_ SETME_X3 : 29|2@0+ (1,0) [0|3] "" XXX
- SG_ PERCENTAGE : 39|8@0+ (1,0) [0|255] "" XXX
- SG_ TORQUE_WIND_DOWN : 47|8@0+ (1,0) [0|255] "" XXX
- SG_ ANGLE : 55|8@0- (0.5,0) [0|255] "" XXX
- SG_ STEER_ANGLE_CMD : 15|16@0- (0.0573,0) [-540|540] "" XXX
- SG_ STEER_REQUEST_2 : 25|1@0+ (1,0) [0|1] "" XXX
- SG_ LKA_ACTIVE : 26|1@0+ (1,0) [0|1] "" XXX
- SG_ CLEAR_HOLD_STEERING_ALERT : 30|1@0+ (1,0) [0|1] "" XXX
- SG_ COUNTER : 6|6@0+ (1,0) [0|255] "" XXX
- SG_ STEER_REQUEST : 0|1@0+ (1,0) [0|1] "" XXX
- SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
+CM_ "IMPORT _toyota_adas_standard.dbc";
 
 BO_ 550 BRAKE_MODULE: 8 XXX
  SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
@@ -44,16 +31,6 @@ BO_ 1014 BSM: 8 XXX
  SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
  SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
 
-CM_ SG_ 401 PERCENTAGE "driver override percentage (0-100), very close to steeringPressed in OP";
-CM_ SG_ 401 TORQUE_WIND_DOWN "used to wind down torque on user override";
-CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
-CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
-CM_ SG_ 401 CLEAR_HOLD_STEERING_ALERT "set to 1 when user clears LKAS_HUD->LDA_ALERT ('Hold Steering') by applying torque to steering wheel";
-CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
-CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
-CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
-CM_ SG_ 401 SETME_X1 "usually 1, seen at 0 on some South American Corollas indicating lack of stock Lane Tracing Assist";
-CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, but may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
@@ -71,7 +48,6 @@ CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled 
 CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 
-VAL_ 401 SETME_X3 3 "TSS 2.0" 1 "TSS 2.5 or 2022 RAV4" 0 "TSS 2.0 on Alphard, Highlander, NX";
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
 VAL_ 610 LKA_STATE 25 "temporary_fault" 17 "permanent_fault" 11 "lka_missing_unavailable2" 9 "temporary_fault2" 5 "active" 3 "lka_missing_unavailable" 1 "standby";
 VAL_ 610 LTA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 3 "lta_missing_unavailable" 1 "standby";

--- a/opendbc/dbc/generator/toyota/toyota_nodsu_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_nodsu_pt.dbc
@@ -1,6 +1,20 @@
 CM_ "IMPORT _toyota_2017.dbc";
 CM_ "IMPORT _toyota_adas_standard.dbc";
 
+BO_ 401 STEERING_LTA: 8 XXX
+ SG_ CHECKSUM : 63|8@0+ (1,0) [0|255] "" XXX
+ SG_ SETME_X3 : 29|2@0+ (1,0) [0|3] "" XXX
+ SG_ PERCENTAGE : 39|8@0+ (1,0) [0|255] "" XXX
+ SG_ TORQUE_WIND_DOWN : 47|8@0+ (1,0) [0|255] "" XXX
+ SG_ ANGLE : 55|8@0- (0.5,0) [0|255] "" XXX
+ SG_ STEER_ANGLE_CMD : 15|16@0- (0.0573,0) [-540|540] "" XXX
+ SG_ STEER_REQUEST_2 : 25|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKA_ACTIVE : 26|1@0+ (1,0) [0|1] "" XXX
+ SG_ CLEAR_HOLD_STEERING_ALERT : 30|1@0+ (1,0) [0|1] "" XXX
+ SG_ COUNTER : 6|6@0+ (1,0) [0|255] "" XXX
+ SG_ STEER_REQUEST : 0|1@0+ (1,0) [0|1] "" XXX
+ SG_ SETME_X1 : 7|1@0+ (1,0) [0|1] "" XXX
+
 BO_ 550 BRAKE_MODULE: 8 XXX
  SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX
  SG_ BRAKE_POSITION : 16|9@0+ (1,0) [0|511] "" XXX
@@ -31,6 +45,16 @@ BO_ 1014 BSM: 8 XXX
  SG_ ADJACENT_ENABLED : 7|1@0+ (1,0) [0|1] "" XXX
  SG_ APPROACHING_ENABLED : 15|1@0+ (1,0) [0|1] "" XXX
 
+CM_ SG_ 401 PERCENTAGE "driver override percentage (0-100), very close to steeringPressed in OP";
+CM_ SG_ 401 TORQUE_WIND_DOWN "used to wind down torque on user override";
+CM_ SG_ 401 ANGLE "angle of car relative to lane center on LTA camera";
+CM_ SG_ 401 STEER_ANGLE_CMD "desired angle, OEM steers up to 95 degrees, no angle limit but torque will bottom out";
+CM_ SG_ 401 CLEAR_HOLD_STEERING_ALERT "set to 1 when user clears LKAS_HUD->LDA_ALERT ('Hold Steering') by applying torque to steering wheel";
+CM_ SG_ 401 STEER_REQUEST "enable bit for steering, 1 to steer, 0 to not";
+CM_ SG_ 401 STEER_REQUEST_2 "enable bit for steering, 1 to steer, 0 to not";
+CM_ SG_ 401 LKA_ACTIVE "1 when using LTA for LKA";
+CM_ SG_ 401 SETME_X1 "usually 1, seen at 0 on some South American Corollas indicating lack of stock Lane Tracing Assist";
+CM_ SG_ 401 SETME_X3 "almost completely correlates with Toyota Safety Sense version, but may instead describe max torque when using LTA. if TSS 2.5 or 2022 RAV4, this is always 1. if TSS 2.0 this is always 3 (or 0 on Alphard, Highlander, NX)";
 CM_ SG_ 550 BRAKE_PRESSURE "seems prop to pedal force";
 CM_ SG_ 550 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
@@ -48,6 +72,7 @@ CM_ SG_ 1014 R_APPROACHING "vehicle approaching from right side of car. enabled 
 CM_ SG_ 1014 ADJACENT_ENABLED "when BSM is enabled in settings, this is on along with APPROACHING_ENABLED. this controls bsm alert visibility";
 CM_ SG_ 1014 APPROACHING_ENABLED "when BSM is enabled in settings, this is on along with ADJACENT_ENABLED. this controls bsm alert visibility";
 
+VAL_ 401 SETME_X3 3 "TSS 2.0" 1 "TSS 2.5 or 2022 RAV4" 0 "TSS 2.0 on Alphard, Highlander, NX";
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";
 VAL_ 610 LKA_STATE 25 "temporary_fault" 17 "permanent_fault" 11 "lka_missing_unavailable2" 9 "temporary_fault2" 5 "active" 3 "lka_missing_unavailable" 1 "standby";
 VAL_ 610 LTA_STATE 25 "temporary_fault" 9 "temporary_fault2" 5 "active" 3 "lta_missing_unavailable" 1 "standby";

--- a/opendbc/dbc/generator/toyota/toyota_tnga_k_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_tnga_k_pt.dbc
@@ -1,4 +1,5 @@
 CM_ "IMPORT _toyota_2017.dbc";
+CM_ "IMPORT _toyota_adas_standard.dbc";
 
 BO_ 550 BRAKE_MODULE: 8 XXX
  SG_ BRAKE_PRESSURE : 0|9@0+ (1,0) [0|511] "" XXX


### PR DESCRIPTION
Prereq for #1319 - migrate ADAS messages with SecOC overlaps/conflicts to a separate generator include.