### PR TITLE
interfaces: improve steering pressed signal

### DIFF
--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -327,8 +327,8 @@ class CarStateBase(ABC):
 
   def update_steering_pressed(self, steering_pressed, steering_pressed_min_count):
     """Applies filtering on steering pressed for noisy driver torque signals."""
-    self.steering_pressed_cnt = self.steering_pressed_cnt + 1 if steering_pressed else 0
-    self.steering_pressed_cnt = min(self.steering_pressed_cnt, steering_pressed_min_count + 1)
+    self.steering_pressed_cnt += 1 if steering_pressed else -1
+    self.steering_pressed_cnt = int(np.clip(self.steering_pressed_cnt, 0, steering_pressed_min_count * 2 + 1))
     return self.steering_pressed_cnt > steering_pressed_min_count
 
   def update_blinker_from_stalk(self, blinker_time: int, left_blinker_stalk: bool, right_blinker_stalk: bool):


### PR DESCRIPTION
Now doesn't reset to unpressed if it gets a single sample under the threshold, it ramps back down like CANParser and safety's invalid counter counter. Only difference is we allow going above the threshold by 2x, so also allow time for the torque to switch signs before dropping.

old vs. new (these plots are before https://github.com/commaai/opendbc/pull/2233):

![image](https://github.com/user-attachments/assets/bfbc0f5e-c93c-41a5-b545-9188e299bcb4)
![image](https://github.com/user-attachments/assets/53387afe-dc36-427a-a3a9-5b4827bc6f23)
