### PR TITLE
safety: move Honda to msg block config

### DIFF
--- a/opendbc/safety/safety/safety_honda.h
+++ b/opendbc/safety/safety/safety_honda.h
@@ -322,7 +322,7 @@ static safety_config honda_nidec_init(uint16_t param) {
 }
 
 static safety_config honda_bosch_init(uint16_t param) {
-  static CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0xE5, 0, 8, .check_relay = false}, {0x296, 1, 4, .check_relay = false},
+  static CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0xE5, 0, 8, .check_relay = true}, {0x296, 1, 4, .check_relay = false},
                                          {0x33D, 0, 5, .check_relay = false}, {0x33DA, 0, 5, .check_relay = false}, {0x33DB, 0, 8, .check_relay = false}};  // Bosch
 
   static CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5, .check_relay = true}, {0x1DF, 1, 8, .check_relay = true}, {0x1EF, 1, 8, .check_relay = false},
@@ -413,7 +413,7 @@ static bool honda_bosch_fwd_hook(int bus_num, int addr) {
   bool block_msg = false;
 
   if (bus_num == 2)  {
-    bool is_lkas_msg = (addr == 0xE5) || (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
+    bool is_lkas_msg = (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
     block_msg = is_lkas_msg;
   }
 

--- a/opendbc/safety/safety/safety_honda.h
+++ b/opendbc/safety/safety/safety_honda.h
@@ -332,8 +332,8 @@ static safety_config honda_bosch_init(uint16_t param) {
 
   static CanMsg HONDA_RADARLESS_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x296, 2, 4, .check_relay = false}, {0x33D, 0, 8, .check_relay = false}};  // Bosch radarless
 
-  static CanMsg HONDA_RADARLESS_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x33D, 0, 8, .check_relay = false}, {0x1C8, 0, 8, .check_relay = false},
-                                                  {0x30C, 0, 8, .check_relay = false}};  // Bosch radarless w/ gas and brakes
+  static CanMsg HONDA_RADARLESS_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x33D, 0, 8, .check_relay = false}, {0x1C8, 0, 8, .check_relay = true},
+                                                  {0x30C, 0, 8, .check_relay = true}};  // Bosch radarless w/ gas and brakes
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
   const uint16_t HONDA_PARAM_RADARLESS = 8;
@@ -414,8 +414,7 @@ static bool honda_bosch_fwd_hook(int bus_num, int addr) {
 
   if (bus_num == 2)  {
     bool is_lkas_msg = (addr == 0xE4) || (addr == 0xE5) || (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
-    bool is_acc_msg = ((addr == 0x1C8) || (addr == 0x30C)) && honda_bosch_radarless && honda_bosch_long;
-    block_msg = is_lkas_msg || is_acc_msg;
+    block_msg = is_lkas_msg;
   }
 
   return block_msg;

--- a/opendbc/safety/safety/safety_honda.h
+++ b/opendbc/safety/safety/safety_honda.h
@@ -323,16 +323,16 @@ static safety_config honda_nidec_init(uint16_t param) {
 
 static safety_config honda_bosch_init(uint16_t param) {
   static CanMsg HONDA_BOSCH_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0xE5, 0, 8, .check_relay = true}, {0x296, 1, 4, .check_relay = false},
-                                         {0x33D, 0, 5, .check_relay = false}, {0x33DA, 0, 5, .check_relay = false}, {0x33DB, 0, 8, .check_relay = false}};  // Bosch
+                                         {0x33D, 0, 5, .check_relay = true}, {0x33DA, 0, 5, .check_relay = true}, {0x33DB, 0, 8, .check_relay = true}};  // Bosch
 
   static CanMsg HONDA_BOSCH_LONG_TX_MSGS[] = {{0xE4, 1, 5, .check_relay = true}, {0x1DF, 1, 8, .check_relay = true}, {0x1EF, 1, 8, .check_relay = false},
-                                              {0x1FA, 1, 8, .check_relay = false}, {0x30C, 1, 8, .check_relay = false}, {0x33D, 1, 5, .check_relay = false},
-                                              {0x33DA, 1, 5, .check_relay = false}, {0x33DB, 1, 8, .check_relay = false}, {0x39F, 1, 8, .check_relay = false},
+                                              {0x1FA, 1, 8, .check_relay = false}, {0x30C, 1, 8, .check_relay = false}, {0x33D, 1, 5, .check_relay = true},
+                                              {0x33DA, 1, 5, .check_relay = true}, {0x33DB, 1, 8, .check_relay = true}, {0x39F, 1, 8, .check_relay = false},
                                               {0x18DAB0F1, 1, 8, .check_relay = false}};  // Bosch w/ gas and brakes
 
-  static CanMsg HONDA_RADARLESS_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x296, 2, 4, .check_relay = false}, {0x33D, 0, 8, .check_relay = false}};  // Bosch radarless
+  static CanMsg HONDA_RADARLESS_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x296, 2, 4, .check_relay = false}, {0x33D, 0, 8, .check_relay = true}};  // Bosch radarless
 
-  static CanMsg HONDA_RADARLESS_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x33D, 0, 8, .check_relay = false}, {0x1C8, 0, 8, .check_relay = true},
+  static CanMsg HONDA_RADARLESS_LONG_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x33D, 0, 8, .check_relay = true}, {0x1C8, 0, 8, .check_relay = true},
                                                   {0x30C, 0, 8, .check_relay = true}};  // Bosch radarless w/ gas and brakes
 
   const uint16_t HONDA_PARAM_ALT_BRAKE = 1;
@@ -409,17 +409,6 @@ static bool honda_nidec_fwd_hook(int bus_num, int addr) {
   return block_msg;
 }
 
-static bool honda_bosch_fwd_hook(int bus_num, int addr) {
-  bool block_msg = false;
-
-  if (bus_num == 2)  {
-    bool is_lkas_msg = (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
-    block_msg = is_lkas_msg;
-  }
-
-  return block_msg;
-}
-
 const safety_hooks honda_nidec_hooks = {
   .init = honda_nidec_init,
   .rx = honda_rx_hook,
@@ -434,7 +423,6 @@ const safety_hooks honda_bosch_hooks = {
   .init = honda_bosch_init,
   .rx = honda_rx_hook,
   .tx = honda_tx_hook,
-  .fwd = honda_bosch_fwd_hook,
   .get_counter = honda_get_counter,
   .get_checksum = honda_get_checksum,
   .compute_checksum = honda_compute_checksum,

--- a/opendbc/safety/safety/safety_honda.h
+++ b/opendbc/safety/safety/safety_honda.h
@@ -413,7 +413,7 @@ static bool honda_bosch_fwd_hook(int bus_num, int addr) {
   bool block_msg = false;
 
   if (bus_num == 2)  {
-    bool is_lkas_msg = (addr == 0xE4) || (addr == 0xE5) || (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
+    bool is_lkas_msg = (addr == 0xE5) || (addr == 0x33D) || (addr == 0x33DA) || (addr == 0x33DB);
     block_msg = is_lkas_msg;
   }
 

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -375,7 +375,7 @@ class TestHondaBoschSafetyBase(HondaBase):
 
   TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4,)}  # STEERING_CONTROL
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0xE5)}  # STEERING_CONTROL, BOSCH_SUPPLEMENTAL_1
 
   def setUp(self):
     self.packer = CANPackerPanda("honda_accord_2018_can_generated")
@@ -459,7 +459,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
 
   STEER_BUS = 1
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE5, 0x33D, 0x33DA, 0x33DB]}
+  FWD_BLACKLISTED_ADDRS = {2: [0x33D, 0x33DA, 0x33DB]}
   # 0x1DF is to test that radar is disabled
   RELAY_MALFUNCTION_ADDRS = {1: (0xE4, 0x1DF)}  # STEERING_CONTROL, ACC_CONTROL
 
@@ -511,7 +511,8 @@ class TestHondaBoschRadarlessSafetyBase(TestHondaBoschSafetyBase):
   BUTTONS_BUS = 2  # camera controls ACC, need to send buttons on bus 2
 
   TX_MSGS = [[0xE4, 0], [0x296, 2], [0x33D, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
+  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x33D, 0x33DA, 0x33DB]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4,)}  # STEERING_CONTROL
 
   def setUp(self):
     self.packer = CANPackerPanda("honda_civic_ex_2022_can_generated")
@@ -546,7 +547,7 @@ class TestHondaBoschRadarlessLongSafety(common.LongitudinalAccelSafetyTest, Hond
     Covers the Honda Bosch Radarless safety mode with longitudinal control
   """
   TX_MSGS = [[0xE4, 0], [0x33D, 0], [0x1C8, 0], [0x30C, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB, 0x1C8, 0x30C]}
+  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x33D, 0x33DA, 0x33DB, 0x1C8, 0x30C]}
   RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x1C8, 0x30C)}
 
   def setUp(self):

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -375,7 +375,7 @@ class TestHondaBoschSafetyBase(HondaBase):
 
   TX_MSGS = [[0xE4, 0], [0xE5, 0], [0x296, 1], [0x33D, 0], [0x33DA, 0], [0x33DB, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0xE5)}  # STEERING_CONTROL, BOSCH_SUPPLEMENTAL_1
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB)}  # STEERING_CONTROL, BOSCH_SUPPLEMENTAL_1
 
   def setUp(self):
     self.packer = CANPackerPanda("honda_accord_2018_can_generated")
@@ -459,9 +459,9 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
 
   STEER_BUS = 1
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
-  FWD_BLACKLISTED_ADDRS = {2: [0x33D, 0x33DA, 0x33DB]}
+  FWD_BLACKLISTED_ADDRS = {}
   # 0x1DF is to test that radar is disabled
-  RELAY_MALFUNCTION_ADDRS = {1: (0xE4, 0x1DF)}  # STEERING_CONTROL, ACC_CONTROL
+  RELAY_MALFUNCTION_ADDRS = {1: (0xE4, 0x1DF, 0x33D, 0x33DA, 0x33DB)}  # STEERING_CONTROL, ACC_CONTROL
 
   def setUp(self):
     super().setUp()
@@ -511,8 +511,8 @@ class TestHondaBoschRadarlessSafetyBase(TestHondaBoschSafetyBase):
   BUTTONS_BUS = 2  # camera controls ACC, need to send buttons on bus 2
 
   TX_MSGS = [[0xE4, 0], [0x296, 2], [0x33D, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x33D, 0x33DA, 0x33DB]}
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4,)}  # STEERING_CONTROL
+  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x33D]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x33D)}  # STEERING_CONTROL
 
   def setUp(self):
     self.packer = CANPackerPanda("honda_civic_ex_2022_can_generated")
@@ -547,8 +547,8 @@ class TestHondaBoschRadarlessLongSafety(common.LongitudinalAccelSafetyTest, Hond
     Covers the Honda Bosch Radarless safety mode with longitudinal control
   """
   TX_MSGS = [[0xE4, 0], [0x33D, 0], [0x1C8, 0], [0x30C, 0]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x33D, 0x33DA, 0x33DB, 0x1C8, 0x30C]}
-  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x1C8, 0x30C)}
+  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x33D, 0x1C8, 0x30C]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x1C8, 0x30C, 0x33D)}
 
   def setUp(self):
     super().setUp()

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -249,6 +249,7 @@ class HondaBase(common.PandaCarSafetyTest):
 class TestHondaNidecSafetyBase(HondaBase):
   TX_MSGS = HONDA_N_COMMON_TX_MSGS
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0x194, 0x33D, 0x30C]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x194, 0x33D, 0x30C)}
 
   PT_BUS = 0
   STEER_BUS = 0

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -459,7 +459,7 @@ class TestHondaBoschLongSafety(HondaButtonEnableBase, TestHondaBoschSafetyBase):
 
   STEER_BUS = 1
   TX_MSGS = [[0xE4, 1], [0x1DF, 1], [0x1EF, 1], [0x1FA, 1], [0x30C, 1], [0x33D, 1], [0x33DA, 1], [0x33DB, 1], [0x39F, 1], [0x18DAB0F1, 1]]
-  FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB]}
+  FWD_BLACKLISTED_ADDRS = {2: [0xE5, 0x33D, 0x33DA, 0x33DB]}
   # 0x1DF is to test that radar is disabled
   RELAY_MALFUNCTION_ADDRS = {1: (0xE4, 0x1DF)}  # STEERING_CONTROL, ACC_CONTROL
 

--- a/opendbc/safety/tests/test_honda.py
+++ b/opendbc/safety/tests/test_honda.py
@@ -547,6 +547,7 @@ class TestHondaBoschRadarlessLongSafety(common.LongitudinalAccelSafetyTest, Hond
   """
   TX_MSGS = [[0xE4, 0], [0x33D, 0], [0x1C8, 0], [0x30C, 0]]
   FWD_BLACKLISTED_ADDRS = {2: [0xE4, 0xE5, 0x33D, 0x33DA, 0x33DB, 0x1C8, 0x30C]}
+  RELAY_MALFUNCTION_ADDRS = {0: (0xE4, 0x1C8, 0x30C)}
 
   def setUp(self):
     super().setUp()


### PR DESCRIPTION
TODO:
- [x] verify it's okay to forward camera messages to radar with Bosch long (since we're sending on bus 1, the forwarding logic doesn't block any of these from reaching bus 0/the radar but it should be okay since it's disabled) - https://connect.comma.ai/84ec13cd18bc76ca/000000ff--0eb28a38b6