### PR TITLE
Nissan: Add passenger seatbelt latched/unlatched

### DIFF
--- a/opendbc/dbc/generator/nissan/nissan_leaf_2018.dbc
+++ b/opendbc/dbc/generator/nissan/nissan_leaf_2018.dbc
@@ -1,11 +1,12 @@
 CM_ "IMPORT _nissan_common.dbc";
 
 BO_ 42 SEATBELT: 8 XXX
- SG_ SEATBELT_DRIVER_LATCHED : 27|1@1+ (1,0) [0|3] "" XXX
- SG_ SEATBELT_DRIVER_UNLATCHED : 26|1@0+ (1,0) [0|1] "" XXX
- SG_ unknown2 : 31|4@0+ (1,0) [0|15] "" XXX
- SG_ unknown3 : 24|2@1+ (1,0) [0|3] "" XXX
  SG_ unknown1 : 7|24@0+ (1,0) [0|16777215] "" XXX
+ SG_ SEATBELT_PASSENGER_UNLATCHED : 24|1@0+ (1,0) [0|1] "" XXX
+ SG_ SEATBELT_PASSENGER_LATCHED : 25|1@0+ (1,0) [0|1] "" XXX
+ SG_ SEATBELT_DRIVER_UNLATCHED : 26|1@0+ (1,0) [0|1] "" XXX
+ SG_ SEATBELT_DRIVER_LATCHED : 27|1@1+ (1,0) [0|3] "" XXX
+ SG_ unknown2 : 31|4@0+ (1,0) [0|15] "" XXX
  SG_ unknown4 : 39|16@0+ (1,0) [0|65535] "" XXX
 
 BO_ 460 BRAKE_PEDAL: 8 XXX


### PR DESCRIPTION
This pull request updates the `nissan_leaf_2018.dbc` file to enhance the clarity and accuracy of signal definitions for the Nissan Leaf 2018 model. The most important changes involve adding signal definitions within the `SEATBELT` message.

### Updates to signal definitions in `SEATBELT` message:

* Added new signals: `SEATBELT_PASSENGER_UNLATCHED` and `SEATBELT_PASSENGER_LATCHED` to represent passenger seatbelt states.