### PR TITLE
angle safety: implement realtime checks

### DIFF
--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -83,7 +83,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
 
     // every RT_INTERVAL set the new limits
     uint32_t ts_elapsed = get_ts_elapsed(ts, ts_torque_check_last);
-    if (ts_elapsed > MAX_TORQUE_RT_INTERVAL) {
+    if (ts_elapsed > MAX_RT_INTERVAL) {
       rt_torque_last = desired_torque;
       ts_torque_check_last = ts;
     }

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -190,6 +190,7 @@ static bool toyota_tx_hook(const CANPacket_t *to_send) {
       {5., 25., 25.},
       {0.36, 0.26, 0.26}
     },
+    .frequency = 50,
   };
 
   const int TOYOTA_LTA_MAX_MEAS_TORQUE = 1500;

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -75,6 +75,7 @@ uint32_t heartbeat_engaged_mismatches = 0;  // count of mismatches between heart
 
 // for safety modes with angle steering control
 int rt_angle_last = 0;
+float rt_speed_last = 0;
 uint32_t ts_angle_check_last = 0;
 int desired_angle_last = 0;
 struct sample_t angle_meas;         // last 6 steer angles/curvatures
@@ -439,6 +440,7 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   desired_torque_last = 0;
   rt_torque_last = 0;
   rt_angle_last = 0;
+  rt_speed_last = 0.0;
   desired_angle_last = 0;
   ts_torque_check_last = 0;
   ts_angle_check_last = 0;

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -74,7 +74,8 @@ bool heartbeat_engaged = false;             // openpilot enabled, passed in hear
 uint32_t heartbeat_engaged_mismatches = 0;  // count of mismatches between heartbeat_engaged and controls_allowed
 
 // for safety modes with angle steering control
-uint32_t ts_angle_last = 0;
+int rt_angle_last = 0;
+uint32_t ts_angle_check_last = 0;
 int desired_angle_last = 0;
 struct sample_t angle_meas;         // last 6 steer angles/curvatures
 
@@ -437,9 +438,10 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   cruise_button_prev = 0;
   desired_torque_last = 0;
   rt_torque_last = 0;
-  ts_angle_last = 0;
+  rt_angle_last = 0;
   desired_angle_last = 0;
   ts_torque_check_last = 0;
+  ts_angle_check_last = 0;
   ts_steer_req_mismatch_last = 0;
   valid_steer_req_count = 0;
   invalid_steer_req_count = 0;

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -281,6 +281,7 @@ extern uint32_t heartbeat_engaged_mismatches;  // count of mismatches between he
 
 // for safety modes with angle steering control
 extern int rt_angle_last;
+extern float rt_speed_last;
 extern uint32_t ts_angle_check_last;
 extern int desired_angle_last;
 extern struct sample_t angle_meas;         // last 6 steer angles/curvatures

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -280,7 +280,8 @@ extern bool heartbeat_engaged;             // openpilot enabled, passed in heart
 extern uint32_t heartbeat_engaged_mismatches;  // count of mismatches between heartbeat_engaged and controls_allowed
 
 // for safety modes with angle steering control
-extern uint32_t ts_angle_last;
+extern int rt_angle_last;
+extern uint32_t ts_angle_check_last;
 extern int desired_angle_last;
 extern struct sample_t angle_meas;         // last 6 steer angles/curvatures
 

--- a/opendbc/safety/safety_declarations.h
+++ b/opendbc/safety/safety_declarations.h
@@ -63,7 +63,7 @@ extern const int MAX_WRONG_COUNTERS;
 #define MAX_SAMPLE_VALS 6
 // used to represent floating point vehicle speed in a sample_t
 #define VEHICLE_SPEED_FACTOR 1000.0
-#define MAX_TORQUE_RT_INTERVAL 250000U
+#define MAX_RT_INTERVAL 250000U
 
 // Conversions
 #define KPH_TO_MS (1.0 / 3.6)
@@ -109,7 +109,7 @@ typedef struct {
 
   const int max_rate_up;
   const int max_rate_down;
-  const int max_rt_delta;  // max change in torque per 250ms interval (MAX_TORQUE_RT_INTERVAL)
+  const int max_rt_delta;  // max change in torque per 250ms interval (MAX_RT_INTERVAL)
 
   const SteeringControlType type;
 

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -759,6 +759,8 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
             should_tx = controls_allowed if steer_control_enabled else angle_cmd == angle_meas
             self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, steer_control_enabled)))
 
+  # TODO: only one is needed, copied from motor and driver torque tests
+  # Driver torque
   def test_realtime_limits(self):
     self.safety.set_controls_allowed(True)
 
@@ -781,6 +783,7 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA - 1))))
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))
 
+  # Motor torque
   def test_realtime_limit_up(self):
     self.safety.set_controls_allowed(True)
 

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -498,6 +498,7 @@ class DriverTorqueSteeringSafetyTest(TorqueSteeringSafetyTestBase, abc.ABC):
         self.assertTrue(self._tx(self._torque_cmd_msg(t)))
 
       # Increase timer to update rt_torque_last
+      # TODO: test RT_INTERVAL doesn't reset it for mutation test
       self.safety.set_timer(self.RT_INTERVAL + 1)
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA - 1))))
       self.assertTrue(self._tx(self._torque_cmd_msg(sign * (self.MAX_RT_DELTA + 1))))

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -759,6 +759,23 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
             should_tx = controls_allowed if steer_control_enabled else angle_cmd == angle_meas
             self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(angle_cmd, steer_control_enabled)))
 
+  def test_realtime_limits_angle(self):
+    self.safety.set_controls_allowed(True)
+    print()
+
+    s = 15  # todo: loop
+    for sign in (1,):
+      self.safety.init_tests()
+
+      self._set_prev_desired_angle(0)
+      self._reset_angle_measurement(0)
+      self._reset_speed_measurement(s)
+
+      max_delta_up = np.interp(s, self.ANGLE_RATE_BP, self.ANGLE_RATE_UP)
+      max_delta_down = np.interp(s, self.ANGLE_RATE_BP, self.ANGLE_RATE_DOWN)
+      print(s, max_delta_up, max_delta_down)
+
+
   # TODO: only one is needed, copied from motor and driver torque tests
   # Driver torque
   def test_realtime_limits(self):


### PR DESCRIPTION
- every 250ms window, store previous angle ~and speed~
- to calculate the max delta for this current 250ms window, use old angle and new speed
  - if speed decreases, old angle and new speed will allow correct higher non-realtime angle delta
  - if speed increases, old angle and new speed will block higher than allowed angle delta