### PR TITLE
Move static forward declaration

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -114,6 +114,9 @@ uint16_t current_safety_param = 0;
 static const safety_hooks *current_hooks = &nooutput_hooks;
 safety_config current_safety_config;
 
+static void generic_rx_checks(void);
+static void stock_ecu_check(bool stock_ecu_detected);
+
 static bool is_msg_valid(RxCheck addr_list[], int index) {
   bool valid = true;
   if (index != -1) {

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -194,8 +194,6 @@ void gen_crc_lookup_table_8(uint8_t poly, uint8_t crc_lut[]);
 #ifdef CANFD
 void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]);
 #endif
-static void generic_rx_checks(void);
-static void stock_ecu_check(bool stock_ecu_detected);
 bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueSteeringLimits limits);
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits);
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits);


### PR DESCRIPTION
For https://github.com/commaai/panda/issues/2171.

We are in an unfortunate situation right now where we are trying to migrate the panda repo to source/header style. This is fundamentally incompatible with forward-declared static functions that were implemented in  https://github.com/commaai/opendbc/pull/2088 (see https://github.com/commaai/opendbc/pull/2088/files#diff-99ed3acebc587c8e2e9a0ffd69d9c8e87c62183fcdf7e6bac0286acc5e30eeb8)

This PR is a temporary hack to help us land https://github.com/commaai/panda/issues/2171 without major changes to opendbc.

This should be a no-op.
