### PR TITLE
safety: start per-message fwd config

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -223,7 +223,7 @@ bool safety_rx_hook(const CANPacket_t *to_push) {
   const int addr = GET_ADDR(to_push);
   for (int i = 0; i < current_safety_config.tx_msgs_len; i++) {
     const CanMsg *m = &current_safety_config.tx_msgs[i];
-    if (m->check_relay) {
+    if (m->blocked) {
       generic_rx_checks((m->addr == addr) && (m->bus == bus));
     }
   }

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -52,7 +52,7 @@ typedef struct {
   int addr;
   int bus;
   int len;
-  bool check_relay;
+  bool blocked;
 } CanMsg;
 
 typedef enum {


### PR DESCRIPTION
Split from https://github.com/commaai/opendbc/pull/1954 with only brands that do not have any conflicts and for only currently checked relay msgs first