### PR TITLE
Tesla: fix steer fault when quickly overriding

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -37,7 +37,7 @@ class CarState(CarStateBase):
 
     # Steering wheel
     epas_status = cp_party.vl["EPAS3S_sysStatus"]
-    ret.steeringDisengage = epas_status["EPAS3S_handsOnLevel"] >= 3
+    ret.steeringDisengage = epas_status["EPAS3S_handsOnLevel"] >= 3 or (epas_status["EPAS3S_eacStatus"] == 0 and epas_status["EPAS3S_eacErrorCode"] == 9)
     ret.steeringAngleDeg = -epas_status["EPAS3S_internalSAS"]
     ret.steeringRateDeg = -cp_ap_party.vl["SCCM_steeringAngleSensor"]["SCCM_steeringAngleSpeed"]
     ret.steeringTorque = -epas_status["EPAS3S_torsionBarTorque"]

--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -49,6 +49,7 @@ class CarState(CarStateBase):
     ret.steerFaultTemporary = eac_status == "EAC_INHIBITED"
 
     # FSD disengages using union of handsOnLevel (slow overrides) and high angle rate faults (fast overrides, high speed)
+    # TODO: implement in safety
     eac_error_code = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacErrorCode"].get(int(epas_status["EPAS3S_eacErrorCode"]), None)
     ret.steeringDisengage = epas_status["EPAS3S_handsOnLevel"] >= 3 or (eac_status == "EAC_INHIBITED" and
                                                                         eac_error_code == "EAC_ERROR_HIGH_ANGLE_RATE_SAFETY")

--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -37,7 +37,6 @@ class CarState(CarStateBase):
 
     # Steering wheel
     epas_status = cp_party.vl["EPAS3S_sysStatus"]
-    ret.steeringDisengage = epas_status["EPAS3S_handsOnLevel"] >= 3 or (epas_status["EPAS3S_eacStatus"] == 0 and epas_status["EPAS3S_eacErrorCode"] == 9)
     ret.steeringAngleDeg = -epas_status["EPAS3S_internalSAS"]
     ret.steeringRateDeg = -cp_ap_party.vl["SCCM_steeringAngleSensor"]["SCCM_steeringAngleSpeed"]
     ret.steeringTorque = -epas_status["EPAS3S_torsionBarTorque"]
@@ -48,6 +47,11 @@ class CarState(CarStateBase):
     eac_status = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacStatus"].get(int(epas_status["EPAS3S_eacStatus"]), None)
     ret.steerFaultPermanent = eac_status == "EAC_FAULT"
     ret.steerFaultTemporary = eac_status == "EAC_INHIBITED"
+
+    # FSD disengages using union of handsOnLevel (slow overrides) and high angle rate faults (fast overrides, high speed)
+    eac_error_code = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacErrorCode"].get(int(epas_status["EPAS3S_eacErrorCode"]), None)
+    ret.steeringDisengage = epas_status["EPAS3S_handsOnLevel"] >= 3 or (eac_status == "EAC_INHIBITED" and
+                                                                        eac_error_code == "EAC_ERROR_HIGH_ANGLE_RATE_SAFETY")
 
     # Cruise state
     cruise_state = self.can_define.dv["DI_state"]["DI_cruiseState"].get(int(cp_party.vl["DI_state"]["DI_cruiseState"]), None)


### PR DESCRIPTION
Normally we use the hands on level to disengage, however that seems to be quite delayed. FSD will disengage on the union of hands on level for normal, slow overrides, as well as an EAC status of `EAC_INHIBITED` && fault code of `EAC_ERROR_HIGH_ANGLE_RATE_SAFETY`. When this new combination is true, FSD disengages as normal--no alerts/faults/messages, just a disengage chime. This PR matches that.

Confusingly, we actually re-enabled steering after these events when you expected it to disengage. That's fixed.

FSD route testing rapid overriding: https://connect.comma.ai/2c912ca5de3b1ee9/0000023e--ad364991c0/657/715

![image](https://github.com/user-attachments/assets/f380b40a-0058-432e-83d6-1abd31798fde)
