### PR TITLE
Hyundai CAN FD: Fix steering messages in safety replay

### DIFF
--- a/opendbc/safety/tests/safety_replay/helpers.py
+++ b/opendbc/safety/tests/safety_replay/helpers.py
@@ -1,4 +1,5 @@
 from opendbc.car.ford.values import FordSafetyFlags
+from opendbc.car.hyundai.values import HyundaiSafetyFlags
 from opendbc.car.toyota.values import ToyotaSafetyFlags
 from opendbc.car.structs import CarParams
 from opendbc.safety.tests.libsafety import libsafety_py
@@ -20,8 +21,9 @@ def is_steering_msg(mode, param, addr):
   elif mode == CarParams.SafetyModel.hyundai:
     ret = addr == 832
   elif mode == CarParams.SafetyModel.hyundaiCanfd:
-    # TODO: other params
-    ret = addr == 0x50
+    ret = addr == (0x110 if param & HyundaiSafetyFlags.CANFD_LKA_STEERING_ALT else
+                   0x50 if param & HyundaiSafetyFlags.CANFD_LKA_STEERING else
+                   0x12A)
   elif mode == CarParams.SafetyModel.chrysler:
     ret = addr == 0x292
   elif mode == CarParams.SafetyModel.subaru:


### PR DESCRIPTION
Noticed a good amount of blocked tx messages when running some CAN FD routes via safety replay in this PR:
- https://github.com/commaai/opendbc/pull/1903

**Before**
```
replaying b5d6dc830ad63071|2022-12-12--21-28-25/12 with safety mode 28, param 13, alternative experience 0
no steering msgs found!

RX
total rx msgs: 190253
invalid rx msgs: 0
safety tick rx invalid: False
invalid addrs: set()

TX
total openpilot msgs: 10200
total msgs with controls allowed: 6698
blocked msgs: 265
blocked with controls allowed: 81
blocked addrs: Counter({298: 203, 416: 62})
```

**After**
```
replaying b5d6dc830ad63071|2022-12-12--21-28-25/12 with safety mode 28, param 13, alternative experience 0

RX
total rx msgs: 190253
invalid rx msgs: 0
safety tick rx invalid: False
invalid addrs: set()

TX
total openpilot msgs: 10200
total msgs with controls allowed: 6908
blocked msgs: 0
blocked with controls allowed: 0
blocked addrs: Counter()
```