### PR TITLE
Ford: Make CarDocs obvious

### DIFF
--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -1,6 +1,5 @@
-import copy
 import re
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from enum import Enum, IntFlag
 
 from opendbc.car import AngleSteeringLimits, Bus, CarSpecs, DbcDict, PlatformConfig, Platforms, uds
@@ -69,8 +68,6 @@ class Footnote(Enum):
 @dataclass
 class FordCarDocs(CarDocs):
   package: str = "Co-Pilot360 Assist+"
-  hybrid: bool = False
-  plug_in_hybrid: bool = False
 
   def init_make(self, CP: CarParams):
     harness = CarHarness.ford_q4 if CP.flags & FordFlags.CANFD else CarHarness.ford_q3
@@ -91,15 +88,6 @@ class FordPlatformConfig(PlatformConfig):
     Bus.pt: 'ford_lincoln_base_pt',
     Bus.radar: RADAR.DELPHI_MRR,
   })
-
-  def init(self):
-    for car_docs in list(self.car_docs):
-      if car_docs.hybrid:
-        name = f"{car_docs.make} {car_docs.model} Hybrid {car_docs.years}"
-        self.car_docs.append(replace(copy.deepcopy(car_docs), name=name))
-      if car_docs.plug_in_hybrid:
-        name = f"{car_docs.make} {car_docs.model} Plug-in Hybrid {car_docs.years}"
-        self.car_docs.append(replace(copy.deepcopy(car_docs), name=name))
 
 
 @dataclass
@@ -128,14 +116,20 @@ class CAR(Platforms):
   )
   FORD_ESCAPE_MK4 = FordPlatformConfig(
     [
-      FordCarDocs("Ford Escape 2020-22", hybrid=True, plug_in_hybrid=True),
-      FordCarDocs("Ford Kuga 2020-23", "Adaptive Cruise Control with Lane Centering", hybrid=True, plug_in_hybrid=True),
+      FordCarDocs("Ford Escape 2020-22"),
+      FordCarDocs("Ford Escape Hybrid 2020-22"),
+      FordCarDocs("Ford Escape Plug-in Hybrid 2020-22"),
+      FordCarDocs("Ford Kuga 2020-23", "Adaptive Cruise Control with Lane Centering"),
+      FordCarDocs("Ford Kuga Hybrid 2020-23", "Adaptive Cruise Control with Lane Centering"),
+      FordCarDocs("Ford Kuga Plug-in Hybrid 2020-23", "Adaptive Cruise Control with Lane Centering"),
     ],
     CarSpecs(mass=1750, wheelbase=2.71, steerRatio=16.7),
   )
   FORD_ESCAPE_MK4_5 = FordCANFDPlatformConfig(
     [
-      FordCarDocs("Ford Escape 2023-24", hybrid=True, plug_in_hybrid=True, setup_video="https://www.youtube.com/watch?v=M6uXf4b2SHM"),
+      FordCarDocs("Ford Escape 2023-24", setup_video="https://www.youtube.com/watch?v=M6uXf4b2SHM"),
+      FordCarDocs("Ford Escape Hybrid 2023-24", setup_video="https://www.youtube.com/watch?v=M6uXf4b2SHM"),
+      FordCarDocs("Ford Escape Plug-in Hybrid 2023-24", setup_video="https://www.youtube.com/watch?v=M6uXf4b2SHM"),
       FordCarDocs("Ford Kuga Hybrid 2024", "All"),
       FordCarDocs("Ford Kuga Plug-in Hybrid 2024", "All"),
     ],
@@ -143,17 +137,22 @@ class CAR(Platforms):
   )
   FORD_EXPLORER_MK6 = FordPlatformConfig(
     [
-      FordCarDocs("Ford Explorer 2020-24", hybrid=True),  # Hybrid: Limited and Platinum only
-      FordCarDocs("Lincoln Aviator 2020-24", "Co-Pilot360 Plus", plug_in_hybrid=True),  # Hybrid: Grand Touring only
+      FordCarDocs("Ford Explorer 2020-24"),
+      FordCarDocs("Ford Explorer Hybrid 2020-24"),  # Hybrid: Limited and Platinum only
+      FordCarDocs("Lincoln Aviator 2020-24", "Co-Pilot360 Plus"),
+      FordCarDocs("Lincoln Aviator Plug-in Hybrid 2020-24", "Co-Pilot360 Plus"),  # Hybrid: Grand Touring only
     ],
     CarSpecs(mass=2050, wheelbase=3.025, steerRatio=16.8),
   )
   FORD_EXPEDITION_MK4 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford Expedition 2022-24", "Co-Pilot360 Assist 2.0", hybrid=False)],
+    [FordCarDocs("Ford Expedition 2022-24", "Co-Pilot360 Assist 2.0")],
     CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
   FORD_F_150_MK14 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford F-150 2021-23", "Co-Pilot360 Assist 2.0", hybrid=True)],
+    [
+      FordCarDocs("Ford F-150 2021-23", "Co-Pilot360 Assist 2.0"),
+      FordCarDocs("Ford F-150 Hybrid 2021-23", "Co-Pilot360 Assist 2.0"),
+    ],
     CarSpecs(mass=2000, wheelbase=3.69, steerRatio=17.0),
   )
   FORD_F_150_LIGHTNING_MK1 = FordF150LightningPlatform(
@@ -161,13 +160,18 @@ class CAR(Platforms):
     CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )
   FORD_FOCUS_MK4 = FordPlatformConfig(
-    [FordCarDocs("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS], hybrid=True)],  # mHEV only
+    [
+      FordCarDocs("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),
+      FordCarDocs("Ford Focus Hybrid 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS]),  # mHEV only
+    ],
     CarSpecs(mass=1350, wheelbase=2.7, steerRatio=15.0),
   )
   FORD_MAVERICK_MK1 = FordPlatformConfig(
     [
-      FordCarDocs("Ford Maverick 2022", "LARIAT Luxury", hybrid=True),
-      FordCarDocs("Ford Maverick 2023-24", "Co-Pilot360 Assist", hybrid=True),
+      FordCarDocs("Ford Maverick 2022", "LARIAT Luxury"),
+      FordCarDocs("Ford Maverick Hybrid 2022", "LARIAT Luxury"),
+      FordCarDocs("Ford Maverick 2023-24", "Co-Pilot360 Assist"),
+      FordCarDocs("Ford Maverick Hybrid 2023-24", "Co-Pilot360 Assist"),
     ],
     CarSpecs(mass=1650, wheelbase=3.076, steerRatio=17.0),
   )

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -138,9 +138,9 @@ class CAR(Platforms):
   FORD_EXPLORER_MK6 = FordPlatformConfig(
     [
       FordCarDocs("Ford Explorer 2020-24"),
-      FordCarDocs("Ford Explorer Hybrid 2020-24"),  # Hybrid: Limited and Platinum only
+      FordCarDocs("Ford Explorer Hybrid 2020-24"),  # Limited and Platinum only
       FordCarDocs("Lincoln Aviator 2020-24", "Co-Pilot360 Plus"),
-      FordCarDocs("Lincoln Aviator Plug-in Hybrid 2020-24", "Co-Pilot360 Plus"),  # Hybrid: Grand Touring only
+      FordCarDocs("Lincoln Aviator Plug-in Hybrid 2020-24", "Co-Pilot360 Plus"),  # Grand Touring only
     ],
     CarSpecs(mass=2050, wheelbase=3.025, steerRatio=16.8),
   )


### PR DESCRIPTION
- Making the implicit explicit
- All other brands make models explicit but then you get to `Ford` and models get added during runtime
- Removed `hybrid` / `plug_in_hybrid` flag since it was only used for doc purposes unlike how `Hyundai` uses the `hybrid` flags