### PR TITLE
Bolt 70kW Regen Signal

### DIFF
--- a/opendbc/dbc/generator/gm/gm_global_a_powertrain.dbc
+++ b/opendbc/dbc/generator/gm/gm_global_a_powertrain.dbc
@@ -307,7 +307,7 @@ CM_ SG_ 481 ACCAlwaysOne "Usually 1 if the car is equipped with ACC";
 CM_ SG_ 562 FrictionBrakeUnavailable "1 when ACC brake control is unavailable. Stays high if brake command messages are blocked for a period of time";
 CM_ SG_ 497 SystemPowerMode "Describes ignition";
 CM_ SG_ 497 SystemBackUpPowerMode "Describes ignition + preconditioning mode, noisy";
-CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 4=L10";
+CM_ SG_ 501 PRNDL2 "When ManualMode is Active, Value is 13=L1 12=L2 11=L3 ... 5=Full 70kW Paddle Regen Unlocked for Gen2 Bolts 4=L10";
 CM_ SG_ 532 UserBrakePressure "can be lower than other brake position signals when the brakes are pre-filled from ACC braking and the user presses on the brakes. user-only pressure?";
 CM_ SG_ 608 ClusterSpeed "Cluster speed signal seems to match dash on newer cars, but is a lower rate and can be noisier.";
 CM_ SG_ 761 UserBrakePressure2 "Similar to BRAKE_RELATED->UserBrakePressure";
@@ -347,6 +347,6 @@ VAL_ 715 GasRegenCmdActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 Intellibeam 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsActive 1 "Active" 0 "Inactive" ;
 VAL_ 320 HighBeamsTemporary 1 "Active" 0 "Inactive" ;
-VAL_ 501 PRNDL2 6 "L" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Shifting";
+VAL_ 501 PRNDL2 7 "L3" 6 "L" 5 "L2" 4 "D" 3 "N" 2 "R" 1 "P" 0 "Shifting";
 VAL_ 501 TransmissionState 11 "Shifting" 10 "Reverse" 9 "Forward" 8 "Disengaged";
 VAL_ 501 ManualMode 1 "Active" 0 "Inactive"


### PR DESCRIPTION
When paired with EBCMRegenPaddle, State "5" unlocks the full 70kW regen available to the chevy bolt (State 7 is for gen1 bolts, state 5 is gen2). Static bytes must also be defined and sent for car to accept the signal. 

I'm using it to get access to full regen with a pedal interceptor, but it may also be an applicable method for regen blending on GM acc enabled vehicles. Still testing. 
<img width="410" alt="Screenshot 2025-03-29 at 9 20 44 PM" src="https://github.com/user-attachments/assets/17fc9dfb-faec-498d-abaa-7b93c9ab1eb7" />

