### PR TITLE
Toyota: tweak longitudinal gains

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,9 +39,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
-  kiBP = [0.]
+  kiBP = [0., 5.]
   if CP.carFingerprint in TSS2_CAR:
-    kiV = [0.25]
+    kiV = [0.5, 0.25]
 
   else:
     kiBP = [0., 5., 35.]
@@ -218,7 +218,9 @@ class CarController(CarControllerBase):
         prev_aego = self.aego.x
         self.aego.update(a_ego_blended)
         j_ego = (self.aego.x - prev_aego) / (DT_CTRL * 3)
-        a_ego_future = a_ego_blended + j_ego * 0.5
+
+        future_t = float(np.interp(CS.out.vEgo, [0., 5.], [0.25, 0.5]))
+        a_ego_future = a_ego_blended + j_ego * future_t
 
         if actuators.longControlState == LongCtrlState.pid:
           # constantly slowly unwind integral to recover from large temporary errors

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -218,7 +218,7 @@ class CarController(CarControllerBase):
         self.aego.update(a_ego_blended)
         j_ego = (self.aego.x - prev_aego) / (DT_CTRL * 3)
 
-        future_t = float(np.interp(CS.out.vEgo, [0., 5.], [0.25, 0.5]))
+        future_t = float(np.interp(CS.out.vEgo, [2., 5.], [0.25, 0.5]))
         a_ego_future = a_ego_blended + j_ego * future_t
 
         if CC.longActive:

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -39,10 +39,9 @@ MAX_LTA_DRIVER_TORQUE_ALLOWANCE = 150  # slightly above steering pressed allows 
 
 
 def get_long_tune(CP, params):
-  kiBP = [0., 5.]
   if CP.carFingerprint in TSS2_CAR:
+    kiBP = [2., 5.]
     kiV = [0.5, 0.25]
-
   else:
     kiBP = [0., 5., 35.]
     kiV = [3.6, 2.4, 1.5]


### PR DESCRIPTION
The Prius TSS2 displays much worse braking undershoot/let off when stopping compared to any of our cars here I've tested. This PR increases the gain at lower speeds to compensate for the higher PCM accel processing only displayed at low speed.

User reports and looking at the routes show improved behavior, including less instances where the car stops too close to the lead.

1d5211a9795b6ec2/0000015d--d282782d47

![image](https://github.com/user-attachments/assets/f781a04a-e820-44dd-af43-2157bd20bc23)

Closes: https://github.com/commaai/opendbc/issues/1632