### PR TITLE
Ford: radar is invalid when in reverse

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -307,6 +307,7 @@ struct RadarData @0x888ad6581cf0aacb {
     canError @0;
     fault @1;
     wrongConfig @2;
+    unavailableTemporary @3;  # radar data is temporarily unavailable due to conditions the car sets
   }
 
   # similar to LiveTracks

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -305,9 +305,9 @@ struct RadarData @0x888ad6581cf0aacb {
 
   struct Error {
     canError @0 :Bool;
-    fault @1 :Bool;
+    radarFault @1 :Bool;
     wrongConfig @2 :Bool;
-    unavailableTemporary @3 :Bool;  # radar data is temporarily unavailable due to conditions the car sets
+    radarUnavailableTemporary @3 :Bool;  # radar data is temporarily unavailable due to conditions the car sets
   }
 
   # similar to LiveTracks

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -307,7 +307,7 @@ struct RadarData @0x888ad6581cf0aacb {
     canError @0 :Bool;
     fault @1 :Bool;
     wrongConfig @2 :Bool;
-    unavailableTemporary @3;  # radar data is temporarily unavailable due to conditions the car sets
+    unavailableTemporary @3 :Bool;  # radar data is temporarily unavailable due to conditions the car sets
   }
 
   # similar to LiveTracks

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -182,7 +182,7 @@ class RadarInterface(RadarInterfaceBase):
       self.pts.clear()
       self.points.clear()
       self.clusters.clear()
-      ret.errors.unavailableTemporary = True
+      ret.errors.radarUnavailableTemporary = True
       return True
 
     # Use points with Doppler coverage of +-60 m/s, reduces similar points

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -136,7 +136,6 @@ class RadarInterface(RadarInterfaceBase):
       errors.extend(_errors)
       if not _update:
         return None
-      print('sending')
 
     ret = structs.RadarData()
     ret.points = list(self.pts.values())

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -230,7 +230,7 @@ class RadarInterface(RadarInterfaceBase):
 
         self.points.append([dRel, yRel * 2, distRate * 2])
 
-    # Update with stored points once we've cycled through all 4 scan modes
+    # Cluster and publish using stored points once we've cycled through all 4 scan modes
     if headerScanIndex != 3:
       return False, []
 

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -182,8 +182,8 @@ class RadarInterface(RadarInterfaceBase):
       self.pts.clear()
       self.points.clear()
       self.clusters.clear()
-      errors.append("unavailableTemporary")
-      return True, errors
+      ret.errors.unavailableTemporary = True
+      return True
 
     # Use points with Doppler coverage of +-60 m/s, reduces similar points
     if headerScanIndex not in (2, 3):

--- a/opendbc/car/ford/radar_interface.py
+++ b/opendbc/car/ford/radar_interface.py
@@ -173,7 +173,7 @@ class RadarInterface(RadarInterfaceBase):
     headerScanIndex = int(self.rcp.vl["MRR_Header_InformationDetections"]['CAN_SCAN_INDEX']) & 0b11
 
     # Use points with Doppler coverage of +-60 m/s, reduces similar points
-    if headerScanIndex in (0, 1):
+    if headerScanIndex not in (2, 3):
       return False, []
 
     errors = []
@@ -213,7 +213,7 @@ class RadarInterface(RadarInterfaceBase):
 
         self.points.append([dRel, yRel * 2, distRate * 2])
 
-    # Update once we've cycled through all 4 scan modes
+    # Cluster and publish once we've cycled through all 4 scan modes
     if headerScanIndex != 3:
       return False, []
 

--- a/opendbc/car/gm/radar_interface.py
+++ b/opendbc/car/gm/radar_interface.py
@@ -59,7 +59,7 @@ class RadarInterface(RadarInterfaceBase):
     if not self.rcp.can_valid:
       ret.errors.canError = True
     if fault:
-      ret.errors.fault = True
+      ret.errors.radarFault = True
 
     currentTargets = set()
     num_targets = header['FLRRNumValidTargets']

--- a/opendbc/car/honda/radar_interface.py
+++ b/opendbc/car/honda/radar_interface.py
@@ -70,7 +70,7 @@ class RadarInterface(RadarInterfaceBase):
     if not self.rcp.can_valid:
       ret.errors.canError = True
     if self.radar_fault:
-      ret.errors.fault = True
+      ret.errors.radarFault = True
     if self.radar_wrong_config:
       ret.errors.wrongConfig = True
 


### PR DESCRIPTION
Radar just sends the last message while in reverse (for everything; tracks, headers, etc.), so we need to detect a stalled scan index and add a fault instead of stop sending liveTracks:

![image](https://github.com/user-attachments/assets/00d67afa-5aaa-462f-835b-f5d8934fbdea)
