### PR TITLE
Honda: CANFD Gearbox

### DIFF
--- a/opendbc/dbc/generator/honda/honda_pilot_2023_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_pilot_2023_can.dbc
@@ -2,6 +2,11 @@ CM_ "IMPORT _honda_common.dbc";
 CM_ "IMPORT _bosch_2018.dbc";
 CM_ "IMPORT _steering_sensors_a.dbc";
 
+BO_ 401 GEARBOX_15T: 8 PCM
+ SG_ GEAR_SHIFTER : 5|6@0+ (1,0) [0|63] "" EON
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" EON
+
 BO_ 419 GEARBOX: 8 XXX
  SG_ GEAR_SHIFTER : 24|8@1+ (1,0) [0|255] "" XXX
  SG_ GEAR : 32|8@1+ (1,0) [0|255] "" XXX
@@ -80,6 +85,7 @@ CM_ SG_ 479 AEB_PREPARE "set 1s before AEB";
 CM_ SG_ 829 BEEP "beeps are pleasant, chimes are for warnings etc...";
 CM_ SG_ 829 LANE_LINES "related to lane lines on cluster, left/right white/green";
 
+VAL_ 401 GEAR_SHIFTER 32 "L" 16 "S" 8 "D" 4 "N" 2 "R" 1 "P";
 VAL_ 419 GEAR_SHIFTER 2 "S" 32 "D" 16 "N" 8 "R" 4 "P";
 VAL_ 419 GEAR 26 "S" 20 "D" 19 "N" 18 "R" 17 "P";
 VAL_ 829 BEEP 3 "single_beep" 2 "triple_beep" 1 "repeated_beep" 0 "no_beep";


### PR DESCRIPTION
This gearbox message is actually used on the non-Hybrid 6th gen CRV. Similar to the Accord 1.5/2.0L gearbox differences.

Verification - 2dc4489d7e1410ca/00000004--eb4c907d01

See https://github.com/commaai/opendbc/pull/1057