### PR TITLE
Safety Replay: add Hyundai Legacy to steering message checks

### DIFF
--- a/opendbc/safety/tests/safety_replay/helpers.py
+++ b/opendbc/safety/tests/safety_replay/helpers.py
@@ -18,7 +18,7 @@ def is_steering_msg(mode, param, addr):
     ret = addr == (0x191 if param & ToyotaSafetyFlags.LTA else 0x2E4)
   elif mode == CarParams.SafetyModel.gm:
     ret = addr == 384
-  elif mode == CarParams.SafetyModel.hyundai:
+  elif mode in (CarParams.SafetyModel.hyundai, CarParams.SafetyModel.hyundaiLegacy):
     ret = addr == 832
   elif mode == CarParams.SafetyModel.hyundaiCanfd:
     ret = addr == (0x110 if param & HyundaiSafetyFlags.CANFD_LKA_STEERING_ALT else
@@ -52,7 +52,7 @@ def get_steer_value(mode, param, to_send):
   elif mode == CarParams.SafetyModel.gm:
     torque = ((to_send.data[0] & 0x7) << 8) | to_send.data[1]
     torque = to_signed(torque, 11)
-  elif mode == CarParams.SafetyModel.hyundai:
+  elif mode in (CarParams.SafetyModel.hyundai, CarParams.SafetyModel.hyundaiLegacy):
     torque = (((to_send.data[3] & 0x7) << 8) | to_send.data[2]) - 1024
   elif mode == CarParams.SafetyModel.hyundaiCanfd:
     torque = ((to_send.data[5] >> 1) | (to_send.data[6] & 0xF) << 7) - 1024


### PR DESCRIPTION
Was analyzing [this issue](https://github.com/commaai/opendbc/issues/1994) and realized that we never had `hyundaiLegacy` in the steering message checks in safety replay 😁

Before:
```
replaying 3687c15bdfe09295/0000005f--888dec6063/2 with safety mode 23, param 0, alternative experience 1
no steering msgs found!

RX
total rx msgs: 230451
invalid rx msgs: 0
safety tick rx invalid: False
invalid addrs: set()

TX
total openpilot msgs: 6000
total msgs with controls allowed: 0
blocked msgs: 5966
blocked with controls allowed: 0
blocked addrs: Counter({832: 5966})
```

After:
```
replaying 3687c15bdfe09295/0000005f--888dec6063/2 with safety mode 23, param 0, alternative experience 1

RX
total rx msgs: 230451
invalid rx msgs: 0
safety tick rx invalid: False
invalid addrs: set()

TX
total openpilot msgs: 6000
total msgs with controls allowed: 6000
blocked msgs: 0
blocked with controls allowed: 0
blocked addrs: Counter()
```

- Used in https://github.com/commaai/opendbc/pull/2004