### PR TITLE
Car docs: fix year test

### DIFF
--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -168,7 +168,7 @@ class CAR(Platforms):
     [
       HondaCarDocs("Honda Civic 2022-24", "All", video="https://youtu.be/ytiOT5lcp6Q"),
       HondaCarDocs("Honda Civic Hatchback 2022-24", "All", video="https://youtu.be/ytiOT5lcp6Q"),
-      HondaCarDocs("Honda Civic Hatchback Hybrid 2023 (Europe only)", "All"),
+      HondaCarDocs("Honda Civic Hatchback Hybrid (Europe only) 2023", "All"),
       # TODO: Confirm 2024
       HondaCarDocs("Honda Civic Hatchback Hybrid 2025", "All"),
     ],

--- a/opendbc/car/tests/test_docs.py
+++ b/opendbc/car/tests/test_docs.py
@@ -61,7 +61,10 @@ class TestCarDocs:
   def test_year_format(self, subtests):
     for car in self.all_cars:
       with subtests.test(car=car.name):
-        assert re.search(r"\d{4}-\d{4}", car.name) is None, f"Format years correctly: {car.name}"
+        if car.name == "comma body":
+          pytest.skip()
+
+        assert car.years and car.year_list, f"Format years correctly: {car.name}"
 
   def test_harnesses(self, subtests):
     for car in self.all_cars:

--- a/opendbc/car/tests/test_docs.py
+++ b/opendbc/car/tests/test_docs.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 import pytest
-import re
 
 from opendbc.car.car_helpers import interfaces
 from opendbc.car.docs import get_all_car_docs


### PR DESCRIPTION
We've been weighting what to fail during runtime and what to fail during tests: Causing an exception during run time is too much for a misformatted docs string, better to keep in the test for now