### PR TITLE
safety: replace fwd hooks with relay addr check config

### DIFF
--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -145,6 +145,11 @@ static bool tesla_tx_hook(const CANPacket_t *to_send) {
 static bool tesla_fwd_hook(int bus_num, int addr) {
   bool block_msg = false;
 
+  // TODO: ensure this message doesn't show on bus 0 when we're passing through stock AEB
+  if (tesla_longitudinal) {
+    generic_rx_checks((addr == 0x2b9) && (bus_num == 0));
+  }
+
   if (bus_num == 2) {
     // DAS_steeringControl, APS_eacMonitor
     if ((addr == 0x488) || (addr == 0x27d)) {
@@ -170,7 +175,7 @@ static safety_config tesla_init(uint16_t param) {
 
   static const CanMsg TESLA_M3_Y_LONG_TX_MSGS[] = {
     {0x488, 0, 4, true},  // DAS_steeringControl
-    {0x2b9, 0, 8, true},  // DAS_control
+    {0x2b9, 0, 8, false},  // DAS_control
     {0x27D, 0, 3, true},  // APS_eacMonitor
   };
 

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -53,7 +53,7 @@ typedef struct {
   int addr;
   int bus;
   int len;
-  bool check_relay;
+  bool blocked;
 } CanMsg;
 
 typedef enum {

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -919,7 +919,8 @@ class PandaCarSafetyTest(PandaSafetyTest):
     for bus in range(3):
       for addr in self.SCANNED_ADDRS:
         self.safety.set_relay_malfunction(False)
-        self._rx(make_msg(bus, addr, 8))
+        # self._rx(make_msg(bus, addr, 8))
+        self.safety.safety_fwd_hook(bus, addr)
         should_relay_malfunction = addr in self.RELAY_MALFUNCTION_ADDRS.get(bus, ())
         self.assertEqual(should_relay_malfunction, self.safety.get_relay_malfunction(), (bus, hex(addr)))
 


### PR DESCRIPTION
We're in a tricky spot with some safety modes, such as Tesla which need these to be dynamic, but we stopped giving the safety mode these messages if they're not in the rx checks anymore