### PR TITLE
safety tests: remove redundant test skips

### DIFF
--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -95,11 +95,6 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
   packer: CANPackerPanda
   safety: libsafety_py.Panda
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestFordSafetyBase":
-      raise unittest.SkipTest
-
   def get_canfd_curvature_limits(self, speed):
     # Round it in accordance with the safety
     curvature_accel_limit = MAX_LATERAL_ACCEL / (max(speed, 1) ** 2)
@@ -427,11 +422,6 @@ class TestFordLongitudinalSafetyBase(TestFordSafetyBase):
   MAX_GAS = 2.0
   MIN_GAS = -0.5
   INACTIVE_GAS = -5.0
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestFordLongitudinalSafetyBase":
-      raise unittest.SkipTest
 
   # ACC command
   def _acc_command_msg(self, gas: float, brake: float, brake_actuation: bool, cmbb_deny: bool = False):

--- a/opendbc/safety/tests/test_gm.py
+++ b/opendbc/safety/tests/test_gm.py
@@ -88,13 +88,6 @@ class TestGmSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSaf
 
   PCM_CRUISE = True  # openpilot is tied to the PCM state if not longitudinal
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestGmSafetyBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def setUp(self):
     self.packer = CANPackerPanda("gm_global_a_powertrain_generated")
     self.packer_chassis = CANPackerPanda("gm_global_a_chassis")
@@ -164,15 +157,6 @@ class TestGmAscmSafety(GmLongitudinalBase, TestGmSafetyBase):
 
 
 class TestGmCameraSafetyBase(TestGmSafetyBase):
-
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestGmCameraSafetyBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _user_brake_msg(self, brake):
     values = {"BrakePressed": brake}
     return self.packer.make_can_msg_panda("ECMEngineStatus", 0, values)

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -180,13 +180,6 @@ class HondaBase(common.PandaCarSafetyTest):
   cnt_powertrain_data = 0
   cnt_acc_state = 0
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__.endswith("Base"):
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _powertrain_data_msg(self, cruise_on=None, brake_pressed=None, gas_pressed=None):
     # preserve the state
     if cruise_on is None:

--- a/opendbc/safety/tests/test_hyundai_canfd.py
+++ b/opendbc/safety/tests/test_hyundai_canfd.py
@@ -38,14 +38,6 @@ class TestHyundaiCanfdBase(HyundaiButtonBase, common.PandaCarSafetyTest, common.
   GAS_MSG = ("", "")
   BUTTONS_TX_BUS = 1
 
-  @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-    if cls.__name__ == "TestHyundaiCanfdBase":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _torque_driver_msg(self, torque):
     values = {"STEERING_COL_TORQUE": torque}
     return self.packer.make_can_msg_panda("MDPS", self.PT_BUS, values)

--- a/opendbc/safety/tests/test_rivian.py
+++ b/opendbc/safety/tests/test_rivian.py
@@ -24,11 +24,6 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
   DRIVER_TORQUE_ALLOWANCE = 100
   DRIVER_TORQUE_FACTOR = 2
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestRivianSafetyBase":
-      raise unittest.SkipTest
-
   def _torque_driver_msg(self, torque):
     values = {"EPAS_TorsionBarTorque": torque / 100.0}
     return self.packer.make_can_msg_panda("EPAS_SystemStatus", 0, values)

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -36,11 +36,6 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
 
   packer: CANPackerPanda
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestTeslaSafetyBase":
-      raise unittest.SkipTest
-
   def setUp(self):
     self.packer = CANPackerPanda("tesla_model3_party")
     self.define = CANDefine("tesla_model3_party")

--- a/opendbc/safety/tests/test_toyota.py
+++ b/opendbc/safety/tests/test_toyota.py
@@ -28,13 +28,6 @@ class TestToyotaSafetyBase(common.PandaCarSafetyTest, common.LongitudinalAccelSa
   packer: CANPackerPanda
   safety: libsafety_py.Panda
 
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__.endswith("Base"):
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
-
   def _torque_meas_msg(self, torque: int, driver_torque: int | None = None):
     values = {"STEER_TORQUE_EPS": (torque / self.EPS_SCALE) * 100.}
     if driver_torque is not None:

--- a/opendbc/safety/tests/test_volkswagen_mqb.py
+++ b/opendbc/safety/tests/test_volkswagen_mqb.py
@@ -23,7 +23,7 @@ MSG_ACC_02 = 0x30C      # TX by OP, ACC HUD data to the instrument cluster
 MSG_LDW_02 = 0x397      # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenMqbSafety(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
+class TestVolkswagenMqbSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   RELAY_MALFUNCTION_ADDRS = {0: (MSG_HCA_01,)}
 
   MAX_RATE_UP = 4
@@ -34,13 +34,6 @@ class TestVolkswagenMqbSafety(common.PandaCarSafetyTest, common.DriverTorqueStee
 
   DRIVER_TORQUE_ALLOWANCE = 80
   DRIVER_TORQUE_FACTOR = 3
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestVolkswagenMqbSafety":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   # Wheel speeds _esp_19_msg
   def _speed_msg(self, speed):
@@ -135,7 +128,7 @@ class TestVolkswagenMqbSafety(common.PandaCarSafetyTest, common.DriverTorqueStee
     self.assertEqual(0, self.safety.get_torque_driver_min())
 
 
-class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
+class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafetyBase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_LH_EPS_03, 2], [MSG_GRA_ACC_01, 0], [MSG_GRA_ACC_01, 2]]
   FWD_BLACKLISTED_ADDRS = {0: [MSG_LH_EPS_03], 2: [MSG_HCA_01, MSG_LDW_02]}
 
@@ -155,7 +148,7 @@ class TestVolkswagenMqbStockSafety(TestVolkswagenMqbSafety):
     self.assertTrue(self._tx(self._gra_acc_01_msg(resume=1)))
 
 
-class TestVolkswagenMqbLongSafety(TestVolkswagenMqbSafety):
+class TestVolkswagenMqbLongSafety(TestVolkswagenMqbSafetyBase):
   TX_MSGS = [[MSG_HCA_01, 0], [MSG_LDW_02, 0], [MSG_LH_EPS_03, 2], [MSG_ACC_02, 0], [MSG_ACC_06, 0], [MSG_ACC_07, 0]]
   FWD_BLACKLISTED_ADDRS = {0: [MSG_LH_EPS_03], 2: [MSG_HCA_01, MSG_LDW_02, MSG_ACC_02, MSG_ACC_06, MSG_ACC_07]}
   INACTIVE_ACCEL = 3.01

--- a/opendbc/safety/tests/test_volkswagen_pq.py
+++ b/opendbc/safety/tests/test_volkswagen_pq.py
@@ -19,7 +19,7 @@ MSG_ACC_GRA_ANZEIGE = 0x56A   # TX by OP, ACC HUD
 MSG_LDW_1 = 0x5BE             # TX by OP, Lane line recognition and text alerts
 
 
-class TestVolkswagenPqSafety(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
+class TestVolkswagenPqSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteeringSafetyTest):
   cruise_engaged = False
 
   RELAY_MALFUNCTION_ADDRS = {0: (MSG_HCA_1,)}
@@ -32,13 +32,6 @@ class TestVolkswagenPqSafety(common.PandaCarSafetyTest, common.DriverTorqueSteer
 
   DRIVER_TORQUE_ALLOWANCE = 80
   DRIVER_TORQUE_FACTOR = 3
-
-  @classmethod
-  def setUpClass(cls):
-    if cls.__name__ == "TestVolkswagenPqSafety":
-      cls.packer = None
-      cls.safety = None
-      raise unittest.SkipTest
 
   def _set_prev_torque(self, t):
     self.safety.set_desired_torque_last(t)
@@ -117,7 +110,7 @@ class TestVolkswagenPqSafety(common.PandaCarSafetyTest, common.DriverTorqueSteer
     self.assertEqual(0, self.safety.get_torque_driver_min())
 
 
-class TestVolkswagenPqStockSafety(TestVolkswagenPqSafety):
+class TestVolkswagenPqStockSafety(TestVolkswagenPqSafetyBase):
   # Transmit of GRA_Neu is allowed on bus 0 and 2 to keep compatibility with gateway and camera integration
   TX_MSGS = [[MSG_HCA_1, 0], [MSG_GRA_NEU, 0], [MSG_GRA_NEU, 2], [MSG_LDW_1, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_1, MSG_LDW_1]}
@@ -138,7 +131,7 @@ class TestVolkswagenPqStockSafety(TestVolkswagenPqSafety):
     self.assertTrue(self._tx(self._button_msg(resume=True)))
 
 
-class TestVolkswagenPqLongSafety(TestVolkswagenPqSafety, common.LongitudinalAccelSafetyTest):
+class TestVolkswagenPqLongSafety(TestVolkswagenPqSafetyBase, common.LongitudinalAccelSafetyTest):
   TX_MSGS = [[MSG_HCA_1, 0], [MSG_LDW_1, 0], [MSG_ACC_SYSTEM, 0], [MSG_ACC_GRA_ANZEIGE, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [MSG_HCA_1, MSG_LDW_1, MSG_ACC_SYSTEM, MSG_ACC_GRA_ANZEIGE]}
   INACTIVE_ACCEL = 3.01


### PR DESCRIPTION
common already checks for Base suffix