### PR TITLE
Honda - match stock hud lane lines

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -228,8 +228,9 @@ class CarController(CarControllerBase):
     # Send dashboard UI commands.
     # On Nidec, this controls longitudinal positive acceleration
     if self.frame % 10 == 0:
+      display_lines = hud_control.lanesVisible and (abs(apply_torque) < self.params.STEER_MAX)
       hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
-                    hud_control.lanesVisible, fcw_display, acc_alert, steer_required, hud_control.leadDistanceBars)
+                    display_lines, fcw_display, acc_alert, steer_required, hud_control.leadDistanceBars)
       can_sends.extend(hondacan.create_ui_commands(self.packer, self.CAN, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud, CS.lkas_hud))
 
       if self.CP.openpilotLongitudinalControl and self.CP.carFingerprint not in HONDA_BOSCH:

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -171,6 +171,7 @@ def create_ui_commands(packer, CAN, CP, enabled, pcm_speed, hud, is_metric, acc_
     'SET_ME_X41': 0x41,
     'STEERING_REQUIRED': hud.steer_required,
     'SOLID_LANES': hud.lanes_visible,
+    'DASHED_LANES': int(enabled),
     'BEEP': 0,
   }
 


### PR DESCRIPTION
Update Honda lane lines in HUD to match stock ACC:
- When ACC enabled but LKAS unavailable, show dashed lines.  Per tester request, show this when steer is saturated.
- When ACC enabled and steering is controlled, show solid lines.

Validation
* Dongle ID: d7233a428eb7d0b5
* Route: 00000002--afc9b6dd9b (see 9:06 timestamp)

Stock Honda controls are:
lkas disabled:
LKAS_HUD / DASHED_LANES = 0
LKAS_HUD / SOLID_LANES = 0

lkas enabled
LKAS_HUD / DASHED_LANES = 1
LKAS_HUD / SOLID_LANES = 0

lkas active (helps steer)
LKAS_HUD / DASHED_LANES = 1
LKAS_HUD / SOLID_LANES = 1