### PR TITLE
perf: refactor to lazy interface loading

### DIFF
--- a/opendbc/car/tests/conftest.py
+++ b/opendbc/car/tests/conftest.py
@@ -1,0 +1,9 @@
+from opendbc.car.car_helpers import _get_interface_names, load_interfaces
+import pytest
+
+
+# imports from directory opendbc/car/<name>/
+@pytest.fixture(scope="module")
+def interfaces():
+    interface_names = _get_interface_names()
+    return load_interfaces(interface_names)

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from typing import Any
 
 from opendbc.car import DT_CTRL, CanData, gen_empty_fingerprint, structs
-from opendbc.car.car_helpers import interfaces
 from opendbc.car.fingerprints import FW_VERSIONS
 from opendbc.car.fw_versions import FW_QUERY_CONFIGS
 from opendbc.car.interfaces import get_interface_attr
@@ -53,7 +52,7 @@ class TestCarInterfaces:
   @settings(max_examples=MAX_EXAMPLES, deadline=None,
             phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
-  def test_car_interfaces(self, car_name, data):
+  def test_car_interfaces(self, car_name, data, interfaces):
     CarInterface = interfaces[car_name]
 
     args = get_fuzzy_car_interface_args(data.draw)

--- a/opendbc/car/tests/test_docs.py
+++ b/opendbc/car/tests/test_docs.py
@@ -2,7 +2,6 @@ from collections import defaultdict
 import pytest
 import re
 
-from opendbc.car.car_helpers import interfaces
 from opendbc.car.docs import get_all_car_docs
 from opendbc.car.docs_definitions import Cable, Column, PartType, Star, SupportType
 from opendbc.car.honda.values import CAR as HONDA
@@ -26,7 +25,7 @@ class TestCarDocs:
           assert year not in make_model_years[make_model], f"{car.name}: Duplicate model year"
           make_model_years[make_model].append(year)
 
-  def test_missing_car_docs(self, subtests):
+  def test_missing_car_docs(self, subtests, interfaces):
     all_car_docs_platforms = [name for name, config in PLATFORMS.items()]
     for platform in sorted(interfaces.keys()):
       with subtests.test(platform=platform):

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -4,7 +4,6 @@ import time
 from collections import defaultdict
 
 from opendbc.car.can_definitions import CanData
-from opendbc.car.car_helpers import interfaces
 from opendbc.car.structs import CarParams
 from opendbc.car.fingerprints import FW_VERSIONS
 from opendbc.car.fw_versions import FW_QUERY_CONFIGS, FUZZY_EXCLUDE_ECUS, VERSIONS, build_fw_dict, \
@@ -122,7 +121,7 @@ class TestFwFingerprint:
         with subtests.test(car_model=car_model.value):
           assert not len(bad_ecus), f'{car_model}: Fingerprints contain ECUs added for data collection: {bad_ecus}'
 
-  def test_blacklisted_ecus(self, subtests):
+  def test_blacklisted_ecus(self, subtests, interfaces):
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():
       with subtests.test(car_model=car_model.value):

--- a/opendbc/car/tests/test_lateral_limits.py
+++ b/opendbc/car/tests/test_lateral_limits.py
@@ -17,7 +17,7 @@ MAX_LAT_JERK_UP_TOLERANCE = 0.5  # m/s^3
 JERK_MEAS_T = 0.5
 
 @pytest.fixture
-def car_params(request, interfaces):
+def test_params(request, interfaces):
   return TestLateralLimits.setup(request.param, interfaces)
 
 class TestLateralLimits:
@@ -58,15 +58,15 @@ class TestLateralLimits:
     # Convert to m/s^3
     return accel_up_0_5_sec / JERK_MEAS_T, accel_down_0_5_sec / JERK_MEAS_T
 
-@pytest.mark.parametrize('car_params', sorted(PLATFORMS), indirect=True)
-def test_jerk_limits(car_params):
-  up_jerk, down_jerk = TestLateralLimits.calculate_0_5s_jerk(car_params.control_params, car_params.torque_params)
+@pytest.mark.parametrize('test_params', sorted(PLATFORMS), indirect=True)
+def test_jerk_limits(test_params):
+  up_jerk, down_jerk = TestLateralLimits.calculate_0_5s_jerk(test_params.control_params, test_params.torque_params)
   assert up_jerk <= MAX_LAT_JERK_UP + MAX_LAT_JERK_UP_TOLERANCE
   assert down_jerk <= MAX_LAT_JERK_DOWN
 
-@pytest.mark.parametrize('car_params', sorted(PLATFORMS), indirect=True)
-def test_max_lateral_accel(car_params):
-  assert car_params.torque_params["MAX_LAT_ACCEL_MEASURED"] <= ISO_LATERAL_ACCEL
+@pytest.mark.parametrize('test_params', sorted(PLATFORMS), indirect=True)
+def test_max_lateral_accel(test_params):
+  assert test_params.torque_params["MAX_LAT_ACCEL_MEASURED"] <= ISO_LATERAL_ACCEL
 
 
 class LatAccelReport:


### PR DESCRIPTION
Relates to https://github.com/commaai/opendbc/issues/1184

By moving the `car_helpers.py` imports to a `pytest.fixture`, we can shorten the collection time.


Refactors the `car` tests to use:
* a pytest `fixture` for the interface loading (this import is not executed during collection)
* ~`pytest.mark.parametrize` instead of the `parametrize` in select places to enable properly using the fixture.~ coincidentally already fixed in https://github.com/commaai/opendbc/pull/1930

I tried to keep the diff as small as possible.

There are 3 big chunks of time spent during the pytest collection on a fresh run (after compilation):
* first import of `CANDefine`, aka the packer_pyx compiled library (only slow the first run after compilation)
* import of the interfaces in `car_helpers.py` (always slow)
* import of pytest plugins

"Fresh" denotes a recompilation of the `cython` modules.


## Collect only 

`pytest opendbc/car/tests --collect-only` 

| State  | Fresh           | Second Run         |
|--------|-----------------|-------------------|
| master  | 0.56s  | 0.27s  |
| PR | 0.16s  | 0.13s  |

compare to

`pytest opendbc/can/tests --collect-only` 

| State  | Fresh           | Second Run         |
|--------|-----------------|-------------------|
| master  | 0.32s | 0.02s  |
| PR | 0.29s  | 0.04s  |

## Collection + execution

`pytest opendbc/car/tests`

| State  | Fresh           | Second Run         |
|--------|-----------------|-------------------|
| master  | 6.42s   | 6.19s |
| PR | 5.92s | 5.76s |