### PR TITLE
Tesla: lower comfort angle rate limit

### DIFF
--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -7,7 +7,7 @@ from opendbc.car.tesla.teslacan import TeslaCAN
 from opendbc.car.tesla.values import CarControllerParams
 from opendbc.car.vehicle_model import VehicleModel
 
-MAX_ANGLE_RATE = 10  # deg/20ms frame, EPS faults at 12 at a standstill
+MAX_ANGLE_RATE = 5  # deg/20ms frame, EPS faults at 12 at a standstill
 
 # Add extra tolerance for average banked road since safety doesn't have the roll
 AVERAGE_ROAD_ROLL = 0.06  # ~3.4 degrees, 6% superelevation. higher actual roll lowers lateral acceleration

--- a/opendbc/car/tesla/carcontroller.py
+++ b/opendbc/car/tesla/carcontroller.py
@@ -7,6 +7,7 @@ from opendbc.car.tesla.teslacan import TeslaCAN
 from opendbc.car.tesla.values import CarControllerParams
 from opendbc.car.vehicle_model import VehicleModel
 
+# limit angle rate to both prevent a fault and for low speed comfort (~12 mph rate down to 0 mph)
 MAX_ANGLE_RATE = 5  # deg/20ms frame, EPS faults at 12 at a standstill
 
 # Add extra tolerance for average banked road since safety doesn't have the roll


### PR DESCRIPTION
We limit the lateral jerk for Tesla, but because at very low speed this allows for super high angle rates, we should limit it for comfort. Once the models get better, we can gradually raise this.