### PR TITLE
Tesla safety: check 2nd speed source

### DIFF
--- a/opendbc/dbc/tesla_model3_party.dbc
+++ b/opendbc/dbc/tesla_model3_party.dbc
@@ -111,6 +111,14 @@ BO_ 341 ESP_B: 8 PARTY
  SG_ ESP_wheelPulseCountFrR : 8|8@1+ (1,0) [0|254] "1"  app
  SG_ ESP_wheelPulseCountFrL : 0|8@1+ (1,0) [0|254] "1"  app
 
+BO_ 373 ESP_wheelSpeeds: 8 CH
+ SG_ ESP_wheelSpeedsChecksum : 56|8@1+ (1,0) [0|255] ""  das
+ SG_ ESP_wheelSpeedsCounter : 52|4@1+ (1,0) [0|15] ""  das
+ SG_ ESP_wheelSpeedReR : 39|13@1+ (0.04,0) [0|327.64] "km/h"  das
+ SG_ ESP_wheelSpeedReL : 26|13@1+ (0.04,0) [0|327.64] "km/h"  das
+ SG_ ESP_wheelSpeedFrR : 13|13@1+ (0.04,0) [0|327.64] "km/h"  das
+ SG_ ESP_wheelSpeedFrL : 0|13@1+ (0.04,0) [0|327.64] "km/h"  das
+
 BO_ 969 APS_status: 4 PARTY
  SG_ APS_statusCounter : 22|4@1+ (1,0) [0|15] ""  X
  SG_ APS_apbGpioState : 20|2@1+ (1,0) [0|3] ""  gtw

--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -38,14 +38,19 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
     // Vehicle speed (DI_speed)
     if (addr == 0x257) {
       // Vehicle speed: ((val * 0.08) - 40) / MS_TO_KPH
-      float speed = ((((GET_BYTE(to_push, 2) << 4) | (GET_BYTE(to_push, 1) >> 4)) * 0.08) - 40) / 3.6;
+      float speed = ((((GET_BYTE(to_push, 2) << 4) | (GET_BYTE(to_push, 1) >> 4)) * 0.08) - 40.) / 3.6;
+      printf("Vehicle speed: %f\n", speed);
       UPDATE_VEHICLE_SPEED(speed);
     }
 
     // 2nd vehicle speed (ESP_B)
     if (addr == 0x155) {
       // Disable controls if speeds from DI (Drive Inverter) and ESP wheel speed sensors are too far apart.
-      float esp_speed = (((GET_BYTE(to_push, 6) & 0x0FU) << 6) || GET_BYTE(to_push, 5) >> 2) * 0.5 / 3.6;
+      float esp_speed = (((GET_BYTE(to_push, 6) & 0x0FU) << 6) | GET_BYTE(to_push, 5) >> 2) * 0.5 / 3.6;
+      printf("byte 6: %d\n", GET_BYTE(to_push, 6));
+      printf("byte 5: %d\n", GET_BYTE(to_push, 5));
+      printf("ESP speed: %f\n", esp_speed);
+//      printf("Vehicle speed: %f\n", ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR));
       bool is_invalid_speed = ABS(esp_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > TESLA_MAX_SPEED_DELTA;
       // TODO: this should generically cause rx valid to fall until re-enable
       if (is_invalid_speed) {

--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -44,7 +44,7 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
 
     // 2nd vehicle speed (ESP_B)
     if (addr == 0x155) {
-      // Disable controls if speeds from DI (Drive Inverter) and ESP wheel speed sensors are too far apart.
+      // Disable controls if speeds from DI (Drive Inverter) and ESP ECUs are too far apart.
       float esp_speed = (((GET_BYTE(to_push, 6) & 0x0FU) << 6) | GET_BYTE(to_push, 5) >> 2) * 0.5 / 3.6;
       bool is_invalid_speed = ABS(esp_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > TESLA_MAX_SPEED_DELTA;
       // TODO: this should generically cause rx valid to fall until re-enable

--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -46,10 +46,6 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
     if (addr == 0x155) {
       // Disable controls if speeds from DI (Drive Inverter) and ESP wheel speed sensors are too far apart.
       float esp_speed = (((GET_BYTE(to_push, 6) & 0x0FU) << 6) | GET_BYTE(to_push, 5) >> 2) * 0.5 / 3.6;
-//      printf("byte 6: %d\n", GET_BYTE(to_push, 6));
-//      printf("byte 5: %d\n", GET_BYTE(to_push, 5));
-      printf("ESP speed: %f\n", esp_speed);
-      printf("Vehicle speed: %f\n", ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR));
       bool is_invalid_speed = ABS(esp_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > TESLA_MAX_SPEED_DELTA;
       // TODO: this should generically cause rx valid to fall until re-enable
       if (is_invalid_speed) {

--- a/opendbc/safety/safety/safety_tesla.h
+++ b/opendbc/safety/safety/safety_tesla.h
@@ -39,7 +39,6 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
     if (addr == 0x257) {
       // Vehicle speed: ((val * 0.08) - 40) / MS_TO_KPH
       float speed = ((((GET_BYTE(to_push, 2) << 4) | (GET_BYTE(to_push, 1) >> 4)) * 0.08) - 40.) / 3.6;
-      printf("Vehicle speed: %f\n", speed);
       UPDATE_VEHICLE_SPEED(speed);
     }
 
@@ -47,10 +46,10 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
     if (addr == 0x155) {
       // Disable controls if speeds from DI (Drive Inverter) and ESP wheel speed sensors are too far apart.
       float esp_speed = (((GET_BYTE(to_push, 6) & 0x0FU) << 6) | GET_BYTE(to_push, 5) >> 2) * 0.5 / 3.6;
-      printf("byte 6: %d\n", GET_BYTE(to_push, 6));
-      printf("byte 5: %d\n", GET_BYTE(to_push, 5));
+//      printf("byte 6: %d\n", GET_BYTE(to_push, 6));
+//      printf("byte 5: %d\n", GET_BYTE(to_push, 5));
       printf("ESP speed: %f\n", esp_speed);
-//      printf("Vehicle speed: %f\n", ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR));
+      printf("Vehicle speed: %f\n", ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR));
       bool is_invalid_speed = ABS(esp_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > TESLA_MAX_SPEED_DELTA;
       // TODO: this should generically cause rx valid to fall until re-enable
       if (is_invalid_speed) {

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 import unittest
+import numpy as np
+import math
 
 from opendbc.car.tesla.values import TeslaSafetyFlags
 from opendbc.car.structs import CarParams
@@ -34,6 +36,9 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
   MIN_ACCEL = -3.48
   INACTIVE_ACCEL = 0.0
 
+  # Max allowed delta between car speeds
+  MAX_SPEED_DELTA = 2.0  # m/s
+
   cnt_epas = 0
 
   packer: CANPackerPanda
@@ -64,7 +69,14 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
 
   def _speed_msg(self, speed):
     values = {"DI_vehicleSpeed": speed * 3.6}
+    print('sending to safety:', values)
     return self.packer.make_can_msg_panda("DI_speed", 0, values)
+
+  def _speed_msg_2(self, speed):
+    values = {"ESP_vehicleSpeed": speed * 3.6}
+    ret = self.packer.make_can_msg_panda("ESP_B", 0, values)
+    print('sending to safety:', values)
+    return ret
 
   def _vehicle_moving_msg(self, speed: float):
     values = {"DI_cruiseState": 3 if speed <= self.STANDSTILL_THRESHOLD else 2}
@@ -101,6 +113,27 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
     # OVERRIDDEN: 79.1667 is the max speed in m/s
     self._common_measurement_test(self._speed_msg, 0, 285 / 3.6, 1,
                                   self.safety.get_vehicle_speed_min, self.safety.get_vehicle_speed_max)
+
+  def test_rx_hook_speed_mismatch(self):
+    # TODO: this can be a common test w/ Ford
+    # Tesla relies on speed for lateral limits close to ISO 11270, so it checks two sources
+    for speed in np.arange(0, 40, 0.5):
+      # Python does banker's rounding with mismatches with CANParser, hence the floor(x + 0.5)
+      speed = math.floor(speed / 0.08 * 3.6 + 0.5) * 0.08 / 3.6
+      print()
+      for speed_delta in np.arange(-5, 5, 0.1):
+        print('speed_1', speed)
+        speed_2 = round(max(speed + speed_delta, 0), 1)
+        speed_2 = math.floor(speed_2 * 2 * 3.6 + 0.5) / 2 / 3.6
+        print('speed_2', speed_2)
+        # Set controls allowed in between rx since first message can reset it
+        self._rx(self._speed_msg(speed))
+        self.safety.set_controls_allowed(True)
+        self._rx(self._speed_msg_2(speed_2))
+        print()
+
+        within_delta = abs(speed - speed_2) <= self.MAX_SPEED_DELTA
+        self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
   def test_steering_wheel_disengage(self):
     # Tesla disengages when the user forcibly overrides the locked-in angle steering control

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -118,7 +118,7 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
       # Python does banker's rounding which mismatches with C++ CANParser, hence the floor(x + 0.5)
       speed = math.floor(speed / 0.08 * 3.6 + 0.5) * 0.08 / 3.6
       for speed_delta in np.arange(-5, 5, 0.1):
-        speed_2 = round(max(speed + speed_delta, 0), 1)
+        speed_2 = max(speed + speed_delta, 0)
         speed_2 = math.floor(speed_2 * 2 * 3.6 + 0.5) / 2 / 3.6
         # Set controls allowed in between rx since first message can reset it
         self._rx(self._speed_msg(speed))

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -115,6 +115,7 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
     # TODO: this can be a common test w/ Ford
     # Tesla relies on speed for lateral limits close to ISO 11270, so it checks two sources
     for speed in np.arange(0, 40, 0.5):
+      # match signal rounding on CAN
       # Python does banker's rounding which mismatches with C++ CANParser, hence the floor(x + 0.5)
       speed = math.floor(speed / 0.08 * 3.6 + 0.5) * 0.08 / 3.6
       for speed_delta in np.arange(-5, 5, 0.1):

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -120,6 +120,7 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
       for speed_delta in np.arange(-5, 5, 0.1):
         speed_2 = max(speed + speed_delta, 0)
         speed_2 = math.floor(speed_2 * 2 * 3.6 + 0.5) / 2 / 3.6
+
         # Set controls allowed in between rx since first message can reset it
         self._rx(self._speed_msg(speed))
         self.safety.set_controls_allowed(True)


### PR DESCRIPTION
Closes https://github.com/commaai/opendbc/issues/2200, matching how https://github.com/commaai/opendbc/pull/2049 added 2nd speed check, which was based on Ford

It looks like the signal in `DI_speed` uses the motor speeds to calculate its speed (calibration is likely [mentioned here](https://service.tesla.com/docs/ModelY/ServiceManual/en-us/GUID-5B457CEE-3E8B-4EBA-920E-5F9A2402F131.html), look for "Inverter Resolver Error Learning"), and the signal in `ESP_B` uses the wheel speed sensors ([mentioned here](https://service.tesla.com/docs/Model3/ServiceManual/en-us/GUID-E4D1FACE-A01E-4645-8DA0-0D9296C5AB4C.html)).

The closest Tesla error code I found was [DIR_a075_motorSpeedMismatch](https://tesware.net/alerts/model3/DIR_a075_motorSpeedMismatch), so it's very likely it also checks for mismatches between ESP and DI for Autopilot and would disengage.

An example of ESP_vehicleSpeed showing some noise correlating with wheel speeds:

<details><Summary>View</summary>

![image](https://github.com/user-attachments/assets/73c6aec7-63ef-4339-851d-2770c59e9f13)
</details>
