### PR TITLE
GM: Silverado/Sierra better longitudinal tune

### DIFF
--- a/opendbc/car/gm/interface.py
+++ b/opendbc/car/gm/interface.py
@@ -193,6 +193,8 @@ class CarInterface(CarInterfaceBase):
       # TODO: check if this is split by EV/ICE with more platforms in the future
       if ret.openpilotLongitudinalControl:
         ret.minEnableSpeed = -1.
+        ret.longitudinalActuatorDelay = 0.625
+        ret.stopAccel = -0.39
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
     elif candidate == CAR.CHEVROLET_EQUINOX:


### PR DESCRIPTION
This PR proposes reducing stopAccel from -2.0 to -0.39. The current value introduces overly aggressive braking, as shown in the comparison log where aEgo sharply spikes to -2.0 m/s², diverging from planner intent.

In contrast, a value of -0.39 closely matches stock ACC behavior and aligns well with planner targets, producing smoother and more natural stops.

📊 Three comparative logs are included:

Stock OpenPilot (-2.0) — aggressive decel with overshoot
dc7716b32bf25574/00000029--3581c1f42c/2 (OP Long stopAccel = -2.0)
![image](https://github.com/user-attachments/assets/308aa8de-b06d-43b2-b71e-177c042a7d04)

OEM ACC — smooth taper, no jerk
dc7716b32bf25574/0000002a--a6b57eae9a/1 (Stock Long)
![image](https://github.com/user-attachments/assets/99bb2f1e-e1d1-4b66-bd26-cacd10f990e9)

Tuned OpenPilot (-0.39) — matched decel to planner and actuator, no overshoot
dc7716b32bf25574/0000002c--ee2c92ef33/1 (OP Long stopAccel = -0.39)
![image](https://github.com/user-attachments/assets/0c135d77-c24f-40c3-a27a-ec35b88f707a)

🧪 Delay Compensation Evaluation
To validate the effective longitudinal actuator delay, we compare the planned acceleration across various delay indices (6–9) with the actual actuator command.

📈 Full-segment analysis (shown below) demonstrates:
dc7716b32bf25574/0000002c--ee2c92ef33/1:6
![image](https://github.com/user-attachments/assets/9ccd64a5-0bba-4d26-843e-1a9dec9eae21)


This confirms that the system behaves as if it has ~0.625s delay. Combined with the stop behavior analysis, this supports reducing stopAccel to -0.39 to avoid overshoot due to delay-compensated controller output.



* Dongle ID: dc7716b32bf25574

I hope @sshane can sanction this slightly improvement :D
