### PR TITLE
Ford: pull F150 Lightning out of dashcam

### DIFF
--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -21,9 +21,6 @@ class CarInterface(CarInterfaceBase):
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "ford"
 
-    # see https://github.com/commaai/openpilot/issues/30302
-    ret.dashcamOnly = candidate == CAR.FORD_F_150_LIGHTNING_MK1
-
     ret.radarUnavailable = Bus.radar not in DBC[candidate]
     ret.steerControlType = structs.CarParams.SteerControlType.angle
     ret.steerActuatorDelay = 0.2

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -2,7 +2,7 @@ import numpy as np
 from opendbc.car import Bus, get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.ford.fordcan import CanBus
-from opendbc.car.ford.values import CAR, CarControllerParams, DBC, Ecu, FordFlags, RADAR, FordSafetyFlags
+from opendbc.car.ford.values import CarControllerParams, DBC, Ecu, FordFlags, RADAR, FordSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 
 TransmissionType = structs.CarParams.TransmissionType

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -106,15 +106,12 @@ class FordCANFDPlatformConfig(FordPlatformConfig):
     self.flags |= FordFlags.CANFD
 
 @dataclass
-class FordF150LightningPlatform(FordPlatformConfig):
-  dbc_dict: DbcDict = field(default_factory=lambda: {
-    Bus.pt: 'ford_lincoln_base_pt',
-  })
-
+class FordF150LightningPlatform(FordCANFDPlatformConfig):
   def init(self):
+    super().init()
+
     # Don't show in docs until this issue is resolved. See https://github.com/commaai/openpilot/issues/30302
     self.car_docs = []
-    self.flags |= FordFlags.CANFD
 
 
 class CAR(Platforms):

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -105,6 +105,17 @@ class FordCANFDPlatformConfig(FordPlatformConfig):
     super().init()
     self.flags |= FordFlags.CANFD
 
+@dataclass
+class FordF150LightningPlatform(FordPlatformConfig):
+  dbc_dict: DbcDict = field(default_factory=lambda: {
+    Bus.pt: 'ford_lincoln_base_pt',
+  })
+
+  def init(self):
+    # Don't show in docs until this issue is resolved. See https://github.com/commaai/openpilot/issues/30302
+    self.car_docs = []
+    self.flags |= FordFlags.CANFD
+
 
 class CAR(Platforms):
   FORD_BRONCO_SPORT_MK1 = FordPlatformConfig(
@@ -129,7 +140,7 @@ class CAR(Platforms):
     [FordCarDocs("Ford F-150 2022-23", "Co-Pilot360 Assist 2.0", hybrid=True, support_type=SupportType.REVIEW)],
     CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
-  FORD_F_150_LIGHTNING_MK1 = FordCANFDPlatformConfig(
+  FORD_F_150_LIGHTNING_MK1 = FordF150LightningPlatform(
     [FordCarDocs("Ford F-150 Lightning 2022-23", "Co-Pilot360 Assist 2.0", support_type=SupportType.REVIEW)],
     CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )


### PR DESCRIPTION
There's an issue preventing F150 Lightning from having a smooth install. A custom, extended harness is required or another solution needs to be identified.

See: https://github.com/commaai/openpilot/issues/30302