### PR TITLE
Docs: Remove `requirements` from CarDocs

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -244,16 +244,8 @@ class CarDocs:
   # make + model + model years
   name: str
 
-  # Example for Toyota Corolla MY20
-  # requirements: Lane Tracing Assist (LTA) and Dynamic Radar Cruise Control (DRCC)
-  # US Market reference: "All", since all Corolla in the US come standard with LTA and DRCC
-
   # the simplest description of the requirements for the US market
   package: str
-
-  # the minimum compatibility requirements for this model, regardless
-  # of market. can be a package, trim, or list of features
-  requirements: str | None = None
 
   video: str | None = None
   setup_video: str | None = None


### PR DESCRIPTION
- remove `requirements` since it is not being used by any models
- `package` and `requirements` have overlapping purposes
- docs isn't using `requirements` now, `package` with the combination of `footnotes` seem to be working fine

Seems like `requirements` were for cases like how non-US Subaru models have Eyesight but can also be found w/out lane keep assist. You would then use `requirements` to state that.

Looks like `footnotes` has been the solution found in most car brands if they need to note some sort of requirements for non-US Cars.

Example Footnotes:
[Subaru](https://github.com/commaai/opendbc/blob/master/opendbc/car/subaru/values.py#L89)
[Volkswagen](https://github.com/commaai/opendbc/blob/master/opendbc/car/volkswagen/values.py#L176)
[Ford](https://github.com/commaai/opendbc/blob/master/opendbc/car/ford/values.py#L62)