### PR TITLE
Tesla: Jerk Limit

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -58,6 +58,7 @@ class CarState(CarStateBase):
     ret.cruiseState.available = cruise_state == "STANDBY" or ret.cruiseState.enabled
     ret.cruiseState.standstill = False  # This needs to be false, since we can resume from stop without sending anything special
     ret.standstill = cruise_state == "STANDSTILL"
+    ret.accFaulted = cruise_state == "FAULT"
 
     # Gear
     ret.gearShifter = GEAR_MAP[self.can_define.dv["DI_systemStatus"]["DI_gear"].get(int(cp_party.vl["DI_systemStatus"]["DI_gear"]), "DI_GEAR_INVALID")]

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -61,8 +61,8 @@ class CarControllerParams:
   ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[0., 5., 15.], angle_v=[10., 7.0, 0.8])
   ACCEL_MIN = -3.48  # m/s^2
   ACCEL_MAX = 2.0    # m/s^2
-  JERK_LIMIT_MAX = 5
-  JERK_LIMIT_MIN = -5
+  JERK_LIMIT_MAX = 4.9
+  JERK_LIMIT_MIN = -4.9
 
 
 class TeslaFlags(IntFlag):

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -61,8 +61,8 @@ class CarControllerParams:
   ANGLE_RATE_LIMIT_DOWN = AngleRateLimit(speed_bp=[0., 5., 15.], angle_v=[10., 7.0, 0.8])
   ACCEL_MIN = -3.48  # m/s^2
   ACCEL_MAX = 2.0    # m/s^2
-  JERK_LIMIT_MAX = 4.9
-  JERK_LIMIT_MIN = -4.9
+  JERK_LIMIT_MAX = 4.9  # m/s^3, ACC faults at 5.0
+  JERK_LIMIT_MIN = -4.9  # m/s^3, ACC faults at 5.0
 
 
 class TeslaFlags(IntFlag):


### PR DESCRIPTION
While experimenting with the Longitudinal Maneuvers Testing Tool, I noticed that the Model 3 throws an ACC fault `JERK_ISO_OUT_OF_BOUNDS` when the jerk is equal 5 and the accel is 0.
To avoid this fault, the jerk must be below 5.0 m/s³.

4.9m/s^3 Jerk: 
b5f2b5b4ef23f4b6/0000004c--a25a821a66

5.0m/s^3 Jerk (ACC Faulted):
b5f2b5b4ef23f4b6/0000004d--9567898415