### PR TITLE
Fix phrasing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ If you're not so lucky, start with a "developer harness" from comma.ai/shop and 
 
 ### Structure of a port
 
-Depending on , most of this basic structure will already be in place.
+Depending on the brand, most of this basic structure will already be in place.
 
-The entirery of a car port lives in `opendbc/car/<brand>/`:
+The entirety of a car port lives in `opendbc/car/<brand>/`:
 * `carstate.py`: parses out the relevant information from the CAN stream using the car's DBC file
 * `carcontroller.py`: outputs CAN messages to control the car
 * `<brand>can.py`: thin Python helpers around the DBC file to build CAN messages


### PR DESCRIPTION
## Summary
- clarify structure section phrase
- fix typo `entirery` -> `entirety`

## Testing
- `./setup.sh` *(fails: Failed to fetch pytest-mock from pypi.org)*