### PR TITLE
Add support for another Hyundai Tucson 4TH GEN

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1047,6 +1047,7 @@ FW_VERSIONS = {
   },
   CAR.HYUNDAI_TUCSON_4TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
+      b'\xf1\x00NX4 FR_CMR AT EUR LHD 1.00 1.00 99211-N9250 14W',
       b'\xf1\x00NX4 FR_CMR AT CAN LHD 1.00 1.00 99211-N9260 14Y',
       b'\xf1\x00NX4 FR_CMR AT CAN LHD 1.00 1.01 99211-N9100 14A',
       b'\xf1\x00NX4 FR_CMR AT CAN LHD 1.00 1.00 99211-N9220 14K',
@@ -1061,6 +1062,7 @@ FW_VERSIONS = {
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
+      b'\xf1\x00NX4__               1.01 1.02 99110-N9000         ',
       b'\xf1\x00NX4__               1.00 1.00 99110-N9100         ',
       b'\xf1\x00NX4__               1.00 1.01 99110-N9000         ',
       b'\xf1\x00NX4__               1.00 1.02 99110-N9000         ',


### PR DESCRIPTION
Hi,
I would like to add a fingerprint from my Hyundai Tucson Hybrid 2024 - EU version.
Fingerprint created from log data:
`       {
        "ecu" : "fwdCamera",
        "fwVersion" : b'xf1\x00\x4e\x58\x34\x20\x46\x52\x5f\x43\x4d\x52\x20\x41\x54\x20\',
                  b'x45\x55\x52\x20\x4c\x48\x44\x20\x31\x2e\x30\x30\x20\x31\x2e\x30\',
                  b'x30\x20\x39\x39\x32\x31\x31\x2d\x4e\x39\x32\x35\x30\x20\x31\x34\',
                  b'x57\',
        "address" : 1988,
        "subAddress" : 0,
        "responseAddress" : 1996,
        "request" : [
          b'x22\xf1\x00\'
        ],
        "brand" : "hyundai",
        "bus" : 0,
        "logging" : false,
        "obdMultiplexing" : true
      },
      {
        "ecu" : "fwdRadar",
        "fwVersion" : b'xf1\x00\x4e\x58\x34\x5f\x5f\x20\x20\x20\x20\x20\x20\x20\x20\x20\',
                  b'x20\x20\x20\x20\x20\x20\x31\x2e\x30\x31\x20\x31\x2e\x30\x32\x20\',
                  b'x39\x39\x31\x31\x30\x2d\x4e\x39\x30\x30\x30\x20\x20\x20\x20\x20\',
                  b'x20\x20\x20\x20\',
        "address" : 2000,
        "subAddress" : 0,
        "responseAddress" : 2008,
        "request" : [
          b'x22\xf1\x00\'
        ],
        "brand" : "hyundai",
        "bus" : 0,
        "logging" : false,
        "obdMultiplexing" : true
      },`
Change tested - calibration done and a short drive with OP engaged also done.