### PR TITLE
docs: add long OBD-C cable length

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -75,7 +75,7 @@ class Mount(EnumBase):
 
 
 class Cable(EnumBase):
-  long_obdc_cable = BasePart("long OBD-C cable")
+  long_obdc_cable = BasePart("long OBD-C cable (9.5 ft)")
   usb_a_2_a_cable = BasePart("USB A-A cable")
   usbc_otg_cable = BasePart("USB C OTG cable")
   usbc_coupler = BasePart("USB-C coupler")


### PR DESCRIPTION
Match the [website][1]

![image](https://github.com/user-attachments/assets/c12021cc-35b5-40af-b418-8efb2f11077f)

[1]: https://comma.ai/shop/obd-c-cable