### PR TITLE
car interfaces: each specify their own dependencies

### DIFF
--- a/opendbc/car/body/interface.py
+++ b/opendbc/car/body/interface.py
@@ -1,10 +1,15 @@
 import math
 from opendbc.car import get_safety_config, structs
-from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.body.carcontroller import CarController
+from opendbc.car.body.carstate import CarState
 from opendbc.car.body.values import SPEED_FROM_RPM
+from opendbc.car.interfaces import CarInterfaceBase
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.notCar = True

--- a/opendbc/car/body/radar_interface.py
+++ b/opendbc/car/body/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -170,7 +170,7 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
     carlog.error({"event": "car doesn't match any fingerprints", "fingerprints": repr(fingerprints)})
     candidate = "MOCK"
 
-  CarInterface, _, _, _ = interfaces[candidate]
+  CarInterface = interfaces[candidate]
   CP: CarParams = CarInterface.get_params(candidate, fingerprints, car_fw, experimental_long_allowed, docs=False)
   CP.carVin = vin
   CP.carFw = car_fw
@@ -182,6 +182,6 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
 
 def get_demo_car_params():
   platform = MOCK.MOCK
-  CarInterface, _, _, _ = interfaces[platform]
+  CarInterface = interfaces[platform]
   CP = CarInterface.get_non_essential_params(platform)
   return CP

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -10,18 +10,52 @@ from opendbc.car.fw_versions import ObdCallback, get_fw_versions_ordered, get_pr
 from opendbc.car.mock.values import CAR as MOCK
 from opendbc.car.values import BRANDS
 from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
+
+from opendbc.car.body.interface import CarInterface as BodyCarInterface
+from opendbc.car.chrysler.interface import CarInterface as ChryslerCarInterface
+from opendbc.car.ford.interface import CarInterface as FordCarInterface
+from opendbc.car.gm.interface import CarInterface as GmCarInterface
+from opendbc.car.honda.interface import CarInterface as HondaCarInterface
+from opendbc.car.hyundai.interface import CarInterface as HyundaiCarInterface
+from opendbc.car.mazda.interface import CarInterface as MazdaCarInterface
+from opendbc.car.mock.interface import CarInterface as MockCarInterface
+from opendbc.car.nissan.interface import CarInterface as NissanCarInterface
+from opendbc.car.rivian.interface import CarInterface as RivianCarInterface
+from opendbc.car.subaru.interface import CarInterface as SubaruCarInterface
+from opendbc.car.tesla.interface import CarInterface as TeslaCarInterface
 from opendbc.car.toyota.interface import CarInterface as ToyotaCarInterface
+from opendbc.car.volkswagen.interface import CarInterface as VolkswagenCarInterface
 
 FRAME_FINGERPRINT = 100  # 1s
 
 
 def load_interfaces(brand_names):
   ret = {}
-  for brand_name in brand_names:
-    path = f'opendbc.car.{brand_name}'
-    CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
-    for model_name in brand_names[brand_name]:
-      ret[model_name] = CarInterface
+  # for brand_name in brand_names:
+  #   path = f'opendbc.car.{brand_name}'
+  #   CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
+  #   for model_name in brand_names[brand_name]:
+  #     ret[model_name] = CarInterface
+  for interface in (
+    BodyCarInterface,
+    ChryslerCarInterface,
+    FordCarInterface,
+    GmCarInterface,
+    HondaCarInterface,
+    HyundaiCarInterface,
+    MazdaCarInterface,
+    MockCarInterface,
+    NissanCarInterface,
+    RivianCarInterface,
+    SubaruCarInterface,
+    TeslaCarInterface,
+    ToyotaCarInterface,
+    VolkswagenCarInterface,
+  ):
+    brand_name = interface.__module__.split('.')[-2]
+    models = brand_names[brand_name]
+    for model_name in models:
+      ret[model_name] = interface
   return ret
 
 
@@ -36,11 +70,11 @@ def _get_interface_names() -> dict[str, list[str]]:
 
 
 # imports from directory opendbc/car/<name>/
-interface_names = _get_interface_names()
+interface_names = _get_interface_names()  # TODO: INTERFACE_NAMES
 interfaces = load_interfaces(interface_names)
-INTERFACES = {
-  "toyota": (ToyotaCarInterface, ToyotaCarInterface.CarController, ToyotaCarInterface.CarState, ToyotaCarInterface.RadarInterface)
-}
+# INTERFACES = {
+#   model: interface for brand in BRANDS for model, interface in brand.__module__.split('.')[-2].items()
+# }
 
 
 def can_fingerprint(can_recv: CanRecvCallable) -> tuple[str | None, dict[int, dict]]:

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -10,7 +10,6 @@ from opendbc.car.fw_versions import ObdCallback, get_fw_versions_ordered, get_pr
 from opendbc.car.mock.values import CAR as MOCK
 from opendbc.car.values import BRANDS
 from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
-from opendbc.car.toyota.interface import CarInterface as ToyotaCarInterface
 
 FRAME_FINGERPRINT = 100  # 1s
 
@@ -38,9 +37,6 @@ def _get_interface_names() -> dict[str, list[str]]:
 # imports from directory opendbc/car/<name>/
 interface_names = _get_interface_names()
 interfaces = load_interfaces(interface_names)
-INTERFACES = {
-  "toyota": (ToyotaCarInterface, ToyotaCarInterface.CarController, ToyotaCarInterface.CarState, ToyotaCarInterface.RadarInterface)
-}
 
 
 def can_fingerprint(can_recv: CanRecvCallable) -> tuple[str | None, dict[int, dict]]:

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -10,52 +10,18 @@ from opendbc.car.fw_versions import ObdCallback, get_fw_versions_ordered, get_pr
 from opendbc.car.mock.values import CAR as MOCK
 from opendbc.car.values import BRANDS
 from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
-
-from opendbc.car.body.interface import CarInterface as BodyCarInterface
-from opendbc.car.chrysler.interface import CarInterface as ChryslerCarInterface
-from opendbc.car.ford.interface import CarInterface as FordCarInterface
-from opendbc.car.gm.interface import CarInterface as GmCarInterface
-from opendbc.car.honda.interface import CarInterface as HondaCarInterface
-from opendbc.car.hyundai.interface import CarInterface as HyundaiCarInterface
-from opendbc.car.mazda.interface import CarInterface as MazdaCarInterface
-from opendbc.car.mock.interface import CarInterface as MockCarInterface
-from opendbc.car.nissan.interface import CarInterface as NissanCarInterface
-from opendbc.car.rivian.interface import CarInterface as RivianCarInterface
-from opendbc.car.subaru.interface import CarInterface as SubaruCarInterface
-from opendbc.car.tesla.interface import CarInterface as TeslaCarInterface
 from opendbc.car.toyota.interface import CarInterface as ToyotaCarInterface
-from opendbc.car.volkswagen.interface import CarInterface as VolkswagenCarInterface
 
 FRAME_FINGERPRINT = 100  # 1s
 
 
 def load_interfaces(brand_names):
   ret = {}
-  # for brand_name in brand_names:
-  #   path = f'opendbc.car.{brand_name}'
-  #   CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
-  #   for model_name in brand_names[brand_name]:
-  #     ret[model_name] = CarInterface
-  for interface in (
-    BodyCarInterface,
-    ChryslerCarInterface,
-    FordCarInterface,
-    GmCarInterface,
-    HondaCarInterface,
-    HyundaiCarInterface,
-    MazdaCarInterface,
-    MockCarInterface,
-    NissanCarInterface,
-    RivianCarInterface,
-    SubaruCarInterface,
-    TeslaCarInterface,
-    ToyotaCarInterface,
-    VolkswagenCarInterface,
-  ):
-    brand_name = interface.__module__.split('.')[-2]
-    models = brand_names[brand_name]
-    for model_name in models:
-      ret[model_name] = interface
+  for brand_name in brand_names:
+    path = f'opendbc.car.{brand_name}'
+    CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
+    for model_name in brand_names[brand_name]:
+      ret[model_name] = CarInterface
   return ret
 
 
@@ -70,11 +36,11 @@ def _get_interface_names() -> dict[str, list[str]]:
 
 
 # imports from directory opendbc/car/<name>/
-interface_names = _get_interface_names()  # TODO: INTERFACE_NAMES
+interface_names = _get_interface_names()
 interfaces = load_interfaces(interface_names)
-# INTERFACES = {
-#   model: interface for brand in BRANDS for model, interface in brand.__module__.split('.')[-2].items()
-# }
+INTERFACES = {
+  "toyota": (ToyotaCarInterface, ToyotaCarInterface.CarController, ToyotaCarInterface.CarState, ToyotaCarInterface.RadarInterface)
+}
 
 
 def can_fingerprint(can_recv: CanRecvCallable) -> tuple[str | None, dict[int, dict]]:

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -152,16 +152,6 @@ def fingerprint(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_mu
   return car_fingerprint, finger, vin, car_fw, source, exact_match
 
 
-def get_car_interface(CP: CarParams):
-  CarInterface = interfaces[CP.carFingerprint]
-  return CarInterface(CP)
-
-
-def get_radar_interface(CP: CarParams):
-  CarInterface = interfaces[CP.carFingerprint]
-  return CarInterface.RadarInterface(CP)
-
-
 def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multiplexing: ObdCallback, experimental_long_allowed: bool,
             num_pandas: int = 1, cached_params: CarParamsT | None = None):
   candidate, fingerprints, vin, car_fw, source, exact_match = fingerprint(can_recv, can_send, set_obd_multiplexing, num_pandas, cached_params)
@@ -177,7 +167,7 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
   CP.fingerprintSource = source
   CP.fuzzyFingerprint = not exact_match
 
-  return get_car_interface(CP)
+  return interfaces[CP.carFingerprint](CP)
 
 
 def get_demo_car_params():

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -20,15 +20,9 @@ def load_interfaces(brand_names):
   for brand_name in brand_names:
     path = f'opendbc.car.{brand_name}'
     CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
-    try:
-      CarState = CarInterface.CarState
-    except:
-      CarState = __import__(path + '.carstate', fromlist=['CarState']).CarState
+    CarState = CarInterface.CarState
     CarController = CarInterface.CarController
-    try:
-      RadarInterface = CarInterface.RadarInterface
-    except:
-      RadarInterface = __import__(path + '.radar_interface', fromlist=['RadarInterface']).RadarInterface
+    RadarInterface = CarInterface.RadarInterface
     for model_name in brand_names[brand_name]:
       ret[model_name] = (CarInterface, CarController, CarState, RadarInterface)
   return ret

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -20,9 +20,15 @@ def load_interfaces(brand_names):
   for brand_name in brand_names:
     path = f'opendbc.car.{brand_name}'
     CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
-    CarState = __import__(path + '.carstate', fromlist=['CarState']).CarState
-    CarController = __import__(path + '.carcontroller', fromlist=['CarController']).CarController
-    RadarInterface = __import__(path + '.radar_interface', fromlist=['RadarInterface']).RadarInterface
+    try:
+      CarState = CarInterface.CarState
+    except:
+      CarState = __import__(path + '.carstate', fromlist=['CarState']).CarState
+    CarController = CarInterface.CarController
+    try:
+      RadarInterface = CarInterface.RadarInterface
+    except:
+      RadarInterface = __import__(path + '.radar_interface', fromlist=['RadarInterface']).RadarInterface
     for model_name in brand_names[brand_name]:
       ret[model_name] = (CarInterface, CarController, CarState, RadarInterface)
   return ret

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -10,6 +10,7 @@ from opendbc.car.fw_versions import ObdCallback, get_fw_versions_ordered, get_pr
 from opendbc.car.mock.values import CAR as MOCK
 from opendbc.car.values import BRANDS
 from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
+from opendbc.car.toyota.interface import CarInterface as ToyotaCarInterface
 
 FRAME_FINGERPRINT = 100  # 1s
 
@@ -40,6 +41,9 @@ def _get_interface_names() -> dict[str, list[str]]:
 # imports from directory opendbc/car/<name>/
 interface_names = _get_interface_names()
 interfaces = load_interfaces(interface_names)
+INTERFACES = {
+  "toyota": (ToyotaCarInterface, ToyotaCarInterface.CarController, ToyotaCarInterface.CarState, ToyotaCarInterface.RadarInterface)
+}
 
 
 def can_fingerprint(can_recv: CanRecvCallable) -> tuple[str | None, dict[int, dict]]:

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -20,11 +20,8 @@ def load_interfaces(brand_names):
   for brand_name in brand_names:
     path = f'opendbc.car.{brand_name}'
     CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
-    CarState = CarInterface.CarState
-    CarController = CarInterface.CarController
-    RadarInterface = CarInterface.RadarInterface
     for model_name in brand_names[brand_name]:
-      ret[model_name] = (CarInterface, CarController, CarState, RadarInterface)
+      ret[model_name] = CarInterface
   return ret
 
 
@@ -156,13 +153,13 @@ def fingerprint(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_mu
 
 
 def get_car_interface(CP: CarParams):
-  CarInterface, CarController, CarState, _ = interfaces[CP.carFingerprint]
-  return CarInterface(CP, CarController, CarState)
+  CarInterface = interfaces[CP.carFingerprint]
+  return CarInterface(CP)
 
 
 def get_radar_interface(CP: CarParams):
-  _, _, _, RadarInterface = interfaces[CP.carFingerprint]
-  return RadarInterface(CP)
+  CarInterface = interfaces[CP.carFingerprint]
+  return CarInterface.RadarInterface(CP)
 
 
 def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multiplexing: ObdCallback, experimental_long_allowed: bool,

--- a/opendbc/car/chrysler/interface.py
+++ b/opendbc/car/chrysler/interface.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 from opendbc.car import get_safety_config, structs
+from opendbc.car.chrysler.carcontroller import CarController
+from opendbc.car.chrysler.carstate import CarState
 from opendbc.car.chrysler.values import CAR, RAM_HD, RAM_DT, RAM_CARS, ChryslerFlags, ChryslerSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "chrysler"

--- a/opendbc/car/chrysler/interface.py
+++ b/opendbc/car/chrysler/interface.py
@@ -2,6 +2,7 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.chrysler.carcontroller import CarController
 from opendbc.car.chrysler.carstate import CarState
+from opendbc.car.chrysler.radar_interface import RadarInterface
 from opendbc.car.chrysler.values import CAR, RAM_HD, RAM_DT, RAM_CARS, ChryslerFlags, ChryslerSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 
@@ -9,6 +10,7 @@ from opendbc.car.interfaces import CarInterfaceBase
 class CarInterface(CarInterfaceBase):
   CarState = CarState
   CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/docs.py
+++ b/opendbc/car/docs.py
@@ -30,9 +30,9 @@ EXTRA_PLATFORMS: dict[str, ExtraPlatform] = {str(platform): platform for brand i
 
 def get_params_for_docs(platform) -> CarParams:
   cp_platform = platform if platform in interfaces else MOCK.MOCK
-  CP: CarParams = interfaces[cp_platform][0].get_params(cp_platform, fingerprint=gen_empty_fingerprint(),
-                                                        car_fw=[CarParams.CarFw(ecu=CarParams.Ecu.unknown)],
-                                                        experimental_long=True, docs=True)
+  CP: CarParams = interfaces[cp_platform].get_params(cp_platform, fingerprint=gen_empty_fingerprint(),
+                                                     car_fw=[CarParams.CarFw(ecu=CarParams.Ecu.unknown)],
+                                                     experimental_long=True, docs=True)
   return CP
 
 

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -5,6 +5,7 @@ from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.ford.carcontroller import CarController
 from opendbc.car.ford.carstate import CarState
 from opendbc.car.ford.fordcan import CanBus
+from opendbc.car.ford.radar_interface import RadarInterface
 from opendbc.car.ford.values import CarControllerParams, DBC, Ecu, FordFlags, RADAR, FordSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 
@@ -14,6 +15,7 @@ TransmissionType = structs.CarParams.TransmissionType
 class CarInterface(CarInterfaceBase):
   CarState = CarState
   CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):

--- a/opendbc/car/ford/interface.py
+++ b/opendbc/car/ford/interface.py
@@ -2,6 +2,8 @@ import numpy as np
 from opendbc.car import Bus, get_safety_config, structs
 from opendbc.car.carlog import carlog
 from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.ford.carcontroller import CarController
+from opendbc.car.ford.carstate import CarState
 from opendbc.car.ford.fordcan import CanBus
 from opendbc.car.ford.values import CarControllerParams, DBC, Ecu, FordFlags, RADAR, FordSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
@@ -10,6 +12,9 @@ TransmissionType = structs.CarParams.TransmissionType
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     # PCM doesn't allow acceleration near cruise_speed,

--- a/opendbc/car/gm/interface.py
+++ b/opendbc/car/gm/interface.py
@@ -7,7 +7,7 @@ from opendbc.car.common.basedir import BASEDIR
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.gm.carcontroller import CarController
 from opendbc.car.gm.carstate import CarState
-from opendbc.car.gm.radar_interface import RADAR_HEADER_MSG
+from opendbc.car.gm.radar_interface import RadarInterface, RADAR_HEADER_MSG
 from opendbc.car.gm.values import CAR, CarControllerParams, EV_CAR, CAMERA_ACC_CAR, SDGM_CAR, ALT_ACCS, CanBus, GMSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase, TorqueFromLateralAccelCallbackType, FRICTION_THRESHOLD, LatControlInputs, NanoFFModel
 
@@ -26,6 +26,7 @@ NEURAL_PARAMS_PATH = os.path.join(BASEDIR, 'torque_data/neural_ff_weights.json')
 class CarInterface(CarInterfaceBase):
   CarState = CarState
   CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):

--- a/opendbc/car/gm/interface.py
+++ b/opendbc/car/gm/interface.py
@@ -5,6 +5,8 @@ from math import fabs, exp
 from opendbc.car import get_safety_config, get_friction, structs
 from opendbc.car.common.basedir import BASEDIR
 from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.gm.carcontroller import CarController
+from opendbc.car.gm.carstate import CarState
 from opendbc.car.gm.radar_interface import RADAR_HEADER_MSG
 from opendbc.car.gm.values import CAR, CarControllerParams, EV_CAR, CAMERA_ACC_CAR, SDGM_CAR, ALT_ACCS, CanBus, GMSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase, TorqueFromLateralAccelCallbackType, FRICTION_THRESHOLD, LatControlInputs, NanoFFModel
@@ -22,6 +24,9 @@ NEURAL_PARAMS_PATH = os.path.join(BASEDIR, 'torque_data/neural_ff_weights.json')
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     return CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -7,11 +7,16 @@ from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA
                                                  HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.disable_ecu import disable_ecu
+from opendbc.car.honda.carcontroller import CarController
+from opendbc.car.honda.carstate import CarState
 
 TransmissionType = structs.CarParams.TransmissionType
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     if CP.carFingerprint in HONDA_BOSCH:

--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -2,13 +2,14 @@
 import numpy as np
 from opendbc.car import get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
+from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.honda.hondacan import CanBus
 from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA_BOSCH, \
                                                  HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
-from opendbc.car.interfaces import CarInterfaceBase
-from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.honda.carcontroller import CarController
 from opendbc.car.honda.carstate import CarState
+from opendbc.car.honda.radar_interface import RadarInterface
+from opendbc.car.interfaces import CarInterfaceBase
 
 TransmissionType = structs.CarParams.TransmissionType
 
@@ -16,6 +17,7 @@ TransmissionType = structs.CarParams.TransmissionType
 class CarInterface(CarInterfaceBase):
   CarState = CarState
   CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -6,6 +6,8 @@ from opendbc.car.hyundai.values import HyundaiFlags, CAR, DBC, \
 from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.disable_ecu import disable_ecu
+from opendbc.car.hyundai.carcontroller import CarController
+from opendbc.car.hyundai.carstate import CarState
 
 ButtonType = structs.CarState.ButtonEvent.Type
 Ecu = structs.CarParams.Ecu
@@ -15,6 +17,9 @@ ENABLE_BUTTONS = (ButtonType.accelCruise, ButtonType.decelCruise, ButtonType.can
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "hyundai"

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -8,6 +8,7 @@ from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.hyundai.carcontroller import CarController
 from opendbc.car.hyundai.carstate import CarState
+from opendbc.car.hyundai.radar_interface import RadarInterface
 
 ButtonType = structs.CarState.ButtonEvent.Type
 Ecu = structs.CarParams.Ecu
@@ -19,6 +20,7 @@ ENABLE_BUTTONS = (ButtonType.accelCruise, ButtonType.decelCruise, ButtonType.can
 class CarInterface(CarInterfaceBase):
   CarState = CarState
   CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -85,7 +85,25 @@ def get_torque_params():
 
 # generic car and radar interfaces
 
+class RadarInterfaceBase(ABC):
+  def __init__(self, CP: structs.CarParams):
+    self.CP = CP
+    self.rcp = None
+    self.pts: dict[int, structs.RadarData.RadarPoint] = {}
+    self.frame = 0
+
+  def update(self, can_packets: list[tuple[int, list[CanData]]]) -> structs.RadarDataT | None:
+    self.frame += 1
+    if (self.frame % 5) == 0:  # 20 Hz is very standard
+      return structs.RadarData()
+    return None
+
+
 class CarInterfaceBase(ABC):
+  CarState: 'CarStateBase'
+  CarController: 'CarControllerBase'
+  RadarInterface: 'RadarInterfaceBase' = RadarInterfaceBase
+
   def __init__(self, CP: structs.CarParams, CarController, CarState):
     self.CP = CP
 
@@ -250,20 +268,6 @@ class CarInterfaceBase(ABC):
     self.CS.out = ret
 
     return ret
-
-
-class RadarInterfaceBase(ABC):
-  def __init__(self, CP: structs.CarParams):
-    self.CP = CP
-    self.rcp = None
-    self.pts: dict[int, structs.RadarData.RadarPoint] = {}
-    self.frame = 0
-
-  def update(self, can_packets: list[tuple[int, list[CanData]]]) -> structs.RadarDataT | None:
-    self.frame += 1
-    if (self.frame % 5) == 0:  # 20 Hz is very standard
-      return structs.RadarData()
-    return None
 
 
 class CarStateBase(ABC):

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -104,17 +104,17 @@ class CarInterfaceBase(ABC):
   CarController: 'CarControllerBase'
   RadarInterface: 'RadarInterfaceBase' = RadarInterfaceBase
 
-  def __init__(self, CP: structs.CarParams, CarController, CarState):
+  def __init__(self, CP: structs.CarParams):
     self.CP = CP
 
     self.frame = 0
     self.v_ego_cluster_seen = False
 
-    self.CS: CarStateBase = CarState(CP)
+    self.CS: CarStateBase = self.CarState(CP)
     self.can_parsers: dict[StrEnum, CANParser] = self.CS.get_can_parsers(CP)
 
     dbc_names = {bus: cp.dbc_name for bus, cp in self.can_parsers.items()}
-    self.CC: CarControllerBase = CarController(dbc_names, CP)
+    self.CC: CarControllerBase = self.CarController(dbc_names, CP)
 
   def apply(self, c: structs.CarControl, now_nanos: int | None = None) -> tuple[structs.CarControl.Actuators, list[CanData]]:
     if now_nanos is None:

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -85,6 +85,7 @@ def get_torque_params():
 
 # generic car and radar interfaces
 
+
 class RadarInterfaceBase(ABC):
   def __init__(self, CP: structs.CarParams):
     self.CP = CP

--- a/opendbc/car/mazda/interface.py
+++ b/opendbc/car/mazda/interface.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 from opendbc.car import get_safety_config, structs
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.mazda.values import CAR, LKAS_LIMITS
 from opendbc.car.interfaces import CarInterfaceBase
-
+from opendbc.car.mazda.carcontroller import CarController
+from opendbc.car.mazda.carstate import CarState
+from opendbc.car.mazda.values import CAR, LKAS_LIMITS
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/mazda/radar_interface.py
+++ b/opendbc/car/mazda/radar_interface.py
@@ -1,5 +1,0 @@
-#!/usr/bin/env python3
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/mock/interface.py
+++ b/opendbc/car/mock/interface.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 from opendbc.car import structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.mock.carcontroller import CarController
+from opendbc.car.mock.carstate import CarState
 
 
 # mocked car interface for dashcam mode
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/mock/radar_interface.py
+++ b/opendbc/car/mock/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/nissan/interface.py
+++ b/opendbc/car/nissan/interface.py
@@ -1,9 +1,13 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.nissan.carcontroller import CarController
+from opendbc.car.nissan.carstate import CarState
 from opendbc.car.nissan.values import CAR, NissanSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/nissan/radar_interface.py
+++ b/opendbc/car/nissan/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/rivian/interface.py
+++ b/opendbc/car/rivian/interface.py
@@ -1,8 +1,12 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.rivian.carcontroller import CarController
+from opendbc.car.rivian.carstate import CarState
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/rivian/interface.py
+++ b/opendbc/car/rivian/interface.py
@@ -2,11 +2,13 @@ from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.rivian.carcontroller import CarController
 from opendbc.car.rivian.carstate import CarState
+from opendbc.car.rivian.radar_interface import RadarInterface
 
 
 class CarInterface(CarInterfaceBase):
   CarState = CarState
   CarController = CarController
+  RadarInterface = RadarInterface
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -1,10 +1,14 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.subaru.carcontroller import CarController
+from opendbc.car.subaru.carstate import CarState
 from opendbc.car.subaru.values import CAR, GLOBAL_ES_ADDR, SubaruFlags, SubaruSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate: CAR, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/subaru/radar_interface.py
+++ b/opendbc/car/subaru/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -1,9 +1,13 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.tesla.carcontroller import CarController
+from opendbc.car.tesla.carstate import CarState
 from opendbc.car.tesla.values import TeslaSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
 
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:

--- a/opendbc/car/tesla/radar_interface.py
+++ b/opendbc/car/tesla/radar_interface.py
@@ -1,5 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-
-class RadarInterface(RadarInterfaceBase):
-  pass

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -54,13 +54,13 @@ class TestCarInterfaces:
             phases=(Phase.reuse, Phase.generate, Phase.shrink))
   @given(data=st.data())
   def test_car_interfaces(self, car_name, data):
-    CarInterface, CarController, CarState, RadarInterface = interfaces[car_name]
+    CarInterface = interfaces[car_name]
 
     args = get_fuzzy_car_interface_args(data.draw)
 
     car_params = CarInterface.get_params(car_name, args['fingerprints'], args['car_fw'],
                                          experimental_long=args['experimental_long'], docs=False)
-    car_interface = CarInterface(car_params, CarController, CarState)
+    car_interface = CarInterface(car_params)
     assert car_params
     assert car_interface
 
@@ -107,7 +107,7 @@ class TestCarInterfaces:
       now_nanos += DT_CTRL * 1e9  # 10ms
 
     # Test radar interface
-    radar_interface = RadarInterface(car_params)
+    radar_interface = CarInterface.RadarInterface(car_params)
     assert radar_interface
 
     # Run radar interface once

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -126,7 +126,7 @@ class TestFwFingerprint:
     blacklisted_addrs = (0x7c4, 0x7d0)  # includes A/C ecu and an unknown ecu
     for car_model, ecus in FW_VERSIONS.items():
       with subtests.test(car_model=car_model.value):
-        CP = interfaces[car_model][0].get_non_essential_params(car_model)
+        CP = interfaces[car_model].get_non_essential_params(car_model)
         if CP.brand == 'subaru':
           for ecu in ecus.keys():
             assert ecu[1] not in blacklisted_addrs, f'{car_model}: Blacklisted ecu: (Ecu.{ecu[0]}, {hex(ecu[1])})'

--- a/opendbc/car/tests/test_lateral_limits.py
+++ b/opendbc/car/tests/test_lateral_limits.py
@@ -26,7 +26,7 @@ class TestLateralLimits:
 
   @classmethod
   def setup_class(cls):
-    CarInterface, _, _, _ = interfaces[cls.car_model]
+    CarInterface = interfaces[cls.car_model]
     CP = CarInterface.get_non_essential_params(cls.car_model)
 
     if cls.car_model == 'MOCK':

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -1,4 +1,7 @@
 from opendbc.car import Bus, structs, get_safety_config, uds
+from opendbc.car.toyota.carstate import CarState
+from opendbc.car.toyota.carcontroller import CarController
+from opendbc.car.toyota.radar_interface import RadarInterface
 from opendbc.car.toyota.values import Ecu, CAR, DBC, ToyotaFlags, CarControllerParams, TSS2_CAR, RADAR_ACC_CAR, NO_DSU_CAR, \
                                                   MIN_ACC_SPEED, EPS_SCALE, UNSUPPORTED_DSU_CAR, NO_STOP_TIMER_CAR, ANGLE_CONTROL_CAR, \
                                                   ToyotaSafetyFlags
@@ -9,6 +12,10 @@ SteerControlType = structs.CarParams.SteerControlType
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+  RadarInterface = RadarInterface
+
   @staticmethod
   def get_pid_accel_limits(CP, current_speed, cruise_speed):
     return CarControllerParams(CP).ACCEL_MIN, CarControllerParams(CP).ACCEL_MAX

--- a/opendbc/car/volkswagen/interface.py
+++ b/opendbc/car/volkswagen/interface.py
@@ -1,9 +1,14 @@
 from opendbc.car import get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
+from opendbc.car.volkswagen.carcontroller import CarController
+from opendbc.car.volkswagen.carstate import CarState
 from opendbc.car.volkswagen.values import CAR, NetworkLocation, TransmissionType, VolkswagenFlags, VolkswagenSafetyFlags
 
 
 class CarInterface(CarInterfaceBase):
+  CarState = CarState
+  CarController = CarController
+
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate: CAR, fingerprint, car_fw, experimental_long, docs) -> structs.CarParams:
     ret.brand = "volkswagen"

--- a/opendbc/car/volkswagen/radar_interface.py
+++ b/opendbc/car/volkswagen/radar_interface.py
@@ -1,4 +1,0 @@
-from opendbc.car.interfaces import RadarInterfaceBase
-
-class RadarInterface(RadarInterfaceBase):
-  pass


### PR DESCRIPTION
Removes need to define empty radar interface file, one less thing when porting a car. pytest collection time is not sped up with the static imports, so leaving that out until there's a cleaner solution