### PR TITLE
Hyundai Camera SCC long safety: check SCC 12 relay malfunction

### DIFF
--- a/opendbc/safety/safety/safety_hyundai.h
+++ b/opendbc/safety/safety/safety_hyundai.h
@@ -33,7 +33,7 @@ const LongitudinalLimits HYUNDAI_LONG_LIMITS = {
 #define HYUNDAI_LONG_COMMON_TX_MSGS(scc_bus) \
   HYUNDAI_COMMON_TX_MSGS(scc_bus)                                                            \
   {0x420, 0,       8, .check_relay = false},           /* SCC11 Bus 0                     */ \
-  {0x421, 0,       8, .check_relay = (scc_bus) == 0},  /* SCC12 Bus 0                     */ \
+  {0x421, 0,       8, .check_relay = true},            /* SCC12 Bus 0                     */ \
   {0x50A, 0,       8, .check_relay = false},           /* SCC13 Bus 0                     */ \
   {0x389, 0,       8, .check_relay = false},           /* SCC14 Bus 0                     */ \
   {0x4A2, 0,       2, .check_relay = false},           /* FRT_RADAR11 Bus 0               */ \

--- a/opendbc/safety/tests/test_hyundai.py
+++ b/opendbc/safety/tests/test_hyundai.py
@@ -239,6 +239,7 @@ class TestHyundaiLongitudinalSafetyCameraSCC(HyundaiLongitudinalBase, TestHyunda
   TX_MSGS = [[0x340, 0], [0x4F1, 2], [0x485, 0], [0x420, 0], [0x421, 0], [0x50A, 0], [0x389, 0], [0x4A2, 0]]
 
   FWD_BLACKLISTED_ADDRS = {2: [0x340, 0x485, 0x420, 0x421, 0x50A, 0x389]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0x340, 0x421)}  # LKAS11, SCC12
 
   def setUp(self):
     self.packer = CANPackerPanda("hyundai_kia_generic")


### PR DESCRIPTION
Bug found in https://github.com/commaai/opendbc/pull/2092

If we're sending SCC messages on bus 0, we should always check for relay malfunction. Previously camera SCC long safety didn't check for this, it was only radar SCC that we checked.