### PR TITLE
Ford: fix required package docs

### DIFF
--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -121,7 +121,7 @@ class CAR(Platforms):
     CarSpecs(mass=2050, wheelbase=3.025, steerRatio=16.8),
   )
   FORD_F_150_MK14 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford F-150 2022-23", "Co-Pilot360 Active 2.0", hybrid=True, support_type=SupportType.REVIEW)],
+    [FordCarDocs("Ford F-150 2022-23", "Co-Pilot360 Assist 2.0", hybrid=True, support_type=SupportType.REVIEW)],
     CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
   FORD_F_150_LIGHTNING_MK1 = FordCANFDPlatformConfig(

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -140,7 +140,7 @@ class CAR(Platforms):
     CarSpecs(mass=1650, wheelbase=3.076, steerRatio=17.0),
   )
   FORD_MUSTANG_MACH_E_MK1 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford Mustang Mach-E 2021-23", "Co-Pilot360 Active 2.0", support_type=SupportType.REVIEW)],
+    [FordCarDocs("Ford Mustang Mach-E 2021-23", "All", support_type=SupportType.REVIEW)],
     CarSpecs(mass=2200, wheelbase=2.984, steerRatio=17.0),  # TODO: check steer ratio
   )
   FORD_RANGER_MK2 = FordCANFDPlatformConfig(

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -125,7 +125,7 @@ class CAR(Platforms):
     CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
   FORD_F_150_LIGHTNING_MK1 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford F-150 Lightning 2021-23", "Co-Pilot360 Active 2.0", support_type=SupportType.REVIEW)],
+    [FordCarDocs("Ford F-150 Lightning 2022-23", "Co-Pilot360 Assist 2.0", support_type=SupportType.REVIEW)],
     CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )
   FORD_FOCUS_MK4 = FordPlatformConfig(


### PR DESCRIPTION
Assist has ACC w/ stop and go and lane centering. 2021 Lightning doesn't exist

https://media.ford.com/content/dam/fordmedia/North%20America/US/product/2022/f-150-lightning/pdf/F-150_Lightning_Tech_Specs.pdf

https://live.dealer-asset.co/me18/product/file/EN-F-150-Brochure.pdf

![image](https://github.com/user-attachments/assets/7d7a0b0a-4134-474d-ac16-1f757e69edd3)

All Mach-E come with Assist 2.0: https://cdn.dealereprocess.org/cdn/brochures/ford/2021-mustangmache.pdf

![image](https://github.com/user-attachments/assets/6c6329b7-102b-415c-a939-f8947464c352)
