### PR TITLE
Tesla: let CANPacker set counters

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -27,10 +27,10 @@ class CarController(CarControllerBase):
       self.apply_angle_last = apply_std_steer_angle_limits(actuators.steeringAngleDeg, self.apply_angle_last, CS.out.vEgo,
                                                            CS.out.steeringAngleDeg, lat_active, CarControllerParams.ANGLE_LIMITS)
 
-      can_sends.append(self.tesla_can.create_steering_control(self.apply_angle_last, lat_active, (self.frame // 2) % 16))
+      can_sends.append(self.tesla_can.create_steering_control(self.apply_angle_last, lat_active))
 
     if self.frame % 10 == 0:
-      can_sends.append(self.tesla_can.create_steering_allowed((self.frame // 10) % 16))
+      can_sends.append(self.tesla_can.create_steering_allowed())
 
     # Longitudinal control
     if self.CP.openpilotLongitudinalControl:

--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -13,19 +13,18 @@ class TeslaCAN:
     ret += sum(dat)
     return ret & 0xFF
 
-  def create_steering_control(self, angle, enabled, counter):
+  def create_steering_control(self, angle, enabled):
     values = {
       "DAS_steeringAngleRequest": -angle,
       "DAS_steeringHapticRequest": 0,
       "DAS_steeringControlType": 1 if enabled else 0,
-      "DAS_steeringControlCounter": counter,
     }
 
     data = self.packer.make_can_msg("DAS_steeringControl", CANBUS.party, values)[1]
     values["DAS_steeringControlChecksum"] = self.checksum(0x488, data[:3])
     return self.packer.make_can_msg("DAS_steeringControl", CANBUS.party, values)
 
-  def create_longitudinal_command(self, acc_state, accel, cntr, v_ego, active):
+  def create_longitudinal_command(self, acc_state, accel, counter, v_ego, active):
     set_speed = max(v_ego * CV.MS_TO_KPH, 0)
     if active:
       # TODO: this causes jerking after gas override when above set speed
@@ -39,17 +38,16 @@ class TeslaCAN:
       "DAS_jerkMax": CarControllerParams.JERK_LIMIT_MAX,
       "DAS_accelMin": accel,
       "DAS_accelMax": max(accel, 0),
-      "DAS_controlCounter": cntr,
+      "DAS_controlCounter": counter,
       "DAS_controlChecksum": 0,
     }
     data = self.packer.make_can_msg("DAS_control", CANBUS.party, values)[1]
     values["DAS_controlChecksum"] = self.checksum(0x2b9, data[:7])
     return self.packer.make_can_msg("DAS_control", CANBUS.party, values)
 
-  def create_steering_allowed(self, counter):
+  def create_steering_allowed(self):
     values = {
       "APS_eacAllow": 1,
-      "APS_eacMonitorCounter": counter,
     }
 
     data = self.packer.make_can_msg("APS_eacMonitor", CANBUS.party, values)[1]


### PR DESCRIPTION
Still need to manually set `DAS_control` since we try to match the stock counter when canceling with stock long

```python
print(packer.make_can_msg('APS_eacMonitor', 0, {})[1].hex())
000000
print(packer.make_can_msg('APS_eacMonitor', 0, {})[1].hex())
000100
print(packer.make_can_msg('APS_eacMonitor', 0, {})[1].hex())
000200
print(packer.make_can_msg('APS_eacMonitor', 0, {})[1].hex())
000300
print(packer.make_can_msg('APS_eacMonitor', 0, {})[1].hex())
000400
print(packer.make_can_msg('APS_eacMonitor', 0, {})[1].hex())
```