### PR TITLE
docs: Add support for 2025 Toyota RAV4 Hybrid

### DIFF
--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -258,7 +258,7 @@ class CAR(Platforms):
   TOYOTA_RAV4_TSS2_2023 = ToyotaTSS2PlatformConfig(
     [
       ToyotaCarDocs("Toyota RAV4 2023-24"),
-      ToyotaCarDocs("Toyota RAV4 Hybrid 2023-24"),
+      ToyotaCarDocs("Toyota RAV4 Hybrid 2023-25", video_link="https://youtu.be/4eIsEq4L4Ng"),
     ],
     TOYOTA_RAV4_TSS2.specs,
     flags=ToyotaFlags.RADAR_ACC | ToyotaFlags.ANGLE_CONTROL,


### PR DESCRIPTION
This PR adds the 2025 Toyota RAV4 Hybrid to the list of supported models.

Route for validation: `259d13f76542c811/00000005--7a4743f55f`