### PR TITLE
Fix yaw-rate to steer conversion when speed is zero

### DIFF
--- a/opendbc/car/tests/test_vehicle_model.py
+++ b/opendbc/car/tests/test_vehicle_model.py
@@ -23,6 +23,9 @@ class TestVehicleModel:
 
           assert sa == pytest.approx(new_sa)
 
+  def test_get_steer_from_yaw_rate_zero_speed(self):
+    assert self.VM.get_steer_from_yaw_rate(0.1, 0.0, 0.0) == 0.0
+
   def test_dyn_ss_sol_against_yaw_rate(self):
     """Verify that the yaw_rate helper function matches the results
     from the state space model."""

--- a/opendbc/car/vehicle_model.py
+++ b/opendbc/car/vehicle_model.py
@@ -132,6 +132,9 @@ class VehicleModel:
     Returns:
       Steering wheel angle [rad]
     """
+    if abs(u) < 1e-3:
+      return 0.0
+
     curv = yaw_rate / u
     return self.get_steer_from_curvature(curv, u, roll)
 


### PR DESCRIPTION
## Summary
- avoid divide-by-zero in `VehicleModel.get_steer_from_yaw_rate`
- test zero-speed behavior in vehicle model

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_683f967e9b24833384beac10fee52f70