### PR TITLE
Genesis: Add FW versions for GV70 Electrified 2024

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -62,7 +62,7 @@
 |Genesis|GV70 (2.5T Trim, without HDA II) 2022-23|All|[Upstream](#upstream)|
 |Genesis|GV70 (3.5T Trim, without HDA II) 2022-23|All|[Upstream](#upstream)|
 |Genesis|GV70 Electrified (Australia Only) 2022|All|[Upstream](#upstream)|
-|Genesis|GV70 Electrified (with HDA II) 2023|Highway Driving Assist II|[Upstream](#upstream)|
+|Genesis|GV70 Electrified (with HDA II) 2023-24|Highway Driving Assist II|[Upstream](#upstream)|
 |Genesis|GV80 2023|All|[Upstream](#upstream)|
 |GMC|Sierra 1500 2020-21|Driver Alert Package II|[Upstream](#upstream)|
 |GMC|Yukon 2019-20|Adaptive Cruise Control (ACC) & LKAS|[Dashcam mode](#dashcam)|

--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1102,6 +1102,7 @@ FW_VERSIONS = {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00JK1EMFC  AT AUS RHD 1.00 1.01 99211-DS100 220125',
       b'\xf1\x00JK1EMFC  AT USA LHD 1.00 1.00 99211-IT100 220919',
+      b'\xf1\x00JK1EMFC  AT USA LHD 1.00 1.01 99211-IT100 230628',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00JKev SCC -----      1.00 1.01 99110-DS000         ',

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -543,7 +543,7 @@ class CAR(Platforms):
   GENESIS_GV70_ELECTRIFIED_1ST_GEN = HyundaiCanFDPlatformConfig(
     [
       HyundaiCarDocs("Genesis GV70 Electrified (Australia Only) 2022", "All", car_parts=CarParts.common([CarHarness.hyundai_q])),
-      HyundaiCarDocs("Genesis GV70 Electrified (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q])),
+      HyundaiCarDocs("Genesis GV70 Electrified (with HDA II) 2023-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q])),
     ],
     CarSpecs(mass=2260, wheelbase=2.87, steerRatio=17.1),
     flags=HyundaiFlags.EV,


### PR DESCRIPTION
Add firmware versions for the 2024 Genesis GV70 Electrified. Expand supported model-year range up to 2024.

Dongle ID: `d83a7170c18fb4ff`

Thanks to the community 2024 Genesis GV70 Electrified ownerjaredislate.