### PR TITLE
Rivian: remove a VDM ACC fault signal

### DIFF
--- a/opendbc/car/rivian/carstate.py
+++ b/opendbc/car/rivian/carstate.py
@@ -61,7 +61,8 @@ class CarState(CarStateBase):
     ret.accFaulted = (cp_cam.vl["ACM_Status"]["ACM_FaultStatus"] == 1 or
                       # VDM_AdasFaultStatus=Brk_Intv is the default for some reason
                       # VDM_AdasFaultStatus=Imps_Cmd was seen when sending it rapidly changing ACC enable commands
-                      cp.vl["VDM_AdasSts"]["VDM_AdasFaultStatus"] in (2, 3))  # 2=Cntr_Fault, 3=Imps_Cmd
+                      # VDM_AdasFaultStatus=Cntr_Fault isn't fully understood, but we've seen it in the wild
+                      cp.vl["VDM_AdasSts"]["VDM_AdasFaultStatus"] in (3,))  # 3=Imps_Cmd
 
     # Gear
     ret.gearShifter = GEAR_MAP.get(int(cp.vl["VDM_PropStatus"]["VDM_Prndl_Status"]), GearShifter.unknown)


### PR DESCRIPTION
We've caused Imps by sending the VDM implausible commands (rapidly oscillating cruise states), but haven't repro'd Cntr. We've seen at least one user hit this, so we're removing until we confirm it's actually a fault that prevents enabling. VDM_AdasFaultStatus_Brk_Intv is the default, so maybe it's a fine state to enable in.