### PR TITLE
CI: Fix `GIT_REF` formatting in safety mutation workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ${{ github.repository == 'commaai/opendbc' && 'namespace-profile-amd64-8x16' || 'ubuntu-latest' }}
     timeout-minutes: 20
     env:
-      GIT_REF: ${{ github.event_name == 'push' && github.ref == 'refs/heads/${{ github.event.repository.default_branch }}' && github.event.before || 'origin/${{ github.event.repository.default_branch }}' }}
+      GIT_REF: ${{ github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && github.event.before || format('origin/{0}', github.event.repository.default_branch) }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
- Introduced in https://github.com/commaai/opendbc/pull/1956, safety mutation test in `master` currently does not do a git diff to run mutation tests properly due to bad formatting
- Fix nested GitHub expression syntax in mutation job
- Replace nested `${{ ... }}` with `format()` function
- Fix reference to default branch in GIT_REF environment variable
- Ensure proper evaluation of branch conditions in workflow

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/45763542-fee6-4659-b74d-1d1e8ea3cb5d) | ![image](https://github.com/user-attachments/assets/7de895d1-55d0-43eb-83df-559128fe61fd) |


