### PR TITLE
rm panda as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
   "crcmod",
   "tqdm",
   "pycapnp",
-  "pandacan@git+https://github.com/commaai/panda.git@master",
   "setuptools",
   "pycryptodome",
 ]
@@ -48,7 +47,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--ignore=panda/ -Werror --strict-config --strict-markers --durations=10 -n auto"
+addopts = "-Werror --strict-config --strict-markers --durations=10 -n auto"
 python_files = "test_*.py"
 testpaths = [
   "opendbc"


### PR DESCRIPTION
pre-req to publishing car/ to pypi

`Can't have direct dependency: pandacan@`: https://github.com/commaai/opendbc/actions/runs/13252490998/job/36993192664