### PR TITLE
Tesla: remove old fault prevention code

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -28,8 +28,8 @@ class CarController(CarControllerBase):
         # Angular rate limit based on speed
         apply_angle = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgo, CarControllerParams)
 
-        # To not fault the EPS
-        apply_angle = float(np.clip(apply_angle, CS.out.steeringAngleDeg - 20, CS.out.steeringAngleDeg + 20))
+        # # To not fault the EPS
+        # apply_angle = float(np.clip(apply_angle, CS.out.steeringAngleDeg - 40, CS.out.steeringAngleDeg + 40))
       else:
         apply_angle = CS.out.steeringAngleDeg
 

--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -28,8 +28,8 @@ class CarController(CarControllerBase):
         # Angular rate limit based on speed
         apply_angle = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgo, CarControllerParams)
 
-        # # To not fault the EPS
-        # apply_angle = float(np.clip(apply_angle, CS.out.steeringAngleDeg - 40, CS.out.steeringAngleDeg + 40))
+        # FSD has been seen with deltas up to ~40
+        apply_angle = float(np.clip(apply_angle, CS.out.steeringAngleDeg - 40, CS.out.steeringAngleDeg + 40))
       else:
         apply_angle = CS.out.steeringAngleDeg
 


### PR DESCRIPTION
Unclear if this does anything on newer cars. FSD is seen at 35+, and during high curvature rate turns, this effectively limits the rate much lower than intended.

https://connect.comma.ai/2c912ca5de3b1ee9/00000061--464f9c85c3

![image](https://github.com/user-attachments/assets/d8c3ca60-2340-44a6-bf2a-f90f43cb4ba5)

See the up and down limits are effectively the same because of this:

![image](https://github.com/user-attachments/assets/d8c852c6-9118-4c11-a34e-eb39b3652eec)