### PR TITLE
CI: Set GIT_REF as an environment variable for safety mutation tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ github.repository == 'commaai/opendbc' && 'namespace-profile-amd64-8x16' || 'ubuntu-latest' }}
     timeout-minutes: 20
     env:
-      GIT_REF: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }}
+      GIT_REF: ${{ github.event_name == 'push' && github.ref == 'refs/heads/${{ github.event.repository.default_branch }}' && github.event.before || 'origin/${{ github.event.repository.default_branch }}' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,8 @@ jobs:
     name: Safety mutation tests
     runs-on: ${{ github.repository == 'commaai/opendbc' && 'namespace-profile-amd64-8x16' || 'ubuntu-latest' }}
     timeout-minutes: 20
+    env:
+      GIT_REF: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -102,4 +104,4 @@ jobs:
         run: |
           source setup.sh
           scons -j8
-          GIT_REF=${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && github.event.before || 'origin/master' }} cd opendbc/safety/tests && ./mutation.sh
+          cd opendbc/safety/tests && ./mutation.sh


### PR DESCRIPTION
This change moves the GIT_REF definition into the environment section, otherwise it's not really used as expected by the script


## Note to maintainers
I can also set it like this 

```
GIT_REF: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.before || format('origin/{0}', github.event.repository.default_branch) }}
```

I think this is better for forks in the long run as some (like us at SP for the time being) use `master-new` for our rewrite with this it becomes more universal