### PR TITLE
update steerRatio to match the actual Volkswagen Steer Ratio

### DIFF
--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -165,7 +165,7 @@ class VolkswagenPQPlatformConfig(VolkswagenMQBPlatformConfig):
 @dataclass(frozen=True, kw_only=True)
 class VolkswagenCarSpecs(CarSpecs):
   centerToFrontRatio: float = 0.45
-  steerRatio: float = 15.6
+  steerRatio: float = 16.4
   minSteerSpeed: float = CarControllerParams.DEFAULT_MIN_STEER_SPEED
 
 


### PR DESCRIPTION
update steerRatio to match the actual Volkswagen Steer Ratio which is `16.4`, instead of the 15.6 that was used previously (which is incorrect)