### PR TITLE
Rivian: add VDM fault signal

### DIFF
--- a/opendbc/car/rivian/carstate.py
+++ b/opendbc/car/rivian/carstate.py
@@ -53,10 +53,11 @@ class CarState(CarStateBase):
     ret.cruiseState.available = True  # cp.vl["VDM_AdasSts"]["VDM_AdasInterfaceStatus"] == 1
     ret.cruiseState.standstill = cp.vl["VDM_AdasSts"]["VDM_AdasAccelRequestAcknowledged"] == 1
 
+    # VDM_AdasFaultStatus=Brk_Intv is the default for some reason
     # VDM_AdasFaultStatus=Imps_Cmd was seen when sending it rapidly changing ACC enable commands
     ret.accFaulted = (cp_cam.vl["ACM_Status"]["ACM_FaultStatus"] == 1 or
-                      # Brk_Intv, Cntr_Fault, Imps_Cmd
-                      cp.vl["VDM_AdasSts"]["VDM_AdasFaultStatus"] in (1, 2, 3))
+                      # Cntr_Fault, Imps_Cmd
+                      cp.vl["VDM_AdasSts"]["VDM_AdasFaultStatus"] in (2, 3))
 
     # Gear
     ret.gearShifter = GEAR_MAP[int(cp.vl["VDM_PropStatus"]["VDM_Prndl_Status"])]

--- a/opendbc/car/rivian/carstate.py
+++ b/opendbc/car/rivian/carstate.py
@@ -52,7 +52,11 @@ class CarState(CarStateBase):
       ret.cruiseState.speed = 0
     ret.cruiseState.available = True  # cp.vl["VDM_AdasSts"]["VDM_AdasInterfaceStatus"] == 1
     ret.cruiseState.standstill = cp.vl["VDM_AdasSts"]["VDM_AdasAccelRequestAcknowledged"] == 1
-    ret.accFaulted = cp_cam.vl["ACM_Status"]["ACM_FaultStatus"] == 1
+
+    # VDM_AdasFaultStatus=Imps_Cmd was seen when sending it rapidly changing ACC enable commands
+    ret.accFaulted = (cp_cam.vl["ACM_Status"]["ACM_FaultStatus"] == 1 or
+                      # Brk_Intv, Cntr_Fault, Imps_Cmd
+                      cp.vl["VDM_AdasSts"]["VDM_AdasFaultStatus"] in (1, 2, 3))
 
     # Gear
     ret.gearShifter = GEAR_MAP[int(cp.vl["VDM_PropStatus"]["VDM_Prndl_Status"])]


### PR DESCRIPTION
Found when testing https://github.com/commaai/opendbc/pull/1910. A value of 3 can cancel stock ACC (ACM/Autonomous eXperience Module), but likely permanently faults it after some time:

2d2da5dea63b5c5e/00000004--c739b2e2a0

![image](https://github.com/user-attachments/assets/57fc6ece-3c76-40a0-b63b-bdec16af0e16)
