### PR TITLE
Tesla: fix convenience blinker

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -71,8 +71,8 @@ class CarState(CarStateBase):
     ret.doorOpen = cp_party.vl["UI_warning"]["anyDoorOpen"] == 1
 
     # Blinkers
-    ret.leftBlinker = cp_party.vl["UI_warning"]["leftBlinkerOn"] != 0
-    ret.rightBlinker = cp_party.vl["UI_warning"]["rightBlinkerOn"] != 0
+    ret.leftBlinker = cp_party.vl["UI_warning"]["leftBlinkerBlinking"] in (1, 2)
+    ret.rightBlinker = cp_party.vl["UI_warning"]["rightBlinkerBlinking"] in (1, 2)
 
     # Seatbelt
     ret.seatbeltUnlatched = cp_party.vl["UI_warning"]["buckleStatus"] != 1


### PR DESCRIPTION
The existing signal would only describe the stalk position if the auto-cancel blinker option was disabled, in effect it would be a single frame. This now captures all states properly