### PR TITLE
Ford: expand F-150 model year to include 2021

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -36,8 +36,8 @@
 |Ford|Escape Plug-in Hybrid 2020-22|Co-Pilot360 Assist+|[Upstream](#upstream)|
 |Ford|Explorer 2020-24|Co-Pilot360 Assist+|[Upstream](#upstream)|
 |Ford|Explorer Hybrid 2020-24|Co-Pilot360 Assist+|[Upstream](#upstream)|
-|Ford|F-150 2022-23|Co-Pilot360 Assist 2.0|[Under review](#upstream)|
-|Ford|F-150 Hybrid 2022-23|Co-Pilot360 Assist 2.0|[Under review](#upstream)|
+|Ford|F-150 2021-23|Co-Pilot360 Assist 2.0|[Under review](#upstream)|
+|Ford|F-150 Hybrid 2021-23|Co-Pilot360 Assist 2.0|[Under review](#upstream)|
 |Ford|Focus 2018|Adaptive Cruise Control with Lane Centering|[Upstream](#upstream)|
 |Ford|Focus Hybrid 2018|Adaptive Cruise Control with Lane Centering|[Upstream](#upstream)|
 |Ford|Kuga 2020-22|Adaptive Cruise Control with Lane Centering|[Upstream](#upstream)|

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -134,7 +134,7 @@ class CAR(Platforms):
     CarSpecs(mass=2050, wheelbase=3.025, steerRatio=16.8),
   )
   FORD_F_150_MK14 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford F-150 2022-23", "Co-Pilot360 Assist 2.0", hybrid=True, support_type=SupportType.REVIEW)],
+    [FordCarDocs("Ford F-150 2021-23", "Co-Pilot360 Assist 2.0", hybrid=True, support_type=SupportType.REVIEW)],
     CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
   FORD_F_150_LIGHTNING_MK1 = FordF150LightningPlatform(


### PR DESCRIPTION
Route: `05dafe69b25c52d8/00000001--25b7fa8377`