### PR TITLE
Toyota: raise long gain at low speed

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -38,9 +38,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
-  kiBP = [0.]
+  kiBP = [0., 2.5]
   if CP.carFingerprint in TSS2_CAR:
-    kiV = [0.25]
+    kiV = [0.5, 0.25]
 
   else:
     kiBP = [0., 5., 35.]

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,7 +39,7 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 def get_long_tune(CP, params):
   if CP.carFingerprint in TSS2_CAR:
-    kiBP = [0., 2.5]
+    kiBP = [0., 3.]
     kiV = [0.5, 0.25]
   else:
     kiBP = [0., 5., 35.]

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -38,10 +38,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
-  kiBP = [0., 2.5]
   if CP.carFingerprint in TSS2_CAR:
+    kiBP = [0., 2.5]
     kiV = [0.5, 0.25]
-
   else:
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]


### PR DESCRIPTION
0.5 was the original gain before the new long tune, but using the estimated future aEgo makes that too high. We can get away with a higher gain at lower speeds however to more quickly compensate for the PCM's inconsistent low speed handling of accel. Closes #1510 