### PR TITLE
interfaces: remove redundant function

### DIFF
--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -239,9 +239,6 @@ class CarInterfaceBase(ABC):
     tune.torque.latAccelOffset = 0.0
     tune.torque.steeringAngleDeadzoneDeg = steering_angle_deadzone_deg
 
-  def _update(self) -> structs.CarState:
-    return self.CS.update(self.can_parsers)
-
   def update(self, can_packets: list[tuple[int, list[CanData]]]) -> structs.CarState:
     # parse can
     for cp in self.can_parsers.values():
@@ -249,7 +246,7 @@ class CarInterfaceBase(ABC):
         cp.update_strings(can_packets)
 
     # get CarState
-    ret = self._update()
+    ret = self.CS.update(self.can_parsers)
 
     ret.canValid = all(cp.can_valid for cp in self.can_parsers.values())
     ret.canTimeout = any(cp.bus_timeout for cp in self.can_parsers.values())


### PR DESCRIPTION
Maybe at one point it used to do more

Edit: ah yeah, these are all gone: https://github.com/commaai/openpilot/blob/0eba392cf24e5ebbd09d7a3ff4acd9f98daeb3bb/selfdrive/car/toyota/interface.py#L291-L319