### PR TITLE
safety: remove duplicate msg fields in RxCheck

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -134,9 +134,9 @@ static int get_addr_check_index(const CANPacket_t *to_push, RxCheck addr_list[],
   for (int i = 0; i < len; i++) {
     // if multiple msgs are allowed, determine which one is present on the bus
     if (!addr_list[i].status.msg_seen) {
-      for (uint8_t j = 0U; (j < MAX_ADDR_CHECK_MSGS) && (addr_list[i].msg[j].addr != 0); j++) {
-        if ((addr == addr_list[i].msg[j].addr) && (bus == addr_list[i].msg[j].bus) &&
-              (length == addr_list[i].msg[j].len)) {
+      for (uint8_t j = 0U; (j < MAX_ADDR_CHECK_MSGS) && (addr_list[i].msg[j].msg.addr != 0); j++) {
+        if ((addr == addr_list[i].msg[j].msg.addr) && (bus == addr_list[i].msg[j].msg.bus) &&
+              (length == addr_list[i].msg[j].msg.len)) {
           addr_list[i].status.index = j;
           addr_list[i].status.msg_seen = true;
           break;
@@ -146,8 +146,8 @@ static int get_addr_check_index(const CANPacket_t *to_push, RxCheck addr_list[],
 
     if (addr_list[i].status.msg_seen) {
       int idx = addr_list[i].status.index;
-      if ((addr == addr_list[i].msg[idx].addr) && (bus == addr_list[i].msg[idx].bus) &&
-          (length == addr_list[i].msg[idx].len)) {
+      if ((addr == addr_list[i].msg[idx].msg.addr) && (bus == addr_list[i].msg[idx].msg.bus) &&
+          (length == addr_list[i].msg[idx].msg.len)) {
         index = i;
         break;
       }

--- a/opendbc/safety/safety/safety_toyota.h
+++ b/opendbc/safety/safety/safety_toyota.h
@@ -22,13 +22,13 @@
   {0x750, 0, 8},  /* radar diagnostic address */                                                                                            \
 
 #define TOYOTA_COMMON_RX_CHECKS(lta)                                                                          \
-  {.msg = {{ 0xaa, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 83U}, { 0 }, { 0 }}},  \
-  {.msg = {{0x260, 0, 8, .ignore_counter = true, .quality_flag = (lta), .frequency = 50U}, { 0 }, { 0 }}},    \
-  {.msg = {{0x1D2, 0, 8, .ignore_counter = true, .frequency = 33U},                                           \
-           {0x176, 0, 8, .ignore_counter = true, .frequency = 32U}, { 0 }}},                                  \
-  {.msg = {{0x101, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 50U},                  \
-           {0x224, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 40U},                  \
-           {0x226, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 40U}}},                \
+  {.msg = {{.msg = {0xaa, 0, 8}, .ignore_checksum = true, .ignore_counter = true, .frequency = 83U}, { 0 }, { 0 }}},  \
+  {.msg = {{.msg = {0x260, 0, 8}, .ignore_counter = true, .quality_flag = (lta), .frequency = 50U}, { 0 }, { 0 }}},    \
+  {.msg = {{.msg = {0x1D2, 0, 8}, .ignore_counter = true, .frequency = 33U},                                           \
+           {.msg = {0x176, 0, 8}, .ignore_counter = true, .frequency = 32U}, { 0 }}},                                  \
+  {.msg = {{.msg = {0x101, 0, 8}, .ignore_checksum = true, .ignore_counter = true, .frequency = 50U},                  \
+           {.msg = {0x224, 0, 8}, .ignore_checksum = true, .ignore_counter = true, .frequency = 40U},                  \
+           {.msg = {0x226, 0, 8}, .ignore_checksum = true, .ignore_counter = true, .frequency = 40U}}},                \
 
 static bool toyota_secoc = false;
 static bool toyota_alt_brake = false;

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -21,6 +21,12 @@
     (config).tx_msgs_len = sizeof((tx)) / sizeof((tx)[0]); \
   } while(0);
 
+#define SET_FWD_MSGS(fwd, config) \
+  do { \
+    (config).fwd_msgs = (fwd); \
+    (config).fwd_msgs_len = sizeof((fwd)) / sizeof((fwd)[0]); \
+  } while(0);
+
 #define UPDATE_VEHICLE_SPEED(val_ms) (update_sample(&vehicle_speed, ROUND((val_ms) * VEHICLE_SPEED_FACTOR)))
 
 uint32_t GET_BYTES(const CANPacket_t *msg, int start, int len);
@@ -118,9 +124,7 @@ typedef struct {
 } LongitudinalLimits;
 
 typedef struct {
-  const int addr;
-  const int bus;
-  const int len;
+  const CanMsg msg;
   const bool ignore_checksum;        // checksum check is not performed when set to true
   const bool ignore_counter;         // counter check is not performed when set to true
   const uint8_t max_counter;         // maximum value of the counter. 0 means that the counter check is skipped
@@ -151,6 +155,8 @@ typedef struct {
   int rx_checks_len;
   const CanMsg *tx_msgs;
   int tx_msgs_len;
+  const CanMsg *fwd_msgs;
+  int fwd_msgs_len;
 } safety_config;
 
 typedef uint32_t (*get_checksum_t)(const CANPacket_t *to_push);

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -21,12 +21,6 @@
     (config).tx_msgs_len = sizeof((tx)) / sizeof((tx)[0]); \
   } while(0);
 
-#define SET_FWD_MSGS(fwd, config) \
-  do { \
-    (config).fwd_msgs = (fwd); \
-    (config).fwd_msgs_len = sizeof((fwd)) / sizeof((fwd)[0]); \
-  } while(0);
-
 #define UPDATE_VEHICLE_SPEED(val_ms) (update_sample(&vehicle_speed, ROUND((val_ms) * VEHICLE_SPEED_FACTOR)))
 
 uint32_t GET_BYTES(const CANPacket_t *msg, int start, int len);
@@ -155,8 +149,6 @@ typedef struct {
   int rx_checks_len;
   const CanMsg *tx_msgs;
   int tx_msgs_len;
-  const CanMsg *fwd_msgs;
-  int fwd_msgs_len;
 } safety_config;
 
 typedef uint32_t (*get_checksum_t)(const CANPacket_t *to_push);


### PR DESCRIPTION
.msg.msg is confusing