### PR TITLE
Add buttonEnable carState field

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -214,6 +214,7 @@ struct CarState {
 
   # button presses
   buttonEvents @11 :List(ButtonEvent);
+  buttonEnable @57 :Bool;  # user is requesting enable, usually one frame. set if pcmCruise=False
   leftBlinker @20 :Bool;
   rightBlinker @21 :Bool;
   genericToggle @23 :Bool;

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -35,11 +35,10 @@ class CarState(CarStateBase):
 
   def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
     """ The ECM allows enabling on falling edge of set, but only rising edge of resume """
-    if not self.CP.pcmCruise:
-      for b in buttonEvents:
-        if (b.type == ButtonType.accelCruise and b.pressed) or \
-          (b.type == ButtonType.decelCruise and not b.pressed):
-          return True
+    for b in buttonEvents:
+      if (b.type == ButtonType.accelCruise and b.pressed) or \
+        (b.type == ButtonType.decelCruise and not b.pressed):
+        return True
     return False
 
   def update(self, can_parsers) -> structs.CarState:

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -34,9 +34,9 @@ class CarState(CarStateBase):
     self.distance_button = 0
 
   def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
-    """The ECM allows enabling on falling edge of set, but only rising edge of resume"""
     if not self.CP.pcmCruise:
       for b in buttonEvents:
+        # The ECM allows enabling on falling edge of set, but only rising edge of resume
         if (b.type == ButtonType.accelCruise and b.pressed) or \
           (b.type == ButtonType.decelCruise and not b.pressed):
           return True

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -33,6 +33,15 @@ class CarState(CarStateBase):
 
     self.distance_button = 0
 
+  def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
+    """ The ECM allows enabling on falling edge of set, but only rising edge of resume """
+    if not self.CP.pcmCruise:
+      for b in buttonEvents:
+        if (b.type == ButtonType.accelCruise and b.pressed) or \
+          (b.type == ButtonType.decelCruise and not b.pressed):
+          return True
+    return False
+
   def update(self, can_parsers) -> structs.CarState:
     pt_cp = can_parsers[Bus.pt]
     cam_cp = can_parsers[Bus.cam]
@@ -148,13 +157,6 @@ class CarState(CarStateBase):
         *create_button_events(self.distance_button, prev_distance_button,
                               {1: ButtonType.gapAdjustCruise})
       ]
-
-      if not self.CP.pcmCruise:
-        # The ECM allows enabling on falling edge of set, but only rising edge of resume
-        for b in ret.buttonEvents:
-          if (b.type == ButtonType.accelCruise and b.pressed) or \
-            (b.type == ButtonType.decelCruise and not b.pressed):
-            ret.buttonEnable = True
 
     return ret
 

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -35,10 +35,11 @@ class CarState(CarStateBase):
 
   def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
     """ The ECM allows enabling on falling edge of set, but only rising edge of resume """
-    for b in buttonEvents:
-      if (b.type == ButtonType.accelCruise and b.pressed) or \
-        (b.type == ButtonType.decelCruise and not b.pressed):
-        return True
+    if not self.CP.pcmCruise:
+      for b in buttonEvents:
+        if (b.type == ButtonType.accelCruise and b.pressed) or \
+          (b.type == ButtonType.decelCruise and not b.pressed):
+          return True
     return False
 
   def update(self, can_parsers) -> structs.CarState:

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -149,6 +149,13 @@ class CarState(CarStateBase):
                               {1: ButtonType.gapAdjustCruise})
       ]
 
+      if not self.CP.pcmCruise:
+        # The ECM allows enabling on falling edge of set, but only rising edge of resume
+        for b in ret.buttonEvents:
+          if (b.type == ButtonType.accelCruise and b.pressed) or \
+            (b.type == ButtonType.decelCruise and not b.pressed):
+            ret.buttonEnable = True
+
     return ret
 
   @staticmethod

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -34,7 +34,7 @@ class CarState(CarStateBase):
     self.distance_button = 0
 
   def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
-    """ The ECM allows enabling on falling edge of set, but only rising edge of resume """
+    """The ECM allows enabling on falling edge of set, but only rising edge of resume"""
     if not self.CP.pcmCruise:
       for b in buttonEvents:
         if (b.type == ButtonType.accelCruise and b.pressed) or \

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -244,7 +244,8 @@ class CarInterfaceBase(ABC):
     if ret.cruiseState.speedCluster == 0:
       ret.cruiseState.speedCluster = ret.cruiseState.speed
 
-    ret.buttonEnable = self.CS.update_button_enable(ret.buttonEvents)
+    if not self.CP.pcmCruise:
+      ret.buttonEnable = self.CS.update_button_enable(ret.buttonEvents)
 
     # save for next iteration
     self.CS.out = ret
@@ -349,11 +350,10 @@ class CarStateBase(ABC):
     return bool(left_blinker_stalk or self.left_blinker_cnt > 0), bool(right_blinker_stalk or self.right_blinker_cnt > 0)
 
   def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
-    if not self.CP.pcmCruise:
-      for b in buttonEvents:
-        # Enable OP long on falling edge of enable buttons
-        if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
-          return True
+    for b in buttonEvents:
+      # Enable OP long on falling edge of enable buttons
+      if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
+        return True
     return False
 
   @staticmethod

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -244,8 +244,7 @@ class CarInterfaceBase(ABC):
     if ret.cruiseState.speedCluster == 0:
       ret.cruiseState.speedCluster = ret.cruiseState.speed
 
-    if not self.CP.pcmCruise:
-      ret.buttonEnable = self.CS.update_button_enable(ret.buttonEvents)
+    ret.buttonEnable = self.CS.update_button_enable(ret.buttonEvents)
 
     # save for next iteration
     self.CS.out = ret
@@ -350,10 +349,11 @@ class CarStateBase(ABC):
     return bool(left_blinker_stalk or self.left_blinker_cnt > 0), bool(right_blinker_stalk or self.right_blinker_cnt > 0)
 
   def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
-    for b in buttonEvents:
-      # Enable OP long on falling edge of enable buttons
-      if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
-        return True
+    if not self.CP.pcmCruise:
+      for b in buttonEvents:
+        # Enable OP long on falling edge of enable buttons
+        if b.type in (ButtonType.accelCruise, ButtonType.decelCruise) and not b.pressed:
+          return True
     return False
 
   @staticmethod

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -6,6 +6,8 @@ from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.volkswagen.values import DBC, CANBUS, NetworkLocation, TransmissionType, GearShifter, \
                                                       CarControllerParams, VolkswagenFlags
 
+ButtonType = structs.CarState.ButtonEvent.Type
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -17,6 +19,14 @@ class CarState(CarStateBase):
     self.esp_hold_confirmation = False
     self.upscale_lead_car_signal = False
     self.eps_stock_values = False
+
+  def update_button_enable(self, buttonEvents: list[structs.CarState.ButtonEvent]):
+    if not self.CP.pcmCruise:
+      for b in buttonEvents:
+        # Enable OP long on falling edge of enable buttons
+        if b.type in (ButtonType.setCruise, ButtonType.resumeCruise) and not b.pressed:
+          return True
+    return False
 
   def create_button_events(self, pt_cp, buttons):
     button_events = []


### PR DESCRIPTION
To remove logic that lives in openpilot now for handling the brands' various implementation of button enabling. Pt. 1 of deleting [car_specific.py](https://github.com/commaai/openpilot/blob/master/selfdrive/car/car_specific.py)