### PR TITLE
mazda: fix unreliable cruiseState.standstill

### DIFF
--- a/opendbc/car/mazda/carstate.py
+++ b/opendbc/car/mazda/carstate.py
@@ -88,7 +88,7 @@ class CarState(CarStateBase):
     #       it should be used for carState.cruiseState.nonAdaptive instead
     ret.cruiseState.available = cp.vl["CRZ_CTRL"]["CRZ_AVAILABLE"] == 1
     ret.cruiseState.enabled = cp.vl["CRZ_CTRL"]["CRZ_ACTIVE"] == 1
-    ret.cruiseState.standstill = cp.vl["PEDALS"]["STANDSTILL"] == 1
+    ret.cruiseState.standstill = ret.standstill
     ret.cruiseState.speed = cp.vl["CRZ_EVENTS"]["CRZ_SPEED"] * CV.KPH_TO_MS
 
     # stock lkas should be on


### PR DESCRIPTION
I have witnessed cases where the cp.vl["PEDALS"]["STANDSTILL"] signal is not accurate which makes it so openpilot will not create the resume button command as can be seen in the plot. 

![image](https://github.com/user-attachments/assets/02fe464c-b740-48fd-a20a-6caeda23d6b5)

It is possible that in this case, the vehicles cruise control system will not allow a resume signal, in which case this is a mazda ECU bug. 


[c585568edc695aed_00000002--af81e42324--2--qlog.zip](https://github.com/user-attachments/files/21050225/c585568edc695aed_00000002--af81e42324--2--qlog.zip)

