### PR TITLE
Tesla coop steer

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -54,9 +54,10 @@ class CarState(CarStateBase):
     self.hands_on_level = epas_status["EPAS3S_handsOnLevel"]
     ret.steeringAngleDeg = -epas_status["EPAS3S_internalSAS"]
     ret.steeringRateDeg = -cp_ap_party.vl["SCCM_steeringAngleSensor"]["SCCM_steeringAngleSpeed"]
+    ret.steeringTorque = -epas_status["EPAS3S_torsionBarTorque"]
 
     # stock handsOnLevel uses >0.5 for 0.25s, but is too slow
-    ret.steeringPressed = self.update_steering_pressed(abs(-epas_status["EPAS3S_torsionBarTorque"]) > STEER_THRESHOLD, 5)
+    ret.steeringPressed = self.update_steering_pressed(abs(ret.steeringTorque) > STEER_THRESHOLD, 5)
 
     eac_status = self.can_define.dv["EPAS3S_sysStatus"]["EPAS3S_eacStatus"].get(int(epas_status["EPAS3S_eacStatus"]), None)
     ret.steerFaultPermanent = eac_status == "EAC_FAULT"


### PR DESCRIPTION
Adds steer angle offset based on measured driver torque value. 
Uses +/-0.2Nm deadzone to filter out torque sensor offset and other disturbances. 

- [x] target angle from lat accel
- [ ] enable full angle range and higher steering velocity at low speed - but ensure stability
- [ ] ~~learn steering torque offset~~ eh, just increase deadzone to 0.5Nm, since it's somewhat angle dependant
- [ ] 100Hz angle request won't work?


-------
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 
* Route: 
