### PR TITLE
docs: add setup note

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -190,7 +190,7 @@ class CarParts:
     return self.parts + parts
 
 
-CarFootnote = namedtuple("CarFootnote", ["text", "column", "docs_only", "shop_footnote"], defaults=(False, False))
+CarFootnote = namedtuple("CarFootnote", ["text", "column", "docs_only", "setup_note"], defaults=(False, False))
 
 
 class CommonFootnote(Enum):

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
-from enum import IntFlag
+from enum import Enum, IntFlag
 
 from opendbc.car import AngleSteeringLimits, Bus, CarSpecs, DbcDict, PlatformConfig, Platforms, uds
 from opendbc.car.structs import CarParams
-from opendbc.car.docs_definitions import CarDocs, CarHarness, CarParts
+from opendbc.car.docs_definitions import CarDocs, CarFootnote, CarHarness, CarParts, Column
 from opendbc.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
 Ecu = CarParams.Ecu
@@ -29,10 +29,19 @@ class NissanSafetyFlags(IntFlag):
   ALT_EPS_BUS = 1
 
 
+class Footnote(Enum):
+  NISSAN_SETUP = CarFootnote(
+    "See more setup details for <a href=\"https://github.com/commaai/openpilot/wiki/nissan\">Nissan</a>.",
+    Column.MAKE, setup_note=True)
+
+
 @dataclass
 class NissanCarDocs(CarDocs):
   package: str = "ProPILOT Assist"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.nissan_a]))
+
+  def init_make(self, CP: CarParams):
+    self.footnotes.append(Footnote.NISSAN_SETUP)
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Add an example setup note to be shown on the website setup guide

It looks like we don't use `shop_footnote` anywhere anymore, so I re-used it for this (I might have missed somewhere?)
![image](https://github.com/user-attachments/assets/4ea33394-1398-4bf9-9dfa-f3b8834679d7)

In the future if we want to support more possibilities we could use the column attr to define a SetupColumn and attach footnotes to different parts of the setup guide

