### PR TITLE
VW MQB: Change source of gear position signal

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -88,7 +88,7 @@ class CarState(CarStateBase):
 
     # Update gear and/or clutch position data.
     if self.CP.transmissionType == TransmissionType.automatic:
-      ret.gearShifter = self.parse_gear_shifter(self.CCP.shifter_values.get(pt_cp.vl["Getriebe_11"]["GE_Fahrstufe"], None))
+      ret.gearShifter = self.parse_gear_shifter(self.CCP.shifter_values.get(pt_cp.vl["Gateway_73"]["GE_Fahrstufe"], None))
     elif self.CP.transmissionType == TransmissionType.direct:
       ret.gearShifter = self.parse_gear_shifter(self.CCP.shifter_values.get(pt_cp.vl["Motor_EV_01"]["MO_Waehlpos"], None))
     elif self.CP.transmissionType == TransmissionType.manual:
@@ -292,6 +292,7 @@ class CarState(CarStateBase):
       ("TSK_06", 50),       # From J623 Engine control module
       ("ESP_02", 50),       # From J104 ABS/ESP controller
       ("GRA_ACC_01", 33),   # From J533 CAN gateway (via LIN from steering wheel controls)
+      ("Gateway_73", 20),   # From J533 CAN gateway (aggregated data)
       ("Gateway_72", 10),   # From J533 CAN gateway (aggregated data)
       ("Motor_14", 10),     # From J623 Engine control module
       ("Airbag_02", 5),     # From J234 Airbag control module
@@ -300,9 +301,7 @@ class CarState(CarStateBase):
       ("Kombi_03", 0),      # From J285 instrument cluster (not present on older cars, 1Hz when present)
     ]
 
-    if CP.transmissionType == TransmissionType.automatic:
-      pt_messages.append(("Getriebe_11", 20))  # From J743 Auto transmission control module
-    elif CP.transmissionType == TransmissionType.direct:
+    if CP.transmissionType == TransmissionType.direct:
       pt_messages.append(("Motor_EV_01", 10))  # From J??? unknown EV control module
 
     if CP.networkLocation == NetworkLocation.fwdCamera:

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -80,7 +80,7 @@ class CarControllerParams:
       self.STEER_DELTA_DOWN = 10          # Min HCA reached in 0.60s (STEER_MAX / (50Hz * 0.60))
 
       if CP.transmissionType == TransmissionType.automatic:
-        self.shifter_values = can_define.dv["Getriebe_11"]["GE_Fahrstufe"]
+        self.shifter_values = can_define.dv["Gateway_73"]["GE_Fahrstufe"]
       elif CP.transmissionType == TransmissionType.direct:
         self.shifter_values = can_define.dv["Motor_EV_01"]["MO_Waehlpos"]
       self.hca_status_values = can_define.dv["LH_EPS_03"]["EPS_HCA_Status"]

--- a/opendbc/dbc/vw_meb.dbc
+++ b/opendbc/dbc/vw_meb.dbc
@@ -1281,7 +1281,10 @@ BO_ 987 Gateway_72: 8 Gateway_MQB
  SG_ BCM1_Aussen_Temp_ungef : 56|8@1+ (0.5,-50) [-50|76] "Unit_DegreCelsi" Getriebe_DQ_Hybrid_MQB,Getriebe_DQ_MQB,Motor_Diesel_MQB,Motor_Hybrid_MQB,Motor_Otto_MQB
 
 BO_ 988 Gateway_73: 8 XXX
+ SG_ UNKNOWN_1 : 15|2@0+ (1,0) [0|3] "" XXX
+ SG_ GE_Fahrstufe : 40|4@1+ (1,0) [0|15] "" XXX
  SG_ EPB_Status : 53|3@1+ (1,0) [0|7] "" XXX
+ SG_ UNKNOWN_2 : 58|3@0+ (1,0) [0|7] "" XXX
 
 BO_ 997 TSG_FT_02: 8 Gateway
  SG_ TSG_FT_02_CRC : 0|8@1+ (1,0) [0|255] "" Vector__XXX
@@ -2828,6 +2831,7 @@ VAL_ 982 LH_Bremsl_mi_def 0 "OK" 1 "defekt";
 VAL_ 982 LH_Bremsl_li_ges_def 0 "OK" 1 "Alle Bremslichter hinten links defekt";
 VAL_ 982 LH_Bremsl_re_ges_def 0 "OK" 1 "Alle Bremslichter hinten rechts defekt";
 VAL_ 988 EPB_Status 0 "offen" 1 "geschlossen_Parken" 2 "teilgespannt_Halten" 3 "im_Lauf_oeffnen" 4 "im_Lauf_schliessen" 5 "tbd" 6 "Init" 7 "unbekannt";
+VAL_ 988 GE_Fahrstufe 0 "Zwischenstellung" 1 "Init" 5 "P" 6 "R" 7 "N" 8 "D" 9 "D" 10 "E" 13 "T" 14 "T" 15 "Fehler";
 VAL_ 997 FT_Tuer_Status 0 "Init" 1 "Tuer_geschlossen" 2 "Tuer_offen" 3 "Fehler";
 VAL_ 997 FT_Tuer_Status_QBit 0 "Status_Tuerkontakt_sicher" 1 "Status_Tuerkontakt_unsicher";
 VAL_ 997 FT_Lock_Taster_02 0 "nicht_betaetigt" 1 "betaetigt";

--- a/opendbc/dbc/vw_mqb_2010.dbc
+++ b/opendbc/dbc/vw_mqb_2010.dbc
@@ -1761,6 +1761,8 @@ VAL_ 681 AWV_Warnlevel 0 "keine_Gefaehrdung" 63 "max_Gefaehrdung" ;
 VAL_ 391 MO_Waehlpos 2 "P" 3 "R" 4 "N" 5 "D" 6 "D" ;
 VAL_ 391 EV_Rekuperationsstufe 0 "default" 1 "B1" 2 "B2" 3 "B3" ;
 VAL_ 870 Fast_Send_Rate_Active 0 "1 Hz" 1 "50 Hz" ;
+VAL_ 988 EPB_Status 0 "offen" 1 "geschlossen_Parken" 2 "teilgespannt_Halten" 3 "im_Lauf_oeffnen" 4 "im_Lauf_schliessen" 5 "tbd" 6 "Init" 7 "unbekannt";
+VAL_ 988 GE_Fahrstufe 0 "Zwischenstellung" 1 "Init" 5 "P" 6 "R" 7 "N" 8 "D" 9 "D" 10 "E" 13 "T" 14 "T" 15 "Fehler";
 VAL_ 1720 KBI_Variante_USA 0 "keine USA-Variante" 1 "USA-Variante" ;
 VAL_ 1720 KBI_Variante 0 "Zeiger Kombiinstrument" 1 "Volldisplay Kombiinstrument" ;
 VAL_ 1720 KBI_BCmE_aktiv 0 "Anzeige_nicht_aktiv" 1 "Anzeige_aktiv" ;

--- a/opendbc/dbc/vw_mqb_2010.dbc
+++ b/opendbc/dbc/vw_mqb_2010.dbc
@@ -1491,6 +1491,10 @@ BO_ 1123 PSD_05: 8 XXX
 BO_ 1124 PSD_06: 8 XXX
 
 BO_ 988 Gateway_73: 8 XXX
+ SG_ UNKNOWN_1 : 15|2@0+ (1,0) [0|3] "" XXX
+ SG_ GE_Fahrstufe : 40|4@1+ (1,0) [0|15] "" XXX
+ SG_ EPB_Status : 53|3@1+ (1,0) [0|7] "" XXX
+ SG_ UNKNOWN_2 : 58|3@0+ (1,0) [0|7] "" XXX
 
 BO_ 792 Kamera_Status: 8 XXX
 


### PR DESCRIPTION
Switch from reading the transmission message directly, to an aggregate/proxy message from the CAN gateway. This allows the exact same gear-position handling for MQB, MQBevo, and MEB.

We still have to detect presence of Getriebe_11 as part of MQB startup, this is deliberate. I was hoping we could get rid of the special-case for e-Golf, but sadly the proxy message doesn't translate that for us.

**Verification**

* Validated behavior against the comma car segments dataset
* `pytest selfdrive/car`
* `selfdrive/test/process_replay/test_processes.py`

@sshane When openpilot bumps opendbc, this will produce a tiny process_replay diff for gear position, just due to timing. We get Getriebe_11 at 100Hz and Gateway_73 is 20Hz.

```
***** results for segment regenED976DEB757|2024-08-30--03-18-02--0 *****
    card
        ....
        carState.gearShifter: 1
```

```
Analyzing segment 12d6ae3057c04b0d/2021-09-04--21-21-21/0/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 7d76baac7cf42e15/2024-01-13--03-42-46/3/s    for SKODA KAROQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 12d6ae3057c04b0d/2021-09-04--21-21-21/2/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 12d6ae3057c04b0d/2021-09-04--21-21-21/1/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 7d76baac7cf42e15/2024-01-13--03-42-46/2/s    for SKODA KAROQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 8a5da7c1d1783730/2024-01-16--13-55-19/39/s   for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2ca49a03c8084514/2023-12-12--18-09-13/2/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2ca49a03c8084514/2023-08-04--07-24-41/13/s   for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2ca49a03c8084514/2023-12-31--17-35-56/27/s   for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 8a5da7c1d1783730/2023-11-13--06-57-54/5/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment dd154b34dc4d8c52/2023-11-25--21-40-41/135/s  for VOLKSWAGEN GOLF 7TH GEN
  Gateway_73      gear_pos=1.0
Analyzing segment 1f032f5173c8ad99/2023-12-29--18-51-29/17/s   for VOLKSWAGEN GOLF 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 1f032f5173c8ad99/2023-12-20--10-28-41/13/s   for VOLKSWAGEN GOLF 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment dd407d074aa10036/2024-01-22--09-14-45/5/s    for VOLKSWAGEN GOLF 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment e4221d4d60b6d43e/2024-01-12--18-44-43/39/s   for VOLKSWAGEN GOLF 7TH GEN
  Gateway_73      gear_pos=1.0
  Motor_EV_01     gear_pos=6.0
Analyzing segment b08418a961021457/2023-11-09--11-47-17/6/s    for VOLKSWAGEN TIGUAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 4aadfdcf6846d356/2024-01-10--20-45-06/5/s    for VOLKSWAGEN TIGUAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 07ddd23c582b8e2a/2023-12-08--16-53-49/14/s   for VOLKSWAGEN TIGUAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 4aadfdcf6846d356/2024-01-06--20-07-47/6/s    for VOLKSWAGEN TIGUAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 1b5cf3b409037cc4/2023-12-11--10-23-35/30/s   for VOLKSWAGEN TIGUAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 5ac586afbb236b5d/2024-01-10--22-23-18/15/s   for VOLKSWAGEN ARTEON 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 5ac586afbb236b5d/2024-01-20--16-32-00/13/s   for VOLKSWAGEN ARTEON 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0662797832aac2eb/2023-11-17--19-03-33/158/s  for VOLKSWAGEN ARTEON 1ST GEN
  Getriebe_11     gear_pos=10.0
  Gateway_73      gear_pos=10.0
Analyzing segment 5ac586afbb236b5d/2023-11-08--08-55-08/6/s    for VOLKSWAGEN ARTEON 1ST GEN
  Getriebe_11     gear_pos=9.0
  Gateway_73      gear_pos=9.0
Analyzing segment 5ac586afbb236b5d/2023-11-16--17-51-52/4/s    for VOLKSWAGEN ARTEON 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment fd81eb7cc97ce831/2023-11-09--08-49-52/4/s    for VOLKSWAGEN PASSAT 8TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2d7d87433a67c925/2024-01-11--19-25-35/29/s   for VOLKSWAGEN PASSAT 8TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 40443218782e5709/2023-12-25--07-48-17/16/s   for VOLKSWAGEN PASSAT 8TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2d7d87433a67c925/2024-01-10--20-03-47/27/s   for VOLKSWAGEN PASSAT 8TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 5405cac0c9d58c3d/2023-11-02--08-38-34/1/s    for VOLKSWAGEN PASSAT 8TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 98a3015c4f16846d/2023-11-08--19-23-02/11/s   for AUDI Q3 2ND GEN
  Getriebe_11     gear_pos=9.0
  Gateway_73      gear_pos=9.0
Analyzing segment cdc1627feb1c82d3/2023-11-28--06-53-26/24/s   for AUDI Q3 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment cdc1627feb1c82d3/2024-01-03--15-27-49/4/s    for AUDI Q3 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment bb3faa76dcaea9b1/2023-12-21--07-22-58/2/s    for AUDI Q3 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 839125529d3c3cdf/2023-11-29--15-49-50/56/s   for AUDI Q3 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 7d82b2f3a9115f1f/2021-10-21--15-39-42/2/s    for VOLKSWAGEN TAOS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 7d82b2f3a9115f1f/2021-10-21--15-39-42/1/s    for VOLKSWAGEN TAOS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 7d82b2f3a9115f1f/2021-10-21--15-39-42/0/s    for VOLKSWAGEN TAOS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment d7251ede344ff957/2024-01-22--10-14-18/27/s   for VOLKSWAGEN ATLAS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment e80066d826c705a9/2023-11-25--19-03-30/58/s   for VOLKSWAGEN ATLAS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment e80066d826c705a9/2024-01-07--18-35-29/51/s   for VOLKSWAGEN ATLAS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2bbad62414dc6d9b/2023-12-24--14-42-51/8/s    for VOLKSWAGEN ATLAS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2c7a3609df28e226/2023-11-28--18-46-38/19/s   for VOLKSWAGEN ATLAS 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 026b6d18fba6417f/2021-03-26--09-17-04/2/s    for SKODA SCALA 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 026b6d18fba6417f/2021-03-26--09-17-04/0/s    for SKODA SCALA 1ST GEN
  Getriebe_11     gear_pos=5.0
  Gateway_73      gear_pos=5.0
Analyzing segment 026b6d18fba6417f/2021-03-26--09-17-04/1/s    for SKODA SCALA 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2744c89a8dda9a51/2021-07-24--21-28-06/2/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2744c89a8dda9a51/2021-07-24--21-28-06/1/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 2744c89a8dda9a51/2021-07-24--21-28-06/0/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 6c6b466346192818/2021-06-06--14-17-47/0/s    for AUDI Q2 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 6c6b466346192818/2021-06-06--14-17-47/2/s    for AUDI Q2 1ST GEN
  Getriebe_11     gear_pos=9.0
  Gateway_73      gear_pos=9.0
Analyzing segment 6c6b466346192818/2021-06-06--14-17-47/1/s    for AUDI Q2 1ST GEN
  Getriebe_11     gear_pos=9.0
  Gateway_73      gear_pos=9.0
Analyzing segment a589dcc642fdb10a/2021-06-14--20-54-26/0/s    for VOLKSWAGEN TOURAN 2ND GEN
  Getriebe_11     gear_pos=5.0
  Gateway_73      gear_pos=5.0
Analyzing segment a589dcc642fdb10a/2021-06-14--20-54-26/1/s    for VOLKSWAGEN TOURAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a589dcc642fdb10a/2021-06-14--20-54-26/2/s    for VOLKSWAGEN TOURAN 2ND GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a7adec1fdbb46a1c/2023-11-15--12-10-45/40/s   for SKODA SUPERB 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 54ada937747ef8ca/2023-10-29--14-42-35/57/s   for SKODA SUPERB 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 54ada937747ef8ca/2023-11-14--16-01-01/15/s   for SKODA SUPERB 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 54ada937747ef8ca/2024-01-13--18-41-12/3/s    for SKODA SUPERB 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 54ada937747ef8ca/2023-11-14--13-04-50/17/s   for SKODA SUPERB 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0bbe367c98fa1538/2023-03-04--17-46-11/1/s    for VOLKSWAGEN POLO 6TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0bbe367c98fa1538/2023-03-04--17-46-11/2/s    for VOLKSWAGEN POLO 6TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0bbe367c98fa1538/2023-03-04--17-46-11/0/s    for VOLKSWAGEN POLO 6TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment fc6b6c9a3471c846/2021-05-27--13-39-56/1/s    for SEAT LEON 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment be419d0f971f77e3/2023-12-20--16-25-12/5/s    for SEAT LEON 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment fc6b6c9a3471c846/2021-05-27--13-39-56/0/s    for SEAT LEON 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment fc6b6c9a3471c846/2021-05-27--13-39-56/2/s    for SEAT LEON 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment aef9c04d6ec5cd57/2023-07-15--16-49-38/12/s   for SEAT LEON 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 66e5edc3a16459c5/2021-05-25--19-00-29/1/s    for SKODA OCTAVIA 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 66e5edc3a16459c5/2021-05-25--19-00-29/2/s    for SKODA OCTAVIA 3RD GEN
  Getriebe_11     gear_pos=14.0
  Gateway_73      gear_pos=14.0
Analyzing segment f5392228324cda8d/2023-07-19--09-22-26/1/s    for SKODA OCTAVIA 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 3fa7570f2fcace3d/2023-08-02--14-13-00/2/s    for SKODA OCTAVIA 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment f5392228324cda8d/2023-10-30--19-28-48/2/s    for SKODA OCTAVIA 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a459f4556782eba1/2021-09-19--09-48-00/2/s    for VOLKSWAGEN TRANSPORTER T6.1
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 207b9d7ee3fb513a/2023-12-19--14-59-25/16/s   for VOLKSWAGEN TRANSPORTER T6.1
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 207b9d7ee3fb513a/2023-12-19--14-59-25/14/s   for VOLKSWAGEN TRANSPORTER T6.1
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a459f4556782eba1/2023-12-10--12-43-04/32/s   for VOLKSWAGEN TRANSPORTER T6.1
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 207b9d7ee3fb513a/2023-12-19--14-59-25/3/s    for VOLKSWAGEN TRANSPORTER T6.1
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0bbe367c98fa1538/2023-07-01--19-42-26/7/s    for VOLKSWAGEN POLO 6TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0bbe367c98fa1538/2023-11-10--17-33-08/7/s    for VOLKSWAGEN POLO 6TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0cd0b7f7e31a3853/2021-11-03--19-30-22/2/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0cd0b7f7e31a3853/2021-11-03--19-30-22/0/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 14da75f0b8f732e2/2023-11-25--09-26-31/105/s  for VOLKSWAGEN POLO 6TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0cd0b7f7e31a3853/2021-11-18--00-38-32/2/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0cd0b7f7e31a3853/2021-11-18--00-38-32/0/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0cd0b7f7e31a3853/2021-11-18--00-38-32/1/s    for SKODA KODIAQ 1ST GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a4653a9be878a408/2023-12-11--10-05-45/15/s   for VOLKSWAGEN JETTA 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 86654c388fec9152/2023-11-07--09-03-39/15/s   for VOLKSWAGEN JETTA 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a4653a9be878a408/2024-01-05--15-50-01/24/s   for VOLKSWAGEN JETTA 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a4653a9be878a408/2024-01-21--13-02-04/12/s   for VOLKSWAGEN JETTA 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 0649d406184b7131/2023-11-17--16-13-17/6/s    for VOLKSWAGEN JETTA 7TH GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 359bcd3ea48092f6/2023-10-29--09-19-10/14/s   for AUDI A3 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
  Motor_EV_01     gear_pos=5.0
Analyzing segment 23daff6c438612d2/2023-12-29--19-17-54/85/s   for AUDI A3 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment a973e9182bc96a2c/2023-11-22--10-33-10/21/s   for AUDI A3 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
  Motor_EV_01     gear_pos=5.0
Analyzing segment 200c952f826a6447/2023-12-03--15-12-39/13/s   for AUDI A3 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analyzing segment 23daff6c438612d2/2023-11-26--07-53-19/23/s   for AUDI A3 3RD GEN
  Getriebe_11     gear_pos=8.0
  Gateway_73      gear_pos=8.0
Analysis finished
​```