### PR TITLE
Hyundai: fix recent enable button press regression

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -207,7 +207,7 @@ struct CarState {
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
-  blockPcmEnable @60 :Bool;  # whether to block PCM to enable this frame
+  blockPcmEnable @60 :Bool;  # whether to allow PCM to enable this frame
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -207,7 +207,7 @@ struct CarState {
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
-  allowEnable @60 :Bool;  # whether to allow PCM to enable this frame
+  allowPcmEnable @60 :Bool;  # whether to allow PCM to enable this frame
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -207,6 +207,7 @@ struct CarState {
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
+  allowEnable @60 :Bool;  # whether to allow PCM to enable this frame
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -207,7 +207,7 @@ struct CarState {
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
-  allowPcmEnable @60 :Bool;  # whether to allow PCM to enable this frame
+  blockPcmEnable @60 :Bool;  # whether to block PCM to enable this frame
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -196,7 +196,7 @@ class CarState(CarStateBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    ret.allowPcmEnable = any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons)
+    ret.blockPcmEnable = not (any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons))
 
     return ret
 

--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -17,7 +17,7 @@ CLUSTER_SAMPLE_RATE = 20  # frames
 STANDSTILL_THRESHOLD = 12 * 0.03125 * CV.KPH_TO_MS
 
 # Cancel button can sometimes be ACC pause/resume button, main button can also enable on some cars
-ENABLE_BUTTONS = (ButtonType.accelCruise, ButtonType.decelCruise, ButtonType.cancel, ButtonType.mainCruise)
+ENABLE_BUTTONS = (Buttons.RES_ACCEL, Buttons.SET_DECEL, Buttons.CANCEL)
 BUTTONS_DICT = {Buttons.RES_ACCEL: ButtonType.accelCruise, Buttons.SET_DECEL: ButtonType.decelCruise,
                 Buttons.GAP_DIST: ButtonType.gapAdjustCruise, Buttons.CANCEL: ButtonType.cancel}
 
@@ -196,7 +196,7 @@ class CarState(CarStateBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    ret.allowPcmEnable = any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons)
+    ret.allowPcmEnable = any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
 
     return ret
 

--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -196,7 +196,7 @@ class CarState(CarStateBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    ret.allowPcmEnable = any(btn in ENABLE_BUTTONS for btn in self.CS.cruise_buttons) or any(self.CS.main_buttons)
+    ret.allowPcmEnable = any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons)
 
     return ret
 

--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -196,7 +196,7 @@ class CarState(CarStateBase):
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
     # To avoid re-engaging when openpilot cancels, check user engagement intention via buttons
     # Main button also can trigger an engagement on these cars
-    ret.allowEnable = any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons)
+    ret.allowPcmEnable = any(btn in ENABLE_BUTTONS for btn in self.cruise_buttons) or any(self.main_buttons)
 
     return ret
 

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -239,9 +239,6 @@ class CarInterfaceBase(ABC):
     tune.torque.latAccelOffset = 0.0
     tune.torque.steeringAngleDeadzoneDeg = steering_angle_deadzone_deg
 
-  def _update(self) -> structs.CarState:
-    return self.CS.update(self.can_parsers)
-
   def update(self, can_packets: list[tuple[int, list[CanData]]]) -> structs.CarState:
     # parse can
     for cp in self.can_parsers.values():
@@ -249,7 +246,9 @@ class CarInterfaceBase(ABC):
         cp.update_strings(can_packets)
 
     # get CarState
-    ret = self._update()
+    ret = structs.CarState()
+    ret.allowPcmEnable = True
+    self.CS.update(ret, self.can_parsers)
 
     ret.canValid = all(cp.can_valid for cp in self.can_parsers.values())
     ret.canTimeout = any(cp.bus_timeout for cp in self.can_parsers.values())
@@ -300,7 +299,7 @@ class CarStateBase(ABC):
     self.v_ego_kf = KF1D(x0=x0, A=A, C=C[0], K=K)
 
   @abstractmethod
-  def update(self, can_parsers) -> structs.CarState:
+  def update(self, ret: structs.CarState, can_parsers: dict) -> structs.CarState:
     pass
 
   def update_speed_kf(self, v_ego_raw):

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -239,6 +239,9 @@ class CarInterfaceBase(ABC):
     tune.torque.latAccelOffset = 0.0
     tune.torque.steeringAngleDeadzoneDeg = steering_angle_deadzone_deg
 
+  def _update(self) -> structs.CarState:
+    return self.CS.update(self.can_parsers)
+
   def update(self, can_packets: list[tuple[int, list[CanData]]]) -> structs.CarState:
     # parse can
     for cp in self.can_parsers.values():
@@ -246,9 +249,7 @@ class CarInterfaceBase(ABC):
         cp.update_strings(can_packets)
 
     # get CarState
-    ret = structs.CarState()
-    ret.allowPcmEnable = True
-    self.CS.update(ret, self.can_parsers)
+    ret = self._update()
 
     ret.canValid = all(cp.can_valid for cp in self.can_parsers.values())
     ret.canTimeout = any(cp.bus_timeout for cp in self.can_parsers.values())
@@ -299,7 +300,7 @@ class CarStateBase(ABC):
     self.v_ego_kf = KF1D(x0=x0, A=A, C=C[0], K=K)
 
   @abstractmethod
-  def update(self, ret: structs.CarState, can_parsers: dict) -> structs.CarState:
+  def update(self, can_parsers) -> structs.CarState:
     pass
 
   def update_speed_kf(self, v_ego_raw):


### PR DESCRIPTION
We went from checking every 50 Hz CLU11 button message to checking at 100 Hz, so we halve the time we sample for user button presses. I guess this wasn't a problem for most cars, but the issue below shows the PCM enabling a little bit out of the new halved sample window which is now fixed again.

Broken in https://github.com/commaai/openpilot/pull/33710

Closes https://github.com/commaai/opendbc/issues/2156

Matching old reference carstate and interface: https://github.com/commaai/openpilot/blob/6a15aa3f8c58e40e5e47c7ce4c906f5368ec243a/selfdrive/car/hyundai/interface.py