### PR TITLE
safety: check tx message frequency

### DIFF
--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -281,8 +281,13 @@ static safety_config honda_nidec_init(uint16_t param) {
   // 0x1FA is dynamically forwarded based on stock AEB
   // 0xE4 is steering on all cars except CRV and RDX, 0x194 for CRV and RDX,
   // 0x1FA is brake control, 0x30C is acc hud, 0x33D is lkas hud
-  static CanMsg HONDA_N_TX_MSGS[] = {{0xE4, 0, 5, .check_relay = true}, {0x194, 0, 4, .check_relay = true}, {0x1FA, 0, 8, .check_relay = false},
-                                     {0x30C, 0, 8, .check_relay = true}, {0x33D, 0, 5, .check_relay = true}};
+  static TxCheck HONDA_N_TX_MSGS[] = {
+    {.msg = {0xE4, 0, 5, .check_relay = true}},
+    {.msg = {0x194, 0, 4, .check_relay = true}},
+    {.msg = {0x1FA, 0, 8, .check_relay = false}},
+    {.msg = {0x30C, 0, 8, .check_relay = true}},
+    {.msg = {0x33D, 0, 5, .check_relay = true}},
+  };
 
   const uint16_t HONDA_PARAM_NIDEC_ALT = 4;
 

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -8,12 +8,12 @@
 
 #define TOYOTA_COMMON_TX_MSGS \
   TOYOTA_BASE_TX_MSGS \
-  {0x2E4, 0, 5, .check_relay = true}, \
+  {0x2E4, 0, 5, .check_relay = true, .frequency = 100U}, \
   {0x343, 0, 8, .check_relay = false},  /* ACC cancel cmd */  \
 
 #define TOYOTA_COMMON_SECOC_TX_MSGS \
   TOYOTA_BASE_TX_MSGS \
-  {0x2E4, 0, 8, .check_relay = true}, {0x131, 0, 8, .check_relay = true}, \
+  {0x2E4, 0, 8, .check_relay = true, .frequency = 100U}, {0x131, 0, 8, .check_relay = true}, \
   {0x343, 0, 8, .check_relay = false},  /* ACC cancel cmd */  \
 
 #define TOYOTA_COMMON_LONG_TX_MSGS \

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -19,20 +19,20 @@
 #define TOYOTA_COMMON_LONG_TX_MSGS \
   TOYOTA_COMMON_TX_MSGS \
   /* DSU bus 0 */ \
-  {0x283, 0, 7, .check_relay = false}, {0x2E6, 0, 8, .check_relay = false}, {0x2E7, 0, 8, .check_relay = false}, {0x33E, 0, 7, .check_relay = false}, \
-  {0x344, 0, 8, .check_relay = false}, {0x365, 0, 7, .check_relay = false}, {0x366, 0, 7, .check_relay = false}, {0x4CB, 0, 8, .check_relay = false}, \
+  {.msg = {0x283, 0, 7, .check_relay = false}}, {.msg = {0x2E6, 0, 8, .check_relay = false}}, {.msg = {0x2E7, 0, 8, .check_relay = false}}, {.msg = {0x33E, 0, 7, .check_relay = false}}, \
+  {.msg = {0x344, 0, 8, .check_relay = false}}, {.msg = {0x365, 0, 7, .check_relay = false}}, {.msg = {0x366, 0, 7, .check_relay = false}}, {.msg = {0x4CB, 0, 8, .check_relay = false}}, \
   /* DSU bus 1 */ \
-  {0x128, 1, 6, .check_relay = false}, {0x141, 1, 4, .check_relay = false}, {0x160, 1, 8, .check_relay = false}, {0x161, 1, 7, .check_relay = false}, \
-  {0x470, 1, 4, .check_relay = false}, \
+  {.msg = {0x128, 1, 6, .check_relay = false}}, {.msg = {0x141, 1, 4, .check_relay = false}}, {.msg = {0x160, 1, 8, .check_relay = false}}, {.msg = {0x161, 1, 7, .check_relay = false}}, \
+  {.msg = {0x470, 1, 4, .check_relay = false}}, \
   /* PCS_HUD */                        \
-  {0x411, 0, 8, .check_relay = false}, \
+  {.msg = {0x411, 0, 8, .check_relay = false}}, \
   /* radar diagnostic address */       \
-  {0x750, 0, 8, .check_relay = false}, \
+  {.msg = {0x750, 0, 8, .check_relay = false}}, \
   /* ACC */                            \
-  {0x343, 0, 8, .check_relay = true},  \
+  {.msg = {0x343, 0, 8, .check_relay = true}},  \
 
 #define TOYOTA_COMMON_RX_CHECKS(lta)                                                                                                       \
-  {.msg = {{ 0xaa, 0, 8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 83U}, { 0 }, { 0 }}},  \
+  {.msg = {{ 0xaa, 0, 8, .ignore_checksum = true, .ignore_counter = true, .ignore_quality_flag = true, .frequency = 83U`}`, { 0 }, { 0 }}},  \
   {.msg = {{0x260, 0, 8, .ignore_counter = true, .ignore_quality_flag=!(lta), .frequency = 50U}, { 0 }, { 0 }}},                           \
 
 #define TOYOTA_RX_CHECKS(lta)                                                                                                               \

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -482,6 +482,9 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
     for (int j = 0; j < current_safety_config.rx_checks_len; j++) {
       current_safety_config.rx_checks[j].status = (RxStatus){0};
     }
+    for (int j = 0; j < current_safety_config.tx_msgs_len; j++) {
+      current_safety_config.tx_msgs[j].status = (TxStatus){0};
+    }
   }
   return set_status;
 }

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -195,6 +195,11 @@ typedef struct {
   bool lagging;                      // true if and only if the time between updates is excessive
 } RxStatus;
 
+typedef struct {
+  // dynamic flags, reset on safety mode init
+  uint32_t last_timestamp;  // micro-s
+} TxStatus;
+
 // params and flags about checksum, counter and frequency checks for each monitored address
 typedef struct {
   const CanMsgCheck msg[MAX_ADDR_CHECK_MSGS];  // check either messages (e.g. honda steer)
@@ -202,9 +207,14 @@ typedef struct {
 } RxCheck;
 
 typedef struct {
+  const CanMsg msg;
+  TxStatus status;
+} TxCheck;
+
+typedef struct {
   RxCheck *rx_checks;
   int rx_checks_len;
-  const CanMsg *tx_msgs;
+  TxCheck *tx_msgs;
   int tx_msgs_len;
   bool disable_forwarding;
 } safety_config;

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -94,6 +94,7 @@ typedef struct {
   int len;
   bool check_relay;              // if true, trigger relay malfunction if existence on destination bus and block forwarding to destination bus
   bool disable_static_blocking;  // if true, static blocking is disabled so safety mode can dynamically handle it (e.g. selective AEB pass-through)
+  uint32_t frequency;           // expected frequency of the message [Hz]
 } CanMsg;
 
 typedef enum {


### PR DESCRIPTION
This PR is to add a generic max frequency param that is checked for any message that specifies it, such as lat/long actuation messages. It will replace the rt logic:

https://github.com/commaai/opendbc/blob/65b880d13b416fd662d2d2961c89b9eb66a4a123/opendbc/safety/safety.h#L665-L673