### PR TITLE
Toyota: remove longitudinal derivative

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,17 +39,14 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 def get_long_tune(CP, params):
   kiBP = [0.]
-  kdBP = [0.]
-  kdV = [0.]
   if CP.carFingerprint in TSS2_CAR:
     kiV = [0.25]
-    kdV = [0]
 
   else:
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]
 
-  return PIDController(0.0, (kiBP, kiV), k_f=1.0, k_d=(kdBP, kdV),
+  return PIDController(0.0, (kiBP, kiV), k_f=1.0,
                        pos_limit=params.ACCEL_MAX, neg_limit=params.ACCEL_MIN,
                        rate=1 / (DT_CTRL * 3))
 
@@ -69,12 +66,7 @@ class CarController(CarControllerBase):
 
     # *** start long control state ***
     self.long_pid = get_long_tune(self.CP, self.params)
-
-    self.error_rate = FirstOrderFilter(0.0, 0.5, DT_CTRL * 3)
-    self.prev_error = 0.0
-
     self.aego = FirstOrderFilter(0.0, 0.25, DT_CTRL * 3)
-
     self.pitch = FirstOrderFilter(0, 0.5, DT_CTRL)
 
     self.accel = 0
@@ -228,18 +220,12 @@ class CarController(CarControllerBase):
         a_ego_future = a_ego_blended + j_ego * 0.5
 
         if actuators.longControlState == LongCtrlState.pid:
-          error = pcm_accel_cmd - a_ego_blended
-          self.error_rate.update((error - self.prev_error) / (DT_CTRL * 3))
-          self.prev_error = error
-
           error_future = pcm_accel_cmd - a_ego_future
-          pcm_accel_cmd = self.long_pid.update(error_future, error_rate=self.error_rate.x,
+          pcm_accel_cmd = self.long_pid.update(error_future,
                                                speed=CS.out.vEgo,
                                                feedforward=pcm_accel_cmd)
         else:
           self.long_pid.reset()
-          self.error_rate.x = 0.0
-          self.prev_error = 0.0
 
         # Along with rate limiting positive jerk above, this greatly improves gas response time
         # Consider the net acceleration request that the PCM should be applying (pitch included)

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -43,7 +43,7 @@ def get_long_tune(CP, params):
   kdV = [0.]
   if CP.carFingerprint in TSS2_CAR:
     kiV = [0.25]
-    kdV = [0.25 / 4]
+    kdV = [0]
 
   else:
     kiBP = [0., 5., 35.]


### PR DESCRIPTION
Doesn't do much. The future estimated aEgo we use for error correction provides a similar effect to derivative but is more pronounced and less noisy at larger scales, so we'll just keep that.

On the bottom of each plot, orange is derivative **removed** (this PR), green is the real route with current derivative.

Highway coasting: ![image](https://github.com/user-attachments/assets/f892ad9c-d511-4d3f-a105-0c981cddccac)
Highway accel: ![image](https://github.com/user-attachments/assets/61ddae8e-4190-4d4e-acf3-9d3ba77359ac)

Medium speed accel: ![image](https://github.com/user-attachments/assets/4a25db1d-5a6e-4580-9a8f-31ff720dca7d)
Medium speed braking: ![image](https://github.com/user-attachments/assets/c2c6bdf2-c43f-4f03-886e-934cd29b70c6)