### PR TITLE
Replace @parameterized.expand with @pytest.mark.parametrize to improve test speed

### DIFF
--- a/opendbc/car/tests/test_can_fingerprint.py
+++ b/opendbc/car/tests/test_can_fingerprint.py
@@ -1,12 +1,11 @@
-from parameterized import parameterized
-
+import pytest
 from opendbc.car.can_definitions import CanData
 from opendbc.car.car_helpers import FRAME_FINGERPRINT, can_fingerprint
 from opendbc.car.fingerprints import _FINGERPRINTS as FINGERPRINTS
 
 
 class TestCanFingerprint:
-  @parameterized.expand(list(FINGERPRINTS.items()))
+  @pytest.mark.parametrize("car_model, fingerprints", list(FINGERPRINTS.items()))
   def test_can_fingerprint(self, car_model, fingerprints):
     """Tests online fingerprinting function on offline fingerprints"""
 

--- a/opendbc/car/tests/test_can_fingerprint.py
+++ b/opendbc/car/tests/test_can_fingerprint.py
@@ -5,7 +5,7 @@ from opendbc.car.fingerprints import _FINGERPRINTS as FINGERPRINTS
 
 
 class TestCanFingerprint:
-  @pytest.mark.parametrize("car_model, fingerprints", list(FINGERPRINTS.items()))
+  @pytest.mark.parametrize("car_model, fingerprints", FINGERPRINTS.items())
   def test_can_fingerprint(self, car_model, fingerprints):
     """Tests online fingerprinting function on offline fingerprints"""
 

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -1,8 +1,8 @@
 import os
 import math
 import hypothesis.strategies as st
+import pytest
 from hypothesis import Phase, given, settings
-from parameterized import parameterized
 from collections.abc import Callable
 from typing import Any
 
@@ -49,7 +49,7 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
 class TestCarInterfaces:
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
   #  many generated examples to overrun when max_examples > ~20, don't use it
-  @parameterized.expand([(car,) for car in sorted(PLATFORMS)] + [MOCK.MOCK])
+  @pytest.mark.parametrize("car_name", sorted(PLATFORMS) + [MOCK.MOCK])
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
             phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -49,7 +49,7 @@ def get_fuzzy_car_interface_args(draw: DrawType) -> dict:
 class TestCarInterfaces:
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
   #  many generated examples to overrun when max_examples > ~20, don't use it
-  @pytest.mark.parametrize("car_name", sorted(PLATFORMS) + [MOCK.MOCK])
+  @pytest.mark.parametrize("car_name", sorted(PLATFORMS))
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
             phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -23,7 +23,8 @@ class TestFwFingerprint:
     assert len(candidates) == 1, f"got more than one candidate: {candidates}"
     assert candidates[0] == expected
 
-  @pytest.mark.parametrize("brand, car_model, ecus, test_non_essential", [(b, c, e[c], n) for b, e in VERSIONS.items() for c in e for n in (True, False)])
+  @pytest.mark.parametrize("brand, car_model, ecus, test_non_essential",
+                           [(b, c, e[c], n) for b, e in VERSIONS.items() for c in e for n in (True, False)])
   def test_exact_match(self, brand, car_model, ecus, test_non_essential):
     config = FW_QUERY_CONFIGS[brand]
     CP = CarParams()

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -2,7 +2,6 @@ import pytest
 import random
 import time
 from collections import defaultdict
-from parameterized import parameterized
 
 from opendbc.car.can_definitions import CanData
 from opendbc.car.car_helpers import interfaces
@@ -24,7 +23,7 @@ class TestFwFingerprint:
     assert len(candidates) == 1, f"got more than one candidate: {candidates}"
     assert candidates[0] == expected
 
-  @parameterized.expand([(b, c, e[c], n) for b, e in VERSIONS.items() for c in e for n in (True, False)])
+  @pytest.mark.parametrize("brand, car_model, ecus, test_non_essential", [(b, c, e[c], n) for b, e in VERSIONS.items() for c in e for n in (True, False)])
   def test_exact_match(self, brand, car_model, ecus, test_non_essential):
     config = FW_QUERY_CONFIGS[brand]
     CP = CarParams()
@@ -48,7 +47,7 @@ class TestFwFingerprint:
         if len(matches) != 0:
           self.assertFingerprints(matches, car_model)
 
-  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  @pytest.mark.parametrize("brand, car_model, ecus", [(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
   def test_custom_fuzzy_match(self, brand, car_model, ecus):
     # Assert brand-specific fuzzy fingerprinting function doesn't disagree with standard fuzzy function
     config = FW_QUERY_CONFIGS[brand]
@@ -70,7 +69,7 @@ class TestFwFingerprint:
       if len(matches) == 1 and len(brand_matches) == 1:
         assert matches == brand_matches
 
-  @parameterized.expand([(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
+  @pytest.mark.parametrize("brand, car_model, ecus", [(b, c, e[c]) for b, e in VERSIONS.items() for c in e])
   def test_fuzzy_match_ecu_count(self, brand, car_model, ecus):
     # Asserts that fuzzy matching does not count matching FW, but ECU address keys
     valid_ecus = [e for e in ecus if e[0] not in FUZZY_EXCLUDE_ECUS]

--- a/opendbc/car/tests/test_routes.py
+++ b/opendbc/car/tests/test_routes.py
@@ -1,10 +1,10 @@
-from parameterized import parameterized
+import pytest
 
 from opendbc.car.values import PLATFORMS
 from opendbc.car.tests.routes import non_tested_cars, routes
 
 
-@parameterized.expand(PLATFORMS.keys())
+@pytest.mark.parametrize("platform", PLATFORMS.keys())
 def test_test_route_present(platform):
   tested_platforms = [r.car_model for r in routes]
   assert platform in set(tested_platforms) | set(non_tested_cars), \


### PR DESCRIPTION
This change reduces the `car/tests/` collection time to ~0.4s.

```
~/opendbc$ pytest --cache-clear --collect-only opendbc/car/tests/

================================ 1735 tests collected in 0.42s ===========================
```

This links to https://github.com/commaai/opendbc/issues/1184.