### PR TITLE
VW MQB: Implement vEgoCluster

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -105,7 +105,8 @@ class CarController(CarControllerBase):
       if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:  # Don't display lead until we know the scaling factor
         lead_distance = 512 if CS.upscale_lead_car_signal else 8
       acc_hud_status = self.CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
-      # FIXME: follow the recent displayed-speed updates, also use mph_kmh toggle to fix display rounding problem?
+      # FIXME: PQ may need to use the on-the-wire mph/kmh toggle to fix rounding errors
+      # FIXME: Detect clusters with vEgoCluster offsets and apply an identical vCruiseCluster offset
       set_speed = hud_control.setSpeed * CV.MS_TO_KPH
       can_sends.append(self.CCS.create_acc_hud_control(self.packer_pt, CANBUS.pt, acc_hud_status, set_speed,
                                                        lead_distance, hud_control.leadDistanceBars))

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -118,6 +118,7 @@ class CarState(CarStateBase):
 
     ret.vEgoRaw = float(np.mean([ret.wheelSpeeds.fl, ret.wheelSpeeds.fr, ret.wheelSpeeds.rl, ret.wheelSpeeds.rr]))
     ret.vEgo, ret.aEgo = self.update_speed_kf(ret.vEgoRaw)
+    ret.vEgoCluster = pt_cp.vl["Kombi_01"]["KBI_angez_Geschw"] * CV.KPH_TO_MS
 
     ret.steeringAngleDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradwinkel"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradwinkel"])]
     ret.steeringRateDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradw_Geschw"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradw_Geschw"])]


### PR DESCRIPTION
As many other vehicles do, certain VW MQB have a small positive offset for the speed displayed in the instrument cluster. It isn't always present; it doesn't happen on any of the cars I own. I think it may only be cars outside the USA.

Solving for the stock ACC case is easy: the instrument cluster reports the speed it displayed. We'll just always use that. This PR implements the change.

Solving for openpilot longitudinal is more nuanced. We need to know when/how to offset `vCruiseCluster`. We might not need to offset it at all, the cluster may do it for us. If we need to, the offset looks to be `vEgo * ~1.045` with some rounding effects. If the USA-only theory is correct, the cluster also exports a handy bit-flag for USA clusters. All of this will need to be checked against commaCarSegments, and will have to wait until I can spend time on VW alpha long.

**Route:** `9d09cc205c254c4b/00000143--601c3ee13a`

![image](https://github.com/user-attachments/assets/3c3e5614-081f-4f83-a348-d65097d13572)
