### PR TITLE
Allow configurable maximum angle for AngleSteeringSafetyTest

### DIFF
--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -683,6 +683,7 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
   def test_angle_cmd_when_enabled(self):
     # when controls are allowed, angle cmd rate limit is enforced
     speeds = [0., 1., 5., 10., 15., 50.]
+    # TODO: what should CANPacker do here? we should also have good coverage checks on this
     if self.STEER_ANGLE_TEST_MAX is None:
         self.STEER_ANGLE_TEST_MAX = self.STEER_ANGLE_MAX * 2
     angles = np.concatenate((np.arange(-self.STEER_ANGLE_TEST_MAX, self.STEER_ANGLE_TEST_MAX, 5), [0]))

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -644,6 +644,7 @@ class VehicleSpeedSafetyTest(PandaSafetyTestBase):
 class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
 
   STEER_ANGLE_MAX: float = 300
+  STEER_ANGLE_TEST_MAX: float = None
   DEG_TO_CAN: float
   ANGLE_RATE_BP: list[float]
   ANGLE_RATE_UP: list[float]  # windup limit
@@ -682,7 +683,9 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
   def test_angle_cmd_when_enabled(self):
     # when controls are allowed, angle cmd rate limit is enforced
     speeds = [0., 1., 5., 10., 15., 50.]
-    angles = np.concatenate((np.arange(-self.STEER_ANGLE_MAX * 2, self.STEER_ANGLE_MAX * 2, 5), [0]))
+    if self.STEER_ANGLE_TEST_MAX is None:
+        self.STEER_ANGLE_TEST_MAX = self.STEER_ANGLE_MAX * 2
+    angles = np.concatenate((np.arange(-self.STEER_ANGLE_TEST_MAX, self.STEER_ANGLE_TEST_MAX, 5), [0]))
     for a in angles:
       for s in speeds:
         max_delta_up = np.interp(s, self.ANGLE_RATE_BP, self.ANGLE_RATE_UP)


### PR DESCRIPTION
The Subaru LKAS_ANGLE message is limited to a signed, 17-bit integer, which is more than enough for it's maximum steering of around 485 degrees (at least for my Ascent). However, the `test_angle_cmd_when_enabled()` defaults to twice the maximum steering angle, which will overflow this value and result in erroneously failed tests.

I have added a class variable, and logic that will default the test angle to twice the max angle value when it is not specifically configured. This keeps current behavior for existing tests, but will allow me to constraint he maximum test angle to the limits of my CAN bus messages. It's quite possible that other vehicles will be affected as more angle-based steering systems are supported, too.