### PR TITLE
Honda: Move away from using CarDocs for min speed

### DIFF
--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -253,8 +253,8 @@ class CAR(Platforms):
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
   HONDA_HRV = HondaNidecPlatformConfig(
-    [HondaCarDocs("Honda HR-V 2019-22", min_steer_speed=12. * CV.MPH_TO_MS)],
-    HONDA_HRV_3G.specs,
+    [HondaCarDocs("Honda HR-V 2019-22")],
+    HONDA_HRV_3G.specs.override(minSteerSpeed=12. * CV.MPH_TO_MS),
     radar_dbc_dict('honda_fit_ex_2018_can_generated'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )
@@ -278,10 +278,10 @@ class CAR(Platforms):
   )
   HONDA_PILOT = HondaNidecPlatformConfig(
     [
-      HondaCarDocs("Honda Pilot 2016-22", min_steer_speed=12. * CV.MPH_TO_MS),
-      HondaCarDocs("Honda Passport 2019-25", "All", min_steer_speed=12. * CV.MPH_TO_MS),
+      HondaCarDocs("Honda Pilot 2016-22"),
+      HondaCarDocs("Honda Passport 2019-25", "All"),
     ],
-    HONDA_PILOT_4G.specs,
+    HONDA_PILOT_4G.specs.override(minSteerSpeed=12. * CV.MPH_TO_MS),
     radar_dbc_dict('acura_ilx_2016_can_generated'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES,
   )


### PR DESCRIPTION
- Moved min speed to use CarSpecs instead of CarDocs

---

## Stuck on
```
  HONDA_CIVIC_BOSCH = HondaBoschPlatformConfig(
    [
      HondaCarDocs("Honda Civic 2019-21", "All", video="https://www.youtube.com/watch?v=4Iz1Mz5LGF8",
                   footnotes=[Footnote.CIVIC_DIESEL], min_steer_speed=2. * CV.MPH_TO_MS),
      HondaCarDocs("Honda Civic Hatchback 2017-21", min_steer_speed=12. * CV.MPH_TO_MS),
    ],
    CarSpecs(mass=1326, wheelbase=2.7, steerRatio=15.38, centerToFrontRatio=0.4),  # steerRatio: 10.93 is end-to-end spec
    {Bus.pt: 'honda_civic_hatchback_ex_2017_can_generated'},
  )
```

The Civic Hatchback and the Civic 2019-21 share the same platform but have different `minSteerSpeed`. Before `CarDocs` seemed to act as the solution to give a value to specific models within a platform but since CarDocs wont be doing that anymore it seems like I could either:
- Use `interface.py` to the use the ECU to then give the certain model the value. Maybe something like:
```
    if candidate == CAR.HONDA_CIVIC_BOSCH:
      is_hatchback = any(fw.ecu == "eps" and fw.fwVersion.startswith(b"39990-TGG") for fw in car_fw)
      ret.minSteerSpeed = (12. if is_hatchback else 2.) * CV.MPH_TO_MS
```
^Still learning more though how reliable this solution could be

or

- Civic Hatchback should have its own platform since the min steer speed is different(but maybe this is not worth it)
- ______ other solution I have not yet thought of yet