### PR TITLE
safety: switch to field initializer for check_relay

### DIFF
--- a/opendbc/safety/safety/safety_body.h
+++ b/opendbc/safety/safety/safety_body.h
@@ -36,7 +36,7 @@ static safety_config body_init(uint16_t param) {
 
   static const CanMsg BODY_TX_MSGS[] = {{0x250, 0, 8, .check_relay = false}, {0x250, 0, 6, .check_relay = false}, {0x251, 0, 5, .check_relay = false},  // body
                                         {0x350, 0, 8, .check_relay = false}, {0x350, 0, 6, .check_relay = false}, {0x351, 0, 5, .check_relay = false},  // knee
-                                        {0x1, 0, 8, .check_relay = false}}; // CAN flasher
+                                        {0x1, 0, 8, .check_relay = false}};  // CAN flasher
 
   UNUSED(param);
   safety_config ret = BUILD_SAFETY_CFG(body_rx_checks, BODY_TX_MSGS);

--- a/opendbc/safety/safety/safety_body.h
+++ b/opendbc/safety/safety/safety_body.h
@@ -34,9 +34,9 @@ static safety_config body_init(uint16_t param) {
     {.msg = {{0x201, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 100U}, { 0 }, { 0 }}},
   };
 
-  static const CanMsg BODY_TX_MSGS[] = {{0x250, 0, 8, false}, {0x250, 0, 6, false}, {0x251, 0, 5, false},  // body
-                                        {0x350, 0, 8, false}, {0x350, 0, 6, false}, {0x351, 0, 5, false},  // knee
-                                        {0x1, 0, 8, false}}; // CAN flasher
+  static const CanMsg BODY_TX_MSGS[] = {{0x250, 0, 8, .check_relay = false}, {0x250, 0, 6, .check_relay = false}, {0x251, 0, 5, .check_relay = false},  // body
+                                        {0x350, 0, 8, .check_relay = false}, {0x350, 0, 6, .check_relay = false}, {0x351, 0, 5, .check_relay = false},  // knee
+                                        {0x1, 0, 8, .check_relay = false}}; // CAN flasher
 
   UNUSED(param);
   safety_config ret = BUILD_SAFETY_CFG(body_rx_checks, BODY_TX_MSGS);

--- a/opendbc/safety/safety/safety_chrysler.h
+++ b/opendbc/safety/safety/safety_chrysler.h
@@ -219,15 +219,15 @@ static safety_config chrysler_init(uint16_t param) {
   };
 
   static const CanMsg CHRYSLER_TX_MSGS[] = {
-    {CHRYSLER_ADDRS.CRUISE_BUTTONS, 0, 3, false},
-    {CHRYSLER_ADDRS.LKAS_COMMAND, 0, 6, true},
-    {CHRYSLER_ADDRS.DAS_6, 0, 8, false},
+    {CHRYSLER_ADDRS.CRUISE_BUTTONS, 0, 3, .check_relay = false},
+    {CHRYSLER_ADDRS.LKAS_COMMAND, 0, 6, .check_relay = true},
+    {CHRYSLER_ADDRS.DAS_6, 0, 8, .check_relay = false},
   };
 
   static const CanMsg CHRYSLER_RAM_DT_TX_MSGS[] = {
-    {CHRYSLER_RAM_DT_ADDRS.CRUISE_BUTTONS, 2, 3, false},
-    {CHRYSLER_RAM_DT_ADDRS.LKAS_COMMAND, 0, 8, true},
-    {CHRYSLER_RAM_DT_ADDRS.DAS_6, 0, 8, false},
+    {CHRYSLER_RAM_DT_ADDRS.CRUISE_BUTTONS, 2, 3, .check_relay = false},
+    {CHRYSLER_RAM_DT_ADDRS.LKAS_COMMAND, 0, 8, .check_relay = true},
+    {CHRYSLER_RAM_DT_ADDRS.DAS_6, 0, 8, .check_relay = false},
   };
 
 #ifdef ALLOW_DEBUG
@@ -252,9 +252,9 @@ static safety_config chrysler_init(uint16_t param) {
   };
 
   static const CanMsg CHRYSLER_RAM_HD_TX_MSGS[] = {
-    {CHRYSLER_RAM_HD_ADDRS.CRUISE_BUTTONS, 2, 3, false},
-    {CHRYSLER_RAM_HD_ADDRS.LKAS_COMMAND, 0, 8, true},
-    {CHRYSLER_RAM_HD_ADDRS.DAS_6, 0, 8, false},
+    {CHRYSLER_RAM_HD_ADDRS.CRUISE_BUTTONS, 2, 3, .check_relay = false},
+    {CHRYSLER_RAM_HD_ADDRS.LKAS_COMMAND, 0, 8, .check_relay = true},
+    {CHRYSLER_RAM_HD_ADDRS.DAS_6, 0, 8, .check_relay = false},
   };
 
   const uint32_t CHRYSLER_PARAM_RAM_HD = 2U;  // set for Ram HD platform

--- a/opendbc/safety/safety/safety_ford.h
+++ b/opendbc/safety/safety/safety_ford.h
@@ -350,7 +350,7 @@ static safety_config ford_init(uint16_t param) {
     {.msg = {{FORD_DesiredTorqBrk, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 50U}, { 0 }, { 0 }}},
   };
 
-  #define FORD_COMMON_TX_MSGS              \
+  #define FORD_COMMON_TX_MSGS \
     {FORD_Steering_Data_FD1, 0, 8, .check_relay = false}, \
     {FORD_Steering_Data_FD1, 2, 8, .check_relay = false}, \
     {FORD_ACCDATA_3, 0, 8, .check_relay = true},          \

--- a/opendbc/safety/safety/safety_ford.h
+++ b/opendbc/safety/safety/safety_ford.h
@@ -351,32 +351,32 @@ static safety_config ford_init(uint16_t param) {
   };
 
   #define FORD_COMMON_TX_MSGS              \
-    {FORD_Steering_Data_FD1, 0, 8, false}, \
-    {FORD_Steering_Data_FD1, 2, 8, false}, \
-    {FORD_ACCDATA_3, 0, 8, true},          \
-    {FORD_Lane_Assist_Data1, 0, 8, true},  \
-    {FORD_IPMA_Data, 0, 8, true},          \
+    {FORD_Steering_Data_FD1, 0, 8, .check_relay = false}, \
+    {FORD_Steering_Data_FD1, 2, 8, .check_relay = false}, \
+    {FORD_ACCDATA_3, 0, 8, .check_relay = true},          \
+    {FORD_Lane_Assist_Data1, 0, 8, .check_relay = true},  \
+    {FORD_IPMA_Data, 0, 8, .check_relay = true},          \
 
   static const CanMsg FORD_CANFD_LONG_TX_MSGS[] = {
     FORD_COMMON_TX_MSGS
-    {FORD_ACCDATA, 0, 8, true},
-    {FORD_LateralMotionControl2, 0, 8, true},
+    {FORD_ACCDATA, 0, 8, .check_relay = true},
+    {FORD_LateralMotionControl2, 0, 8, .check_relay = true},
   };
 
   static const CanMsg FORD_CANFD_STOCK_TX_MSGS[] = {
     FORD_COMMON_TX_MSGS
-    {FORD_LateralMotionControl2, 0, 8, true},
+    {FORD_LateralMotionControl2, 0, 8, .check_relay = true},
   };
 
   static const CanMsg FORD_STOCK_TX_MSGS[] = {
     FORD_COMMON_TX_MSGS
-    {FORD_LateralMotionControl, 0, 8, true},
+    {FORD_LateralMotionControl, 0, 8, .check_relay = true},
   };
 
   static const CanMsg FORD_LONG_TX_MSGS[] = {
     FORD_COMMON_TX_MSGS
-    {FORD_ACCDATA, 0, 8, true},
-    {FORD_LateralMotionControl, 0, 8, true},
+    {FORD_ACCDATA, 0, 8, .check_relay = true},
+    {FORD_LateralMotionControl, 0, 8, .check_relay = true},
   };
 
   const uint16_t FORD_PARAM_CANFD = 2;

--- a/opendbc/safety/safety/safety_gm.h
+++ b/opendbc/safety/safety/safety_gm.h
@@ -199,9 +199,9 @@ static safety_config gm_init(uint16_t param) {
     .max_brake = 400,
   };
 
-  static const CanMsg GM_ASCM_TX_MSGS[] = {{0x180, 0, 4, true}, {0x409, 0, 7, false}, {0x40A, 0, 7, false}, {0x2CB, 0, 8, true}, {0x370, 0, 6, false},  // pt bus
-                                           {0xA1, 1, 7, false}, {0x306, 1, 8, false}, {0x308, 1, 7, false}, {0x310, 1, 2, false},   // obs bus
-                                           {0x315, 2, 5, false}};  // ch bus
+  static const CanMsg GM_ASCM_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true}, {0x409, 0, 7, .check_relay = false}, {0x40A, 0, 7, .check_relay = false}, {0x2CB, 0, 8, .check_relay = true}, {0x370, 0, 6, .check_relay = false},  // pt bus
+                                           {0xA1, 1, 7, .check_relay = false}, {0x306, 1, 8, .check_relay = false}, {0x308, 1, 7, .check_relay = false}, {0x310, 1, 2, .check_relay = false},   // obs bus
+                                           {0x315, 2, 5, .check_relay = false}};  // ch bus
 
 
   static const LongitudinalLimits GM_CAM_LONG_LIMITS = {
@@ -211,8 +211,8 @@ static safety_config gm_init(uint16_t param) {
     .max_brake = 400,
   };
 
-  static const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4, true}, {0x315, 0, 5, false}, {0x2CB, 0, 8, true}, {0x370, 0, 6, false},  // pt bus
-                                               {0x184, 2, 8, false}};  // camera bus
+  static const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true}, {0x315, 0, 5, .check_relay = false}, {0x2CB, 0, 8, .check_relay = true}, {0x370, 0, 6, .check_relay = false},  // pt bus
+                                               {0x184, 2, 8, .check_relay = false}};  // camera bus
 
 
   static RxCheck gm_rx_checks[] = {
@@ -224,8 +224,8 @@ static safety_config gm_init(uint16_t param) {
     {.msg = {{0xBD, 0, 7, .ignore_checksum = true, .ignore_counter = true, .frequency = 40U}, { 0 }, { 0 }}},
   };
 
-  static const CanMsg GM_CAM_TX_MSGS[] = {{0x180, 0, 4, true},  // pt bus
-                                          {0x1E1, 2, 7, false}, {0x184, 2, 8, false}};  // camera bus
+  static const CanMsg GM_CAM_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true},  // pt bus
+                                          {0x1E1, 2, 7, .check_relay = false}, {0x184, 2, 8, .check_relay = false}};  // camera bus
 
   gm_hw = GET_FLAG(param, GM_PARAM_HW_CAM) ? GM_CAM : GM_ASCM;
 

--- a/opendbc/safety/safety/safety_honda.h
+++ b/opendbc/safety/safety/safety_honda.h
@@ -278,7 +278,8 @@ static bool honda_tx_hook(const CANPacket_t *to_send) {
 }
 
 static safety_config honda_nidec_init(uint16_t param) {
-  static CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5, true}, {0x194, 0, 4, true}, {0x1FA, 0, 8, false}, {0x30C, 0, 8, false}, {0x33D, 0, 5, false}};
+  static CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x194, 0, 4, .check_relay = true}, {0x1FA, 0, 8, .check_relay = false},
+                                     {0x30C, 0, 8, .check_relay = false}, {0x33D, 0, 5, .check_relay = false}};
 
   const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 
@@ -318,10 +319,18 @@ static safety_config honda_nidec_init(uint16_t param) {
 }
 
 static safety_config honda_bosch_init(uint16_t param) {
-  static CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5, true}, {0xE5, 0, 8, false}, {0x296, 1, 4, false}, {0x33D, 0, 5, false}, {0x33DA, 0, 5, false}, {0x33DB, 0, 8, false}};  // Bosch
-  static CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5, true}, {0x1DF, 1, 8, true}, {0x1EF, 1, 8, false}, {0x1FA, 1, 8, false}, {0x30C, 1, 8, false}, {0x33D, 1, 5, false}, {0x33DA, 1, 5, false}, {0x33DB, 1, 8, false}, {0x39F, 1, 8, false}, {0x18DAB0F1, 1, 8, false}};  // Bosch w/ gas and brakes
-  static CanMsg HONDA_RADARLESS_TX_MSGS[] = {{0xE4, 0, 5, true}, {0x296, 2, 4, false}, {0x33D, 0, 8, false}};  // Bosch radarless
-  static CanMsg HONDA_RADARLESS_LONG_TX_MSGS[] = {{0xE4, 0, 5, true}, {0x33D, 0, 8, false}, {0x1C8, 0, 8, false}, {0x30C, 0, 8, false}};  // Bosch radarless w/ gas and brakes
+  static CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0xE5, 0, 8, .check_relay = false}, {0x296, 1, 4, .check_relay = false},
+                                         {0x33D, 0, 5, .check_relay = false}, {0x33DA, 0, 5, .check_relay = false}, {0x33DB, 0, 8, .check_relay = false}};  // Bosch
+
+  static CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5, .check_relay = true}, {0x1DF, 1, 8, .check_relay = true}, {0x1EF, 1, 8, .check_relay = false},
+                                              {0x1FA, 1, 8, .check_relay = false}, {0x30C, 1, 8, .check_relay = false}, {0x33D, 1, 5, .check_relay = false},
+                                              {0x33DA, 1, 5, .check_relay = false}, {0x33DB, 1, 8, .check_relay = false}, {0x39F, 1, 8, .check_relay = false},
+                                              {0x18DAB0F1, 1, 8, .check_relay = false}};  // Bosch w/ gas and brakes
+
+  static CanMsg HONDA_RADARLESS_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x296, 2, 4, .check_relay = false}, {0x33D, 0, 8, .check_relay = false}};  // Bosch radarless
+
+  static CanMsg HONDA_RADARLESS_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x33D, 0, 8, .check_relay = false}, {0x1C8, 0, 8, .check_relay = false},
+                                                  {0x30C, 0, 8, .check_relay = false}};  // Bosch radarless w/ gas and brakes
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
   const uint16_t HONDA_PARAM_RADARLESS = 8;

--- a/opendbc/safety/safety/safety_hyundai.h
+++ b/opendbc/safety/safety/safety_hyundai.h
@@ -26,17 +26,17 @@ const LongitudinalLimits HYUNDAI_LONG_LIMITS = {
 };
 
 #define HYUNDAI_COMMON_TX_MSGS(scc_bus) \
-  {0x340, 0,       8, true},   /* LKAS11 Bus 0                              */ \
-  {0x4F1, scc_bus, 4, false},  /* CLU11 Bus 0 (radar-SCC) or 2 (camera-SCC) */ \
-  {0x485, 0,       4, false},  /* LFAHDA_MFC Bus 0                          */ \
+  {0x340, 0,       8, .check_relay = true},   /* LKAS11 Bus 0                              */ \
+  {0x4F1, scc_bus, 4, .check_relay = false},  /* CLU11 Bus 0 (radar-SCC) or 2 (camera-SCC) */ \
+  {0x485, 0,       4, .check_relay = false},  /* LFAHDA_MFC Bus 0                          */ \
 
 #define HYUNDAI_LONG_COMMON_TX_MSGS(scc_bus) \
   HYUNDAI_COMMON_TX_MSGS(scc_bus)                                             \
-  {0x420, 0,       8, false},           /* SCC11 Bus 0                     */ \
-  {0x421, 0,       8, (scc_bus) == 0},  /* SCC12 Bus 0                     */ \
-  {0x50A, 0,       8, false},           /* SCC13 Bus 0                     */ \
-  {0x389, 0,       8, false},           /* SCC14 Bus 0                     */ \
-  {0x4A2, 0,       2, false},           /* FRT_RADAR11 Bus 0               */ \
+  {0x420, 0,       8, .check_relay = false},           /* SCC11 Bus 0                     */ \
+  {0x421, 0,       8, .check_relay = (scc_bus) == 0},  /* SCC12 Bus 0                     */ \
+  {0x50A, 0,       8, .check_relay = false},           /* SCC13 Bus 0                     */ \
+  {0x389, 0,       8, .check_relay = false},           /* SCC14 Bus 0                     */ \
+  {0x4A2, 0,       2, .check_relay = false},           /* FRT_RADAR11 Bus 0               */ \
 
 #define HYUNDAI_COMMON_RX_CHECKS(legacy)                                                                                                                  \
   {.msg = {{0x260, 0, 8, .max_counter = 3U, .frequency = 100U},                                                                                           \
@@ -275,9 +275,9 @@ static bool hyundai_fwd_hook(int bus_num, int addr) {
 static safety_config hyundai_init(uint16_t param) {
   static const CanMsg HYUNDAI_LONG_TX_MSGS[] = {
     HYUNDAI_LONG_COMMON_TX_MSGS(0)
-    {0x38D, 0, 8, false}, // FCA11 Bus 0
-    {0x483, 0, 8, false}, // FCA12 Bus 0
-    {0x7D0, 0, 8, false}, // radar UDS TX addr Bus 0 (for radar disable)
+    {0x38D, 0, 8, .check_relay = false}, // FCA11 Bus 0
+    {0x483, 0, 8, .check_relay = false}, // FCA12 Bus 0
+    {0x7D0, 0, 8, .check_relay = false}, // radar UDS TX addr Bus 0 (for radar disable)
   };
 
   static const CanMsg HYUNDAI_CAMERA_SCC_TX_MSGS[] = {

--- a/opendbc/safety/safety/safety_hyundai.h
+++ b/opendbc/safety/safety/safety_hyundai.h
@@ -31,7 +31,7 @@ const LongitudinalLimits HYUNDAI_LONG_LIMITS = {
   {0x485, 0,       4, .check_relay = false},  /* LFAHDA_MFC Bus 0                          */ \
 
 #define HYUNDAI_LONG_COMMON_TX_MSGS(scc_bus) \
-  HYUNDAI_COMMON_TX_MSGS(scc_bus)                                             \
+  HYUNDAI_COMMON_TX_MSGS(scc_bus)                                                            \
   {0x420, 0,       8, .check_relay = false},           /* SCC11 Bus 0                     */ \
   {0x421, 0,       8, .check_relay = (scc_bus) == 0},  /* SCC12 Bus 0                     */ \
   {0x50A, 0,       8, .check_relay = false},           /* SCC13 Bus 0                     */ \

--- a/opendbc/safety/safety/safety_hyundai_canfd.h
+++ b/opendbc/safety/safety/safety_hyundai_canfd.h
@@ -4,21 +4,21 @@
 #include "safety_hyundai_common.h"
 
 #define HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(bus) \
-  {0x1CF, bus, 8, false},  /* CRUISE_BUTTON */   \
+  {0x1CF, bus, 8, .check_relay = false},  /* CRUISE_BUTTON */   \
 
 #define HYUNDAI_CANFD_LKA_STEERING_COMMON_TX_MSGS(a_can, e_can) \
   HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(e_can)                    \
-  {0x50,  a_can, 16, (a_can) == 0},  /* LKAS */                 \
-  {0x2A4, a_can, 24, false},         /* CAM_0x2A4 */            \
+  {0x50,  a_can, 16, .check_relay = (a_can) == 0},  /* LKAS */                 \
+  {0x2A4, a_can, 24, .check_relay = false},         /* CAM_0x2A4 */            \
 
 #define HYUNDAI_CANFD_LKA_STEERING_ALT_COMMON_TX_MSGS(a_can, e_can) \
   HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(e_can)                        \
-  {0x110, a_can, 32, (a_can) == 0},  /* LKAS_ALT */                 \
-  {0x362, a_can, 32, false},         /* CAM_0x362 */                \
+  {0x110, a_can, 32, .check_relay = (a_can) == 0},  /* LKAS_ALT */                 \
+  {0x362, a_can, 32, .check_relay = false},         /* CAM_0x362 */                \
 
 #define HYUNDAI_CANFD_LFA_STEERING_COMMON_TX_MSGS(e_can)  \
-  {0x12A, e_can, 16, (e_can) == 0},  /* LFA */            \
-  {0x1E0, e_can, 16, false},         /* LFAHDA_CLUSTER */ \
+  {0x12A, e_can, 16, .check_relay = (e_can) == 0},  /* LFA */            \
+  {0x1E0, e_can, 16, .check_relay = false},         /* LFAHDA_CLUSTER */ \
 
 #define HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(e_can, longitudinal)   \
   {0x1A0, e_can, 32, (longitudinal)},  /* SCC_CONTROL */                \
@@ -255,13 +255,13 @@ static safety_config hyundai_canfd_init(uint16_t param) {
     HYUNDAI_CANFD_LKA_STEERING_COMMON_TX_MSGS(0, 1)
     HYUNDAI_CANFD_LFA_STEERING_COMMON_TX_MSGS(1)
     HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(1, true)
-    {0x51,  0, 32, false},  // ADRV_0x51
-    {0x730, 1,  8, false},  // tester present for ADAS ECU disable
-    {0x160, 1, 16, false},  // ADRV_0x160
-    {0x1EA, 1, 32, false},  // ADRV_0x1ea
-    {0x200, 1,  8, false},  // ADRV_0x200
-    {0x345, 1,  8, false},  // ADRV_0x345
-    {0x1DA, 1, 32, false},  // ADRV_0x1da
+    {0x51,  0, 32, .check_relay = false},  // ADRV_0x51
+    {0x730, 1,  8, .check_relay = false},  // tester present for ADAS ECU disable
+    {0x160, 1, 16, .check_relay = false},  // ADRV_0x160
+    {0x1EA, 1, 32, .check_relay = false},  // ADRV_0x1ea
+    {0x200, 1,  8, .check_relay = false},  // ADRV_0x200
+    {0x345, 1,  8, .check_relay = false},  // ADRV_0x345
+    {0x1DA, 1, 32, .check_relay = false},  // ADRV_0x1da
   };
 
   static const CanMsg HYUNDAI_CANFD_LFA_STEERING_TX_MSGS[] = {
@@ -274,15 +274,15 @@ static safety_config hyundai_canfd_init(uint16_t param) {
     HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(2)
     HYUNDAI_CANFD_LFA_STEERING_COMMON_TX_MSGS(0)
     HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(0, true)
-    {0x160, 0, 16, false}, // ADRV_0x160
-    {0x7D0, 0, 8, false},  // tester present for radar ECU disable
+    {0x160, 0, 16, .check_relay = false}, // ADRV_0x160
+    {0x7D0, 0, 8, .check_relay = false},  // tester present for radar ECU disable
   };
 
 #define HYUNDAI_CANFD_LFA_STEERING_CAMERA_SCC_TX_MSGS(longitudinal) \
     HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(2) \
     HYUNDAI_CANFD_LFA_STEERING_COMMON_TX_MSGS(0) \
     HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(0, (longitudinal)) \
-    {0x160, 0, 16, false}, /* ADRV_0x160 */ \
+    {0x160, 0, 16, .check_relay = false}, /* ADRV_0x160 */ \
 
   hyundai_common_init(param);
 

--- a/opendbc/safety/safety/safety_hyundai_canfd.h
+++ b/opendbc/safety/safety/safety_hyundai_canfd.h
@@ -7,21 +7,21 @@
   {0x1CF, bus, 8, .check_relay = false},  /* CRUISE_BUTTON */   \
 
 #define HYUNDAI_CANFD_LKA_STEERING_COMMON_TX_MSGS(a_can, e_can) \
-  HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(e_can)                    \
-  {0x50,  a_can, 16, .check_relay = (a_can) == 0},  /* LKAS */                 \
-  {0x2A4, a_can, 24, .check_relay = false},         /* CAM_0x2A4 */            \
+  HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(e_can)                        \
+  {0x50,  a_can, 16, .check_relay = (a_can) == 0},  /* LKAS */      \
+  {0x2A4, a_can, 24, .check_relay = false},         /* CAM_0x2A4 */ \
 
 #define HYUNDAI_CANFD_LKA_STEERING_ALT_COMMON_TX_MSGS(a_can, e_can) \
   HYUNDAI_CANFD_CRUISE_BUTTON_TX_MSGS(e_can)                        \
-  {0x110, a_can, 32, .check_relay = (a_can) == 0},  /* LKAS_ALT */                 \
-  {0x362, a_can, 32, .check_relay = false},         /* CAM_0x362 */                \
+  {0x110, a_can, 32, .check_relay = (a_can) == 0},  /* LKAS_ALT */  \
+  {0x362, a_can, 32, .check_relay = false},         /* CAM_0x362 */ \
 
 #define HYUNDAI_CANFD_LFA_STEERING_COMMON_TX_MSGS(e_can)  \
   {0x12A, e_can, 16, .check_relay = (e_can) == 0},  /* LFA */            \
   {0x1E0, e_can, 16, .check_relay = false},         /* LFAHDA_CLUSTER */ \
 
-#define HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(e_can, longitudinal)   \
-  {0x1A0, e_can, 32, (longitudinal)},  /* SCC_CONTROL */                \
+#define HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(e_can, longitudinal) \
+  {0x1A0, e_can, 32, (longitudinal)},  /* SCC_CONTROL */              \
 
 // *** Addresses checked in rx hook ***
 // EV, ICE, HYBRID: ACCELERATOR (0x35), ACCELERATOR_BRAKE_ALT (0x100), ACCELERATOR_ALT (0x105)

--- a/opendbc/safety/safety/safety_hyundai_canfd.h
+++ b/opendbc/safety/safety/safety_hyundai_canfd.h
@@ -21,7 +21,7 @@
   {0x1E0, e_can, 16, .check_relay = false},         /* LFAHDA_CLUSTER */ \
 
 #define HYUNDAI_CANFD_SCC_CONTROL_COMMON_TX_MSGS(e_can, longitudinal) \
-  {0x1A0, e_can, 32, (longitudinal)},  /* SCC_CONTROL */              \
+  {0x1A0, e_can, 32, .check_relay = (longitudinal)},  /* SCC_CONTROL */ \
 
 // *** Addresses checked in rx hook ***
 // EV, ICE, HYBRID: ACCELERATOR (0x35), ACCELERATOR_BRAKE_ALT (0x100), ACCELERATOR_ALT (0x105)

--- a/opendbc/safety/safety/safety_mazda.h
+++ b/opendbc/safety/safety/safety_mazda.h
@@ -99,7 +99,7 @@ static bool mazda_fwd_hook(int bus, int addr) {
 }
 
 static safety_config mazda_init(uint16_t param) {
-  static const CanMsg MAZDA_TX_MSGS[] = {{MAZDA_LKAS, 0, 8, true}, {MAZDA_CRZ_BTNS, 0, 8, false}, {MAZDA_LKAS_HUD, 0, 8, false}};
+  static const CanMsg MAZDA_TX_MSGS[] = {{MAZDA_LKAS, 0, 8, .check_relay = true}, {MAZDA_CRZ_BTNS, 0, 8, .check_relay = false}, {MAZDA_LKAS_HUD, 0, 8, .check_relay = false}};
 
   static RxCheck mazda_rx_checks[] = {
     {.msg = {{MAZDA_CRZ_CTRL,     0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 50U}, { 0 }, { 0 }}},

--- a/opendbc/safety/safety/safety_nissan.h
+++ b/opendbc/safety/safety/safety_nissan.h
@@ -117,12 +117,12 @@ static bool nissan_fwd_hook(int bus_num, int addr) {
 
 static safety_config nissan_init(uint16_t param) {
   static const CanMsg NISSAN_TX_MSGS[] = {
-    {0x169, 0, 8, true},   // LKAS
-    {0x2b1, 0, 8, false},  // PROPILOT_HUD
-    {0x4cc, 0, 8, false},  // PROPILOT_HUD_INFO_MSG
-    {0x20b, 2, 6, false},  // CRUISE_THROTTLE (X-Trail)
-    {0x20b, 1, 6, false},  // CRUISE_THROTTLE (Altima)
-    {0x280, 2, 8, false}   // CANCEL_MSG (Leaf)
+    {0x169, 0, 8, .check_relay = true},   // LKAS
+    {0x2b1, 0, 8, .check_relay = false},  // PROPILOT_HUD
+    {0x4cc, 0, 8, .check_relay = false},  // PROPILOT_HUD_INFO_MSG
+    {0x20b, 2, 6, .check_relay = false},  // CRUISE_THROTTLE (X-Trail)
+    {0x20b, 1, 6, .check_relay = false},  // CRUISE_THROTTLE (Altima)
+    {0x280, 2, 8, .check_relay = false}   // CANCEL_MSG (Leaf)
   };
 
   // Signals duplicated below due to the fact that these messages can come in on either CAN bus, depending on car model.

--- a/opendbc/safety/safety/safety_rivian.h
+++ b/opendbc/safety/safety/safety_rivian.h
@@ -205,9 +205,9 @@ static bool rivian_fwd_hook(int bus, int addr) {
 
 static safety_config rivian_init(uint16_t param) {
   // 0x120 = ACM_lkaHbaCmd, 0x321 = SCCM_WheelTouch, 0x162 = VDM_AdasSts
-  static const CanMsg RIVIAN_TX_MSGS[] = {{0x120, 0, 8, true}, {0x321, 2, 7, false}, {0x162, 2, 8, false}};
+  static const CanMsg RIVIAN_TX_MSGS[] = {{0x120, 0, 8, .check_relay = true}, {0x321, 2, 7, .check_relay = false}, {0x162, 2, 8, .check_relay = false}};
   // 0x160 = ACM_longitudinalRequest
-  static const CanMsg RIVIAN_LONG_TX_MSGS[] = {{0x120, 0, 8, true}, {0x321, 2, 7, false}, {0x160, 0, 5, true}};
+  static const CanMsg RIVIAN_LONG_TX_MSGS[] = {{0x120, 0, 8, .check_relay = true}, {0x321, 2, 7, .check_relay = false}, {0x160, 0, 5, .check_relay = true}};
 
   static RxCheck rivian_rx_checks[] = {
     {.msg = {{0x208, 0, 8, .frequency = 50U, .max_counter = 14U, .quality_flag = true}, { 0 }, { 0 }}},          // ESP_Status (speed)

--- a/opendbc/safety/safety/safety_subaru.h
+++ b/opendbc/safety/safety/safety_subaru.h
@@ -44,21 +44,21 @@
 #define SUBARU_CAM_BUS  2
 
 #define SUBARU_COMMON_TX_MSGS(alt_bus, lkas_msg)             \
-  {lkas_msg,                     SUBARU_MAIN_BUS, 8, true},  \
-  {MSG_SUBARU_ES_Distance,       alt_bus,         8, false}, \
-  {MSG_SUBARU_ES_DashStatus,     SUBARU_MAIN_BUS, 8, false}, \
-  {MSG_SUBARU_ES_LKAS_State,     SUBARU_MAIN_BUS, 8, false}, \
-  {MSG_SUBARU_ES_Infotainment,   SUBARU_MAIN_BUS, 8, false}, \
+  {lkas_msg,                     SUBARU_MAIN_BUS, 8, .check_relay = true},  \
+  {MSG_SUBARU_ES_Distance,       alt_bus,         8, .check_relay = false}, \
+  {MSG_SUBARU_ES_DashStatus,     SUBARU_MAIN_BUS, 8, .check_relay = false}, \
+  {MSG_SUBARU_ES_LKAS_State,     SUBARU_MAIN_BUS, 8, .check_relay = false}, \
+  {MSG_SUBARU_ES_Infotainment,   SUBARU_MAIN_BUS, 8, .check_relay = false}, \
 
 #define SUBARU_COMMON_LONG_TX_MSGS(alt_bus)                  \
-  {MSG_SUBARU_ES_Brake,          alt_bus,         8, false}, \
-  {MSG_SUBARU_ES_Status,         alt_bus,         8, false}, \
+  {MSG_SUBARU_ES_Brake,          alt_bus,         8, .check_relay = false}, \
+  {MSG_SUBARU_ES_Status,         alt_bus,         8, .check_relay = false}, \
 
 #define SUBARU_GEN2_LONG_ADDITIONAL_TX_MSGS()                \
-  {MSG_SUBARU_ES_UDS_Request,    SUBARU_CAM_BUS,  8, false}, \
-  {MSG_SUBARU_ES_HighBeamAssist, SUBARU_MAIN_BUS, 8, false}, \
-  {MSG_SUBARU_ES_STATIC_1,       SUBARU_MAIN_BUS, 8, false}, \
-  {MSG_SUBARU_ES_STATIC_2,       SUBARU_MAIN_BUS, 8, false}, \
+  {MSG_SUBARU_ES_UDS_Request,    SUBARU_CAM_BUS,  8, .check_relay = false}, \
+  {MSG_SUBARU_ES_HighBeamAssist, SUBARU_MAIN_BUS, 8, .check_relay = false}, \
+  {MSG_SUBARU_ES_STATIC_1,       SUBARU_MAIN_BUS, 8, .check_relay = false}, \
+  {MSG_SUBARU_ES_STATIC_2,       SUBARU_MAIN_BUS, 8, .check_relay = false}, \
 
 #define SUBARU_COMMON_RX_CHECKS(alt_bus)                                                                            \
   {.msg = {{MSG_SUBARU_Throttle,        SUBARU_MAIN_BUS, 8, .max_counter = 15U, .frequency = 100U}, { 0 }, { 0 }}}, \

--- a/opendbc/safety/safety/safety_subaru.h
+++ b/opendbc/safety/safety/safety_subaru.h
@@ -43,18 +43,18 @@
 #define SUBARU_ALT_BUS  1
 #define SUBARU_CAM_BUS  2
 
-#define SUBARU_COMMON_TX_MSGS(alt_bus, lkas_msg)             \
+#define SUBARU_COMMON_TX_MSGS(alt_bus, lkas_msg) \
   {lkas_msg,                     SUBARU_MAIN_BUS, 8, .check_relay = true},  \
   {MSG_SUBARU_ES_Distance,       alt_bus,         8, .check_relay = false}, \
   {MSG_SUBARU_ES_DashStatus,     SUBARU_MAIN_BUS, 8, .check_relay = false}, \
   {MSG_SUBARU_ES_LKAS_State,     SUBARU_MAIN_BUS, 8, .check_relay = false}, \
   {MSG_SUBARU_ES_Infotainment,   SUBARU_MAIN_BUS, 8, .check_relay = false}, \
 
-#define SUBARU_COMMON_LONG_TX_MSGS(alt_bus)                  \
+#define SUBARU_COMMON_LONG_TX_MSGS(alt_bus) \
   {MSG_SUBARU_ES_Brake,          alt_bus,         8, .check_relay = false}, \
   {MSG_SUBARU_ES_Status,         alt_bus,         8, .check_relay = false}, \
 
-#define SUBARU_GEN2_LONG_ADDITIONAL_TX_MSGS()                \
+#define SUBARU_GEN2_LONG_ADDITIONAL_TX_MSGS() \
   {MSG_SUBARU_ES_UDS_Request,    SUBARU_CAM_BUS,  8, .check_relay = false}, \
   {MSG_SUBARU_ES_HighBeamAssist, SUBARU_MAIN_BUS, 8, .check_relay = false}, \
   {MSG_SUBARU_ES_STATIC_1,       SUBARU_MAIN_BUS, 8, .check_relay = false}, \

--- a/opendbc/safety/safety/safety_subaru_preglobal.h
+++ b/opendbc/safety/safety/safety_subaru_preglobal.h
@@ -94,8 +94,8 @@ static bool subaru_preglobal_fwd_hook(int bus_num, int addr) {
 
 static safety_config subaru_preglobal_init(uint16_t param) {
   static const CanMsg SUBARU_PG_TX_MSGS[] = {
-    {MSG_SUBARU_PG_ES_Distance, SUBARU_PG_MAIN_BUS, 8, false},
-    {MSG_SUBARU_PG_ES_LKAS,     SUBARU_PG_MAIN_BUS, 8, true}
+    {MSG_SUBARU_PG_ES_Distance, SUBARU_PG_MAIN_BUS, 8, .check_relay = false},
+    {MSG_SUBARU_PG_ES_LKAS,     SUBARU_PG_MAIN_BUS, 8, .check_relay = true}
   };
 
   // TODO: do checksum and counter checks after adding the signals to the outback dbc file

--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -163,15 +163,15 @@ static bool tesla_fwd_hook(int bus_num, int addr) {
 static safety_config tesla_init(uint16_t param) {
 
   static const CanMsg TESLA_M3_Y_TX_MSGS[] = {
-    {0x488, 0, 4, true},   // DAS_steeringControl
-    {0x2b9, 0, 8, false},  // DAS_control (for cancel)
-    {0x27D, 0, 3, true},   // APS_eacMonitor
+    {0x488, 0, 4, .check_relay = true},   // DAS_steeringControl
+    {0x2b9, 0, 8, .check_relay = false},  // DAS_control (for cancel)
+    {0x27D, 0, 3, .check_relay = true},   // APS_eacMonitor
   };
 
   static const CanMsg TESLA_M3_Y_LONG_TX_MSGS[] = {
-    {0x488, 0, 4, true},  // DAS_steeringControl
-    {0x2b9, 0, 8, true},  // DAS_control
-    {0x27D, 0, 3, true},  // APS_eacMonitor
+    {0x488, 0, 4, .check_relay = true},  // DAS_steeringControl
+    {0x2b9, 0, 8, .check_relay = true},  // DAS_control
+    {0x27D, 0, 3, .check_relay = true},  // APS_eacMonitor
   };
 
   UNUSED(param);

--- a/opendbc/safety/safety/safety_toyota.h
+++ b/opendbc/safety/safety/safety_toyota.h
@@ -4,25 +4,25 @@
 
 // Stock longitudinal
 #define TOYOTA_BASE_TX_MSGS \
-  {0x191, 0, 8, false}, {0x412, 0, 8, false}, {0x1D2, 0, 8, false},  /* LKAS + LTA + PCM cancel cmd */  \
+  {0x191, 0, 8, .check_relay = false}, {0x412, 0, 8, .check_relay = false}, {0x1D2, 0, 8, .check_relay = false},  /* LKAS + LTA + PCM cancel cmd */  \
 
 #define TOYOTA_COMMON_TX_MSGS \
   TOYOTA_BASE_TX_MSGS \
-  {0x2E4, 0, 5, true}, \
-  {0x343, 0, 8, false},  /* ACC cancel cmd */  \
+  {0x2E4, 0, 5, .check_relay = true}, \
+  {0x343, 0, 8, .check_relay = false},  /* ACC cancel cmd */  \
 
 #define TOYOTA_COMMON_SECOC_TX_MSGS \
   TOYOTA_BASE_TX_MSGS \
-  {0x2E4, 0, 8, true}, {0x131, 0, 8, false}, \
-  {0x343, 0, 8, false},  /* ACC cancel cmd */  \
+  {0x2E4, 0, 8, .check_relay = true}, {0x131, 0, 8, .check_relay = false}, \
+  {0x343, 0, 8, .check_relay = false},  /* ACC cancel cmd */  \
 
 #define TOYOTA_COMMON_LONG_TX_MSGS                                                                                                                                                                  \
   TOYOTA_COMMON_TX_MSGS                                                                                                                                                                             \
-  {0x283, 0, 7, false}, {0x2E6, 0, 8, false}, {0x2E7, 0, 8, false}, {0x33E, 0, 7, false}, {0x344, 0, 8, false}, {0x365, 0, 7, false}, {0x366, 0, 7, false}, {0x4CB, 0, 8, false},  /* DSU bus 0 */  \
-  {0x128, 1, 6, false}, {0x141, 1, 4, false}, {0x160, 1, 8, false}, {0x161, 1, 7, false}, {0x470, 1, 4, false},  /* DSU bus 1 */                                                                    \
-  {0x411, 0, 8, false},  /* PCS_HUD */                                                                                                                                                              \
-  {0x750, 0, 8, false},  /* radar diagnostic address */                                                                                                                                             \
-  {0x343, 0, 8, true},  /* ACC */                                                                                                                                                                   \
+  {0x283, 0, 7, .check_relay = false}, {0x2E6, 0, 8, .check_relay = false}, {0x2E7, 0, 8, .check_relay = false}, {0x33E, 0, 7, .check_relay = false}, {0x344, 0, 8, .check_relay = false}, {0x365, 0, 7, .check_relay = false}, {0x366, 0, 7, .check_relay = false}, {0x4CB, 0, 8, .check_relay = false},  /* DSU bus 0 */  \
+  {0x128, 1, 6, .check_relay = false}, {0x141, 1, 4, .check_relay = false}, {0x160, 1, 8, .check_relay = false}, {0x161, 1, 7, .check_relay = false}, {0x470, 1, 4, .check_relay = false},  /* DSU bus 1 */                                                                    \
+  {0x411, 0, 8, .check_relay = false},  /* PCS_HUD */                                                                                                                                                              \
+  {0x750, 0, 8, .check_relay = false},  /* radar diagnostic address */                                                                                                                                             \
+  {0x343, 0, 8, .check_relay = true},  /* ACC */                                                                                                                                                                   \
 
 #define TOYOTA_COMMON_RX_CHECKS(lta)                                                                          \
   {.msg = {{ 0xaa, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 83U}, { 0 }, { 0 }}},  \

--- a/opendbc/safety/safety/safety_toyota.h
+++ b/opendbc/safety/safety/safety_toyota.h
@@ -16,13 +16,20 @@
   {0x2E4, 0, 8, .check_relay = true}, {0x131, 0, 8, .check_relay = false}, \
   {0x343, 0, 8, .check_relay = false},  /* ACC cancel cmd */  \
 
-#define TOYOTA_COMMON_LONG_TX_MSGS                                                                                                                                                                  \
-  TOYOTA_COMMON_TX_MSGS                                                                                                                                                                             \
-  {0x283, 0, 7, .check_relay = false}, {0x2E6, 0, 8, .check_relay = false}, {0x2E7, 0, 8, .check_relay = false}, {0x33E, 0, 7, .check_relay = false}, {0x344, 0, 8, .check_relay = false}, {0x365, 0, 7, .check_relay = false}, {0x366, 0, 7, .check_relay = false}, {0x4CB, 0, 8, .check_relay = false},  /* DSU bus 0 */  \
-  {0x128, 1, 6, .check_relay = false}, {0x141, 1, 4, .check_relay = false}, {0x160, 1, 8, .check_relay = false}, {0x161, 1, 7, .check_relay = false}, {0x470, 1, 4, .check_relay = false},  /* DSU bus 1 */                                                                    \
-  {0x411, 0, 8, .check_relay = false},  /* PCS_HUD */                                                                                                                                                              \
-  {0x750, 0, 8, .check_relay = false},  /* radar diagnostic address */                                                                                                                                             \
-  {0x343, 0, 8, .check_relay = true},  /* ACC */                                                                                                                                                                   \
+#define TOYOTA_COMMON_LONG_TX_MSGS \
+  TOYOTA_COMMON_TX_MSGS \
+  /* DSU bus 0 */ \
+  {0x283, 0, 7, .check_relay = false}, {0x2E6, 0, 8, .check_relay = false}, {0x2E7, 0, 8, .check_relay = false}, {0x33E, 0, 7, .check_relay = false}, \
+  {0x344, 0, 8, .check_relay = false}, {0x365, 0, 7, .check_relay = false}, {0x366, 0, 7, .check_relay = false}, {0x4CB, 0, 8, .check_relay = false}, \
+  /* DSU bus 1 */ \
+  {0x128, 1, 6, .check_relay = false}, {0x141, 1, 4, .check_relay = false}, {0x160, 1, 8, .check_relay = false}, {0x161, 1, 7, .check_relay = false}, \
+  {0x470, 1, 4, .check_relay = false}, \
+  /* PCS_HUD */                        \
+  {0x411, 0, 8, .check_relay = false}, \
+   /* radar diagnostic address */      \
+  {0x750, 0, 8, .check_relay = false}, \
+  /* ACC */                            \
+  {0x343, 0, 8, .check_relay = true},  \
 
 #define TOYOTA_COMMON_RX_CHECKS(lta)                                                                          \
   {.msg = {{ 0xaa, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 83U}, { 0 }, { 0 }}},  \

--- a/opendbc/safety/safety/safety_toyota.h
+++ b/opendbc/safety/safety/safety_toyota.h
@@ -26,7 +26,7 @@
   {0x470, 1, 4, .check_relay = false}, \
   /* PCS_HUD */                        \
   {0x411, 0, 8, .check_relay = false}, \
-   /* radar diagnostic address */      \
+  /* radar diagnostic address */       \
   {0x750, 0, 8, .check_relay = false}, \
   /* ACC */                            \
   {0x343, 0, 8, .check_relay = true},  \

--- a/opendbc/safety/safety/safety_volkswagen_mqb.h
+++ b/opendbc/safety/safety/safety_volkswagen_mqb.h
@@ -9,11 +9,11 @@ static bool volkswagen_mqb_brake_pressure_detected = false;
 
 static safety_config volkswagen_mqb_init(uint16_t param) {
   // Transmit of GRA_ACC_01 is allowed on bus 0 and 2 to keep compatibility with gateway and camera integration
-  static const CanMsg VOLKSWAGEN_MQB_STOCK_TX_MSGS[] = {{MSG_HCA_01, 0, 8, true}, {MSG_GRA_ACC_01, 0, 8, false}, {MSG_GRA_ACC_01, 2, 8, false},
-                                                        {MSG_LDW_02, 0, 8, false}, {MSG_LH_EPS_03, 2, 8, false}};
+  static const CanMsg VOLKSWAGEN_MQB_STOCK_TX_MSGS[] = {{MSG_HCA_01, 0, 8, .check_relay = true}, {MSG_GRA_ACC_01, 0, 8, .check_relay = false}, {MSG_GRA_ACC_01, 2, 8, .check_relay = false},
+                                                        {MSG_LDW_02, 0, 8, .check_relay = false}, {MSG_LH_EPS_03, 2, 8, .check_relay = false}};
 
-  static const CanMsg VOLKSWAGEN_MQB_LONG_TX_MSGS[] = {{MSG_HCA_01, 0, 8, true}, {MSG_LDW_02, 0, 8, false}, {MSG_LH_EPS_03, 2, 8, false},
-                                                       {MSG_ACC_02, 0, 8, false}, {MSG_ACC_06, 0, 8, false}, {MSG_ACC_07, 0, 8, false}};
+  static const CanMsg VOLKSWAGEN_MQB_LONG_TX_MSGS[] = {{MSG_HCA_01, 0, 8, .check_relay = true}, {MSG_LDW_02, 0, 8, .check_relay = false}, {MSG_LH_EPS_03, 2, 8, .check_relay = false},
+                                                       {MSG_ACC_02, 0, 8, .check_relay = false}, {MSG_ACC_06, 0, 8, .check_relay = false}, {MSG_ACC_07, 0, 8, .check_relay = false}};
 
   static RxCheck volkswagen_mqb_rx_checks[] = {
     {.msg = {{MSG_ESP_19, 0, 8, .ignore_checksum = true, .ignore_counter = true, .frequency = 100U}, { 0 }, { 0 }}},

--- a/opendbc/safety/safety/safety_volkswagen_pq.h
+++ b/opendbc/safety/safety/safety_volkswagen_pq.h
@@ -52,11 +52,11 @@ static uint32_t volkswagen_pq_compute_checksum(const CANPacket_t *to_push) {
 
 static safety_config volkswagen_pq_init(uint16_t param) {
   // Transmit of GRA_Neu is allowed on bus 0 and 2 to keep compatibility with gateway and camera integration
-  static const CanMsg VOLKSWAGEN_PQ_STOCK_TX_MSGS[] = {{MSG_HCA_1, 0, 5, true}, {MSG_LDW_1, 0, 8, false},
-                                                {MSG_GRA_NEU, 0, 4, false}, {MSG_GRA_NEU, 2, 4, false}};
+  static const CanMsg VOLKSWAGEN_PQ_STOCK_TX_MSGS[] = {{MSG_HCA_1, 0, 5, .check_relay = true}, {MSG_LDW_1, 0, 8, .check_relay = false},
+                                                {MSG_GRA_NEU, 0, 4, .check_relay = false}, {MSG_GRA_NEU, 2, 4, .check_relay = false}};
 
-  static const CanMsg VOLKSWAGEN_PQ_LONG_TX_MSGS[] =  {{MSG_HCA_1, 0, 5, true}, {MSG_LDW_1, 0, 8, false},
-                                                {MSG_ACC_SYSTEM, 0, 8, false}, {MSG_ACC_GRA_ANZEIGE, 0, 8, false}};
+  static const CanMsg VOLKSWAGEN_PQ_LONG_TX_MSGS[] =  {{MSG_HCA_1, 0, 5, .check_relay = true}, {MSG_LDW_1, 0, 8, .check_relay = false},
+                                                {MSG_ACC_SYSTEM, 0, 8, .check_relay = false}, {MSG_ACC_GRA_ANZEIGE, 0, 8, .check_relay = false}};
 
   static RxCheck volkswagen_pq_rx_checks[] = {
     {.msg = {{MSG_LENKHILFE_3, 0, 6, .max_counter = 15U, .frequency = 100U}, { 0 }, { 0 }}},


### PR DESCRIPTION
For https://github.com/commaai/opendbc/pull/2092

Improves readability. Consistent with RxCheck now. Allows us to add a new field to CanMsg without changing 100 lines (since our compiler warns/errors for this if we don't have at least one named argument).