### PR TITLE
Ford: add F-150 Lightning 2022 FW

### DIFF
--- a/opendbc/car/ford/fingerprints.py
+++ b/opendbc/car/ford/fingerprints.py
@@ -99,13 +99,14 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x706, None): [
       b'ML3T-14H102-ABT\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+      b'RJ6T-14H102-ACJ\x00\x00\x00\x00\x00\x00\x00\x00\x00',
       b'RJ6T-14H102-BBC\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.fwdRadar, 0x764, None): [
       b'ML3T-14D049-AL\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.eps, 0x730, None): [
-      b'RL38-14D003-AA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+      b'RL38-14D003-AA\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
     ],
   },
   CAR.FORD_MUSTANG_MACH_E_MK1: {


### PR DESCRIPTION
Note: route is missing EPS fw...

Route: `0b2c0bec9a28eb0f/00000000--d6637dad8d`
Second route: `0b2c0bec9a28eb0f/00000001--c766afec05` (eps still missing)