### PR TITLE
[bot] Car docs: update model years from new users

### DIFF
--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -174,7 +174,7 @@ class CAR(Platforms):
     flags=HondaFlags.BOSCH_RADARLESS,
   )
   ACURA_RDX_3G = HondaBoschPlatformConfig(
-    [HondaCarDocs("Acura RDX 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
+    [HondaCarDocs("Acura RDX 2019-21", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
     CarSpecs(mass=4068 * CV.LB_TO_KG, wheelbase=2.75, steerRatio=11.95, centerToFrontRatio=0.41, tireStiffnessFactor=0.677),  # as spec
     {Bus.pt: 'acura_rdx_2020_can_generated'},
     flags=HondaFlags.BOSCH_ALT_BRAKE,

--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -174,7 +174,7 @@ class CAR(Platforms):
     flags=HondaFlags.BOSCH_RADARLESS,
   )
   ACURA_RDX_3G = HondaBoschPlatformConfig(
-    [HondaCarDocs("Acura RDX 2019-21", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
+    [HondaCarDocs("Acura RDX 2019-22", "All", min_steer_speed=3. * CV.MPH_TO_MS)],
     CarSpecs(mass=4068 * CV.LB_TO_KG, wheelbase=2.75, steerRatio=11.95, centerToFrontRatio=0.41, tireStiffnessFactor=0.677),  # as spec
     {Bus.pt: 'acura_rdx_2020_can_generated'},
     flags=HondaFlags.BOSCH_ALT_BRAKE,

--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -180,7 +180,7 @@ class CAR(Platforms):
       ToyotaCarDocs("Toyota Corolla Hybrid 2020-22"),
       ToyotaCarDocs("Toyota Corolla Hybrid (South America only) 2020-23", min_enable_speed=7.5),
       ToyotaCarDocs("Toyota Corolla Cross Hybrid (Non-US only) 2020-22", min_enable_speed=7.5),
-      ToyotaCarDocs("Lexus UX Hybrid 2019-23"),
+      ToyotaCarDocs("Lexus UX Hybrid 2019-24"),
     ],
     CarSpecs(mass=3060. * CV.LB_TO_KG, wheelbase=2.67, steerRatio=13.9, tireStiffnessFactor=0.444),
   )


### PR DESCRIPTION

## ✅ Updating model years from 2 dongles (2 platforms) in last 14.0 days:
<details open><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|:-------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------|:----------------------------------------|:---------------|:-------------------------------------------------|
|[814c3b6319db0785](https://useradmin.comma.ai/?onebox=814c3b6319db0785)<br><sub>ACURA_RDX_3G<br>5J8TC2H51........</sub>|ACURA RDX 2022 🆚<br>Acura RDX 2019-21<br><sub>🎉 <b>New model year!</b> 🎉</sub>|3 routes,<br>51 segments<br>(0.8 hours)||- valid torque params: 51<br>- all lat active: 0|
|[1d97969fec3ba24d](https://useradmin.comma.ai/?onebox=1d97969fec3ba24d)<br><sub>TOYOTA_COROLLA_TSS2<br>JTHR6JBHX........</sub>|LEXUS UX Hybrid 2024 🆚<br>Lexus UX Hybrid 2019-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>|1 routes,<br>3 segments<br>(0.1 hours)||- all lat active: 0|

Dongles to re-run category: `1d97969fec3ba24d 814c3b6319db0785`
</details>

## ⏳️ 0 dongles (0 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>

## ⚠️ 0 dongles (0 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>