### PR TITLE
Skip GCC coverage flags and library if Darwin

### DIFF
--- a/opendbc/safety/tests/libsafety/SConscript
+++ b/opendbc/safety/tests/libsafety/SConscript
@@ -23,12 +23,10 @@ env = Environment(
     '-Wfatal-errors',
     '-Wno-pointer-to-int-cast',
     '-DCANFD',
-    # GCC coverage flags
-    '-fprofile-arcs',
-    '-ftest-coverage',
-  ],
+  # GCC coverage flags
+  ] + (['-fprofile-arcs', '-ftest-coverage'] if system != "Darwin" else []),
   CPPPATH=["#", "../../board/"],
-  LIBS=["gcov"],
+  LIBS=["gcov"] if system != "Darwin" else [],
 )
 if system == "Darwin":
   env.PrependENVPath('PATH', '/opt/homebrew/bin')


### PR DESCRIPTION
Error when running `./test.sh` on my Macbook Pro
```
gcc -o opendbc/safety/tests/libsafety/libsafety.so -dynamiclib opendbc/safety/tests/libsafety/safety.os -lgcov
ld: library 'gcov' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [opendbc/safety/tests/libsafety/libsafety.so] Error 1
```


- GCC coverage tools (`-fprofile-arcs`, `-ftest-coverage`, `-lgcov`) incompatible with macOS toolchain
- Installing homebrew GCC doesn't fix it - system gcc still points to clang symlink
<br>

#### Solution:
- Skip GCC coverage flags and library if Darwin