### PR TITLE
fix(macos): macOS 15 and greater

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - os: ${{ github.repository == 'commaai/opendbc' && 'namespace-profile-amd64-8x16' || 'ubuntu-24.04' }}
           - os: macos-latest
+          - os: macos-15
     steps:
     - uses: commaai/timeout@v1
     - uses: actions/checkout@v4

--- a/opendbc/safety/tests/libsafety/SConscript
+++ b/opendbc/safety/tests/libsafety/SConscript
@@ -2,9 +2,12 @@ import platform
 
 CC = 'gcc'
 system = platform.system()
-if system == 'Darwin':
-  # gcc installed by homebrew has version suffix (e.g. gcc-12) in order to be
-  # distinguishable from system one - which acts as a symlink to clang
+mac_ver = platform.mac_ver()
+
+# gcc installed by homebrew has version suffix (e.g. gcc-12) in order to be
+# distinguishable from system one - which acts as a symlink to clang
+# clang works on macOS 15 and greater but has issues on earlier macOS versions.
+if system == 'Darwin' and mac_ver[0] and mac_ver[0] < '15':
   CC += '-13'
 
 env = Environment(

--- a/opendbc/safety/tests/libsafety/SConscript
+++ b/opendbc/safety/tests/libsafety/SConscript
@@ -7,6 +7,7 @@ mac_ver = platform.mac_ver()
 # gcc installed by homebrew has version suffix (e.g. gcc-12) in order to be
 # distinguishable from system one - which acts as a symlink to clang
 # clang works on macOS 15 and greater but has issues on earlier macOS versions.
+# see: https://github.com/commaai/openpilot/issues/35093
 if system == 'Darwin' and mac_ver[0] and mac_ver[0] < '15':
   CC += '-13'
 

--- a/opendbc/safety/tests/libsafety/SConscript
+++ b/opendbc/safety/tests/libsafety/SConscript
@@ -1,5 +1,14 @@
+import platform
+
+CC = 'gcc'
+system = platform.system()
+if system == 'Darwin':
+  # gcc installed by homebrew has version suffix (e.g. gcc-12) in order to be
+  # distinguishable from system one - which acts as a symlink to clang
+  CC += '-13'
+
 env = Environment(
-  CC='gcc',
+  CC=CC,
   CFLAGS=[
     '-Wall',
     "-Wextra",
@@ -12,6 +21,8 @@ env = Environment(
   ],
   CPPPATH=[".", "../../board/", "../../"],
 )
+if system == "Darwin":
+  env.PrependENVPath('PATH', '/opt/homebrew/bin')
 
 if GetOption('mutation'):
   env['CC'] = 'clang-17'

--- a/opendbc/safety/tests/libsafety/SConscript
+++ b/opendbc/safety/tests/libsafety/SConscript
@@ -1,14 +1,5 @@
-import platform
-
-CC = 'gcc'
-system = platform.system()
-if system == 'Darwin':
-  # gcc installed by homebrew has version suffix (e.g. gcc-12) in order to be
-  # distinguishable from system one - which acts as a symlink to clang
-  CC += '-13'
-
 env = Environment(
-  CC=CC,
+  CC='gcc',
   CFLAGS=[
     '-Wall',
     "-Wextra",
@@ -21,8 +12,6 @@ env = Environment(
   ],
   CPPPATH=[".", "../../board/", "../../"],
 )
-if system == "Darwin":
-  env.PrependENVPath('PATH', '/opt/homebrew/bin')
 
 if GetOption('mutation'):
   env['CC'] = 'clang-17'


### PR DESCRIPTION
resolves: https://github.com/commaai/openpilot/issues/35093

special handling was added for mac to resolve gcc (internally, clang) to the actual GNU compiler (resolved as gcc-<ver> with brew): https://github.com/commaai/panda/pull/1241

with a recent update to MacOS (some time near 15.4), `gcc` was broken.

upon checking, clang17 supports `-std=gnu11`, which was the original complaint. as well, builds just fine. but there are still issues with building on less than 15 with clang.

using gcc on less than 15.

<img width="215" alt="image" src="https://github.com/user-attachments/assets/fa8ffec2-81bc-4b3e-91cd-5e4801f89afa" />


```
-- with .app --

➜ clang --version
Apple clang version 17.0.0 (clang-1700.0.13.3)
Target: arm64-apple-darwin24.4.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

-- with default CommandLineTools version, also supported --

➜ clang --version
Apple clang version 17.0.0 (clang-1700.0.13.3)
Target: arm64-apple-darwin24.4.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

<img width="419" alt="image" src="https://github.com/user-attachments/assets/8a6c3a9f-3eb9-47a0-a709-a55ba5a84378" />
