### PR TITLE
Draft - Honda: Bosch gasonly pid

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -5,7 +5,8 @@ from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.honda.hondacan import CanBus
 from opendbc.car.honda.values import CarControllerParams, HondaFlags, CAR, HONDA_BOSCH, HONDA_BOSCH_CANFD, \
-                                                 HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags
+                                                 HONDA_NIDEC_ALT_SCM_MESSAGES, HONDA_BOSCH_RADARLESS, HondaSafetyFlags, \
+                                                 GasOnlyTuning
 from opendbc.car.honda.carcontroller import CarController
 from opendbc.car.honda.carstate import CarState
 from opendbc.car.honda.radar_interface import RadarInterface
@@ -86,10 +87,13 @@ class CarInterface(CarInterfaceBase):
 
     if candidate in HONDA_BOSCH:
       ret.longitudinalActuatorDelay = 0.5 # s
+      # default longitudinal gas-only tuning for all Bosch hondas
+      GasOnlyTuning.kiBP = [0., 5., 35.]
+      GasOnlyTuning.kiV = [1.2, 0.8, 0.5]
       if candidate in HONDA_BOSCH_RADARLESS:
         ret.stopAccel = CarControllerParams.BOSCH_ACCEL_MIN  # stock uses -4.0 m/s^2 once stopped but limited by safety model
     else:
-      # default longitudinal tuning for all hondas
+      # default longitudinal tuning for all Nidec hondas
       ret.longitudinalTuning.kiBP = [0., 5., 35.]
       ret.longitudinalTuning.kiV = [1.2, 0.8, 0.5]
 

--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -83,6 +83,10 @@ class CruiseSettings:
   DISTANCE = 3
   LKAS = 1
 
+class GasOnlyTuning:  # values set in interface
+  kiBP = [0.]
+  kiV = [0.]
+
 
 # See dbc files for info on values
 VISUAL_HUD = {


### PR DESCRIPTION
(replacement of [opendbc pr2179](https://github.com/commaai/opendbc/pull/2179) and [opendbc pr35375](https://github.com/commaai/openpilot/pull/35375), moved to a carcontroller PID at Shane's request.  This is intended to be identical behavior.)

Honda Bosch has a built in PID tuner for brake, but does not have one for gas.

Even after adjusting gas for detectable conditions (incline, speed-based drag), these calculations are always bit off for undetectable conditions like tailwinds, weather/air density, etc. Thus a gas PID tuner is helpful for Honda Bosch.

However, the current openpilot PID tuner is only on overall accel. Any PID adjustment on gas then applies to brake, doubling up with the builtin Honda brake PID, and causing undesired braking strength until openpilot's PID adjustment winds down. Once it winds down, then you get undesired gas strength until it winds up again.

This pr allows for the PID tuner to only impact gas on Honda Bosch models.
Todo: Test route on new carcontroller-only logic


Prior test routes from [opendbc pr2179](https://github.com/commaai/opendbc/pull/2179), that should have identical behavior:

    Bosch C (2023 Honda Accord Hybrid): 15bd03c45fb5f401/0000000a--1805a6553f (test included https://github.com/commaai/opendbc/pull/2191)
    Bosch C (2023 Honda Pilot): 9662a1dab70c9dc3/00000032--d0dac7d95b
    Bosch C (2025 Acura MDX): ad9840558640c31d/00000013--893d36d514
    more coming from other cars in discord

Discord feedback:

    I drove for five hours, and it was an incredible experience."
    "worked well on the way to work today"
    "Worked way better than the 0.9.8 branch I had last been using. Actually useable this time around. "
    "once we can fix the rapid acceleration issue I think I’d daily op long" (retest in process after accel fix in https://github.com/commaai/opendbc/pull/2185)
    "Acceleration and braking were exactly as they should be. I drove over to a construction zone to see how it would handle sudden starts/stops, and it was perfect." (test included https://github.com/commaai/opendbc/pull/2191)

