### PR TITLE
Tesla: lower steering actuator delay

### DIFF
--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -16,7 +16,7 @@ class CarInterface(CarInterfaceBase):
     #ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.tesla)]
 
     ret.steerLimitTimer = 1.0
-    ret.steerActuatorDelay = 0.25
+    ret.steerActuatorDelay = 0.1
 
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.radarUnavailable = True


### PR DESCRIPTION
The delay is much lower than the 0.45 we are using, causing jittery extrapolations

![image](https://github.com/user-attachments/assets/f0fff207-c224-429e-9ef7-bb6f81753a1d)
