### PR TITLE
Rivian safety: check 2nd speed source

### DIFF
--- a/opendbc/safety/safety/safety_ford.h
+++ b/opendbc/safety/safety/safety_ford.h
@@ -153,6 +153,7 @@ static void ford_rx_hook(const CANPacket_t *to_push) {
       // Signal: Veh_V_ActlEng
       float filtered_pcm_speed = ((GET_BYTE(to_push, 6) << 8) | GET_BYTE(to_push, 7)) * 0.01 / 3.6;
       bool is_invalid_speed = ABS(filtered_pcm_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > FORD_MAX_SPEED_DELTA;
+      // TODO: this should generically cause rx valid to fall until re-enable
       if (is_invalid_speed) {
         controls_allowed = false;
       }

--- a/opendbc/safety/safety/safety_rivian.h
+++ b/opendbc/safety/safety/safety_rivian.h
@@ -91,8 +91,8 @@ static void rivian_rx_hook(const CANPacket_t *to_push) {
       gas_pressed = GET_BYTE(to_push, 3) | (GET_BYTE(to_push, 4) & 0xC0U);
 
       // Disable controls if speeds from VDM and ESP ECUs are too far apart.
-      float raw_vdm_speed = ((GET_BYTE(to_push, 5) << 8) | GET_BYTE(to_push, 6)) * 0.01 / 3.6;
-      bool is_invalid_speed = ABS(raw_vdm_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > RIVIAN_MAX_SPEED_DELTA;
+      float vdm_speed = ((GET_BYTE(to_push, 5) << 8) | GET_BYTE(to_push, 6)) * 0.01 / 3.6;
+      bool is_invalid_speed = ABS(vdm_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > RIVIAN_MAX_SPEED_DELTA;
       // TODO: this should generically cause rx valid to fall until re-enable
       if (is_invalid_speed) {
         controls_allowed = false;

--- a/opendbc/safety/tests/test_rivian.py
+++ b/opendbc/safety/tests/test_rivian.py
@@ -101,7 +101,7 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
           if msg == "speed":
             to_push = self._speed_msg(0, quality_flag=quality_flag)
           elif msg == "speed_2":
-            to_push = self._user_gas_msg(0, quality_flag=quality_flag)
+            to_push = self._speed_msg_2(0, quality_flag=quality_flag)
 
           self.assertEqual(quality_flag, self._rx(to_push))
           self.assertEqual(quality_flag, self.safety.get_controls_allowed())

--- a/opendbc/safety/tests/test_rivian.py
+++ b/opendbc/safety/tests/test_rivian.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import unittest
+import numpy as np
 
 from opendbc.car.structs import CarParams
 from opendbc.safety.tests.libsafety import libsafety_py
@@ -38,6 +39,9 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
   DRIVER_TORQUE_ALLOWANCE = 100
   DRIVER_TORQUE_FACTOR = 2
 
+  # Max allowed delta between car speeds
+  MAX_SPEED_DELTA = 2.0  # m/s
+
   cnt_speed = 0
   cnt_speed_2 = 0
 
@@ -55,13 +59,16 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
     self.__class__.cnt_speed += 1
     return self.packer.make_can_msg_panda("ESP_Status", 0, values, fix_checksum=checksum)
 
+  def _speed_msg_2(self, speed, quality_flag=True):
+    return self._user_gas_msg(0, speed, quality_flag)
+
   def _user_brake_msg(self, brake):
     values = {"iBESP2_BrakePedalApplied": brake}
     return self.packer.make_can_msg_panda("iBESP2", 0, values)
 
-  def _user_gas_msg(self, gas, quality_flag=True):
-    values = {"VDM_AcceleratorPedalPosition": gas, "VDM_PropStatus_Counter": self.cnt_speed_2 % 15,
-              "VDM_VehicleSpeedQ": 1 if quality_flag else 0}
+  def _user_gas_msg(self, gas, speed=0, quality_flag=True):
+    values = {"VDM_AcceleratorPedalPosition": gas, "VDM_VehicleSpeed": speed * 3.6,
+              "VDM_PropStatus_Counter": self.cnt_speed_2 % 15, "VDM_VehicleSpeedQ": 1 if quality_flag else 0}
     self.__class__.cnt_speed_2 += 1
     return self.packer.make_can_msg_panda("VDM_PropStatus", 0, values, fix_checksum=checksum)
 
@@ -103,6 +110,20 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
         to_push[0].data[0] = 0
         self.assertFalse(self._rx(to_push))
         self.assertFalse(self.safety.get_controls_allowed())
+
+  def test_rx_hook_speed_mismatch(self):
+    # TODO: this can be a common test w/ Ford
+    # Rivian has a dynamic max torque limit based on speed, so it checks two sources
+    for speed in np.arange(0, 40, 0.5):
+      for speed_delta in np.arange(-5, 5, 0.1):
+        speed_2 = round(max(speed + speed_delta, 0), 1)
+        # Set controls allowed in between rx since first message can reset it
+        self._rx(self._speed_msg(speed))
+        self.safety.set_controls_allowed(True)
+        self._rx(self._speed_msg_2(speed_2))
+
+        within_delta = abs(speed - speed_2) <= self.MAX_SPEED_DELTA
+        self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
 
 class TestRivianStockSafety(TestRivianSafetyBase):


### PR DESCRIPTION
For https://github.com/commaai/opendbc/pull/2016

<details><summary>During a low speed high curvature turn, they can be seen >1 kph apart:</summary>

![image](https://github.com/user-attachments/assets/96a6760d-2c1c-4362-b1c9-19ca214df2c1)
</details>

<details><summary>During braking and acceleration they can be seen close together:</summary>

![image](https://github.com/user-attachments/assets/61b1563c-dfd1-4a51-a827-e27a51d1ca65)
</details>

The comment for the ESP signal is as follows:

```
CM_ SG_ 520 ESP_Vehicle_Speed "ESP calculated vehicle speed. Average of front wheels on rear wheel drive vehicles. Average of all four wheels on dual motor vehicles.";
```

<details><summary>Since we don't have too much information about the VDM signal, we just have to make an educated guess. But from how it varies most when turning, it sounds like it's averaging the wheel speeds differently, or is a more direct measurement from a different location/sensors. Note here how the VDM signal captures leaving a stop earlier than ESP:</summary>

![image](https://github.com/user-attachments/assets/03b5eef2-9963-4d41-82b4-48863ee91b99)
</details>

<details><summary>And if ESP was purely a filtered/delayed version or copy of VDM, then this noise wouldn't make sense:</summary>

![image](https://github.com/user-attachments/assets/c4cc44ab-b4af-4c68-ade2-d8f6592217c0)
</details>

So it's pretty safe to say they are independent of each other.