### PR TITLE
[bot] Car docs: update model years from new users

### DIFF
--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -129,7 +129,7 @@ class CAR(Platforms):
     CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )
   FORD_FOCUS_MK4 = FordPlatformConfig(
-    [FordCarDocs("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS], hybrid=True)],  # mHEV only
+    [FordCarDocs("Ford Focus 2018, 2022", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS], hybrid=True)],  # mHEV only
     CarSpecs(mass=1350, wheelbase=2.7, steerRatio=15.0),
   )
   FORD_MAVERICK_MK1 = FordPlatformConfig(

--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -543,8 +543,8 @@ FW_VERSIONS = {
   },
   CAR.KIA_CEED: {
     (Ecu.fwdRadar, 0x7d0, None): [
-      b'\xf1\x00CD__ SCC F-CUP      1.00 1.02 99110-J7000         ',
       b'\xf1\x00CD__ SCC F-CUP      1.00 1.00 99110-J7500         ',
+      b'\xf1\x00CD__ SCC F-CUP      1.00 1.02 99110-J7000         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00CD  MDPS C 1.00 1.06 56310-XX000 4CDEC106',


### PR DESCRIPTION

## ✅ Updating model years from 1 dongles (1 platforms) in last 14.0 days:
<details open><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|:--------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------|:----------------------------------------|:---------------|:----------------------------------------------------|
|[e886087f430e7fe7](https://useradmin.comma.ai/?onebox=e886087f430e7fe7)<br><sub>FORD_FOCUS_MK4<br>WF0NXXGCH........</sub>|FORD  2022 🆚<br>Ford Focus 2018<br><sub>🎉 <b>New model year!</b> 🎉</sub>|1 routes,<br>26 segments<br>(0.4 hours)||- all lat active: 3<br>- no input all lat active: 2|

Dongles to re-run category: `e886087f430e7fe7`
</details>

## ⏳️ 0 dongles (0 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>

## ⚠️ 0 dongles (0 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>