### PR TITLE
Tesla: fix disengagement without stalk

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -30,7 +30,9 @@ class CarController(CarControllerBase):
     # Longitudinal control
     if self.CP.openpilotLongitudinalControl:
       if self.frame % 4 == 0:
-        state = 13 if CC.cruiseControl.cancel else 4  # 4=ACC_ON, 13=ACC_CANCEL_GENERIC_SILENT
+        # Handle ACC cancel request from autopilot computer for cars without a stalk
+        cancel = CC.cruiseControl.cancel or CS.das_control["DAS_accState"] == 13
+        state = 13 if cancel else 4  # 4=ACC_ON, 13=ACC_CANCEL_GENERIC_SILENT
         accel = float(np.clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX))
         cntr = (self.frame // 4) % 8
         can_sends.append(self.tesla_can.create_longitudinal_command(state, accel, cntr, CS.out.vEgo, CC.longActive))


### PR DESCRIPTION
On Tesla models without a cruise control stalk, the steering wheel scroll wheel is used to engage and disengage. 
Unlike the stalk, pressing the scroll wheel button doesn't change the DI_state. This meant that pressing the scroll wheel button currently does not disengage openpilot, whenever openpilot's longitudinal control is enabled

When the scroll wheel button is pressed to cancel ACC, DAS_accState becomes 13. 
We have to listen to DAS_accState sent by the autopilot computer and add it to the cancel condition, to ensure that openpilot correctly disengages on a scroll wheel button press.

The screenshot shows several button is presses, but the DI_State does not change.
<img width="841" alt="Bildschirmfoto 2025-05-04 um 12 39 51" src="https://github.com/user-attachments/assets/a2112d01-fd3f-48a8-955b-fde3fc6f183d" />

route: f15cb91e37913f92/00000002--ee7e5b52c1

**We need to make sure that ACC_CANCEL_GENERIC_SILENT (state 13) is not sent by the autopilot computer in other scenarios where we don't want to disengage.**
