### PR TITLE
Fix cppcheck cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,10 +51,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: opendbc/safety/tests/misra/cppcheck/
-          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}
-          restore-keys: |
-            cppcheck-cache-${{ runner.os }}-${{ github.ref }}
-            cppcheck-cache-${{ runner.os }}-
+          key: cppcheck-cache-${{ runner.os }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
       - name: Run MISRA C:2012 analysis
         timeout-minutes: ${{ ((steps.restore-scons-cache.outputs.cache-hit == 'true') && 1 || 2) }}
         run: cd opendbc/safety/tests/misra && ./test_misra.sh
@@ -62,7 +59,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: opendbc/safety/tests/misra/cppcheck/
-          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}
+          key: cppcheck-cache-${{ runner.os }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
 
   misra_mutation:
     name: MISRA C:2012 Mutation
@@ -76,10 +73,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: opendbc/safety/tests/misra/cppcheck/
-          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
-          restore-keys: |
-            cppcheck-cache-${{ runner.os }}-${{ github.ref }}
-            cppcheck-cache-${{ runner.os }}-
+          key: cppcheck-cache-${{ runner.os }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
       - name: MISRA mutation tests
         timeout-minutes: 1
         run: |
@@ -92,7 +86,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: opendbc/safety/tests/misra/cppcheck/
-          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
+          key: cppcheck-cache-${{ runner.os }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
 
   mutation:
     name: Safety mutation tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: opendbc/safety/tests/misra/cppcheck/
-          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}
+          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
           restore-keys: |
             cppcheck-cache-${{ runner.os }}-${{ github.ref }}
             cppcheck-cache-${{ runner.os }}-
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: opendbc/safety/tests/misra/cppcheck/
-          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}
+          key: cppcheck-cache-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('opendbc/safety/tests/misra/install.sh') }}
 
   mutation:
     name: Safety mutation tests


### PR DESCRIPTION
Cache hit, but version had been bumped so it always built cppcheck and never cached it. Don't see a reason for per-branch either