### PR TITLE
Toyota: unwind longitudinal integral

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -38,9 +38,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
-  kiBP = [0.]
+  kiBP = [0., 2.5]
   if CP.carFingerprint in TSS2_CAR:
-    kiV = [0.25]
+    kiV = [0.5, 0.25]
 
   else:
     kiBP = [0., 5., 35.]

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,7 +39,7 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 def get_long_tune(CP, params):
   if CP.carFingerprint in TSS2_CAR:
-    kiBP = [0., 2.5]
+    kiBP = [0., 3.]
     kiV = [0.5, 0.25]
   else:
     kiBP = [0., 5., 35.]

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,9 +39,10 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
+  kiBP = [0.]
   if CP.carFingerprint in TSS2_CAR:
-    kiBP = [0., 5.]
-    kiV = [0.25, 0.25]
+    kiV = [0.25]
+
   else:
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]
@@ -218,7 +219,6 @@ class CarController(CarControllerBase):
         self.aego.update(a_ego_blended)
         j_ego = (self.aego.x - prev_aego) / (DT_CTRL * 3)
         a_ego_future = a_ego_blended + j_ego * 0.5
-        self.debug = a_ego_future
 
         if actuators.longControlState == LongCtrlState.pid:
           # constantly slowly unwind integral to recover from large temporary errors
@@ -289,7 +289,6 @@ class CarController(CarControllerBase):
     new_actuators.steerOutputCan = apply_steer
     new_actuators.steeringAngleDeg = float(self.last_angle)
     new_actuators.accel = self.accel
-    new_actuators.debug = float(self.debug)
 
     self.frame += 1
     return new_actuators, can_sends

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -38,10 +38,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
-  kiBP = [0., 2.5]
   if CP.carFingerprint in TSS2_CAR:
+    kiBP = [0., 2.5]
     kiV = [0.5, 0.25]
-
   else:
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -22,7 +22,7 @@ VisualAlert = structs.CarControl.HUDControl.VisualAlert
 # the down limit roughly matches the rate of ACCEL_NET, reducing PCM compensation windup
 ACCEL_WINDUP_LIMIT = 4.0 * DT_CTRL * 3  # m/s^2 / frame
 ACCEL_WINDDOWN_LIMIT = -4.0 * DT_CTRL * 3  # m/s^2 / frame
-ACCEL_PID_UNWIND = 0.03  # m/s^2 / frame
+ACCEL_PID_UNWIND = 0.03 * DT_CTRL * 3  # m/s^2 / frame
 
 # LKA limits
 # EPS faults if you apply torque while the steering rate is above 100 deg/s for too long
@@ -222,7 +222,7 @@ class CarController(CarControllerBase):
 
         if actuators.longControlState == LongCtrlState.pid:
           # constantly slowly unwind integral to recover from large temporary errors
-          self.long_pid.i -= (ACCEL_PID_UNWIND * DT_CTRL * 3) * float(np.sign(self.long_pid.i))
+          self.long_pid.i -= ACCEL_PID_UNWIND * float(np.sign(self.long_pid.i))
 
           error_future = pcm_accel_cmd - a_ego_future
           pcm_accel_cmd = self.long_pid.update(error_future,


### PR DESCRIPTION
Solves issues like: https://github.com/commaai/opendbc/issues/1632 by constantly slowly unwinding integral. This helps us recover from a large momentary error, without needing to oscillate/over/undershoot to the other side to unwind.

An alternative solution to https://github.com/commaai/opendbc/pull/1651. This is more generic, as the Prius example starts undershooting at ~6 m/s, which I haven't seen happen on any of our cars here (mostly 1-2 m/s).

![image](https://github.com/user-attachments/assets/d02fb09d-bc16-4465-bd8c-a1ffd2d0fdab)