### PR TITLE
Rivian: Accel should be zero when longitudinal control is inactive.

### DIFF
--- a/opendbc/car/rivian/carcontroller.py
+++ b/opendbc/car/rivian/carcontroller.py
@@ -36,7 +36,7 @@ class CarController(CarControllerBase):
     # Longitudinal control
     if self.CP.openpilotLongitudinalControl:
       accel = float(np.clip(actuators.accel, CarControllerParams.ACCEL_MIN, CarControllerParams.ACCEL_MAX))
-      can_sends.append(create_longitudinal(self.packer, self.frame, accel, CC.enabled))
+      can_sends.append(create_longitudinal(self.packer, self.frame, accel, CC.enabled, CC.longActive))
     else:
       interface_status = None
       if CC.cruiseControl.cancel:

--- a/opendbc/car/rivian/riviancan.py
+++ b/opendbc/car/rivian/riviancan.py
@@ -62,10 +62,10 @@ def create_wheel_touch(packer, sccm_wheel_touch, enabled):
   return packer.make_can_msg("SCCM_WheelTouch", 2, values)
 
 
-def create_longitudinal(packer, frame, accel, enabled):
+def create_longitudinal(packer, frame, accel, enabled, active):
   values = {
     "ACM_longitudinalRequest_Counter": frame % 15,
-    "ACM_AccelerationRequest": accel if enabled else 0,
+    "ACM_AccelerationRequest": accel if active else 0,
     "ACM_PrndRequest": 0,
     "ACM_longInterfaceEnable": 1 if enabled else 0,
     "ACM_VehicleHoldRequest": 0,


### PR DESCRIPTION
Distinguishes between enabled and active longitudinal control. Ensures acceleration is zero when inactive to prevent safety code from blocking frames, for example, during gas pedal override.