### PR TITLE
safety: common speed mismatch check

### DIFF
--- a/opendbc/safety/modes/ford.h
+++ b/opendbc/safety/modes/ford.h
@@ -94,8 +94,6 @@ static bool ford_get_quality_flag_valid(const CANPacket_t *to_push) {
 
 #define FORD_CANFD_INACTIVE_CURVATURE_RATE 1024U
 
-#define FORD_MAX_SPEED_DELTA 2.0  // m/s
-
 // Curvature rate limits
 #define FORD_LIMITS(limit_lateral_acceleration) {                                               \
   .max_angle = 1000,          /* 0.02 curvature */                                              \
@@ -141,11 +139,7 @@ static void ford_rx_hook(const CANPacket_t *to_push) {
       // Disable controls if speeds from ABS and PCM ECUs are too far apart.
       // Signal: Veh_V_ActlEng
       float filtered_pcm_speed = ((GET_BYTE(to_push, 6) << 8) | GET_BYTE(to_push, 7)) * 0.01 / 3.6;
-      bool is_invalid_speed = ABS(filtered_pcm_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > FORD_MAX_SPEED_DELTA;
-      // TODO: this should generically cause rx valid to fall until re-enable
-      if (is_invalid_speed) {
-        controls_allowed = false;
-      }
+      speed_mismatch_check(filtered_pcm_speed);
     }
 
     // Update vehicle yaw rate

--- a/opendbc/safety/modes/rivian.h
+++ b/opendbc/safety/modes/rivian.h
@@ -2,8 +2,6 @@
 
 #include "opendbc/safety/safety_declarations.h"
 
-#define RIVIAN_MAX_SPEED_DELTA 2.0  // m/s
-
 static uint8_t rivian_get_counter(const CANPacket_t *to_push) {
   int addr = GET_ADDR(to_push);
 
@@ -90,11 +88,7 @@ static void rivian_rx_hook(const CANPacket_t *to_push) {
 
       // Disable controls if speeds from VDM and ESP ECUs are too far apart.
       float vdm_speed = ((GET_BYTE(to_push, 5) << 8) | GET_BYTE(to_push, 6)) * 0.01 / 3.6;
-      bool is_invalid_speed = ABS(vdm_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > RIVIAN_MAX_SPEED_DELTA;
-      // TODO: this should generically cause rx valid to fall until re-enable
-      if (is_invalid_speed) {
-        controls_allowed = false;
-      }
+      speed_mismatch_check(vdm_speed);
     }
 
     // Driver torque

--- a/opendbc/safety/modes/tesla.h
+++ b/opendbc/safety/modes/tesla.h
@@ -9,8 +9,6 @@ typedef struct {
   const float wheelbase;
 } AngleSteeringParams;
 
-#define TESLA_MAX_SPEED_DELTA 2.0  // m/s
-
 static bool tesla_longitudinal = false;
 static bool tesla_stock_aeb = false;
 
@@ -195,11 +193,7 @@ static void tesla_rx_hook(const CANPacket_t *to_push) {
     if (addr == 0x155) {
       // Disable controls if speeds from DI (Drive Inverter) and ESP ECUs are too far apart.
       float esp_speed = (((GET_BYTE(to_push, 6) & 0x0FU) << 6) | GET_BYTE(to_push, 5) >> 2) * 0.5 / 3.6;
-      bool is_invalid_speed = ABS(esp_speed - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > TESLA_MAX_SPEED_DELTA;
-      // TODO: this should generically cause rx valid to fall until re-enable
-      if (is_invalid_speed) {
-        controls_allowed = false;
-      }
+      speed_mismatch_check(esp_speed);
     }
 
     // Gas pressed

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -834,3 +834,12 @@ void pcm_cruise_check(bool cruise_engaged) {
   }
   cruise_engaged_prev = cruise_engaged;
 }
+
+void speed_mismatch_check(const float speed_2) {
+  // Disable controls if speeds from two sources are too far apart
+  const float MAX_SPEED_DELTA = 2.0;  // m/s
+  bool is_invalid_speed = ABS(speed_2 - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > MAX_SPEED_DELTA;
+  if (is_invalid_speed) {
+    controls_allowed = false;
+  }
+}

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -232,6 +232,7 @@ bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits);
 bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits);
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits);
 void pcm_cruise_check(bool cruise_engaged);
+void speed_mismatch_check(const float speed_2);
 
 void safety_tick(const safety_config *safety_config);
 

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -14,6 +14,9 @@ MAX_WRONG_COUNTERS = 5
 MAX_SAMPLE_VALS = 6
 VEHICLE_SPEED_FACTOR = 1000
 
+# Max allowed delta between car speeds
+MAX_SPEED_DELTA = 2.0  # m/s
+
 MessageFunction = Callable[[float], libsafety_py.CANPacket]
 
 

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -8,7 +8,7 @@ from opendbc.car.ford.carcontroller import MAX_LATERAL_ACCEL
 from opendbc.car.ford.values import FordSafetyFlags
 from opendbc.car.structs import CarParams
 from opendbc.safety.tests.libsafety import libsafety_py
-from opendbc.safety.tests.common import CANPackerPanda
+from opendbc.safety.tests.common import CANPackerPanda, MAX_SPEED_DELTA
 
 MSG_EngBrakeData = 0x165           # RX from PCM, for driver brake pedal and cruise state
 MSG_EngVehicleSpThrottle = 0x204   # RX from PCM, for driver throttle input
@@ -72,9 +72,6 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
 
   FWD_BLACKLISTED_ADDRS = {2: [MSG_ACCDATA_3, MSG_Lane_Assist_Data1, MSG_LateralMotionControl,
                                MSG_LateralMotionControl2, MSG_IPMA_Data]}
-
-  # Max allowed delta between car speeds
-  MAX_SPEED_DELTA = 2.0  # m/s
 
   STEER_MESSAGE = 0
 
@@ -232,7 +229,7 @@ class TestFordSafetyBase(common.PandaCarSafetyTest):
         self.safety.set_controls_allowed(True)
         self._rx(self._speed_msg_2(speed_2))
 
-        within_delta = abs(speed - speed_2) <= self.MAX_SPEED_DELTA
+        within_delta = abs(speed - speed_2) <= MAX_SPEED_DELTA
         self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
   def test_angle_measurements(self):

--- a/opendbc/safety/tests/test_rivian.py
+++ b/opendbc/safety/tests/test_rivian.py
@@ -5,7 +5,7 @@ import numpy as np
 from opendbc.car.structs import CarParams
 from opendbc.safety.tests.libsafety import libsafety_py
 import opendbc.safety.tests.common as common
-from opendbc.safety.tests.common import CANPackerPanda
+from opendbc.safety.tests.common import CANPackerPanda, MAX_SPEED_DELTA
 from opendbc.car.rivian.values import RivianSafetyFlags
 from opendbc.car.rivian.riviancan import checksum as _checksum
 
@@ -39,9 +39,6 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
 
   DRIVER_TORQUE_ALLOWANCE = 100
   DRIVER_TORQUE_FACTOR = 2
-
-  # Max allowed delta between car speeds
-  MAX_SPEED_DELTA = 2.0  # m/s
 
   cnt_speed = 0
   cnt_speed_2 = 0
@@ -123,7 +120,7 @@ class TestRivianSafetyBase(common.PandaCarSafetyTest, common.DriverTorqueSteerin
         self.safety.set_controls_allowed(True)
         self._rx(self._speed_msg_2(speed_2))
 
-        within_delta = abs(speed - speed_2) <= self.MAX_SPEED_DELTA
+        within_delta = abs(speed - speed_2) <= MAX_SPEED_DELTA
         self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
 

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -9,7 +9,7 @@ from opendbc.car.vehicle_model import VehicleModel
 from opendbc.can.can_define import CANDefine
 from opendbc.safety.tests.libsafety import libsafety_py
 import opendbc.safety.tests.common as common
-from opendbc.safety.tests.common import CANPackerPanda, MAX_WRONG_COUNTERS, away_round, round_speed
+from opendbc.safety.tests.common import CANPackerPanda, MAX_SPEED_DELTA, MAX_WRONG_COUNTERS, away_round, round_speed
 
 MSG_DAS_steeringControl = 0x488
 MSG_APS_eacMonitor = 0x27d
@@ -45,9 +45,6 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
   MAX_ACCEL = 2.0
   MIN_ACCEL = -3.48
   INACTIVE_ACCEL = 0.0
-
-  # Max allowed delta between car speeds
-  MAX_SPEED_DELTA = 2.0  # m/s
 
   cnt_epas = 0
 
@@ -175,7 +172,7 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
         self.safety.set_controls_allowed(True)
         self.assertTrue(self._rx(self._speed_msg_2(speed_2)))
 
-        within_delta = abs(speed - speed_2) <= self.MAX_SPEED_DELTA
+        within_delta = abs(speed - speed_2) <= MAX_SPEED_DELTA
         self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
     # Test ESP_B quality flag


### PR DESCRIPTION
Used in safety modes that adjust torque (Rivian) or angle limits (Ford, Tesla) based on speed