### PR TITLE
`test_models_trigger.yaml`: add checkout check to prevent opendbc bump fail

### DIFF
--- a/.github/workflows/test_models_trigger.yaml
+++ b/.github/workflows/test_models_trigger.yaml
@@ -37,6 +37,7 @@ jobs:
         submodules: 'true'
 
     - name: bump opendbc
+      if: steps.check_comment.outputs.result == 'true'
       run: |
         cd opendbc_repo
         git fetch origin pull/${{ github.event.issue.number }}/head


### PR DESCRIPTION
whenever we leave a comment we get pinged with a failure due to an if conditional not being added on the bump opendbc step itself. adding this check will allow the workflow to run with no failures.

GHAs Failing: https://github.com/commaai/opendbc/actions/workflows/test_models_trigger.yaml