### PR TITLE
Tesla: reduce jerkiness after gas overwrite

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -46,7 +46,7 @@ class CarController(CarControllerBase):
         state = 13 if cruise_cancel else 4  # 4=ACC_ON, 13=ACC_CANCEL_GENERIC_SILENT
         accel = float(np.clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX))
         cntr = (self.frame // 4) % 8
-        can_sends.append(self.tesla_can.create_longitudinal_command(state, accel, cntr, CC.longActive))
+        can_sends.append(self.tesla_can.create_longitudinal_command(state, accel, cntr, CC.longActive, CS.out.gasPressed))
 
     else:
       # Increment counter so cancel is prioritized even without openpilot longitudinal

--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -52,7 +52,7 @@ class CarController(CarControllerBase):
       # Increment counter so cancel is prioritized even without openpilot longitudinal
       if cruise_cancel:
         cntr = (CS.das_control["DAS_controlCounter"] + 1) % 8
-        can_sends.append(self.tesla_can.create_longitudinal_command(13, 0, cntr, False))
+        can_sends.append(self.tesla_can.create_longitudinal_command(13, 0, cntr, False, False))
 
     # TODO: HUD control
     new_actuators = actuators.as_builder()

--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -5,6 +5,7 @@ from opendbc.car.tesla.values import CANBUS, CarControllerParams
 class TeslaCAN:
   def __init__(self, packer):
     self.packer = packer
+    self.jerk = 0
 
   @staticmethod
   def checksum(msg_id, dat):
@@ -24,14 +25,20 @@ class TeslaCAN:
     values["DAS_steeringControlChecksum"] = self.checksum(0x488, data[:3])
     return self.packer.make_can_msg("DAS_steeringControl", CANBUS.party, values)
 
-  def create_longitudinal_command(self, acc_state, accel, cntr, active):
+  def create_longitudinal_command(self, acc_state, accel, cntr, active, override):
+
+    if override:
+      self.jerk = 0
+    else:
+      self.jerk += 0.025
+
     values = {
       # TODO: this causes jerking after gas override when above set speed
       "DAS_setSpeed": 0 if (accel < 0 or not active) else V_CRUISE_MAX,
       "DAS_accState": acc_state,
       "DAS_aebEvent": 0,
-      "DAS_jerkMin": CarControllerParams.JERK_LIMIT_MIN,
-      "DAS_jerkMax": CarControllerParams.JERK_LIMIT_MAX,
+      "DAS_jerkMin": max(self.jerk * -1, CarControllerParams.JERK_LIMIT_MIN),
+      "DAS_jerkMax": min(self.jerk, CarControllerParams.JERK_LIMIT_MAX),
       "DAS_accelMin": accel,
       "DAS_accelMax": max(accel, 0),
       "DAS_controlCounter": cntr,

--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -26,14 +26,10 @@ class TeslaCAN:
     return self.packer.make_can_msg("DAS_steeringControl", CANBUS.party, values)
 
   def create_longitudinal_command(self, acc_state, accel, cntr, active, override):
-
-    if override:
-      self.jerk = 0
-    else:
-      self.jerk += 0.025
+    # ramp up jerk after a gas overwrite
+    self.jerk = 0 if override else self.jerk + CarControllerParams.JERK_RATE_UP
 
     values = {
-      # TODO: this causes jerking after gas override when above set speed
       "DAS_setSpeed": 0 if (accel < 0 or not active) else V_CRUISE_MAX,
       "DAS_accState": acc_state,
       "DAS_aebEvent": 0,

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -92,6 +92,7 @@ class CarControllerParams:
   ACCEL_MIN = -3.48  # m/s^2
   JERK_LIMIT_MAX = 4.9  # m/s^3, ACC faults at 5.0
   JERK_LIMIT_MIN = -4.9  # m/s^3, ACC faults at 5.0
+  JERK_RATE_UP = 0.03
 
 
 class TeslaSafetyFlags(IntFlag):


### PR DESCRIPTION
Ramping up the jerk after overriding the gas helps to make it feel less jerky.