### PR TITLE
No-op changes to make Panda happy

### DIFF
--- a/opendbc/safety/board/drivers/can_common.h
+++ b/opendbc/safety/board/drivers/can_common.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "can_common_declarations.h"
 
 uint8_t calculate_checksum(const uint8_t *dat, uint32_t len) {

--- a/opendbc/safety/board/utils.h
+++ b/opendbc/safety/board/utils.h
@@ -42,6 +42,6 @@
 
 // compute the time elapsed (in microseconds) from 2 counter samples
 // case where ts < ts_last is ok: overflow is properly re-casted into uint32_t
-uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last) {
+static inline uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last) {
   return ts - ts_last;
 }

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -27,36 +27,6 @@
 #include "safety/safety_hyundai_canfd.h"
 #endif
 
-// from cereal.car.CarParams.SafetyModel
-#define SAFETY_SILENT 0U
-#define SAFETY_HONDA_NIDEC 1U
-#define SAFETY_TOYOTA 2U
-#define SAFETY_ELM327 3U
-#define SAFETY_GM 4U
-#define SAFETY_HONDA_BOSCH_GIRAFFE 5U
-#define SAFETY_FORD 6U
-#define SAFETY_HYUNDAI 8U
-#define SAFETY_CHRYSLER 9U
-#define SAFETY_TESLA 10U
-#define SAFETY_SUBARU 11U
-#define SAFETY_MAZDA 13U
-#define SAFETY_NISSAN 14U
-#define SAFETY_VOLKSWAGEN_MQB 15U
-#define SAFETY_ALLOUTPUT 17U
-#define SAFETY_GM_ASCM 18U
-#define SAFETY_NOOUTPUT 19U
-#define SAFETY_HONDA_BOSCH 20U
-#define SAFETY_VOLKSWAGEN_PQ 21U
-#define SAFETY_SUBARU_PREGLOBAL 22U
-#define SAFETY_HYUNDAI_LEGACY 23U
-#define SAFETY_HYUNDAI_COMMUNITY 24U
-#define SAFETY_STELLANTIS 25U
-#define SAFETY_FAW 26U
-#define SAFETY_BODY 27U
-#define SAFETY_HYUNDAI_CANFD 28U
-#define SAFETY_RIVIAN 33U
-#define SAFETY_VOLKSWAGEN_MEB 34U
-
 uint32_t GET_BYTES(const CANPacket_t *msg, int start, int len) {
   uint32_t ret = 0U;
   for (int i = 0; i < len; i++) {
@@ -113,6 +83,9 @@ uint16_t current_safety_mode = SAFETY_SILENT;
 uint16_t current_safety_param = 0;
 static const safety_hooks *current_hooks = &nooutput_hooks;
 safety_config current_safety_config;
+
+static void generic_rx_checks(void);
+static void stock_ecu_check(bool stock_ecu_detected);
 
 static bool is_msg_valid(RxCheck addr_list[], int index) {
   bool valid = true;

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -3,6 +3,36 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// from cereal.car.CarParams.SafetyModel
+#define SAFETY_SILENT 0U
+#define SAFETY_HONDA_NIDEC 1U
+#define SAFETY_TOYOTA 2U
+#define SAFETY_ELM327 3U
+#define SAFETY_GM 4U
+#define SAFETY_HONDA_BOSCH_GIRAFFE 5U
+#define SAFETY_FORD 6U
+#define SAFETY_HYUNDAI 8U
+#define SAFETY_CHRYSLER 9U
+#define SAFETY_TESLA 10U
+#define SAFETY_SUBARU 11U
+#define SAFETY_MAZDA 13U
+#define SAFETY_NISSAN 14U
+#define SAFETY_VOLKSWAGEN_MQB 15U
+#define SAFETY_ALLOUTPUT 17U
+#define SAFETY_GM_ASCM 18U
+#define SAFETY_NOOUTPUT 19U
+#define SAFETY_HONDA_BOSCH 20U
+#define SAFETY_VOLKSWAGEN_PQ 21U
+#define SAFETY_SUBARU_PREGLOBAL 22U
+#define SAFETY_HYUNDAI_LEGACY 23U
+#define SAFETY_HYUNDAI_COMMUNITY 24U
+#define SAFETY_STELLANTIS 25U
+#define SAFETY_FAW 26U
+#define SAFETY_BODY 27U
+#define SAFETY_HYUNDAI_CANFD 28U
+#define SAFETY_RIVIAN 33U
+#define SAFETY_VOLKSWAGEN_MEB 34U
+
 #define GET_BIT(msg, b) ((bool)!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
 #define GET_BYTE(msg, b) ((msg)->data[(b)])
 #define GET_FLAG(value, mask) (((__typeof__(mask))(value) & (mask)) == (mask)) // cppcheck-suppress misra-c2012-1.2; allow __typeof__
@@ -185,7 +215,6 @@ typedef struct {
 
 bool safety_rx_hook(const CANPacket_t *to_push);
 bool safety_tx_hook(CANPacket_t *to_send);
-uint32_t get_ts_elapsed(uint32_t ts, uint32_t ts_last);
 int to_signed(int d, int bits);
 void update_sample(struct sample_t *sample, int sample_new);
 bool get_longitudinal_allowed(void);
@@ -194,8 +223,6 @@ void gen_crc_lookup_table_8(uint8_t poly, uint8_t crc_lut[]);
 #ifdef CANFD
 void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]);
 #endif
-static void generic_rx_checks(void);
-static void stock_ecu_check(bool stock_ecu_detected);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueSteeringLimits limits);
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits);
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits);


### PR DESCRIPTION
No-op change for https://github.com/commaai/panda/issues/2171

- Moves some functions and declarations around so that they can be correctly included in Panda headers.

## Details

In [panda](https://github.com/commaai/panda), we currently need some defintions from [safety.h](https://github.com/commaai/opendbc/blob/master/opendbc/safety/safety.h). But we can't include safety.h directly because it contains function implementatinos (we eventually should link the implementations at compile time). 

So in this PR, we're just safely moving code that will allow us to include headers from opendbc without compiler errors.

- Panda needs access to `SAFETY_ALLOUTPUT`. But we can't directly include safety.h anywhere in panda because safety.h contains implementations (can't link multiple objects files that contain definitions for the same functions). 
  - Hence, we move the definition of `SAFETY_ALLOUTPUT` to safety_declarations.h, which we can then include in panda source.
- Move forward declarations of `generic_rx_checks` and `stock_ecu_check` from safety_declarations.h to safety.h (since can't include forward-declared static functions without their corresponding implementation)
- make `get_ts_elapsed` static inline! This way we can safely include utils.h without compiler errors for multiple definitions.

Further discussion: https://github.com/commaai/panda/issues/2171#issuecomment-2784918381

