### PR TITLE
Enable "Blind Spot Monitoring" for Mazda

### DIFF
--- a/opendbc/car/mazda/interface.py
+++ b/opendbc/car/mazda/interface.py
@@ -29,4 +29,6 @@ class CarInterface(CarInterfaceBase):
 
     ret.centerToFront = ret.wheelbase * 0.41
 
+    ret.enableBsm = True
+
     return ret


### PR DESCRIPTION
The blind spot signals are mapped here:

https://github.com/commaai/opendbc/blob/2ed580d9f58bfe40d73ab5def33ce628e3a85ca3/opendbc/car/mazda/carstate.py#L51

but they're not enabled. Not sure if there's a reason behind that or if it's merely an oversight.

Credit to @bigboigahoy.