### PR TITLE
Rename CANDefine test class

### DIFF
--- a/opendbc/can/tests/test_define.py
+++ b/opendbc/can/tests/test_define.py
@@ -2,7 +2,7 @@ from opendbc.can.can_define import CANDefine
 from opendbc.can.tests import ALL_DBCS
 
 
-class TestCADNDefine:
+class TestCANDefine:
   def test_civic(self):
 
     dbc_file = "honda_civic_touring_2016_can_generated"


### PR DESCRIPTION
## Summary
- fix a typo in the test class name `TestCANDefine`

## Testing
- `pytest opendbc/can/tests/test_define.py`

------
https://chatgpt.com/codex/tasks/task_e_683f9208bf048333b5240c351b421e23