### PR TITLE
HKG: split CAN and CANFD CarController update function

### DIFF
--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -45,7 +45,6 @@ class CarController(CarControllerBase):
     can_sends = []
     can_sends.extend(tester_present_msgs)
 
-    # CAN SPECIFIC START
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
                                               torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
                                               hud_control.leftLaneVisible, hud_control.rightLaneVisible,
@@ -73,7 +72,6 @@ class CarController(CarControllerBase):
     # 2 Hz front radar options
     if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
       can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
-    # CAN SPECIFIC END
 
     new_actuators = actuators.as_builder()
     new_actuators.torque = apply_torque / self.params.STEER_MAX
@@ -94,7 +92,6 @@ class CarController(CarControllerBase):
     can_sends = []
     can_sends.extend(tester_present_msgs)
 
-    # CANFD SPECIFIC START
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
     lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
 
@@ -126,7 +123,6 @@ class CarController(CarControllerBase):
     else:
       # button presses
       can_sends.extend(self.create_button_messages(CC, CS, use_clu11=False))
-    # CANFD SPECIFIC END
 
     new_actuators = actuators.as_builder()
     new_actuators.torque = apply_torque / self.params.STEER_MAX

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -40,7 +40,6 @@ class CarController(CarControllerBase):
      tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
-
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req, torque_fault, CS.lkas11, sys_warning,
       sys_state, CC.enabled, hud_control.leftLaneVisible, hud_control.rightLaneVisible, left_lane_warning, right_lane_warning))
 
@@ -73,11 +72,10 @@ class CarController(CarControllerBase):
      tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
+    can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))
 
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
     lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
-
-    can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))
 
     # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
     if self.frame % 5 == 0 and lka_steering:

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -88,7 +88,8 @@ class CarController(CarControllerBase):
     sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,
                                                                                       hud_control)
 
-    return apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units
+    return apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning
+
 
 
 
@@ -98,7 +99,7 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units = self.compute_common_controls(CC, CS)
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning = self.compute_common_controls(CC, CS)
 
 
 
@@ -182,7 +183,7 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units = self.compute_common_controls(CC, CS)
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning = self.compute_common_controls(CC, CS)
 
     can_sends = []
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -36,8 +36,7 @@ class CarController(CarControllerBase):
     if self.CP.flags & HyundaiFlags.CANFD:
       return self.update_canfd(CC, CS, now_nanos)
 
-    actuators = CC.actuators
-    hud_control = CC.hudControl
+    actuators, hud_control = CC.actuators, CC.hudControl
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
      tester_present_msgs = self.compute_common_controls(CC, CS)
@@ -82,8 +81,7 @@ class CarController(CarControllerBase):
 
 
   def update_canfd(self, CC, CS, now_nanos):
-    actuators = CC.actuators
-    hud_control = CC.hudControl
+    actuators, hud_control = CC.actuators, CC.hudControl
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
      tester_present_msgs = self.compute_common_controls(CC, CS)

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -84,6 +84,10 @@ class CarController(CarControllerBase):
     stopping = actuators.longControlState == LongCtrlState.stopping
     set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_KPH if CS.is_metric else CV.MS_TO_MPH)
 
+    # HUD messages
+    sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,
+                                                                                      hud_control)
+
     return apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units
 
 
@@ -96,9 +100,7 @@ class CarController(CarControllerBase):
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units = self.compute_common_controls(CC, CS)
 
-    # HUD messages
-    sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,
-                                                                                      hud_control)
+
 
     can_sends = []
 
@@ -181,10 +183,6 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units = self.compute_common_controls(CC, CS)
-
-    # HUD messages
-    sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,
-                                                                                      hud_control)
 
     can_sends = []
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -34,9 +34,7 @@ class CarController(CarControllerBase):
     if self.CP.flags & HyundaiFlags.CANFD:
       return self.update_canfd(CC, CS, now_nanos)
 
-    actuators, hud_control = CC.actuators, CC.hudControl
-
-    (apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
+    (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
      tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
@@ -65,9 +63,7 @@ class CarController(CarControllerBase):
 
 
   def update_canfd(self, CC, CS, now_nanos):
-    actuators, hud_control = CC.actuators, CC.hudControl
-
-    (apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
+    (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
      tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
@@ -156,7 +152,7 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         tester_present_msgs.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 
-    return (apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+    return (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
        right_lane_warning, tester_present_msgs)
 
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -132,7 +132,7 @@ class CarController(CarControllerBase):
 
     sys_warning = (hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw))
 
-    # initialize to no line visible, TODO: this is not accurate for all cars
+    # TODO: this is not accurate for all cars
     sys_state = 1
     if hud_control.leftLaneVisible and hud_control.rightLaneVisible or sys_warning:  # HUD alert only display when LKAS status is active
       sys_state = 3 if enabled or sys_warning else 4
@@ -141,7 +141,6 @@ class CarController(CarControllerBase):
     elif hud_control.rightLaneVisible:
       sys_state = 6
 
-    # initialize to no warnings
     left_lane_warning = (1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.leftLaneDepart else 0
     right_lane_warning = (1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.rightLaneDepart else 0
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -43,10 +43,8 @@ class CarController(CarControllerBase):
 
     can_sends = tester_present_msgs.copy()
 
-    can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
-                                              torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
-                                              hud_control.leftLaneVisible, hud_control.rightLaneVisible,
-                                              left_lane_warning, right_lane_warning))
+    can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req, torque_fault, CS.lkas11, sys_warning,
+      sys_state, CC.enabled, hud_control.leftLaneVisible, hud_control.rightLaneVisible, left_lane_warning, right_lane_warning))
 
     if not self.CP.openpilotLongitudinalControl:
       can_sends.extend(self.create_button_messages(CC, CS, use_clu11=True))
@@ -55,8 +53,7 @@ class CarController(CarControllerBase):
       # TODO: unclear if this is needed
       jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
       use_fca = self.CP.flags & HyundaiFlags.USE_FCA.value
-      can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
-                                                      hud_control, set_speed_in_units, stopping,
+      can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2), hud_control, set_speed_in_units, stopping,
                                                       CC.cruiseControl.override, use_fca, self.CP))
 
     # 20 Hz LFA MFA message
@@ -138,10 +135,8 @@ class CarController(CarControllerBase):
     apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.params)
 
     # >90 degree steering fault prevention
-    self.angle_limit_counter, apply_steer_req = common_fault_avoidance(
-      abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive,
-      self.angle_limit_counter, MAX_ANGLE_FRAMES, MAX_ANGLE_CONSECUTIVE_FRAMES
-    )
+    self.angle_limit_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive, self.angle_limit_counter,
+      MAX_ANGLE_FRAMES, MAX_ANGLE_CONSECUTIVE_FRAMES)
 
     if not CC.latActive:
       apply_torque = 0

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -114,13 +114,6 @@ class CarController(CarControllerBase):
     return self.update_actuators(actuators, apply_torque, accel, can_sends)
 
 
-  def update_actuators(self, actuators, apply_torque, accel, can_sends):
-    new_actuators = actuators.as_builder()
-    new_actuators.torque, new_actuators.torqueOutputCan, new_actuators.accel = apply_torque / self.params.STEER_MAX, apply_torque, accel
-    self.frame += 1
-    return new_actuators, can_sends
-
-
   def update_common(self, CC, CS):
     actuators, hud_control = CC.actuators, CC.hudControl
 
@@ -163,3 +156,10 @@ class CarController(CarControllerBase):
 
     return (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
        right_lane_warning, tester_present_msgs)
+
+
+  def update_actuators(self, actuators, apply_torque, accel, can_sends):
+    new_actuators = actuators.as_builder()
+    new_actuators.torque, new_actuators.torqueOutputCan, new_actuators.accel = apply_torque / self.params.STEER_MAX, apply_torque, accel
+    self.frame += 1
+    return new_actuators, can_sends

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -114,7 +114,7 @@ class CarController(CarControllerBase):
       can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
 
     # blinkers
-    if lka_steering and self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
+    if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS and lka_steering:
       can_sends.extend(hyundaicanfd.create_spas_messages(self.packer, self.CAN, self.frame, CC.leftBlinker, CC.rightBlinker))
 
     if self.CP.openpilotLongitudinalControl:

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -98,8 +98,7 @@ class CarController(CarControllerBase):
             can_sends.append(hyundaicanfd.create_acc_cancel(self.packer, self.CP, self.CAN, CS.cruise_info))
           else:
             can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL) for _ in range(20)])
-        elif CC.cruiseControl.resume:
-          if not self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:  # TODO: resume for alt button cars
+        elif CC.cruiseControl.resume and not (self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS):  # TODO: resume for alt button cars
             can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL) for _ in range(20)])
         self.last_button_frame = self.frame
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -45,7 +45,7 @@ class CarController(CarControllerBase):
       right_lane_warning, tester_present_msgs
     ) = self.compute_common_controls(CC, CS)
 
-    can_sends = tester_present_msgs[:]
+    can_sends = tester_present_msgs.copy()
 
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
                                               torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
@@ -94,7 +94,7 @@ class CarController(CarControllerBase):
       right_lane_warning, tester_present_msgs
     ) = self.compute_common_controls(CC, CS)
 
-    can_sends = tester_present_msgs[:]
+    can_sends = tester_present_msgs.copy()
 
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
     lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -45,8 +45,7 @@ class CarController(CarControllerBase):
       right_lane_warning, tester_present_msgs
     ) = self.compute_common_controls(CC, CS)
 
-    can_sends = []
-    can_sends.extend(tester_present_msgs)
+    can_sends = tester_present_msgs[:]
 
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
                                               torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
@@ -95,8 +94,7 @@ class CarController(CarControllerBase):
       right_lane_warning, tester_present_msgs
     ) = self.compute_common_controls(CC, CS)
 
-    can_sends = []
-    can_sends.extend(tester_present_msgs)
+    can_sends = tester_present_msgs[:]
 
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
     lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -1,4 +1,5 @@
 import numpy as np
+from collections import namedtuple
 from opendbc.can.packer import CANPacker
 from opendbc.car import Bus, DT_CTRL, apply_driver_steer_torque_limits, common_fault_avoidance, make_tester_present_msg, structs
 from opendbc.car.common.conversions import Conversions as CV
@@ -14,6 +15,9 @@ LongCtrlState = structs.CarControl.Actuators.LongControlState
 MAX_ANGLE = 85
 MAX_ANGLE_FRAMES = 89
 MAX_ANGLE_CONSECUTIVE_FRAMES = 2
+
+CommonData = namedtuple("CommonData", ["actuators", "hud_control", "apply_torque", "apply_steer_req", "torque_fault", "accel", "stopping",
+ "set_speed_in_units", "sys_warning", "sys_state", "left_lane_warning", "right_lane_warning", "tester_present_msgs",])
 
 
 class CarController(CarControllerBase):
@@ -145,7 +149,7 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         tester_present_msgs.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 
-    return (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+    return CommonData(actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
        right_lane_warning, tester_present_msgs)
 
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -67,13 +67,12 @@ class CarController(CarControllerBase):
     can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))
 
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
-    lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
 
     # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
     if self.frame % 5 == 0 and lka_steering:
       can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg, self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
 
-    if self.frame % 5 == 0 and (not lka_steering or lka_steering_long):
+    if self.frame % 5 == 0 and (not lka_steering or (lka_steering and self.CP.openpilotLongitudinalControl)):
       can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
 
     if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS and lka_steering:

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -40,7 +40,7 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-     right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
+      right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
 
     can_sends = []
     can_sends.extend(tester_present_msgs)
@@ -89,7 +89,7 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-     right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
+      right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
 
     can_sends = []
     can_sends.extend(tester_present_msgs)

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -98,12 +98,10 @@ class CarController(CarControllerBase):
           if self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:
             can_sends.append(hyundaicanfd.create_acc_cancel(self.packer, self.CP, self.CAN, CS.cruise_info))
           else:
-            for _ in range(20):
-              can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL))
+            can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL) for _ in range(20)])
         elif CC.cruiseControl.resume:
           if not self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:  # TODO: resume for alt button cars
-            for _ in range(20):
-              can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL))
+            can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL) for _ in range(20)])
         self.last_button_frame = self.frame
 
     return self.update_actuators(actuators, apply_torque, accel, can_sends)

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -97,16 +97,14 @@ class CarController(CarControllerBase):
         if CC.cruiseControl.cancel:
           if self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:
             can_sends.append(hyundaicanfd.create_acc_cancel(self.packer, self.CP, self.CAN, CS.cruise_info))
-            self.last_button_frame = self.frame
           else:
             for _ in range(20):
               can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL))
-            self.last_button_frame = self.frame
         elif CC.cruiseControl.resume:
           if not self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:  # TODO: resume for alt button cars
             for _ in range(20):
               can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL))
-            self.last_button_frame = self.frame
+        self.last_button_frame = self.frame
 
     return self.update_actuators(actuators, apply_torque, accel, can_sends)
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -54,7 +54,6 @@ class CarController(CarControllerBase):
         can_sends.append(hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.CANCEL, self.CP))
       elif CC.cruiseControl.resume:
         if (self.frame - self.last_button_frame) * DT_CTRL > 0.1:
-          # send 25 messages at a time to increases the likelihood of resume being accepted
           can_sends.extend([hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.RES_ACCEL, self.CP)] * 25)
           if (self.frame - self.last_button_frame) * DT_CTRL >= 0.15:
             self.last_button_frame = self.frame

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -35,7 +35,7 @@ class CarController(CarControllerBase):
       return self.update_canfd(CC, CS, now_nanos)
 
     (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-     right_lane_warning, tester_present_msgs) = self.compute_common_controls(CC, CS)
+     right_lane_warning, tester_present_msgs) = self.update_common(CC, CS)
 
     can_sends = tester_present_msgs.copy()
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req, torque_fault, CS.lkas11, sys_warning,
@@ -68,7 +68,7 @@ class CarController(CarControllerBase):
 
   def update_canfd(self, CC, CS, now_nanos):
     (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-     right_lane_warning, tester_present_msgs) = self.compute_common_controls(CC, CS)
+     right_lane_warning, tester_present_msgs) = self.update_common(CC, CS)
 
     can_sends = tester_present_msgs.copy()
     can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))
@@ -122,7 +122,7 @@ class CarController(CarControllerBase):
     return new_actuators, can_sends
 
 
-  def compute_common_controls(self, CC, CS):
+  def update_common(self, CC, CS):
     actuators, hud_control = CC.actuators, CC.hudControl
 
     new_torque = int(round(actuators.torque * self.params.STEER_MAX))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -39,7 +39,7 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, \
       right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
 
     can_sends = []
@@ -86,7 +86,7 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, \
       right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
 
     can_sends = []

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -34,8 +34,8 @@ class CarController(CarControllerBase):
     if self.CP.flags & HyundaiFlags.CANFD:
       return self.update_canfd(CC, CS, now_nanos)
 
-    (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
-     tester_present_msgs) = self.compute_common_controls(CC, CS)
+    (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+     right_lane_warning, tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req, torque_fault, CS.lkas11, sys_warning,
@@ -60,8 +60,8 @@ class CarController(CarControllerBase):
 
 
   def update_canfd(self, CC, CS, now_nanos):
-    (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
-     tester_present_msgs) = self.compute_common_controls(CC, CS)
+    (actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+     right_lane_warning, tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
     can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -163,11 +163,10 @@ class CarController(CarControllerBase):
     set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_KPH if CS.is_metric else CV.MS_TO_MPH)
 
     # HUD messages
-    sys_warning, sys_state, left_lane_warning, right_lane_warning = self.process_hud_alert(CC.enabled, self.car_fingerprint,
-                                                                                      hud_control)
+    sys_warning, sys_state, left_lane_warning, right_lane_warning = self.process_hud_alert(CC.enabled, self.car_fingerprint, hud_control)
 
-    tester_present_msgs = []
     # tester present - w/ no response (keeps relevant ECU disabled)
+    tester_present_msgs = []
     if self.frame % 100 == 0 and not (self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC) and self.CP.openpilotLongitudinalControl:
       # for longitudinal control, either radar or ADAS driving ECU
       addr, bus = 0x7d0, self.CAN.ECAN if self.CP.flags & HyundaiFlags.CANFD else 0

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -39,8 +39,8 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning = 
-      self.compute_common_controls(CC, CS)
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+     right_lane_warning = self.compute_common_controls(CC, CS)
 
     can_sends = []
 
@@ -101,8 +101,8 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning = 
-      self.compute_common_controls(CC, CS)
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+     right_lane_warning = self.compute_common_controls(CC, CS)
 
     can_sends = []
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -46,8 +46,8 @@ class CarController(CarControllerBase):
     if self.CP.openpilotLongitudinalControl:
       if self.frame % 2 == 0:
         jerk = 3.0 if cd.actuators.longControlState == LongCtrlState.pid else 1.0  # TODO: unclear if this is needed
-        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, cd.accel, jerk, int(self.frame / 2), cd.hud_control, cd.set_speed_in_units, cd.stopping,
-                                                          CC.cruiseControl.override, self.CP.flags & HyundaiFlags.USE_FCA.value, self.CP))
+        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, cd.accel, jerk, int(self.frame / 2), cd.hud_control, cd.set_speed_in_units,
+                                                          cd.stopping, CC.cruiseControl.override, self.CP.flags & HyundaiFlags.USE_FCA.value, self.CP))
       if self.frame % 20 == 0:
         can_sends.extend(hyundaican.create_acc_opt(self.packer, self.CP))
       if self.frame % 50 == 0:
@@ -101,7 +101,7 @@ class CarController(CarControllerBase):
           else:
             can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL) for _ in range(20)])
         elif CC.cruiseControl.resume and not (self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS):  # TODO: resume for alt button cars
-            can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL) for _ in range(20)])
+          can_sends.extend([hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL) for _ in range(20)])
         self.last_button_frame = self.frame
 
     return self.update_actuators(cd.actuators, cd.apply_torque, cd.accel, can_sends)
@@ -147,8 +147,8 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         tester_present_msgs.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 
-    return CommonData(actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-       right_lane_warning, tester_present_msgs)
+    return CommonData(actuators, hud_control, apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state,
+      left_lane_warning, right_lane_warning, tester_present_msgs)
 
 
   def update_actuators(self, actuators, apply_torque, accel, can_sends):

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -62,7 +62,7 @@ class CarController(CarControllerBase):
     if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
       can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
 
-    return self._build_actuators(actuators, apply_torque, accel, can_sends)
+    return self.build_actuators(actuators, apply_torque, accel, can_sends)
 
 
   def update_canfd(self, CC, CS, now_nanos):
@@ -99,10 +99,10 @@ class CarController(CarControllerBase):
     else:
       can_sends.extend(self.create_button_messages(CC, CS, use_clu11=False))
 
-    return self._build_actuators(actuators, apply_torque, accel, can_sends)
+    return self.build_actuators(actuators, apply_torque, accel, can_sends)
 
 
-  def _build_actuators(self, actuators, apply_torque, accel, can_sends):
+  def build_actuators(self, actuators, apply_torque, accel, can_sends):
     new_actuators = actuators.as_builder()
     new_actuators.torque, new_actuators.torqueOutputCan, new_actuators.accel = apply_torque / self.params.STEER_MAX, apply_torque, accel
     self.frame += 1

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -69,7 +69,7 @@ class CarController(CarControllerBase):
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
 
     if self.frame % 5 == 0:
-      if lka_steering:  # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
+      if lka_steering:
         can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg, self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
       if not lka_steering or self.CP.openpilotLongitudinalControl:
         can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -114,11 +114,9 @@ class CarController(CarControllerBase):
     return self._build_actuators(actuators, apply_torque, accel, can_sends)
 
 
-def _build_actuators(self, actuators, apply_torque, accel, can_sends):
+  def _build_actuators(self, actuators, apply_torque, accel, can_sends):
     new_actuators = actuators.as_builder()
-    new_actuators.torque = apply_torque / self.params.STEER_MAX
-    new_actuators.torqueOutputCan = apply_torque
-    new_actuators.accel = accel
+    new_actuators.torque, new_actuators.torqueOutputCan, new_actuators.accel = apply_torque / self.params.STEER_MAX, apply_torque, accel
     self.frame += 1
     return new_actuators, can_sends
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -72,7 +72,7 @@ class CarController(CarControllerBase):
     if self.frame % 5 == 0 and lka_steering:
       can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg, self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
 
-    if self.frame % 5 == 0 and (not lka_steering or (lka_steering and self.CP.openpilotLongitudinalControl)):
+    if self.frame % 5 == 0 and (not lka_steering or self.CP.openpilotLongitudinalControl):
       can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
 
     if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS and lka_steering:

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -103,10 +103,7 @@ class CarController(CarControllerBase):
               can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL))
             self.last_button_frame = self.frame
         elif CC.cruiseControl.resume:
-          if self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:
-            # TODO: resume for alt button cars
-            pass
-          else:
+          if not self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:  # TODO: resume for alt button cars
             for _ in range(20):
               can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL))
             self.last_button_frame = self.frame

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -68,13 +68,7 @@ class CarController(CarControllerBase):
     if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
       can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
 
-    new_actuators = actuators.as_builder()
-    new_actuators.torque = apply_torque / self.params.STEER_MAX
-    new_actuators.torqueOutputCan = apply_torque
-    new_actuators.accel = accel
-
-    self.frame += 1
-    return new_actuators, can_sends
+    return self._build_actuators(actuators, apply_torque, accel, can_sends)
 
 
   def update_canfd(self, CC, CS, now_nanos):
@@ -117,11 +111,14 @@ class CarController(CarControllerBase):
       # button presses
       can_sends.extend(self.create_button_messages(CC, CS, use_clu11=False))
 
+    return self._build_actuators(actuators, apply_torque, accel, can_sends)
+
+
+def _build_actuators(self, actuators, apply_torque, accel, can_sends):
     new_actuators = actuators.as_builder()
     new_actuators.torque = apply_torque / self.params.STEER_MAX
     new_actuators.torqueOutputCan = apply_torque
     new_actuators.accel = accel
-
     self.frame += 1
     return new_actuators, can_sends
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -159,7 +159,6 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING.value:
         addr, bus = 0x730, self.CAN.ECAN
       tester_present_msgs.append(make_tester_present_msg(addr, bus, suppress_response=True))
-
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         tester_present_msgs.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -203,8 +203,7 @@ class CarController(CarControllerBase):
   def process_hud_alert(self, enabled, fingerprint, hud_control):
     sys_warning = (hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw))
 
-    # initialize to no line visible
-    # TODO: this is not accurate for all cars
+    # initialize to no line visible, TODO: this is not accurate for all cars
     sys_state = 1
     if hud_control.leftLaneVisible and hud_control.rightLaneVisible or sys_warning:  # HUD alert only display when LKAS status is active
       sys_state = 3 if enabled or sys_warning else 4

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -68,12 +68,11 @@ class CarController(CarControllerBase):
 
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
 
-    # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
-    if self.frame % 5 == 0 and lka_steering:
-      can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg, self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
-
-    if self.frame % 5 == 0 and (not lka_steering or self.CP.openpilotLongitudinalControl):
-      can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
+    if self.frame % 5 == 0:
+      if lka_steering:  # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
+        can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg, self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
+      if not lka_steering or self.CP.openpilotLongitudinalControl:
+        can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
 
     if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS and lka_steering:
       can_sends.extend(hyundaicanfd.create_spas_messages(self.packer, self.CAN, self.frame, CC.leftBlinker, CC.rightBlinker))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -63,7 +63,7 @@ class CarController(CarControllerBase):
     if self.frame % 5 == 0 and self.CP.flags & HyundaiFlags.SEND_LFA.value:
       can_sends.append(hyundaican.create_lfahda_mfc(self.packer, CC.enabled))
 
-    return self.build_actuators(actuators, apply_torque, accel, can_sends)
+    return self.update_actuators(actuators, apply_torque, accel, can_sends)
 
 
   def update_canfd(self, CC, CS, now_nanos):
@@ -112,10 +112,10 @@ class CarController(CarControllerBase):
               can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.RES_ACCEL))
             self.last_button_frame = self.frame
 
-    return self.build_actuators(actuators, apply_torque, accel, can_sends)
+    return self.update_actuators(actuators, apply_torque, accel, can_sends)
 
 
-  def build_actuators(self, actuators, apply_torque, accel, can_sends):
+  def update_actuators(self, actuators, apply_torque, accel, can_sends):
     new_actuators = actuators.as_builder()
     new_actuators.torque, new_actuators.torqueOutputCan, new_actuators.accel = apply_torque / self.params.STEER_MAX, apply_torque, accel
     self.frame += 1

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -39,11 +39,8 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    (
-      apply_torque, apply_steer_req, torque_fault, accel, stopping,
-      set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-      right_lane_warning, tester_present_msgs
-    ) = self.compute_common_controls(CC, CS)
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
+     tester_present_msgs = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
 
@@ -88,11 +85,8 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    (
-      apply_torque, apply_steer_req, torque_fault, accel, stopping,
-      set_speed_in_units, sys_warning, sys_state, left_lane_warning,
-      right_lane_warning, tester_present_msgs
-    ) = self.compute_common_controls(CC, CS)
+    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
+     tester_present_msgs = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -56,9 +56,6 @@ class CarController(CarControllerBase):
     self.last_button_frame = 0
 
 
-
-
-
   def compute_common_controls(self, CC, CS):
     actuators = CC.actuators
     hud_control = CC.hudControl
@@ -87,12 +84,7 @@ class CarController(CarControllerBase):
     # HUD messages
     sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,
                                                                                       hud_control)
-
     return apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning
-
-
-
-
 
 
   def update_canfd(self, CC, CS, now_nanos):
@@ -100,8 +92,6 @@ class CarController(CarControllerBase):
     hud_control = CC.hudControl
 
     apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning = self.compute_common_controls(CC, CS)
-
-
 
     can_sends = []
 
@@ -119,13 +109,7 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         can_sends.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 
-
-
-
-
-
     # CANFD SPECIFIC START
-
     lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
     lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
 
@@ -157,10 +141,7 @@ class CarController(CarControllerBase):
     else:
       # button presses
       can_sends.extend(self.create_button_messages(CC, CS, use_clu11=False))
-
     # CANFD SPECIFIC END
-
-
 
     new_actuators = actuators.as_builder()
     new_actuators.torque = apply_torque / self.params.STEER_MAX
@@ -169,11 +150,6 @@ class CarController(CarControllerBase):
 
     self.frame += 1
     return new_actuators, can_sends
-
-
-
-
-
 
 
   def update(self, CC, CS, now_nanos):
@@ -201,13 +177,7 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         can_sends.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 
-
-
-
-
-
     # CAN SPECIFIC START
-
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
                                               torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
                                               hud_control.leftLaneVisible, hud_control.rightLaneVisible,
@@ -235,10 +205,7 @@ class CarController(CarControllerBase):
     # 2 Hz front radar options
     if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
       can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
-
     # CAN SPECIFIC END
-
-
 
     new_actuators = actuators.as_builder()
     new_actuators.torque = apply_torque / self.params.STEER_MAX
@@ -247,7 +214,6 @@ class CarController(CarControllerBase):
 
     self.frame += 1
     return new_actuators, can_sends
-
 
 
   def create_button_messages(self, CC: structs.CarControl, CS: CarState, use_clu11: bool):

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -54,7 +54,7 @@ class CarController(CarControllerBase):
         can_sends.append(hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.CANCEL, self.CP))
       elif CC.cruiseControl.resume:
         if (self.frame - self.last_button_frame) * DT_CTRL > 0.1:
-          can_sends.extend([hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.RES_ACCEL, self.CP)] * 25)
+          can_sends.extend([hyundaican.create_clu11(self.packer, self.frame, CS.clu11, Buttons.RES_ACCEL, self.CP) for _ in range(25)])
           if (self.frame - self.last_button_frame) * DT_CTRL >= 0.15:
             self.last_button_frame = self.frame
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -202,7 +202,7 @@ class CarController(CarControllerBase):
 
 
 
-    # CANFD SPECIFIC START
+    # CAN SPECIFIC START
 
     can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
                                               torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
@@ -232,7 +232,7 @@ class CarController(CarControllerBase):
     if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
       can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
 
-    # CANFD SPECIFIC END
+    # CAN SPECIFIC END
 
 
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -214,11 +214,7 @@ class CarController(CarControllerBase):
       sys_state = 6
 
     # initialize to no warnings
-    left_lane_warning = 0
-    right_lane_warning = 0
-    if hud_control.leftLaneDepart:
-      left_lane_warning = 1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2
-    if hud_control.rightLaneDepart:
-      right_lane_warning = 1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2
+    left_lane_warning = (1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.leftLaneDepart else 0
+    right_lane_warning = (1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.rightLaneDepart else 0
 
     return sys_warning, sys_state, left_lane_warning, right_lane_warning

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -87,8 +87,7 @@ class CarController(CarControllerBase):
 
     # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
     if self.frame % 5 == 0 and lka_steering:
-      can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg,
-                                                        self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
+      can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg, self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
 
     # LFA and HDA icons
     if self.frame % 5 == 0 and (not lka_steering or lka_steering_long):
@@ -188,7 +187,6 @@ class CarController(CarControllerBase):
             for _ in range(20):
               can_sends.append(hyundaicanfd.create_buttons(self.packer, self.CP, self.CAN, CS.buttons_counter + 1, Buttons.CANCEL))
             self.last_button_frame = self.frame
-
         # cruise standstill resume
         elif CC.cruiseControl.resume:
           if self.CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS:

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -24,7 +24,6 @@ class CarController(CarControllerBase):
     self.params = CarControllerParams(CP)
     self.packer = CANPacker(dbc_names[Bus.pt])
     self.angle_limit_counter = 0
-
     self.accel_last = 0
     self.apply_torque_last = 0
     self.car_fingerprint = CP.carFingerprint

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -38,8 +38,8 @@ class CarController(CarControllerBase):
 
     actuators, hud_control = CC.actuators, CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
-     tester_present_msgs = self.compute_common_controls(CC, CS)
+    (apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
+     tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
 
@@ -74,8 +74,8 @@ class CarController(CarControllerBase):
   def update_canfd(self, CC, CS, now_nanos):
     actuators, hud_control = CC.actuators, CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
-     tester_present_msgs = self.compute_common_controls(CC, CS)
+    (apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, right_lane_warning,
+     tester_present_msgs) = self.compute_common_controls(CC, CS)
 
     can_sends = tester_present_msgs.copy()
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -127,8 +127,7 @@ class CarController(CarControllerBase):
 
 
   def compute_common_controls(self, CC, CS):
-    actuators = CC.actuators
-    hud_control = CC.hudControl
+    actuators, hud_control = CC.actuators, CC.hudControl
 
     # steering torque
     new_torque = int(round(actuators.torque * self.params.STEER_MAX))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -119,20 +119,16 @@ class CarController(CarControllerBase):
     set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_KPH if CS.is_metric else CV.MS_TO_MPH)
 
     sys_warning = (hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw))
-
-    # TODO: this is not accurate for all cars
-    sys_state = 1
+    sys_state = 1  # TODO: this is not accurate for all cars
     if hud_control.leftLaneVisible and hud_control.rightLaneVisible or sys_warning:  # HUD alert only display when LKAS status is active
       sys_state = 3 if CC.enabled or sys_warning else 4
     elif hud_control.leftLaneVisible:
       sys_state = 5
     elif hud_control.rightLaneVisible:
       sys_state = 6
-
     left_lane_warning = (1 if self.car_fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.leftLaneDepart else 0
     right_lane_warning = (1 if self.car_fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.rightLaneDepart else 0
 
-    # tester present - w/ no response (keeps relevant ECU disabled)
     tester_present_msgs = []
     if self.frame % 100 == 0 and not (self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC) and self.CP.openpilotLongitudinalControl:
       # for longitudinal control, either radar or ADAS driving ECU

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -131,14 +131,14 @@ class CarController(CarControllerBase):
     # TODO: this is not accurate for all cars
     sys_state = 1
     if hud_control.leftLaneVisible and hud_control.rightLaneVisible or sys_warning:  # HUD alert only display when LKAS status is active
-      sys_state = 3 if enabled or sys_warning else 4
+      sys_state = 3 if CC.enabled or sys_warning else 4
     elif hud_control.leftLaneVisible:
       sys_state = 5
     elif hud_control.rightLaneVisible:
       sys_state = 6
 
-    left_lane_warning = (1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.leftLaneDepart else 0
-    right_lane_warning = (1 if fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.rightLaneDepart else 0
+    left_lane_warning = (1 if self.car_fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.leftLaneDepart else 0
+    right_lane_warning = (1 if self.car_fingerprint in (CAR.GENESIS_G90, CAR.GENESIS_G80) else 2) if hud_control.rightLaneDepart else 0
 
     # tester present - w/ no response (keeps relevant ECU disabled)
     tester_present_msgs = []

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -215,7 +215,7 @@ class CarController(CarControllerBase):
     return can_sends
 
 
-  def process_hud_alert(enabled, fingerprint, hud_control):
+  def process_hud_alert(self, enabled, fingerprint, hud_control):
     sys_warning = (hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw))
 
     # initialize to no line visible

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -111,9 +111,7 @@ class CarController(CarControllerBase):
     if not CC.latActive:
       apply_torque = 0
 
-    # Hold torque with induced temporary fault when cutting the actuation bit
     torque_fault = CC.latActive and not apply_steer_req
-
     self.apply_torque_last = apply_torque
 
     accel = float(np.clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -55,7 +55,7 @@ class CarController(CarControllerBase):
     self.car_fingerprint = CP.carFingerprint
     self.last_button_frame = 0
 
-  def update(self, CC, CS, now_nanos):
+  def update_canfd(self, CC, CS, now_nanos):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
@@ -101,67 +101,45 @@ class CarController(CarControllerBase):
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         can_sends.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 
-    # CAN-FD platforms
-    if self.CP.flags & HyundaiFlags.CANFD:
-      lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
-      lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
 
-      # steering control
-      can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))
 
-      # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
-      if self.frame % 5 == 0 and lka_steering:
-        can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg,
-                                                          self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
+    # CANFD SPECIFIC START
 
-      # LFA and HDA icons
-      if self.frame % 5 == 0 and (not lka_steering or lka_steering_long):
-        can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
+    lka_steering = self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING
+    lka_steering_long = lka_steering and self.CP.openpilotLongitudinalControl
 
-      # blinkers
-      if lka_steering and self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
-        can_sends.extend(hyundaicanfd.create_spas_messages(self.packer, self.CAN, self.frame, CC.leftBlinker, CC.rightBlinker))
+    # steering control
+    can_sends.extend(hyundaicanfd.create_steering_messages(self.packer, self.CP, self.CAN, CC.enabled, apply_steer_req, apply_torque))
 
-      if self.CP.openpilotLongitudinalControl:
-        if lka_steering:
-          can_sends.extend(hyundaicanfd.create_adrv_messages(self.packer, self.CAN, self.frame))
-        else:
-          can_sends.extend(hyundaicanfd.create_fca_warning_light(self.packer, self.CAN, self.frame))
-        if self.frame % 2 == 0:
-          can_sends.append(hyundaicanfd.create_acc_control(self.packer, self.CAN, CC.enabled, self.accel_last, accel, stopping, CC.cruiseControl.override,
-                                                           set_speed_in_units, hud_control))
-          self.accel_last = accel
+    # prevent LFA from activating on LKA steering cars by sending "no lane lines detected" to ADAS ECU
+    if self.frame % 5 == 0 and lka_steering:
+      can_sends.append(hyundaicanfd.create_suppress_lfa(self.packer, self.CAN, CS.lfa_block_msg,
+                                                        self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING_ALT))
+
+    # LFA and HDA icons
+    if self.frame % 5 == 0 and (not lka_steering or lka_steering_long):
+      can_sends.append(hyundaicanfd.create_lfahda_cluster(self.packer, self.CAN, CC.enabled))
+
+    # blinkers
+    if lka_steering and self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
+      can_sends.extend(hyundaicanfd.create_spas_messages(self.packer, self.CAN, self.frame, CC.leftBlinker, CC.rightBlinker))
+
+    if self.CP.openpilotLongitudinalControl:
+      if lka_steering:
+        can_sends.extend(hyundaicanfd.create_adrv_messages(self.packer, self.CAN, self.frame))
       else:
-        # button presses
-        can_sends.extend(self.create_button_messages(CC, CS, use_clu11=False))
+        can_sends.extend(hyundaicanfd.create_fca_warning_light(self.packer, self.CAN, self.frame))
+      if self.frame % 2 == 0:
+        can_sends.append(hyundaicanfd.create_acc_control(self.packer, self.CAN, CC.enabled, self.accel_last, accel, stopping, CC.cruiseControl.override,
+                                                         set_speed_in_units, hud_control))
+        self.accel_last = accel
     else:
-      can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
-                                                torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
-                                                hud_control.leftLaneVisible, hud_control.rightLaneVisible,
-                                                left_lane_warning, right_lane_warning))
+      # button presses
+      can_sends.extend(self.create_button_messages(CC, CS, use_clu11=False))
 
-      if not self.CP.openpilotLongitudinalControl:
-        can_sends.extend(self.create_button_messages(CC, CS, use_clu11=True))
+    # CANFD SPECIFIC END
 
-      if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
-        # TODO: unclear if this is needed
-        jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
-        use_fca = self.CP.flags & HyundaiFlags.USE_FCA.value
-        can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
-                                                        hud_control, set_speed_in_units, stopping,
-                                                        CC.cruiseControl.override, use_fca, self.CP))
 
-      # 20 Hz LFA MFA message
-      if self.frame % 5 == 0 and self.CP.flags & HyundaiFlags.SEND_LFA.value:
-        can_sends.append(hyundaican.create_lfahda_mfc(self.packer, CC.enabled))
-
-      # 5 Hz ACC options
-      if self.frame % 20 == 0 and self.CP.openpilotLongitudinalControl:
-        can_sends.extend(hyundaican.create_acc_opt(self.packer, self.CP))
-
-      # 2 Hz front radar options
-      if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
-        can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
 
     new_actuators = actuators.as_builder()
     new_actuators.torque = apply_torque / self.params.STEER_MAX
@@ -170,6 +148,103 @@ class CarController(CarControllerBase):
 
     self.frame += 1
     return new_actuators, can_sends
+
+
+
+  def update(self, CC, CS, now_nanos):
+    if self.CP.flags & HyundaiFlags.CANFD:
+      return self.update_canfd(CC, CS, now_nanos)
+
+    actuators = CC.actuators
+    hud_control = CC.hudControl
+
+    # steering torque
+    new_torque = int(round(actuators.torque * self.params.STEER_MAX))
+    apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.params)
+
+    # >90 degree steering fault prevention
+    self.angle_limit_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive,
+                                                                       self.angle_limit_counter, MAX_ANGLE_FRAMES,
+                                                                       MAX_ANGLE_CONSECUTIVE_FRAMES)
+
+    if not CC.latActive:
+      apply_torque = 0
+
+    # Hold torque with induced temporary fault when cutting the actuation bit
+    torque_fault = CC.latActive and not apply_steer_req
+
+    self.apply_torque_last = apply_torque
+
+    # accel + longitudinal
+    accel = float(np.clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX))
+    stopping = actuators.longControlState == LongCtrlState.stopping
+    set_speed_in_units = hud_control.setSpeed * (CV.MS_TO_KPH if CS.is_metric else CV.MS_TO_MPH)
+
+    # HUD messages
+    sys_warning, sys_state, left_lane_warning, right_lane_warning = process_hud_alert(CC.enabled, self.car_fingerprint,
+                                                                                      hud_control)
+
+    can_sends = []
+
+    # *** common hyundai stuff ***
+
+    # tester present - w/ no response (keeps relevant ECU disabled)
+    if self.frame % 100 == 0 and not (self.CP.flags & HyundaiFlags.CANFD_CAMERA_SCC) and self.CP.openpilotLongitudinalControl:
+      # for longitudinal control, either radar or ADAS driving ECU
+      addr, bus = 0x7d0, self.CAN.ECAN if self.CP.flags & HyundaiFlags.CANFD else 0
+      if self.CP.flags & HyundaiFlags.CANFD_LKA_STEERING.value:
+        addr, bus = 0x730, self.CAN.ECAN
+      can_sends.append(make_tester_present_msg(addr, bus, suppress_response=True))
+
+      # for blinkers
+      if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
+        can_sends.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
+
+
+
+    # CANFD SPECIFIC START
+
+    can_sends.append(hyundaican.create_lkas11(self.packer, self.frame, self.CP, apply_torque, apply_steer_req,
+                                              torque_fault, CS.lkas11, sys_warning, sys_state, CC.enabled,
+                                              hud_control.leftLaneVisible, hud_control.rightLaneVisible,
+                                              left_lane_warning, right_lane_warning))
+
+    if not self.CP.openpilotLongitudinalControl:
+      can_sends.extend(self.create_button_messages(CC, CS, use_clu11=True))
+
+    if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
+      # TODO: unclear if this is needed
+      jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
+      use_fca = self.CP.flags & HyundaiFlags.USE_FCA.value
+      can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2),
+                                                      hud_control, set_speed_in_units, stopping,
+                                                      CC.cruiseControl.override, use_fca, self.CP))
+
+    # 20 Hz LFA MFA message
+    if self.frame % 5 == 0 and self.CP.flags & HyundaiFlags.SEND_LFA.value:
+      can_sends.append(hyundaican.create_lfahda_mfc(self.packer, CC.enabled))
+
+    # 5 Hz ACC options
+    if self.frame % 20 == 0 and self.CP.openpilotLongitudinalControl:
+      can_sends.extend(hyundaican.create_acc_opt(self.packer, self.CP))
+
+    # 2 Hz front radar options
+    if self.frame % 50 == 0 and self.CP.openpilotLongitudinalControl:
+      can_sends.append(hyundaican.create_frt_radar_opt(self.packer))
+
+    # CANFD SPECIFIC END
+
+
+
+    new_actuators = actuators.as_builder()
+    new_actuators.torque = apply_torque / self.params.STEER_MAX
+    new_actuators.torqueOutputCan = apply_torque
+    new_actuators.accel = accel
+
+    self.frame += 1
+    return new_actuators, can_sends
+
+
 
   def create_button_messages(self, CC: structs.CarControl, CS: CarState, use_clu11: bool):
     can_sends = []

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -156,7 +156,6 @@ class CarController(CarControllerBase):
         addr, bus = 0x730, self.CAN.ECAN
       tester_present_msgs.append(make_tester_present_msg(addr, bus, suppress_response=True))
 
-      # for blinkers
       if self.CP.flags & HyundaiFlags.ENABLE_BLINKERS:
         tester_present_msgs.append(make_tester_present_msg(0x7b1, self.CAN.ECAN, suppress_response=True))
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -39,8 +39,11 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, \
-      right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
+    (
+      apply_torque, apply_steer_req, torque_fault, accel, stopping,
+      set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+      right_lane_warning, tester_present_msgs
+    ) = self.compute_common_controls(CC, CS)
 
     can_sends = []
     can_sends.extend(tester_present_msgs)
@@ -86,8 +89,11 @@ class CarController(CarControllerBase):
     actuators = CC.actuators
     hud_control = CC.hudControl
 
-    apply_torque, apply_steer_req, torque_fault, accel, stopping, set_speed_in_units, sys_warning, sys_state, left_lane_warning, \
-      right_lane_warning, tester_present_msgs = self.compute_common_controls(CC, CS)
+    (
+      apply_torque, apply_steer_req, torque_fault, accel, stopping,
+      set_speed_in_units, sys_warning, sys_state, left_lane_warning,
+      right_lane_warning, tester_present_msgs
+    ) = self.compute_common_controls(CC, CS)
 
     can_sends = []
     can_sends.extend(tester_present_msgs)

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -105,7 +105,6 @@ class CarController(CarControllerBase):
     new_torque = int(round(actuators.torque * self.params.STEER_MAX))
     apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.params)
 
-    # >90 degree steering fault prevention
     self.angle_limit_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive, self.angle_limit_counter,
       MAX_ANGLE_FRAMES, MAX_ANGLE_CONSECUTIVE_FRAMES)
 

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -49,9 +49,8 @@ class CarController(CarControllerBase):
     if self.frame % 2 == 0 and self.CP.openpilotLongitudinalControl:
       # TODO: unclear if this is needed
       jerk = 3.0 if actuators.longControlState == LongCtrlState.pid else 1.0
-      use_fca = self.CP.flags & HyundaiFlags.USE_FCA.value
       can_sends.extend(hyundaican.create_acc_commands(self.packer, CC.enabled, accel, jerk, int(self.frame / 2), hud_control, set_speed_in_units, stopping,
-                                                      CC.cruiseControl.override, use_fca, self.CP))
+                                                      CC.cruiseControl.override, self.CP.flags & HyundaiFlags.USE_FCA.value, self.CP))
 
     if self.frame % 5 == 0 and self.CP.flags & HyundaiFlags.SEND_LFA.value:
       can_sends.append(hyundaican.create_lfahda_mfc(self.packer, CC.enabled))

--- a/opendbc/car/hyundai/carcontroller.py
+++ b/opendbc/car/hyundai/carcontroller.py
@@ -3,7 +3,6 @@ from opendbc.can.packer import CANPacker
 from opendbc.car import Bus, DT_CTRL, apply_driver_steer_torque_limits, common_fault_avoidance, make_tester_present_msg, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.hyundai import hyundaicanfd, hyundaican
-from opendbc.car.hyundai.carstate import CarState
 from opendbc.car.hyundai.hyundaicanfd import CanBus
 from opendbc.car.hyundai.values import HyundaiFlags, Buttons, CarControllerParams, CAR
 from opendbc.car.interfaces import CarControllerBase


### PR DESCRIPTION
This pull request addresses https://github.com/commaai/opendbc/issues/1899 by refactoring the CarController update functions for HKG vehicles, separating the logic for CAN and CANFD communication protocols. The primary changes include:
- Separated update functions for CAN and CANFD to handle their respective messaging protocols.
- Introduced `compute_common_controls` to manage shared logic between CAN and CANFD, reducing redundancy.
- Moved `process_hud_alert` inside the class, as it was not used externally.
- Refactored code structure and ordering for better readability and maintainability.