### PR TITLE
3071 Impreza / Crosstrek

### DIFF
--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -33,6 +33,8 @@ class CarInterface(CarInterfaceBase):
       ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.subaru)]
       if ret.flags & SubaruFlags.GLOBAL_GEN2:
         ret.safetyConfigs[0].safetyParam |= SubaruSafetyFlags.GEN2.value
+      elif ret.flags & (SubaruFlags.IMPREZA_2018 | SubaruFlags.HYBRID) :
+        ret.safetyConfigs[0].safetyParam |= SubaruSafetyFlags.IMPREZA_2018.value
 
     ret.steerLimitTimer = 0.4
     ret.steerActuatorDelay = 0.1
@@ -50,11 +52,11 @@ class CarInterface(CarInterfaceBase):
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.0025, 0.1], [0.00025, 0.01]]
 
     elif candidate == CAR.SUBARU_IMPREZA:
-      ret.steerActuatorDelay = 0.4  # end-to-end angle controller
+      ret.steerActuatorDelay = 0.2  # end-to-end angle controller
       ret.lateralTuning.init('pid')
-      ret.lateralTuning.pid.kf = 0.00005
+      ret.lateralTuning.pid.kf = 0.00003
       ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kpBP = [[0., 20.], [0., 20.]]
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.2, 0.3], [0.02, 0.03]]
+      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.12, 0.18], [0.012, 0.018]]
 
     elif candidate == CAR.SUBARU_IMPREZA_2020:
       ret.lateralTuning.init('pid')

--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -24,8 +24,13 @@ class CarControllerParams:
       self.STEER_DELTA_UP = 40
       self.STEER_DELTA_DOWN = 40
     elif CP.carFingerprint == CAR.SUBARU_IMPREZA_2020:
-      self.STEER_DELTA_UP = 35
       self.STEER_MAX = 1439
+      self.STEER_DELTA_UP = 35
+      self.STEER_DELTA_DOWN = 70
+    elif CP.carFingerprint == CAR.SUBARU_IMPREZA:
+      self.STEER_MAX = 3071
+      self.STEER_DELTA_UP = 60
+      self.STEER_DELTA_DOWN = 60
     else:
       self.STEER_MAX = 2047
 
@@ -57,6 +62,7 @@ class SubaruSafetyFlags(IntFlag):
   GEN2 = 1
   LONG = 2
   PREGLOBAL_REVERSED_DRIVER_TORQUE = 4
+  IMPREZA_2018 = 8
 
 
 class SubaruFlags(IntFlag):
@@ -73,6 +79,7 @@ class SubaruFlags(IntFlag):
   PREGLOBAL = 16
   HYBRID = 32
   LKAS_ANGLE = 64
+  IMPREZA_2018 = 128
 
 
 GLOBAL_ES_ADDR = 0x787
@@ -145,7 +152,8 @@ class CAR(Platforms):
       SubaruCarDocs("Subaru Crosstrek 2018-19", video_link="https://youtu.be/Agww7oE1k-s?t=26"),
       SubaruCarDocs("Subaru XV 2018-19", video_link="https://youtu.be/Agww7oE1k-s?t=26"),
     ],
-    CarSpecs(mass=1568, wheelbase=2.67, steerRatio=15),
+    CarSpecs(mass=1568, wheelbase=2.67, steerRatio=13.5),
+    flags=SubaruFlags.IMPREZA_2018,
   )
   SUBARU_IMPREZA_2020 = SubaruPlatformConfig(
     [

--- a/opendbc/safety/safety/safety_subaru.h
+++ b/opendbc/safety/safety/safety_subaru.h
@@ -72,6 +72,7 @@
 
 static bool subaru_gen2 = false;
 static bool subaru_longitudinal = false;
+static bool subaru_impreza_2018 = false;
 
 static uint32_t subaru_get_checksum(const CANPacket_t *to_push) {
   return (uint8_t)GET_BYTE(to_push, 0);
@@ -138,6 +139,7 @@ static void subaru_rx_hook(const CANPacket_t *to_push) {
 static bool subaru_tx_hook(const CANPacket_t *to_send) {
   const TorqueSteeringLimits SUBARU_STEERING_LIMITS      = SUBARU_STEERING_LIMITS_GENERATOR(2047, 50, 70);
   const TorqueSteeringLimits SUBARU_GEN2_STEERING_LIMITS = SUBARU_STEERING_LIMITS_GENERATOR(1000, 40, 40);
+  const TorqueSteeringLimits SUBARU_IMPREZA_2018_STEERING_LIMITS = SUBARU_STEERING_LIMITS_GENERATOR(3071, 60, 60);
 
   const LongitudinalLimits SUBARU_LONG_LIMITS = {
     .min_gas = 808,       // appears to be engine braking
@@ -160,7 +162,9 @@ static bool subaru_tx_hook(const CANPacket_t *to_send) {
 
     bool steer_req = GET_BIT(to_send, 29U);
 
-    const TorqueSteeringLimits limits = subaru_gen2 ? SUBARU_GEN2_STEERING_LIMITS : SUBARU_STEERING_LIMITS;
+    const TorqueSteeringLimits limits = subaru_gen2 ? SUBARU_GEN2_STEERING_LIMITS :
+    (subaru_impreza_2018 ? SUBARU_IMPREZA_2018_STEERING_LIMITS:
+    SUBARU_STEERING_LIMITS);
     violation |= steer_torque_cmd_checks(desired_torque, steer_req, limits);
   }
 
@@ -238,8 +242,10 @@ static safety_config subaru_init(uint16_t param) {
   };
 
   const uint16_t SUBARU_PARAM_GEN2 = 1;
+  const uint16_t SUBARU_PARAM_IMPREZA_2018 = 8;
 
   subaru_gen2 = GET_FLAG(param, SUBARU_PARAM_GEN2);
+  subaru_impreza_2018 = GET_FLAG(param, SUBARU_PARAM_IMPREZA_2018);
 
 #ifdef ALLOW_DEBUG
   const uint16_t SUBARU_PARAM_LONGITUDINAL = 2;

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -819,6 +819,8 @@ class PandaSafetyTest(PandaSafetyTestBase):
               continue
             if attr.startswith('TestSubaruGen') and current_test.startswith('TestSubaruGen'):
               continue
+            if attr.startswith('TestSubaruImp') and current_test.startswith('TestSubaruImp'):
+              continue
             if attr.startswith('TestSubaruPreglobal') and current_test.startswith('TestSubaruPreglobal'):
               continue
             if {attr, current_test}.issubset({'TestVolkswagenPqSafety', 'TestVolkswagenPqStockSafety', 'TestVolkswagenPqLongSafety'}):

--- a/opendbc/safety/tests/test_subaru.py
+++ b/opendbc/safety/tests/test_subaru.py
@@ -185,6 +185,13 @@ class TestSubaruGen2TorqueStockLongitudinalSafety(TestSubaruStockLongitudinalSaf
   FLAGS = SubaruSafetyFlags.GEN2
   TX_MSGS = lkas_tx_msgs(SUBARU_ALT_BUS)
 
+class TestSubaruImpreza2018TorqueStockLongitudinalSafety(TestSubaruStockLongitudinalSafetyBase, TestSubaruTorqueSafetyBase):
+  MAX_RATE_UP = 60
+  MAX_RATE_DOWN = 60
+  MAX_TORQUE_LOOKUP = [0], [3071]
+  FLAGS = SubaruSafetyFlags.IMPREZA_2018
+  TX_MSGS = lkas_tx_msgs(SUBARU_MAIN_BUS)
+
 
 class TestSubaruGen1LongitudinalSafety(TestSubaruLongitudinalSafetyBase, TestSubaruTorqueSafetyBase):
   FLAGS = SubaruSafetyFlags.LONG


### PR DESCRIPTION
upstream the "correct" values for crosstrek/subaru torque limit. 

This is for Global pre-2020 Impreza/Crosstrek as well as the hybrid although that is dashcam only upstream. 


The limit on these cars for steering is 3071 not 2047. 
Torque is similar but lower than the 2019 Forester which uses the 2047 limit and rate limits. 

stock Slew rate limit is right around 60. (For the forester it is around 30) 