### PR TITLE
[bot] Car docs: update model years from new users

### DIFF
--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -324,7 +324,7 @@ class CAR(Platforms):
     wmis={WMI.VOLKSWAGEN_EUROPE_CAR},
   )
   VOLKSWAGEN_TAOS_MK1 = VolkswagenMQBPlatformConfig(
-    [VWCarDocs("Volkswagen Taos 2022-23")],
+    [VWCarDocs("Volkswagen Taos 2022-24")],
     VolkswagenCarSpecs(mass=1498, wheelbase=2.69),
     chassis_codes={"B2"},
     wmis={WMI.VOLKSWAGEN_MEXICO_SUV, WMI.VOLKSWAGEN_ARGENTINA},


### PR DESCRIPTION

## ✅ Updating model years from 1 dongles (1 platforms) in last 14.0 days:
<details open><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|:-------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------|:-----------------------------------------|:---------------|:------------------------------------------------------------------------------------|
|[d4ac5d022cd5177d](https://useradmin.comma.ai/?onebox=d4ac5d022cd5177d)<br><sub>VOLKSWAGEN_TAOS_MK1<br>3VV5X7B20........</sub>|VOLKSWAGEN Taos 2024 🆚<br>Volkswagen Taos 2022-23<br><sub>🎉 <b>New model year!</b> 🎉</sub>|5 routes,<br>106 segments<br>(1.8 hours)||- all lat active: 21<br>- no input all lat active: 16<br>- valid torque params: 106|

Dongles to re-run category: `d4ac5d022cd5177d`
</details>

## ⏳️ 0 dongles (0 platforms) do not yet have enough data to be added:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>

## ⚠️ 0 dongles (0 platforms) have issues that need to be resolved before adding:
<details ><summary>View table</summary><br>

|Dongle, platform, VIN|Name from VIN 🆚 CarDocs|Segments|Bad seg tags|Good seg tags|
|-------------------------|----------------------------|------------|----------------|-----------------|

Dongles to re-run category: ``
</details>