### PR TITLE
safety: split relay malfunction and generic rx checks

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -358,7 +358,7 @@ static void relay_malfunction_set(void) {
   fault_occurred(FAULT_RELAY_MALFUNCTION);
 }
 
-static void generic_rx_checks() {
+static void generic_rx_checks(void) {
   // exit controls on rising edge of gas press
   if (gas_pressed && !gas_pressed_prev && !(alternative_experience & ALT_EXP_DISABLE_DISENGAGE_ON_GAS)) {
     controls_allowed = false;

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -216,6 +216,9 @@ bool safety_rx_hook(const CANPacket_t *to_push) {
     current_hooks->rx(to_push);
   }
 
+  // Handles gas, brake, and regen paddle
+  generic_rx_checks();
+
   // the relay malfunction hook runs on all incoming rx messages.
   // check all tx msgs for liveness on sending bus if specified.
   // used to detect a relay malfunction or control messages from disabled ECUs like the radar
@@ -227,7 +230,6 @@ bool safety_rx_hook(const CANPacket_t *to_push) {
       stock_ecu_check((m->addr == addr) && (m->bus == bus));
     }
   }
-  generic_rx_checks();
 
   // reset mismatches on rising edge of controls_allowed to avoid rare race condition
   if (controls_allowed && !controls_allowed_prev) {

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -193,7 +193,8 @@ void gen_crc_lookup_table_8(uint8_t poly, uint8_t crc_lut[]);
 #ifdef CANFD
 void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]);
 #endif
-static void generic_rx_checks(bool stock_ecu_detected);
+static void generic_rx_checks();
+static void stock_ecu_check(bool stock_ecu_detected);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueSteeringLimits limits);
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits);
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits);

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -193,7 +193,7 @@ void gen_crc_lookup_table_8(uint8_t poly, uint8_t crc_lut[]);
 #ifdef CANFD
 void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]);
 #endif
-static void generic_rx_checks();
+static void generic_rx_checks(void);
 static void stock_ecu_check(bool stock_ecu_detected);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueSteeringLimits limits);
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits);


### PR DESCRIPTION
Split from https://github.com/commaai/opendbc/pull/2087

Our brake, gas, and regen controls allowed logic only worked because every safety mode implemented at least one message it checked a relay malfunction for. Without that, these would never be executed. Additionally it would be run multiple times per rx message needlessly.

This PR:
- Run generic rx checks only once for every incoming rx message (up from minimum of zero times and down from max of len(rx_msgs)