### PR TITLE
Performance improvements related to #32536 

### DIFF
--- a/opendbc/car/ford/carstate.py
+++ b/opendbc/car/ford/carstate.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 from opendbc.can.can_define import CANDefine
 from opendbc.can.parser import CANParser
 from opendbc.car import Bus, create_button_events, structs
@@ -11,10 +13,15 @@ GearShifter = structs.CarState.GearShifter
 TransmissionType = structs.CarParams.TransmissionType
 
 
+@cache
+def get_can_define(dbc_name):
+  return CANDefine(dbc_name)
+
+
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
-    can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
+    can_define = get_can_define(DBC[CP.carFingerprint][Bus.pt])
     if CP.transmissionType == TransmissionType.automatic:
       self.shifter_values = can_define.dv["PowertrainData_10"]["TrnRng_D_Rq"]
 


### PR DESCRIPTION
Check out [related openpilot PR](https://github.com/commaai/openpilot/pull/35183) for more details

**Description**

Below, I will outline opendbc-specific changes I made to improve the test's performance:

1. Precompute `KF1D` parameters for `CarStateBase.__init__()`: total time execution time went down from ~12.2s to ~9.8s
    - Rationale: `get_kalman_gain()` is non-probabilistic, has no side effects, and always takes a set of constant parameters
2. Ford-specific optimization: introduce cache for `CANDefine` objects created during `CarState` construction, which decreased the per-car execution time from 0.8s (given all the above optimizations) to ~0.54s