### PR TITLE
parser_pyx: add nogil for improved threading performance

### DIFF
--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -80,9 +80,9 @@ cdef extern from "common.h":
   cdef cppclass CANParser:
     bool can_valid
     bool bus_timeout
-    CANParser(int, string, vector[pair[uint32_t, int]]) except +
-    set[uint32_t] update(vector[CanData]&) except +
-    MessageState *getMessageState(uint32_t address)
+    CANParser(int, string, vector[pair[uint32_t, int]]) except + nogil
+    set[uint32_t] update(vector[CanData]&) except + nogil
+    MessageState *getMessageState(uint32_t address) nogil
 
   cdef cppclass CANPacker:
    CANPacker(string)

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -4,7 +4,7 @@
 from libcpp.pair cimport pair
 from libcpp.string cimport string
 from libcpp.vector cimport vector
-from libc.stdint cimport uint32_t
+from libc.stdint cimport uint32_t, int
 
 from .common cimport CANParser as cpp_CANParser
 from .common cimport dbc_lookup, Msg, DBC, CanData
@@ -61,11 +61,19 @@ cdef class CANParser:
       self.ts_nanos[address] = {name: 0.0 for name in signal_names}
       self.ts_nanos[name] = self.ts_nanos[address]
 
-    self.can = new cpp_CANParser(bus, dbc_name, message_v)
+    cdef string cpp_dbc_name
+    if isinstance(dbc_name, str):
+      cpp_dbc_name = (<str>dbc_name).encode('utf-8')
+    else:
+      cpp_dbc_name = dbc_name  # Assume bytes
+    cdef int cpp_bus = bus
+    with nogil:
+      self.can = new cpp_CANParser(cpp_bus, cpp_dbc_name, message_v)
 
   def __dealloc__(self):
     if self.can:
-      del self.can
+      with nogil:
+        del self.can
 
   def update_strings(self, strings, sendcan=False):
     # input format:
@@ -95,13 +103,16 @@ cdef class CANParser:
     except TypeError:
       raise RuntimeError("invalid parameter")
 
-    updated_addrs = self.can.update(can_data_array)
+    with nogil:
+      updated_addrs = self.can.update(can_data_array)
+
     for addr in updated_addrs:
       vl = self.vl[addr]
       vl_all = self.vl_all[addr]
       ts_nanos = self.ts_nanos[addr]
 
-      state = self.can.getMessageState(addr)
+      with nogil:
+        state = self.can.getMessageState(addr)
       for i in range(state.parse_sigs.size()):
         name = <unicode>state.parse_sigs[i].name
         vl[name] = state.vals[i]
@@ -112,11 +123,17 @@ cdef class CANParser:
 
   @property
   def can_valid(self):
-    return self.can.can_valid
+    cdef bint valid
+    with nogil:
+      valid = self.can.can_valid
+    return valid
 
   @property
   def bus_timeout(self):
-    return self.can.bus_timeout
+    cdef bint timeout
+    with nogil:
+      timeout = self.can.bus_timeout
+    return timeout
 
 
 cdef class CANDefine():


### PR DESCRIPTION
This PR adds `nogil` annotations to the cython `CANParser`, enabling the GIL to be released during C++ operations. By allowing the GIL to be freed, this change enhances the potential for improved multi-threaded performance, especially in scenarios where multiple threads need to run concurrently, such as in test cases that involve parsing CAN messages (e.g., test_car_interface).