### PR TITLE
VW: Don't treat the initializing state as a fault

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -269,10 +269,10 @@ class CarState(CarStateBase):
     return ret
 
   def update_hca_state(self, hca_status):
-    # Treat INITIALIZING and FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
+    # Treat FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
     self.eps_init_complete = self.eps_init_complete or (hca_status in ("DISABLED", "READY", "ACTIVE") or self.frame > 600)
-    perm_fault = hca_status == "DISABLED" or (self.eps_init_complete and hca_status in ("INITIALIZING", "FAULT"))
+    perm_fault = hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
     temp_fault = hca_status in ("REJECTED", "PREEMPTED") or not self.eps_init_complete
     return temp_fault, perm_fault
 


### PR DESCRIPTION
In rare configurations, the EPS reverts back to INITIALIZING when auto start-stop has stopped the engine at standstill. It might be related to EPS configuration options that control whether EPS power assist is available with ignition-on but the engine not running.

Route demonstrating the problem: `ba88d39b49c5e6b8/0000000b--afe45956d1`

The other fault states give us the coverage we need.