### PR TITLE
Toyota: fix acceleration discontinuity when stopping

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -220,14 +220,15 @@ class CarController(CarControllerBase):
         j_ego = (self.aego.x - prev_aego) / (DT_CTRL * 3)
         a_ego_future = a_ego_blended + j_ego * 0.5
 
-        if actuators.longControlState == LongCtrlState.pid:
+        if CC.longActive:
           # constantly slowly unwind integral to recover from large temporary errors
           self.long_pid.i -= ACCEL_PID_UNWIND * float(np.sign(self.long_pid.i))
 
           error_future = pcm_accel_cmd - a_ego_future
           pcm_accel_cmd = self.long_pid.update(error_future,
                                                speed=CS.out.vEgo,
-                                               feedforward=pcm_accel_cmd)
+                                               feedforward=pcm_accel_cmd,
+                                               freeze_integrator=actuators.longControlState != LongCtrlState.pid)
         else:
           self.long_pid.reset()
 


### PR DESCRIPTION
Regression from https://github.com/commaai/opendbc/pull/1532

Due to Toyota PCM's overzealous processing of ACC acceleration requests, the small jump that can occur when stopping can cause the brake controller to overreact and let go of the brakes entirely. This is only possible if the PID controller is applying a smaller acceleration than feedforward.

This issue at least affects hybrids, as seen in this case:

https://connect.comma.ai/d9b97c1d3b8c39b2/00000020--177f5572ab/1346/1362

![image](https://github.com/user-attachments/assets/6d334032-ec04-430c-b3df-56baccf33208)

This usually does not happen as [longcontrol.py starts with the last output accel when stopping](https://github.com/commaai/openpilot/blob/540c45bfec37266d943a1433bff82c9f88068fb5/selfdrive/controls/lib/longcontrol.py#L72), but Toyota is the only brand that has its final PID controller in carcontroller due to custom tuning/logic.