### PR TITLE
Tesla: quicker steering pressed logic

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -18,6 +18,7 @@ class CarController(CarControllerBase):
     can_sends = []
 
     # Disengage and allow for user override
+    # TODO: implement and use CC.cruiseControl.cancel for this
     hands_on_fault = CS.hands_on_level >= 3
     lkas_enabled = CC.latActive and not hands_on_fault
 

--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -1,10 +1,11 @@
 import copy
+import numpy as np
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
 from opendbc.car import Bus, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.interfaces import CarStateBase
-from opendbc.car.tesla.values import DBC, CANBUS, GEAR_MAP
+from opendbc.car.tesla.values import DBC, CANBUS, GEAR_MAP, STEER_THRESHOLD
 
 ButtonType = structs.CarState.ButtonEvent.Type
 
@@ -15,6 +16,13 @@ class CarState(CarStateBase):
 
     self.hands_on_level = 0
     self.das_control = None
+
+  def update_steering_pressed(self, steering_pressed, steering_pressed_min_count):
+    """Applies filtering on steering pressed for noisy driver torque signals."""
+    # TODO: this differs from the base implementation by resetting the counter to 0 immediately, unify this
+    self.steering_pressed_cnt = self.steering_pressed_cnt + 1 if steering_pressed else 0
+    self.steering_pressed_cnt = float(np.clip(self.steering_pressed_cnt, 0, steering_pressed_min_count * 2))
+    return self.steering_pressed_cnt > steering_pressed_min_count
 
   def update(self, can_parsers) -> structs.CarState:
     cp_party = can_parsers[Bus.party]
@@ -41,7 +49,9 @@ class CarState(CarStateBase):
     ret.steeringRateDeg = -cp_ap_party.vl["SCCM_steeringAngleSensor"]["SCCM_steeringAngleSpeed"]
     ret.steeringTorque = -epas_status["EPAS3S_torsionBarTorque"]
 
-    ret.steeringPressed = self.hands_on_level > 0
+    # This matches stock logic, but with halved minimum frames (0.25-0.3s)
+    ret.steeringPressed = self.update_steering_pressed(abs(ret.steeringTorque) > STEER_THRESHOLD, 15)
+
     eac_status = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacStatus"].get(int(epas_status["EPAS3S_eacStatus"]), None)
     ret.steerFaultPermanent = eac_status == "EAC_FAULT"
     ret.steerFaultTemporary = eac_status == "EAC_INHIBITED"

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -76,3 +76,5 @@ class TeslaFlags(IntFlag):
 
 
 DBC = CAR.create_dbc_map()
+
+STEER_THRESHOLD = 0.5


### PR DESCRIPTION
The stock signal sets the hands on level to 1 when the torque is above 0.5 for at least around 0.25s to 0.3s, then resets it to 0 the frame that the torque drops below 0.5 again. This matches that but with a quicker activation time. Tested and lane changes felt more responsive and less likely to disengage the system.

Tested stock limits here: https://connect.comma.ai/2c912ca5de3b1ee9/00000036--8e3c857ddb/1463/1764

![image](https://github.com/user-attachments/assets/3eaff218-e8fd-46c5-b7da-59322d8f6a2e)

![image](https://github.com/user-attachments/assets/6b5707b8-d924-430c-a6a5-4e3b1b7ee43e)