### PR TITLE
Honda: Temporarily revoke support for 2022 Acura MDX

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -7,7 +7,7 @@
 |Acura|ILX 2016-19|AcuraWatch Plus|[Upstream](#upstream)|
 |Acura|Integra 2024|All|[Community](#community)|
 |Acura|RDX 2016-18|AcuraWatch Plus|[Upstream](#upstream)|
-|Acura|RDX 2019-22|All|[Upstream](#upstream)|
+|Acura|RDX 2019-21|All|[Upstream](#upstream)|
 |Audi|A3 2014-19|Adaptive Cruise Control (ACC) & Lane Assist|[Upstream](#upstream)|
 |Audi|A3 Sportback e-tron 2017-18|Adaptive Cruise Control (ACC) & Lane Assist|[Upstream](#upstream)|
 |Audi|A4 2016-24|All|[Not compatible](#flexray)|

--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -174,7 +174,7 @@ class CAR(Platforms):
     flags=HondaFlags.BOSCH_RADARLESS,
   )
   ACURA_RDX_3G = HondaBoschPlatformConfig(
-    [HondaCarDocs("Acura RDX 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
+    [HondaCarDocs("Acura RDX 2019-21", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
     CarSpecs(mass=4068 * CV.LB_TO_KG, wheelbase=2.75, steerRatio=11.95, centerToFrontRatio=0.41, tireStiffnessFactor=0.677),  # as spec
     {Bus.pt: 'acura_rdx_2020_can_generated'},
     flags=HondaFlags.BOSCH_ALT_BRAKE,


### PR DESCRIPTION
Due to #1637, temporarily remove 2022 Acura MDX from CARS.md and the comma shop. This is a documentation change only, currently-working cars will continue to work subject to the known bugs.