### PR TITLE
Replace gcov & lcov with gcovr

### DIFF
--- a/opendbc/safety/tests/test.sh
+++ b/opendbc/safety/tests/test.sh
@@ -19,17 +19,16 @@ pytest -n8
 
 # generate and open report
 if [ "$1" == "--report" ]; then
-  geninfo ./libsafety/ -o coverage.info
-  genhtml coverage.info -o coverage-out
+  mkdir -p tests/coverage-out
+  gcovr -r . --html-details tests/coverage-out/index.html
   sensible-browser coverage-out/index.html
 fi
 
 # test coverage
-GCOV_OUTPUT=$(gcov -n ./libsafety/safety.c)
-INCOMPLETE_COVERAGE=$(echo "$GCOV_OUTPUT" | paste -s -d' \n' | grep -E "File.*(\/safety\/safety_.*)|(safety)\.h" | grep -v "100.00%" || true)
-if [ -n "$INCOMPLETE_COVERAGE" ]; then
-  echo "FAILED: Some files have less than 100% coverage:"
-  echo "$INCOMPLETE_COVERAGE"
+cd ..
+GCOV="gcovr -r . --fail-under-line=100 -e ^board/ -e ^tests/libsafety/"
+if ! GCOV_OUTPUT="$($GCOV)"; then
+  echo -e "FAILED:\n$GCOV_OUTPUT"
   exit 1
 else
   echo "SUCCESS: All checked files have 100% coverage!"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 testing = [
   "cffi",
   "ruff",
+  "gcovr",
   "pytest",
   "pytest-coverage",
   "pytest-mock",


### PR DESCRIPTION
This is in order to support exclusion markers e.g. #1851.

This also replaces lcov, since it's one less dependency, is smaller, and can be installed via uv (or apt).

Compared to gcov, gcovr:
➖ txt reports take 180ms instead of 8ms, so test.sh takes 2% longer to run on my machine.

Compared to lcov, gcovr:
➕ html reports take 300ms instead of 800ms, so test.sh is 6% faster.
➕ generated report size is 2.8 MB vs 4.2 MB
➕ transitive install size is 2.15 MB vs 32.07 MB
➕ report is faster to navigate, contains more info (e.g. branch info)
gcovr sample: [link](https://ccdunder.github.io/gcovr-comparison/gcovr/)
lcov sample: [link](https://ccdunder.github.io/gcovr-comparison/lcov/)