### PR TITLE
Docs: Replace dynamic solution for static

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -89,6 +89,11 @@ class Accessory(EnumBase):
   comma_power = BasePart("comma power v3")
 
 
+class Tool(EnumBase):
+  socket_8mm_deep = BasePart("Socket Wrench 8mm or 5/16\" (deep)")
+  pry_tool = BasePart("Pry Tool")
+
+
 @dataclass
 class BaseCarHarness(BasePart):
   parts: list[Enum] = field(default_factory=lambda: [Accessory.harness_box, Accessory.comma_power])
@@ -102,10 +107,10 @@ class CarHarness(EnumBase):
   bosch_c = BaseCarHarness("Honda Bosch C connector")
   toyota_a = BaseCarHarness("Toyota A connector")
   toyota_b = BaseCarHarness("Toyota B connector")
-  subaru_a = BaseCarHarness("Subaru A connector")
-  subaru_b = BaseCarHarness("Subaru B connector")
-  subaru_c = BaseCarHarness("Subaru C connector")
-  subaru_d = BaseCarHarness("Subaru D connector")
+  subaru_a = BaseCarHarness("Subaru A connector", parts=[Accessory.harness_box, Accessory.comma_power, Tool.socket_8mm_deep, Tool.pry_tool])
+  subaru_b = BaseCarHarness("Subaru B connector", parts=[Accessory.harness_box, Accessory.comma_power, Tool.socket_8mm_deep, Tool.pry_tool])
+  subaru_c = BaseCarHarness("Subaru C connector", parts=[Accessory.harness_box, Accessory.comma_power, Tool.socket_8mm_deep, Tool.pry_tool])
+  subaru_d = BaseCarHarness("Subaru D connector", parts=[Accessory.harness_box, Accessory.comma_power, Tool.socket_8mm_deep, Tool.pry_tool])
   fca = BaseCarHarness("FCA connector")
   ram = BaseCarHarness("Ram connector")
   vw_a = BaseCarHarness("VW A connector")
@@ -152,11 +157,6 @@ class Device(EnumBase):
 class Kit(EnumBase):
   red_panda_kit = BasePart("CAN FD panda kit", parts=[Device.red_panda, Accessory.harness_box,
                                                       Cable.usb_a_2_a_cable, Cable.usbc_otg_cable, Cable.obd_c_cable_1_5ft])
-
-
-class Tool(EnumBase):
-  socket_8mm_deep = BasePart("Socket Wrench 8mm or 5/16\" (deep)")
-  pry_tool = BasePart("Pry Tool")
 
 
 class PartType(Enum):

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -138,9 +138,6 @@ class Footnote(Enum):
 class HyundaiCarDocs(CarDocs):
   package: str = "Smart Cruise Control (SCC)"
 
-  def init_make(self, CP: CarParams):
-    if CP.flags & HyundaiFlags.CANFD:
-      self.footnotes.insert(0, Footnote.CANFD)
 
 
 @dataclass
@@ -267,7 +264,7 @@ class CAR(Platforms):
   )
   HYUNDAI_KONA_EV_2ND_GEN = HyundaiCanFDPlatformConfig(
     [HyundaiCarDocs("Hyundai Kona Electric (with HDA II, Korea only) 2023", video="https://www.youtube.com/watch?v=U2fOCmcQ8hw",
-                    car_parts=CarParts.common([CarHarness.hyundai_r]))],
+                    car_parts=CarParts.common([CarHarness.hyundai_r]), footnotes=[Footnote.CANFD])],
     CarSpecs(mass=1740, wheelbase=2.66, steerRatio=13.6, tireStiffnessFactor=0.385),
     flags=HyundaiFlags.EV | HyundaiFlags.CANFD_NO_RADAR_DISABLE,
   )
@@ -315,7 +312,7 @@ class CAR(Platforms):
     flags=HyundaiFlags.UNSUPPORTED_LONGITUDINAL | HyundaiFlags.TCU_GEARS,
   )
   HYUNDAI_STARIA_4TH_GEN = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Hyundai Staria 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_k]))],
+    [HyundaiCarDocs("Hyundai Staria 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_k]), footnotes=[Footnote.CANFD], footnotes=[Footnote.CANFD])],
     CarSpecs(mass=2205, wheelbase=3.273, steerRatio=11.94),  # https://www.hyundai.com/content/dam/hyundai/au/en/models/staria-load/premium-pip-update-2023/spec-sheet/STARIA_Load_Spec-Table_March_2023_v3.1.pdf
   )
   HYUNDAI_TUCSON = HyundaiPlatformConfig(
@@ -346,29 +343,29 @@ class CAR(Platforms):
   )
   HYUNDAI_IONIQ_5 = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Hyundai Ioniq 5 (Southeast Asia and Europe only) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_q])),
-      HyundaiCarDocs("Hyundai Ioniq 5 (without HDA II) 2022-24", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_k])),
-      HyundaiCarDocs("Hyundai Ioniq 5 (with HDA II) 2022-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q])),
+      HyundaiCarDocs("Hyundai Ioniq 5 (Southeast Asia and Europe only) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_q]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Hyundai Ioniq 5 (without HDA II) 2022-24", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_k]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Hyundai Ioniq 5 (with HDA II) 2022-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q]), footnotes=[Footnote.CANFD]),
     ],
     CarSpecs(mass=1948, wheelbase=2.97, steerRatio=14.26, tireStiffnessFactor=0.65),
     flags=HyundaiFlags.EV,
   )
   HYUNDAI_IONIQ_6 = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Hyundai Ioniq 6 (with HDA II) 2023-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]))],
+    [HyundaiCarDocs("Hyundai Ioniq 6 (with HDA II) 2023-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]), footnotes=[Footnote.CANFD])],
     HYUNDAI_IONIQ_5.specs,
     flags=HyundaiFlags.EV | HyundaiFlags.CANFD_NO_RADAR_DISABLE,
   )
   HYUNDAI_TUCSON_4TH_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Hyundai Tucson 2022", car_parts=CarParts.common([CarHarness.hyundai_n])),
-      HyundaiCarDocs("Hyundai Tucson 2023-24", "All", car_parts=CarParts.common([CarHarness.hyundai_n])),
-      HyundaiCarDocs("Hyundai Tucson Hybrid 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_n])),
-      HyundaiCarDocs("Hyundai Tucson Plug-in Hybrid 2024", "All", car_parts=CarParts.common([CarHarness.hyundai_n])),
+      HyundaiCarDocs("Hyundai Tucson 2022", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Hyundai Tucson 2023-24", "All", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Hyundai Tucson Hybrid 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Hyundai Tucson Plug-in Hybrid 2024", "All", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD]),
     ],
     CarSpecs(mass=1630, wheelbase=2.756, steerRatio=13.7, tireStiffnessFactor=0.385),
   )
   HYUNDAI_SANTA_CRUZ_1ST_GEN = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Hyundai Santa Cruz 2022-24", car_parts=CarParts.common([CarHarness.hyundai_n]))],
+    [HyundaiCarDocs("Hyundai Santa Cruz 2022-24", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD])],
     # weight from Limited trim - the only supported trim, steering ratio according to Hyundai News https://www.hyundainews.com/assets/documents/original/48035-2022SantaCruzProductGuideSpecsv2081521.pdf
     CarSpecs(mass=1870, wheelbase=3, steerRatio=14.2),
   )
@@ -397,7 +394,7 @@ class CAR(Platforms):
     flags=HyundaiFlags.MANDO_RADAR | HyundaiFlags.CHECKSUM_CRC8 | HyundaiFlags.HYBRID,
   )
   KIA_K8_HEV_1ST_GEN = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Kia K8 Hybrid (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q]))],
+    [HyundaiCarDocs("Kia K8 Hybrid (with HDA II) 2023", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q]), footnotes=[Footnote.CANFD])],
     # mass: https://carprices.ae/brands/kia/2023/k8/1.6-turbo-hybrid, steerRatio: guesstimate from K5 platform
     CarSpecs(mass=1630, wheelbase=2.895, steerRatio=13.27)
   )
@@ -413,8 +410,8 @@ class CAR(Platforms):
   )
   KIA_NIRO_EV_2ND_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Kia Niro EV (without HDA II) 2023-25", "All", car_parts=CarParts.common([CarHarness.hyundai_a])),
-      HyundaiCarDocs("Kia Niro EV (with HDA II) 2025", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_r])),
+      HyundaiCarDocs("Kia Niro EV (without HDA II) 2023-25", "All", car_parts=CarParts.common([CarHarness.hyundai_a]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Kia Niro EV (with HDA II) 2025", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_r]), footnotes=[Footnote.CANFD]),
     ],
     KIA_NIRO_EV.specs,
     flags=HyundaiFlags.EV,
@@ -445,7 +442,7 @@ class CAR(Platforms):
     flags=HyundaiFlags.HYBRID,
   )
   KIA_NIRO_HEV_2ND_GEN = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Kia Niro Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_a]))],
+    [HyundaiCarDocs("Kia Niro Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_a]), footnotes=[Footnote.CANFD])],
     KIA_NIRO_EV.specs,
   )
   KIA_OPTIMA_G4 = HyundaiPlatformConfig(
@@ -477,8 +474,8 @@ class CAR(Platforms):
   )
   KIA_SPORTAGE_5TH_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Kia Sportage 2023-24", car_parts=CarParts.common([CarHarness.hyundai_n])),
-      HyundaiCarDocs("Kia Sportage Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_n])),
+      HyundaiCarDocs("Kia Sportage 2023-24", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Kia Sportage Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_n]), footnotes=[Footnote.CANFD]),
     ],
     # weight from SX and above trims, average of FWD and AWD version, steering ratio according to Kia News https://www.kiamedia.com/us/en/models/sportage/2023/specifications
     CarSpecs(mass=1725, wheelbase=2.756, steerRatio=13.6),
@@ -493,14 +490,14 @@ class CAR(Platforms):
     flags=HyundaiFlags.CHECKSUM_6B | HyundaiFlags.UNSUPPORTED_LONGITUDINAL,
   )
   KIA_SORENTO_4TH_GEN = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Kia Sorento 2021-23", car_parts=CarParts.common([CarHarness.hyundai_k]))],
+    [HyundaiCarDocs("Kia Sorento 2021-23", car_parts=CarParts.common([CarHarness.hyundai_k]), footnotes=[Footnote.CANFD])],
     CarSpecs(mass=3957 * CV.LB_TO_KG, wheelbase=2.81, steerRatio=13.5),  # average of the platforms
     flags=HyundaiFlags.RADAR_SCC,
   )
   KIA_SORENTO_HEV_4TH_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Kia Sorento Hybrid 2021-23", "All", car_parts=CarParts.common([CarHarness.hyundai_a])),
-      HyundaiCarDocs("Kia Sorento Plug-in Hybrid 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_a])),
+      HyundaiCarDocs("Kia Sorento Hybrid 2021-23", "All", car_parts=CarParts.common([CarHarness.hyundai_a]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Kia Sorento Plug-in Hybrid 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_a]), footnotes=[Footnote.CANFD]),
     ],
     CarSpecs(mass=4395 * CV.LB_TO_KG, wheelbase=2.81, steerRatio=13.5),  # average of the platforms
     flags=HyundaiFlags.RADAR_SCC,
@@ -521,17 +518,17 @@ class CAR(Platforms):
   )
   KIA_EV6 = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Kia EV6 (Southeast Asia only) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_p])),
-      HyundaiCarDocs("Kia EV6 (without HDA II) 2022-24", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_l])),
-      HyundaiCarDocs("Kia EV6 (with HDA II) 2022-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]))
+      HyundaiCarDocs("Kia EV6 (Southeast Asia only) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_p]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Kia EV6 (without HDA II) 2022-24", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_l]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Kia EV6 (with HDA II) 2022-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]), footnotes=[Footnote.CANFD])
     ],
     CarSpecs(mass=2055, wheelbase=2.9, steerRatio=16, tireStiffnessFactor=0.65),
     flags=HyundaiFlags.EV,
   )
   KIA_CARNIVAL_4TH_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Kia Carnival 2022-24", car_parts=CarParts.common([CarHarness.hyundai_a])),
-      HyundaiCarDocs("Kia Carnival (China only) 2023", car_parts=CarParts.common([CarHarness.hyundai_k]))
+      HyundaiCarDocs("Kia Carnival 2022-24", car_parts=CarParts.common([CarHarness.hyundai_a]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Kia Carnival (China only) 2023", car_parts=CarParts.common([CarHarness.hyundai_k]), footnotes=[Footnote.CANFD])
     ],
     CarSpecs(mass=2087, wheelbase=3.09, steerRatio=14.23),
     flags=HyundaiFlags.RADAR_SCC,
@@ -540,8 +537,8 @@ class CAR(Platforms):
   # Genesis
   GENESIS_GV60_EV_1ST_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Genesis GV60 (Advanced Trim) 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_a])),
-      HyundaiCarDocs("Genesis GV60 (Performance Trim) 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_k])),
+      HyundaiCarDocs("Genesis GV60 (Advanced Trim) 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_a]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Genesis GV60 (Performance Trim) 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_k]), footnotes=[Footnote.CANFD]),
     ],
     CarSpecs(mass=2205, wheelbase=2.9, steerRatio=17.6),
     flags=HyundaiFlags.EV,
@@ -564,16 +561,16 @@ class CAR(Platforms):
   GENESIS_GV70_1ST_GEN = HyundaiCanFDPlatformConfig(
     [
       # TODO: Hyundai P is likely the correct harness for HDA II for 2.5T (unsupported due to missing ADAS ECU, is that the radar?)
-      HyundaiCarDocs("Genesis GV70 (2.5T Trim, without HDA II) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_l])),
-      HyundaiCarDocs("Genesis GV70 (3.5T Trim, without HDA II) 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_m])),
+      HyundaiCarDocs("Genesis GV70 (2.5T Trim, without HDA II) 2022-24", "All", car_parts=CarParts.common([CarHarness.hyundai_l]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Genesis GV70 (3.5T Trim, without HDA II) 2022-23", "All", car_parts=CarParts.common([CarHarness.hyundai_m]), footnotes=[Footnote.CANFD]),
     ],
     CarSpecs(mass=1950, wheelbase=2.87, steerRatio=14.6),
     flags=HyundaiFlags.RADAR_SCC,
   )
   GENESIS_GV70_ELECTRIFIED_1ST_GEN = HyundaiCanFDPlatformConfig(
     [
-      HyundaiCarDocs("Genesis GV70 Electrified (Australia Only) 2022", "All", car_parts=CarParts.common([CarHarness.hyundai_q])),
-      HyundaiCarDocs("Genesis GV70 Electrified (with HDA II) 2023-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q])),
+      HyundaiCarDocs("Genesis GV70 Electrified (Australia Only) 2022", "All", car_parts=CarParts.common([CarHarness.hyundai_q]), footnotes=[Footnote.CANFD]),
+      HyundaiCarDocs("Genesis GV70 Electrified (with HDA II) 2023-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_q]), footnotes=[Footnote.CANFD]),
     ],
     CarSpecs(mass=2260, wheelbase=2.87, steerRatio=17.1),
     flags=HyundaiFlags.EV,
@@ -584,7 +581,7 @@ class CAR(Platforms):
     flags=HyundaiFlags.LEGACY,
   )
   GENESIS_G80_2ND_GEN_FL = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Genesis G80 (2.5T Advanced Trim, with HDA II) 2024", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]))],
+    [HyundaiCarDocs("Genesis G80 (2.5T Advanced Trim, with HDA II) 2024", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]), footnotes=[Footnote.CANFD])],
     CarSpecs(mass=2060, wheelbase=3.00, steerRatio=14.0),
   )
   GENESIS_G90 = HyundaiPlatformConfig(
@@ -592,7 +589,7 @@ class CAR(Platforms):
     CarSpecs(mass=2200, wheelbase=3.15, steerRatio=12.069),
   )
   GENESIS_GV80 = HyundaiCanFDPlatformConfig(
-    [HyundaiCarDocs("Genesis GV80 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_m]))],
+    [HyundaiCarDocs("Genesis GV80 2023", "All", car_parts=CarParts.common([CarHarness.hyundai_m]), footnotes=[Footnote.CANFD])],
     CarSpecs(mass=2258, wheelbase=2.95, steerRatio=14.14),
     flags=HyundaiFlags.RADAR_SCC,
   )

--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -100,10 +100,6 @@ class SubaruCarDocs(CarDocs):
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.subaru_a]))
   footnotes: list[Enum] = field(default_factory=lambda: [Footnote.GLOBAL])
 
-  def init_make(self, CP: CarParams):
-    if CP.alphaLongitudinalAvailable:
-      self.footnotes.append(Footnote.EXP_LONG)
-
 
 @dataclass
 class SubaruPlatformConfig(PlatformConfig):
@@ -126,7 +122,7 @@ class SubaruGen2PlatformConfig(SubaruPlatformConfig):
 class CAR(Platforms):
   # Global platform
   SUBARU_ASCENT = SubaruPlatformConfig(
-    [SubaruCarDocs("Subaru Ascent 2019-21", "All")],
+    [SubaruCarDocs("Subaru Ascent 2019-21", "All", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG])],
     CarSpecs(mass=2031, wheelbase=2.89, steerRatio=13.5),
   )
   SUBARU_OUTBACK = SubaruGen2PlatformConfig(
@@ -139,17 +135,17 @@ class CAR(Platforms):
   )
   SUBARU_IMPREZA = SubaruPlatformConfig(
     [
-      SubaruCarDocs("Subaru Impreza 2017-19"),
-      SubaruCarDocs("Subaru Crosstrek 2018-19", video="https://youtu.be/Agww7oE1k-s?t=26"),
-      SubaruCarDocs("Subaru XV 2018-19", video="https://youtu.be/Agww7oE1k-s?t=26"),
+      SubaruCarDocs("Subaru Impreza 2017-19", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG]),
+      SubaruCarDocs("Subaru Crosstrek 2018-19", video="https://youtu.be/Agww7oE1k-s?t=26", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG]),
+      SubaruCarDocs("Subaru XV 2018-19", video="https://youtu.be/Agww7oE1k-s?t=26", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG]),
     ],
     CarSpecs(mass=1568, wheelbase=2.67, steerRatio=15),
   )
   SUBARU_IMPREZA_2020 = SubaruPlatformConfig(
     [
-      SubaruCarDocs("Subaru Impreza 2020-22"),
-      SubaruCarDocs("Subaru Crosstrek 2020-23"),
-      SubaruCarDocs("Subaru XV 2020-21"),
+      SubaruCarDocs("Subaru Impreza 2020-22", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG]),
+      SubaruCarDocs("Subaru Crosstrek 2020-23", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG]),
+      SubaruCarDocs("Subaru XV 2020-21", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG]),
     ],
     CarSpecs(mass=1480, wheelbase=2.67, steerRatio=17),
     flags=SubaruFlags.STEER_RATE_LIMITED,
@@ -161,7 +157,7 @@ class CAR(Platforms):
     flags=SubaruFlags.HYBRID,
   )
   SUBARU_FORESTER = SubaruPlatformConfig(
-    [SubaruCarDocs("Subaru Forester 2019-21", "All")],
+    [SubaruCarDocs("Subaru Forester 2019-21", "All", footnotes=[Footnote.GLOBAL, Footnote.EXP_LONG])],
     CarSpecs(mass=1568, wheelbase=2.67, steerRatio=17),
     flags=SubaruFlags.STEER_RATE_LIMITED,
   )

--- a/opendbc/car/subaru/values.py
+++ b/opendbc/car/subaru/values.py
@@ -101,8 +101,6 @@ class SubaruCarDocs(CarDocs):
   footnotes: list[Enum] = field(default_factory=lambda: [Footnote.GLOBAL])
 
   def init_make(self, CP: CarParams):
-    self.car_parts.parts.extend([Tool.socket_8mm_deep, Tool.pry_tool])
-
     if CP.alphaLongitudinalAvailable:
       self.footnotes.append(Footnote.EXP_LONG)
 

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -195,10 +195,7 @@ class VWCarDocs(CarDocs):
   package: str = "Adaptive Cruise Control (ACC) & Lane Assist"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.vw_j533]))
   footnotes: list[Enum] = field(default_factory=lambda: [Footnote.VW_EXP_LONG])
-
-  def init_make(self, CP: structs.CarParams):
-    if abs(CP.minSteerSpeed - CarControllerParams.DEFAULT_MIN_STEER_SPEED) < 1e-3:
-      self.min_steer_speed = 0
+  min_steer_speed: float = 0
 
 
 # Check the 7th and 8th characters of the VIN before adding a new CAR. If the
@@ -234,8 +231,8 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_CADDY_MK3 = VolkswagenPQPlatformConfig(
     [
-      VWCarDocs("Volkswagen Caddy 2019"),
-      VWCarDocs("Volkswagen Caddy Maxi 2019"),
+      VWCarDocs("Volkswagen Caddy 2019", min_steer_speed=None),
+      VWCarDocs("Volkswagen Caddy Maxi 2019", min_steer_speed=None),
     ],
     VolkswagenCarSpecs(mass=1613, wheelbase=2.6, minSteerSpeed=21 * CV.KPH_TO_MS),
     chassis_codes={"2K"},
@@ -243,11 +240,11 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_CRAFTER_MK2 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Volkswagen Crafter 2017-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
-      VWCarDocs("Volkswagen e-Crafter 2018-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
-      VWCarDocs("Volkswagen Grand California 2019-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
-      VWCarDocs("MAN TGE 2017-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
-      VWCarDocs("MAN eTGE 2020-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("Volkswagen Crafter 2017-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
+      VWCarDocs("Volkswagen e-Crafter 2018-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
+      VWCarDocs("Volkswagen Grand California 2019-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
+      VWCarDocs("MAN TGE 2017-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
+      VWCarDocs("MAN eTGE 2020-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
     ],
     VolkswagenCarSpecs(mass=2100, wheelbase=3.64, minSteerSpeed=50 * CV.KPH_TO_MS),
     chassis_codes={"SY", "SZ", "UY", "UZ"},
@@ -269,7 +266,7 @@ class CAR(Platforms):
     wmis={WMI.VOLKSWAGEN_MEXICO_CAR, WMI.VOLKSWAGEN_EUROPE_CAR},
   )
   VOLKSWAGEN_JETTA_MK6 = VolkswagenPQPlatformConfig(
-    [VWCarDocs("Volkswagen Jetta 2015-18")],
+    [VWCarDocs("Volkswagen Jetta 2015-18", min_steer_speed=None)],
     VolkswagenCarSpecs(mass=1518, wheelbase=2.65, minSteerSpeed=50 * CV.KPH_TO_MS, minEnableSpeed=20 * CV.KPH_TO_MS),
     chassis_codes={"5K", "AJ"},
     wmis={WMI.VOLKSWAGEN_MEXICO_CAR},
@@ -294,7 +291,7 @@ class CAR(Platforms):
     wmis={WMI.VOLKSWAGEN_EUROPE_CAR},
   )
   VOLKSWAGEN_PASSAT_NMS = VolkswagenPQPlatformConfig(
-    [VWCarDocs("Volkswagen Passat NMS 2017-22")],
+    [VWCarDocs("Volkswagen Passat NMS 2017-22", min_steer_speed=None)],
     VolkswagenCarSpecs(mass=1503, wheelbase=2.80, minSteerSpeed=50 * CV.KPH_TO_MS, minEnableSpeed=20 * CV.KPH_TO_MS),
     chassis_codes={"A3"},
     wmis={WMI.VOLKSWAGEN_USA_CAR},
@@ -310,8 +307,8 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_SHARAN_MK2 = VolkswagenPQPlatformConfig(
     [
-      VWCarDocs("Volkswagen Sharan 2018-22"),
-      VWCarDocs("SEAT Alhambra 2018-20"),
+      VWCarDocs("Volkswagen Sharan 2018-22", min_steer_speed=None),
+      VWCarDocs("SEAT Alhambra 2018-20", min_steer_speed=None),
     ],
     VolkswagenCarSpecs(mass=1639, wheelbase=2.92, minSteerSpeed=50 * CV.KPH_TO_MS),
     chassis_codes={"7N"},
@@ -346,8 +343,8 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_TRANSPORTER_T61 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Volkswagen Caravelle 2020", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
-      VWCarDocs("Volkswagen California 2021-23", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("Volkswagen Caravelle 2020", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
+      VWCarDocs("Volkswagen California 2021-23", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533]), min_steer_speed=None),
     ],
     VolkswagenCarSpecs(mass=1926, wheelbase=3.00, minSteerSpeed=14.0),
     chassis_codes={"7H", "7L"},

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -197,9 +197,6 @@ class VWCarDocs(CarDocs):
   footnotes: list[Enum] = field(default_factory=lambda: [Footnote.VW_EXP_LONG])
 
   def init_make(self, CP: structs.CarParams):
-    if CP.carFingerprint in (CAR.VOLKSWAGEN_CRAFTER_MK2, CAR.VOLKSWAGEN_TRANSPORTER_T61):
-      self.car_parts = CarParts([Device.threex_angled_mount, CarHarness.vw_j533])
-
     if abs(CP.minSteerSpeed - CarControllerParams.DEFAULT_MIN_STEER_SPEED) < 1e-3:
       self.min_steer_speed = 0
 
@@ -246,11 +243,11 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_CRAFTER_MK2 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Volkswagen Crafter 2017-24", video="https://youtu.be/4100gLeabmo"),
-      VWCarDocs("Volkswagen e-Crafter 2018-24", video="https://youtu.be/4100gLeabmo"),
-      VWCarDocs("Volkswagen Grand California 2019-24", video="https://youtu.be/4100gLeabmo"),
-      VWCarDocs("MAN TGE 2017-24", video="https://youtu.be/4100gLeabmo"),
-      VWCarDocs("MAN eTGE 2020-24", video="https://youtu.be/4100gLeabmo"),
+      VWCarDocs("Volkswagen Crafter 2017-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("Volkswagen e-Crafter 2018-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("Volkswagen Grand California 2019-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("MAN TGE 2017-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("MAN eTGE 2020-24", video="https://youtu.be/4100gLeabmo", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
     ],
     VolkswagenCarSpecs(mass=2100, wheelbase=3.64, minSteerSpeed=50 * CV.KPH_TO_MS),
     chassis_codes={"SY", "SZ", "UY", "UZ"},
@@ -349,8 +346,8 @@ class CAR(Platforms):
   )
   VOLKSWAGEN_TRANSPORTER_T61 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Volkswagen Caravelle 2020"),
-      VWCarDocs("Volkswagen California 2021-23"),
+      VWCarDocs("Volkswagen Caravelle 2020", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
+      VWCarDocs("Volkswagen California 2021-23", car_parts=CarParts([Device.threex_angled_mount, CarHarness.vw_j533])),
     ],
     VolkswagenCarSpecs(mass=1926, wheelbase=3.00, minSteerSpeed=14.0),
     chassis_codes={"7H", "7L"},

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -194,12 +194,9 @@ class Footnote(Enum):
 class VWCarDocs(CarDocs):
   package: str = "Adaptive Cruise Control (ACC) & Lane Assist"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.vw_j533]))
+  footnotes: list[Enum] = field(default_factory=lambda: [Footnote.VW_EXP_LONG])
 
   def init_make(self, CP: structs.CarParams):
-    self.footnotes.append(Footnote.VW_EXP_LONG)
-    if "SKODA" in CP.carFingerprint:
-      self.footnotes.append(Footnote.SKODA_HEATED_WINDSHIELD)
-
     if CP.carFingerprint in (CAR.VOLKSWAGEN_CRAFTER_MK2, CAR.VOLKSWAGEN_TRANSPORTER_T61):
       self.car_parts = CarParts([Device.threex_angled_mount, CarHarness.vw_j533])
 
@@ -399,44 +396,44 @@ class CAR(Platforms):
     wmis={WMI.SEAT},
   )
   SKODA_FABIA_MK4 = VolkswagenMQBPlatformConfig(
-    [VWCarDocs("Škoda Fabia 2022-23", footnotes=[Footnote.VW_MQB_A0])],
+    [VWCarDocs("Škoda Fabia 2022-23", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD, Footnote.VW_MQB_A0])],
     VolkswagenCarSpecs(mass=1266, wheelbase=2.56),
     chassis_codes={"PJ"},
     wmis={WMI.SKODA},
   )
   SKODA_KAMIQ_MK1 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Škoda Kamiq 2021-23", footnotes=[Footnote.VW_MQB_A0, Footnote.KAMIQ]),
-      VWCarDocs("Škoda Scala 2020-23", footnotes=[Footnote.VW_MQB_A0]),
+      VWCarDocs("Škoda Kamiq 2021-23", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD, Footnote.VW_MQB_A0, Footnote.KAMIQ]),
+      VWCarDocs("Škoda Scala 2020-23", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD, Footnote.VW_MQB_A0]),
     ],
     VolkswagenCarSpecs(mass=1230, wheelbase=2.66),
     chassis_codes={"NW"},
     wmis={WMI.SKODA},
   )
   SKODA_KAROQ_MK1 = VolkswagenMQBPlatformConfig(
-    [VWCarDocs("Škoda Karoq 2019-23")],
+    [VWCarDocs("Škoda Karoq 2019-23", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD])],
     VolkswagenCarSpecs(mass=1278, wheelbase=2.66),
     chassis_codes={"NU"},
     wmis={WMI.SKODA},
   )
   SKODA_KODIAQ_MK1 = VolkswagenMQBPlatformConfig(
-    [VWCarDocs("Škoda Kodiaq 2017-23")],
+    [VWCarDocs("Škoda Kodiaq 2017-23", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD])],
     VolkswagenCarSpecs(mass=1569, wheelbase=2.79),
     chassis_codes={"NS"},
     wmis={WMI.SKODA, WMI.VOLKSWAGEN_GROUP_RUS},
   )
   SKODA_OCTAVIA_MK3 = VolkswagenMQBPlatformConfig(
     [
-      VWCarDocs("Škoda Octavia 2015-19"),
-      VWCarDocs("Škoda Octavia RS 2016"),
-      VWCarDocs("Škoda Octavia Scout 2017-19"),
+      VWCarDocs("Škoda Octavia 2015-19", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD]),
+      VWCarDocs("Škoda Octavia RS 2016", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD]),
+      VWCarDocs("Škoda Octavia Scout 2017-19", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD]),
     ],
     VolkswagenCarSpecs(mass=1388, wheelbase=2.68),
     chassis_codes={"NE"},
     wmis={WMI.SKODA},
   )
   SKODA_SUPERB_MK3 = VolkswagenMQBPlatformConfig(
-    [VWCarDocs("Škoda Superb 2015-22")],
+    [VWCarDocs("Škoda Superb 2015-22", footnotes=[Footnote.VW_EXP_LONG, Footnote.SKODA_HEATED_WINDSHIELD])],
     VolkswagenCarSpecs(mass=1505, wheelbase=2.84),
     chassis_codes={"3V", "NP"},
     wmis={WMI.SKODA},

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -195,6 +195,7 @@ class VWCarDocs(CarDocs):
   package: str = "Adaptive Cruise Control (ACC) & Lane Assist"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.vw_j533]))
   footnotes: list[Enum] = field(default_factory=lambda: [Footnote.VW_EXP_LONG])
+  # More user friendly to default to 0 vs the DEFAULT_MIN_STEER_SPEED
   min_steer_speed: float = 0
 
 


### PR DESCRIPTION
- Thought having 1 PR that includes all the related changes could be more ideal to review than having multiple PRs
- I tried to make each commit for the specific brand in commit message
- lmk if there are any specific brand changes you want me to split if one is simpler to merge
- Assuming moving `CarDocs` out is the right direction, in the short term *some* `values.py` becomes more cluttered with the static solutions (ex. Volkswagen CarDocs)

Todo:

- [x] Hyundai
- [x] Subaru
- [x] Volkswagen
- [ ] GM
- [ ] Honda
- [ ] Ford


---

#### Hyundai
- Use platform definition to figure out whether `CanFD` or not
- `init_make` -> essentially does a static check

#### Subaru
- Moved tools to harness definition
- Explicit EXP_LONG footnotes for models without flags below
```python
# subaru/interface.py
ret.alphaLongitudinalAvailable = not (ret.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.PREGLOBAL |
                                                   SubaruFlags.LKAS_ANGLE | SubaruFlags.HYBRID))
```

#### Volkswagen
- Made footnotes explicit, maybe one day have `class SkodaCarDocs(CarDocs):` so less verbose footnotes?
- Made angled mount cars parts explicit
- Default to `min_Steer_Speed=0`  for doc purposes and use `min_steer_speed=None` to use `CarSpecs` speed