### PR TITLE
safety: split torque and angle steering limits

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -600,7 +600,7 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
 }
 
 // Safety checks for torque-based steering commands
-bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits) {
+bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueSteeringLimits limits) {
   bool violation = false;
   uint32_t ts = microsecond_timer_get();
 
@@ -686,7 +686,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLi
 }
 
 // Safety checks for angle-based steering commands
-bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const SteeringLimits limits) {
+bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits) {
   bool violation = false;
 
   if (controls_allowed && steer_control_enabled) {

--- a/opendbc/safety/safety/safety_chrysler.h
+++ b/opendbc/safety/safety/safety_chrysler.h
@@ -145,7 +145,7 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
     desired_torque -= 1024;
 
     const TorqueSteeringLimits limits = (chrysler_platform == CHRYSLER_PACIFICA) ? CHRYSLER_STEERING_LIMITS :
-                                  (chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_STEERING_LIMITS : CHRYSLER_RAM_HD_STEERING_LIMITS;
+                                        (chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_STEERING_LIMITS : CHRYSLER_RAM_HD_STEERING_LIMITS;
 
     bool steer_req = (chrysler_platform == CHRYSLER_PACIFICA) ? GET_BIT(to_send, 4U) : (GET_BYTE(to_send, 3) & 0x7U) == 2U;
     if (steer_torque_cmd_checks(desired_torque, steer_req, limits)) {

--- a/opendbc/safety/safety/safety_chrysler.h
+++ b/opendbc/safety/safety/safety_chrysler.h
@@ -105,7 +105,7 @@ static void chrysler_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool chrysler_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits CHRYSLER_STEERING_LIMITS = {
+  const TorqueSteeringLimits CHRYSLER_STEERING_LIMITS = {
     .max_steer = 261,
     .max_rt_delta = 112,
     .max_rt_interval = 250000,
@@ -115,7 +115,7 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
     .type = TorqueMotorLimited,
   };
 
-  const SteeringLimits CHRYSLER_RAM_DT_STEERING_LIMITS = {
+  const TorqueSteeringLimits CHRYSLER_RAM_DT_STEERING_LIMITS = {
     .max_steer = 350,
     .max_rt_delta = 112,
     .max_rt_interval = 250000,
@@ -125,7 +125,7 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
     .type = TorqueMotorLimited,
   };
 
-  const SteeringLimits CHRYSLER_RAM_HD_STEERING_LIMITS = {
+  const TorqueSteeringLimits CHRYSLER_RAM_HD_STEERING_LIMITS = {
     .max_steer = 361,
     .max_rt_delta = 182,
     .max_rt_interval = 250000,
@@ -144,7 +144,7 @@ static bool chrysler_tx_hook(const CANPacket_t *to_send) {
     int desired_torque = ((GET_BYTE(to_send, start_byte) & 0x7U) << 8) | GET_BYTE(to_send, start_byte + 1);
     desired_torque -= 1024;
 
-    const SteeringLimits limits = (chrysler_platform == CHRYSLER_PACIFICA) ? CHRYSLER_STEERING_LIMITS :
+    const TorqueSteeringLimits limits = (chrysler_platform == CHRYSLER_PACIFICA) ? CHRYSLER_STEERING_LIMITS :
                                   (chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_STEERING_LIMITS : CHRYSLER_RAM_HD_STEERING_LIMITS;
 
     bool steer_req = (chrysler_platform == CHRYSLER_PACIFICA) ? GET_BIT(to_send, 4U) : (GET_BYTE(to_send, 3) & 0x7U) == 2U;

--- a/opendbc/safety/safety/safety_ford.h
+++ b/opendbc/safety/safety/safety_ford.h
@@ -109,7 +109,7 @@ static bool ford_lkas_msg_check(int addr) {
 
 // Curvature rate limits
 static const AngleSteeringLimits FORD_STEERING_LIMITS = {
-  .max_steer = 1000,
+//  .max_steer = 1000,  // TODO: implement this
   .angle_deg_to_can = 50000,        // 1 / (2e-5) rad to can
   .max_angle_error = 100,           // 0.002 * FORD_STEERING_LIMITS.angle_deg_to_can
   .angle_rate_up_lookup = {

--- a/opendbc/safety/safety/safety_ford.h
+++ b/opendbc/safety/safety/safety_ford.h
@@ -108,7 +108,7 @@ static bool ford_lkas_msg_check(int addr) {
 }
 
 // Curvature rate limits
-static const SteeringLimits FORD_STEERING_LIMITS = {
+static const AngleSteeringLimits FORD_STEERING_LIMITS = {
   .max_steer = 1000,
   .angle_deg_to_can = 50000,        // 1 / (2e-5) rad to can
   .max_angle_error = 100,           // 0.002 * FORD_STEERING_LIMITS.angle_deg_to_can

--- a/opendbc/safety/safety/safety_gm.h
+++ b/opendbc/safety/safety/safety_gm.h
@@ -96,7 +96,7 @@ static void gm_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool gm_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits GM_STEERING_LIMITS = {
+  const TorqueSteeringLimits GM_STEERING_LIMITS = {
     .max_steer = 300,
     .max_rate_up = 10,
     .max_rate_down = 15,

--- a/opendbc/safety/safety/safety_hyundai.h
+++ b/opendbc/safety/safety/safety_hyundai.h
@@ -189,9 +189,9 @@ static void hyundai_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool hyundai_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits HYUNDAI_STEERING_LIMITS = HYUNDAI_LIMITS(384, 3, 7);
-  const SteeringLimits HYUNDAI_STEERING_LIMITS_ALT = HYUNDAI_LIMITS(270, 2, 3);
-  const SteeringLimits HYUNDAI_STEERING_LIMITS_ALT_2 = HYUNDAI_LIMITS(170, 2, 3);
+  const TorqueSteeringLimits HYUNDAI_STEERING_LIMITS = HYUNDAI_LIMITS(384, 3, 7);
+  const TorqueSteeringLimits HYUNDAI_STEERING_LIMITS_ALT = HYUNDAI_LIMITS(270, 2, 3);
+  const TorqueSteeringLimits HYUNDAI_STEERING_LIMITS_ALT_2 = HYUNDAI_LIMITS(170, 2, 3);
 
   bool tx = true;
   int addr = GET_ADDR(to_send);
@@ -232,7 +232,7 @@ static bool hyundai_tx_hook(const CANPacket_t *to_send) {
     int desired_torque = ((GET_BYTES(to_send, 0, 4) >> 16) & 0x7ffU) - 1024U;
     bool steer_req = GET_BIT(to_send, 27U);
 
-    const SteeringLimits limits = hyundai_alt_limits_2 ? HYUNDAI_STEERING_LIMITS_ALT_2 :
+    const TorqueSteeringLimits limits = hyundai_alt_limits_2 ? HYUNDAI_STEERING_LIMITS_ALT_2 :
                                   hyundai_alt_limits ? HYUNDAI_STEERING_LIMITS_ALT : HYUNDAI_STEERING_LIMITS;
 
     if (steer_torque_cmd_checks(desired_torque, steer_req, limits)) {

--- a/opendbc/safety/safety/safety_hyundai_canfd.h
+++ b/opendbc/safety/safety/safety_hyundai_canfd.h
@@ -135,7 +135,7 @@ static void hyundai_canfd_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool hyundai_canfd_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits HYUNDAI_CANFD_STEERING_LIMITS = {
+  const TorqueSteeringLimits HYUNDAI_CANFD_STEERING_LIMITS = {
     .max_steer = 270,
     .max_rt_delta = 112,
     .max_rt_interval = 250000,

--- a/opendbc/safety/safety/safety_mazda.h
+++ b/opendbc/safety/safety/safety_mazda.h
@@ -51,7 +51,7 @@ static void mazda_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool mazda_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits MAZDA_STEERING_LIMITS = {
+  const TorqueSteeringLimits MAZDA_STEERING_LIMITS = {
     .max_steer = 800,
     .max_rate_up = 10,
     .max_rate_down = 25,

--- a/opendbc/safety/safety/safety_nissan.h
+++ b/opendbc/safety/safety/safety_nissan.h
@@ -58,7 +58,7 @@ static void nissan_rx_hook(const CANPacket_t *to_push) {
 
 
 static bool nissan_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits NISSAN_STEERING_LIMITS = {
+  const AngleSteeringLimits NISSAN_STEERING_LIMITS = {
     .angle_deg_to_can = 100,
     .angle_rate_up_lookup = {
       {0., 5., 15.},

--- a/opendbc/safety/safety/safety_rivian.h
+++ b/opendbc/safety/safety/safety_rivian.h
@@ -45,7 +45,7 @@ static void rivian_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool rivian_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits RIVIAN_STEERING_LIMITS = {
+  const TorqueSteeringLimits RIVIAN_STEERING_LIMITS = {
     .max_steer = 250,
     .max_rate_up = 3,
     .max_rate_down = 5,

--- a/opendbc/safety/safety/safety_subaru.h
+++ b/opendbc/safety/safety/safety_subaru.h
@@ -136,8 +136,8 @@ static void subaru_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool subaru_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits SUBARU_STEERING_LIMITS      = SUBARU_STEERING_LIMITS_GENERATOR(2047, 50, 70);
-  const SteeringLimits SUBARU_GEN2_STEERING_LIMITS = SUBARU_STEERING_LIMITS_GENERATOR(1000, 40, 40);
+  const TorqueSteeringLimits SUBARU_STEERING_LIMITS      = SUBARU_STEERING_LIMITS_GENERATOR(2047, 50, 70);
+  const TorqueSteeringLimits SUBARU_GEN2_STEERING_LIMITS = SUBARU_STEERING_LIMITS_GENERATOR(1000, 40, 40);
 
   const LongitudinalLimits SUBARU_LONG_LIMITS = {
     .min_gas = 808,       // appears to be engine braking
@@ -160,7 +160,7 @@ static bool subaru_tx_hook(const CANPacket_t *to_send) {
 
     bool steer_req = GET_BIT(to_send, 29U);
 
-    const SteeringLimits limits = subaru_gen2 ? SUBARU_GEN2_STEERING_LIMITS : SUBARU_STEERING_LIMITS;
+    const TorqueSteeringLimits limits = subaru_gen2 ? SUBARU_GEN2_STEERING_LIMITS : SUBARU_STEERING_LIMITS;
     violation |= steer_torque_cmd_checks(desired_torque, steer_req, limits);
   }
 

--- a/opendbc/safety/safety/safety_subaru_preglobal.h
+++ b/opendbc/safety/safety/safety_subaru_preglobal.h
@@ -56,7 +56,7 @@ static void subaru_preglobal_rx_hook(const CANPacket_t *to_push) {
 }
 
 static bool subaru_preglobal_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits SUBARU_PG_STEERING_LIMITS = {
+  const TorqueSteeringLimits SUBARU_PG_STEERING_LIMITS = {
     .max_steer = 2047,
     .max_rt_delta = 940,
     .max_rt_interval = 250000,

--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -65,7 +65,7 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
 
 
 static bool tesla_tx_hook(const CANPacket_t *to_send) {
-  const SteeringLimits TESLA_STEERING_LIMITS = {
+  const AngleSteeringLimits TESLA_STEERING_LIMITS = {
     .angle_deg_to_can = 10,
     .angle_rate_up_lookup = {
       {0., 5., 25.},

--- a/opendbc/safety/safety/safety_toyota.h
+++ b/opendbc/safety/safety/safety_toyota.h
@@ -163,36 +163,9 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
     .max_invalid_request_frames = 1,
     .min_valid_request_rt_interval = 170000,  // 170ms; a ~10% buffer on cutting every 19 frames
     .has_steer_req_tolerance = true,
-
-    // LTA angle limits
-    // factor for STEER_TORQUE_SENSOR->STEER_ANGLE and STEERING_LTA->STEER_ANGLE_CMD (1 / 0.0573)
-    .angle_deg_to_can = 17.452007,
-    .angle_rate_up_lookup = {
-      {5., 25., 25.},
-      {0.3, 0.15, 0.15}
-    },
-    .angle_rate_down_lookup = {
-      {5., 25., 25.},
-      {0.36, 0.26, 0.26}
-    },
   };
 
   const AngleSteeringLimits TOYOTA_ANGLE_STEERING_LIMITS = {
-    .max_steer = 1500,
-    .max_rate_up = 15,          // ramp up slow
-    .max_rate_down = 25,        // ramp down fast
-    .max_torque_error = 350,    // max torque cmd in excess of motor torque
-    .max_rt_delta = 450,        // the real time limit is 1800/sec, a 20% buffer
-    .max_rt_interval = 250000,
-    .type = TorqueMotorLimited,
-
-    // the EPS faults when the steering angle rate is above a certain threshold for too long. to prevent this,
-    // we allow setting STEER_REQUEST bit to 0 while maintaining the requested torque value for a single frame
-    .min_valid_request_frames = 18,
-    .max_invalid_request_frames = 1,
-    .min_valid_request_rt_interval = 170000,  // 170ms; a ~10% buffer on cutting every 19 frames
-    .has_steer_req_tolerance = true,
-
     // LTA angle limits
     // factor for STEER_TORQUE_SENSOR->STEER_ANGLE and STEERING_LTA->STEER_ANGLE_CMD (1 / 0.0573)
     .angle_deg_to_can = 17.452007,

--- a/opendbc/safety/safety/safety_volkswagen_mqb.h
+++ b/opendbc/safety/safety/safety_volkswagen_mqb.h
@@ -128,7 +128,7 @@ static void volkswagen_mqb_rx_hook(const CANPacket_t *to_push) {
 
 static bool volkswagen_mqb_tx_hook(const CANPacket_t *to_send) {
   // lateral limits
-  const SteeringLimits VOLKSWAGEN_MQB_STEERING_LIMITS = {
+  const TorqueSteeringLimits VOLKSWAGEN_MQB_STEERING_LIMITS = {
     .max_steer = 300,              // 3.0 Nm (EPS side max of 3.0Nm with fault if violated)
     .max_rt_delta = 75,            // 4 max rate up * 50Hz send rate * 250000 RT interval / 1000000 = 50 ; 50 * 1.5 for safety pad = 75
     .max_rt_interval = 250000,     // 250ms between real time checks

--- a/opendbc/safety/safety/safety_volkswagen_pq.h
+++ b/opendbc/safety/safety/safety_volkswagen_pq.h
@@ -155,7 +155,7 @@ static void volkswagen_pq_rx_hook(const CANPacket_t *to_push) {
 
 static bool volkswagen_pq_tx_hook(const CANPacket_t *to_send) {
   // lateral limits
-  const SteeringLimits VOLKSWAGEN_PQ_STEERING_LIMITS = {
+  const TorqueSteeringLimits VOLKSWAGEN_PQ_STEERING_LIMITS = {
     .max_steer = 300,                // 3.0 Nm (EPS side max of 3.0Nm with fault if violated)
     .max_rt_delta = 113,             // 6 max rate up * 50Hz send rate * 250000 RT interval / 1000000 = 75 ; 125 * 1.5 for safety pad = 113
     .max_rt_interval = 250000,       // 250ms between real time checks

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -88,7 +88,41 @@ typedef struct {
 
   const bool enforce_angle_error;        // enables max_angle_error check
   const bool inactive_angle_is_zero;     // if false, enforces angle near meas when disabled (default)
-} SteeringLimits;
+} TorqueSteeringLimits;
+
+typedef struct {
+  // torque cmd limits
+  const int max_steer;
+  const int max_rate_up;
+  const int max_rate_down;
+  const int max_rt_delta;
+  const uint32_t max_rt_interval;
+
+  const SteeringControlType type;
+
+  // driver torque limits
+  const int driver_torque_allowance;
+  const int driver_torque_multiplier;
+
+  // motor torque limits
+  const int max_torque_error;
+
+  // safety around steer req bit
+  const int min_valid_request_frames;
+  const int max_invalid_request_frames;
+  const uint32_t min_valid_request_rt_interval;
+  const bool has_steer_req_tolerance;
+
+  // angle cmd limits
+  const float angle_deg_to_can;
+  const struct lookup_t angle_rate_up_lookup;
+  const struct lookup_t angle_rate_down_lookup;
+  const int max_angle_error;             // used to limit error between meas and cmd while enabled
+  const float angle_error_min_speed;     // minimum speed to start limiting angle error
+
+  const bool enforce_angle_error;        // enables max_angle_error check
+  const bool inactive_angle_is_zero;     // if false, enforces angle near meas when disabled (default)
+} AngleSteeringLimits;
 
 typedef struct {
   // acceleration cmd limits
@@ -180,8 +214,8 @@ void gen_crc_lookup_table_8(uint8_t poly, uint8_t crc_lut[]);
 void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]);
 #endif
 void generic_rx_checks(bool stock_ecu_detected);
-bool steer_torque_cmd_checks(int desired_torque, int steer_req, const SteeringLimits limits);
-bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const SteeringLimits limits);
+bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueSteeringLimits limits);
+bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits);
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits);
 bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limits);
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits);

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -78,41 +78,9 @@ typedef struct {
   const int max_invalid_request_frames;
   const uint32_t min_valid_request_rt_interval;
   const bool has_steer_req_tolerance;
-
-  // angle cmd limits
-  const float angle_deg_to_can;
-  const struct lookup_t angle_rate_up_lookup;
-  const struct lookup_t angle_rate_down_lookup;
-  const int max_angle_error;             // used to limit error between meas and cmd while enabled
-  const float angle_error_min_speed;     // minimum speed to start limiting angle error
-
-  const bool enforce_angle_error;        // enables max_angle_error check
-  const bool inactive_angle_is_zero;     // if false, enforces angle near meas when disabled (default)
 } TorqueSteeringLimits;
 
 typedef struct {
-  // torque cmd limits
-  const int max_steer;
-  const int max_rate_up;
-  const int max_rate_down;
-  const int max_rt_delta;
-  const uint32_t max_rt_interval;
-
-  const SteeringControlType type;
-
-  // driver torque limits
-  const int driver_torque_allowance;
-  const int driver_torque_multiplier;
-
-  // motor torque limits
-  const int max_torque_error;
-
-  // safety around steer req bit
-  const int min_valid_request_frames;
-  const int max_invalid_request_frames;
-  const uint32_t min_valid_request_rt_interval;
-  const bool has_steer_req_tolerance;
-
   // angle cmd limits
   const float angle_deg_to_can;
   const struct lookup_t angle_rate_up_lookup;


### PR DESCRIPTION
confusing that both modes have attributes in the same struct, and we need different max steers for Hyundai now (plus we never used them for other brands, causing blocked messages while disengaged)