### PR TITLE
dbc: fix incorrect endwith check

### DIFF
--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -44,7 +44,7 @@ unsigned int pedal_checksum(uint32_t address, const Signal &sig, const std::vect
   } while (false)
 
 inline bool endswith(const std::string& str, const char* suffix) {
-  return str.find(suffix, 0) == (str.length() - strlen(suffix));
+  return str.find(suffix, str.length() - strlen(suffix)) != std::string::npos;
 }
 
 struct CanFrame {


### PR DESCRIPTION
Two failure modes with current function:

- Suffix one character longer than string: false positive (npos is -1, so is subtraction)
- String starts with suffix and ends with suffix: false negative (gets first occurrence)

```c++
endswith("DI_gearDI", "DI") -> false
endswith("DI_gear", "Checksum") -> true
```