### PR TITLE
FW query: sort brands by percentage of ECU matches

### DIFF
--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -213,6 +213,41 @@ def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, set[Ad
 
   brand_addrs = {brand: {(addr, subaddr) for _, addr, subaddr in config.get_all_ecus(VERSIONS[brand])} for
                  brand, config in FW_QUERY_CONFIGS.items()}
+  print('brand_addrs', brand_addrs)
+  brand_matches: dict[str, set[AddrType]] = {brand: set() for brand, _, _ in REQUESTS}
+
+  brand_rx_offsets = {(brand, r.rx_offset) for brand, _, r in REQUESTS}
+  for addr, sub_addr, _ in ecu_rx_addrs:
+    # Since we can't know what request an ecu responded to, add matches for all possible rx offsets
+    for brand, rx_offset in brand_rx_offsets:
+      a = (uds.get_rx_addr_for_tx_addr(addr, -rx_offset), sub_addr)
+      if a in brand_addrs[brand]:
+        brand_matches[brand].add(a)
+
+  return brand_matches
+
+
+def get_brand_ecu_matches_new(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, set[AddrType]]:
+  """Returns dictionary of brands and matches with ECUs in their FW versions"""
+
+  brand_matches: dict[str, set[AddrType]] = {brand: [] for brand, _, _ in REQUESTS}
+
+  # brand, ecu -> addr, subaddr
+  brand_addrs = {(brand, ecu): (addr, subaddr) for brand, config in FW_QUERY_CONFIGS.items() for
+                 ecu, addr, subaddr in config.get_all_ecus(VERSIONS[brand])}
+
+  for brand, _, r in REQUESTS:
+    print(brand, r)
+    print([brand_addrs[(brand, ecu)] for ecu in r.whitelist_ecus])
+
+
+
+  return brand_matches
+
+
+  brand_addrs = {brand: {(addr, subaddr) for _, addr, subaddr in config.get_all_ecus(VERSIONS[brand])} for
+                 brand, config in FW_QUERY_CONFIGS.items()}
+  print('brand_addrs', brand_addrs)
   brand_matches: dict[str, set[AddrType]] = {brand: set() for brand, _, _ in REQUESTS}
 
   brand_rx_offsets = {(brand, r.rx_offset) for brand, _, r in REQUESTS}

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -252,7 +252,9 @@ def get_fw_versions_ordered(can_recv: CanRecvCallable, can_send: CanSendCallable
   all_car_fw = []
   brand_matches = get_brand_ecu_matches(ecu_rx_addrs)
 
-  for brand in sorted(brand_matches, key=lambda b: len(brand_matches[b]), reverse=True):
+  # Sort brands by number of matching ECUs first, then percentage of matching ECUs in the database
+  # This allows brands with only one ECU to be queried first (e.g. Tesla)
+  for brand in sorted(brand_matches, key=lambda b: (brand_matches[b].count(True), brand_matches[b].count(True) / len(brand_matches[b])), reverse=True):
     # Skip this brand if there are no matching present ECUs
     if not len(brand_matches[brand]):
       continue

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -207,25 +207,7 @@ def get_present_ecus(can_recv: CanRecvCallable, can_send: CanSendCallable, set_o
   return ecu_responses
 
 
-def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, set[AddrType]]:
-  """Returns dictionary of brands and matches with ECUs in their FW versions"""
-
-  brand_addrs = {brand: {(addr, subaddr) for _, addr, subaddr in config.get_all_ecus(VERSIONS[brand])} for
-                 brand, config in FW_QUERY_CONFIGS.items()}
-  brand_matches: dict[str, set[AddrType]] = {brand: set() for brand, _, _ in REQUESTS}
-
-  brand_rx_offsets = {(brand, r.rx_offset) for brand, _, r in REQUESTS}
-  for addr, sub_addr, _ in ecu_rx_addrs:
-    # Since we can't know what request an ecu responded to, add matches for all possible rx offsets
-    for brand, rx_offset in brand_rx_offsets:
-      a = (uds.get_rx_addr_for_tx_addr(addr, -rx_offset), sub_addr)
-      if a in brand_addrs[brand]:
-        brand_matches[brand].add(a)
-
-  return brand_matches
-
-
-def get_brand_ecu_matches_new(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, list[bool]]:
+def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, list[bool]]:
   """Returns dictionary of brands and matches with ECUs in their FW versions"""
 
   brand_matches = {brand: [] for brand, _, _ in REQUESTS}

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -210,9 +210,10 @@ def get_present_ecus(can_recv: CanRecvCallable, can_send: CanSendCallable, set_o
 def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, list[bool]]:
   """Returns dictionary of brands and matches with ECUs in their FW versions"""
 
+  brand_rx_addrs = {brand: set() for brand in FW_QUERY_CONFIGS}
   brand_matches = {brand: [] for brand, _, _ in REQUESTS}
 
-  brand_rx_addrs = {brand: set() for brand in FW_QUERY_CONFIGS}
+  # Since we can't know what request an ecu responded to, check all possible rx addresses
   for brand, config, r in REQUESTS:
     for ecu in config.get_all_ecus(VERSIONS[brand]):
       if len(r.whitelist_ecus) == 0 or ecu[0] in r.whitelist_ecus:
@@ -221,7 +222,6 @@ def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, list[b
   for brand, addrs in brand_rx_addrs.items():
     for addr in addrs:
       # TODO: check bus from request as well
-      print('checking', addr, ecu_rx_addrs, [addr[:2] for addr in ecu_rx_addrs])
       brand_matches[brand].append(addr in [addr[:2] for addr in ecu_rx_addrs])
 
   return brand_matches

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -210,14 +210,9 @@ def get_present_ecus(can_recv: CanRecvCallable, can_send: CanSendCallable, set_o
 def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, list[bool]]:
   """Returns dictionary of brands and matches with ECUs in their FW versions"""
 
-  brand_rx_addrs = {brand: set() for brand in FW_QUERY_CONFIGS}
   brand_matches = {brand: [] for brand, _, _ in REQUESTS}
-
-  # Since we can't know what request an ecu responded to, check all possible rx addresses
-  for brand, config, r in REQUESTS:
-    for ecu in config.get_all_ecus(VERSIONS[brand]):
-      if len(r.whitelist_ecus) == 0 or ecu[0] in r.whitelist_ecus:
-        brand_rx_addrs[brand].add((uds.get_rx_addr_for_tx_addr(ecu[1], r.rx_offset), ecu[2]))
+  brand_rx_addrs = {brand: {(uds.get_rx_addr_for_tx_addr(ecu[1], r.rx_offset), ecu[2]) for ecu in config.get_all_ecus(VERSIONS[brand]) if
+                            len(r.whitelist_ecus) == 0 or ecu[0] in r.whitelist_ecus} for brand, config, r in REQUESTS}
 
   for brand, addrs in brand_rx_addrs.items():
     for addr in addrs:

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -213,7 +213,7 @@ def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, list[b
   brand_rx_addrs = {brand: set() for brand in FW_QUERY_CONFIGS}
   brand_matches = {brand: [] for brand, _, _ in REQUESTS}
 
-  # Since we can't know what request an ecu responded to, check all possible rx addresses
+  # Since we can't know what request an ecu responded to, add matches for all possible rx offsets
   for brand, config, r in REQUESTS:
     for ecu in config.get_all_ecus(VERSIONS[brand]):
       if len(r.whitelist_ecus) == 0 or ecu[0] in r.whitelist_ecus:

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -212,7 +212,6 @@ def get_brand_ecu_matches(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, set[Ad
 
   brand_addrs = {brand: {(addr, subaddr) for _, addr, subaddr in config.get_all_ecus(VERSIONS[brand])} for
                  brand, config in FW_QUERY_CONFIGS.items()}
-  print('brand_addrs', brand_addrs)
   brand_matches: dict[str, set[AddrType]] = {brand: set() for brand, _, _ in REQUESTS}
 
   brand_rx_offsets = {(brand, r.rx_offset) for brand, _, r in REQUESTS}
@@ -231,13 +230,11 @@ def get_brand_ecu_matches_new(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, li
 
   brand_matches = {brand: [] for brand, _, _ in REQUESTS}
 
-  # brand, ecu -> addr, subaddr
   brand_rx_addrs = {brand: set() for brand in FW_QUERY_CONFIGS}
   for brand, config, r in REQUESTS:
     for ecu in config.get_all_ecus(VERSIONS[brand]):
       if len(r.whitelist_ecus) == 0 or ecu[0] in r.whitelist_ecus:
         brand_rx_addrs[brand].add((uds.get_rx_addr_for_tx_addr(ecu[1], r.rx_offset), ecu[2]))
-  print('brand_rx_addrs', brand_rx_addrs)
 
   for brand, addrs in brand_rx_addrs.items():
     for addr in addrs:
@@ -245,28 +242,7 @@ def get_brand_ecu_matches_new(ecu_rx_addrs: set[EcuAddrBusType]) -> dict[str, li
       print('checking', addr, ecu_rx_addrs, [addr[:2] for addr in ecu_rx_addrs])
       brand_matches[brand].append(addr in [addr[:2] for addr in ecu_rx_addrs])
 
-  # for brand, _, r in REQUESTS:
-  #   print(brand, r)
-  #   print([brand_addrs[(brand, ecu)] for ecu in r.whitelist_ecus])
-  #   print()
-
   return brand_matches
-
-
-  # brand_addrs = {brand: {(addr, subaddr) for _, addr, subaddr in config.get_all_ecus(VERSIONS[brand])} for
-  #                brand, config in FW_QUERY_CONFIGS.items()}
-  # print('brand_addrs', brand_addrs)
-  # brand_matches: dict[str, set[AddrType]] = {brand: set() for brand, _, _ in REQUESTS}
-  #
-  # brand_rx_offsets = {(brand, r.rx_offset) for brand, _, r in REQUESTS}
-  # for addr, sub_addr, _ in ecu_rx_addrs:
-  #   # Since we can't know what request an ecu responded to, add matches for all possible rx offsets
-  #   for brand, rx_offset in brand_rx_offsets:
-  #     a = (uds.get_rx_addr_for_tx_addr(addr, -rx_offset), sub_addr)
-  #     if a in brand_addrs[brand]:
-  #       brand_matches[brand].add(a)
-  #
-  # return brand_matches
 
 
 def get_fw_versions_ordered(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multiplexing: ObdCallback, vin: str,

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -179,12 +179,14 @@ class TestFwFingerprint:
         assert request_ecu in {e for e, _, _ in version_ecus}, f"Ecu.{ECU_NAME[request_ecu]} not in {brand} FW versions"
 
   def test_brand_ecu_matches(self):
-    empty_response = {brand: set() for brand, config in FW_QUERY_CONFIGS.items() if len(config.requests)}
-    assert get_brand_ecu_matches(set()) == empty_response
+    brand_matches = get_brand_ecu_matches(set())
+    assert len(brand_matches) > 0
+    assert all(len(e) and not any(e) for e in brand_matches.values())
 
     # we ignore bus
-    expected_response = empty_response | {'toyota': {(0x750, 0xf)}}
-    assert get_brand_ecu_matches({(0x758, 0xf, 99)}) == expected_response
+    brand_matches = get_brand_ecu_matches({(0x758, 0xf, 99)})
+    assert True in brand_matches['toyota']
+    assert not any([any(e) for b, e in brand_matches.items() if b != 'toyota'])
 
 
 class TestFwFingerprintTiming:

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -186,7 +186,7 @@ class TestFwFingerprint:
     # we ignore bus
     brand_matches = get_brand_ecu_matches({(0x758, 0xf, 99)})
     assert True in brand_matches['toyota']
-    assert not any([any(e) for b, e in brand_matches.items() if b != 'toyota'])
+    assert not any(any(e) for b, e in brand_matches.items() if b != 'toyota')
 
 
 class TestFwFingerprintTiming:


### PR DESCRIPTION
Tesla only has one ECU we can query at the moment (EPS), and it also matches several other brands so they are tried first by accident, slowing down FW querying:

```
{'body': set(), 'chrysler': set(), 'ford': {(1840, None)}, 'gm': set(), 'honda': set(), 'hyundai': {(1840, None)}, 'mazda': {(1840, None)}, 'nissan': set(), 'subaru': set(), 'tesla': {(1840, None)}, 'toyota': set(), 'volkswagen': set()}
# Sorted: ['ford', 'hyundai', 'mazda', 'tesla', 'body', 'chrysler', 'gm', 'honda', 'nissan', 'subaru', 'toyota', 'volkswagen']
```