### PR TITLE
safety: add round helper

### DIFF
--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -1,5 +1,6 @@
 import os
 import abc
+import math
 import unittest
 import importlib
 import numpy as np
@@ -14,8 +15,14 @@ MAX_SAMPLE_VALS = 6
 
 MessageFunction = Callable[[float], libsafety_py.CANPacket]
 
+
 def sign_of(a):
   return 1 if a > 0 else -1
+
+
+def away_round(x):
+  # non-banker's/away from zero rounding
+  return math.floor(x + 0.5) if x >= 0 else math.ceil(x - 0.5)
 
 
 def make_msg(bus, addr, length=8, dat=None):

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -21,7 +21,7 @@ def sign_of(a):
 
 
 def away_round(x):
-  # non-banker's/away from zero rounding
+  # non-banker's/away from zero rounding, C++ CANParser uses this style
   return math.floor(x + 0.5) if x >= 0 else math.ceil(x - 0.5)
 
 

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
 import unittest
 import numpy as np
-import math
 
 from opendbc.car.tesla.values import TeslaSafetyFlags
 from opendbc.car.structs import CarParams
 from opendbc.can.can_define import CANDefine
 from opendbc.safety.tests.libsafety import libsafety_py
 import opendbc.safety.tests.common as common
-from opendbc.safety.tests.common import MAX_WRONG_COUNTERS
-from opendbc.safety.tests.common import CANPackerPanda
+from opendbc.safety.tests.common import CANPackerPanda, MAX_WRONG_COUNTERS, away_round
 
 MSG_DAS_steeringControl = 0x488
 MSG_APS_eacMonitor = 0x27d
@@ -153,11 +151,10 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
     # Tesla relies on speed for lateral limits close to ISO 11270, so it checks two sources
     for speed in np.arange(0, 40, 0.5):
       # match signal rounding on CAN
-      # Python does banker's rounding which mismatches with C++ CANParser, hence the floor(x + 0.5)
-      speed = math.floor(speed / 0.08 * 3.6 + 0.5) * 0.08 / 3.6
+      speed = away_round(speed / 0.08 * 3.6) * 0.08 / 3.6
       for speed_delta in np.arange(-5, 5, 0.1):
         speed_2 = max(speed + speed_delta, 0)
-        speed_2 = math.floor(speed_2 * 2 * 3.6 + 0.5) / 2 / 3.6
+        speed_2 = away_round(speed_2 * 2 * 3.6) / 2 / 3.6
 
         # Set controls allowed in between rx since first message can reset it
         self.assertTrue(self._rx(self._speed_msg(speed)))


### PR DESCRIPTION
split from https://github.com/commaai/opendbc/pull/2115

Python doesn't do the same rounding that C++ CANParser does! it tries to avoid bias :'(