### PR TITLE
Subaru: Add FW for 2022 Subaru Outback Touring XL

### DIFF
--- a/opendbc/car/subaru/fingerprints.py
+++ b/opendbc/car/subaru/fingerprints.py
@@ -463,6 +463,7 @@ FW_VERSIONS = {
       b'\xa1  \x06\x00',
       b'\xa1  \x06\x01',
       b'\xa1  \x06\x02',
+      b'\xa1  \x06\x03',
       b'\xa1  \x07\x00',
       b'\xa1  \x07\x02',
       b'\xa1  \x07\x03',
@@ -496,6 +497,7 @@ FW_VERSIONS = {
       b'\xe2"`p\x07',
       b'\xe2"`q\x07',
       b'\xe3,\xa0@\x07',
+      b'\xe2,\xa0p\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\xa5\xf6D@\x00',
@@ -505,6 +507,7 @@ FW_VERSIONS = {
       b'\xa7\x8e\xf40\x00',
       b'\xa7\xf6D@\x00',
       b'\xa7\xfe\xf4@\x00',
+      b'\xa7\xfe\xf6@\x00',
     ],
   },
   CAR.SUBARU_FORESTER_2022: {


### PR DESCRIPTION
Updated abs, engine, and transmission firmware versions for the 2022 Subaru Outback Touring XL
Dongle ID: 9dd15af9f772f8ab