### PR TITLE
Honda: Acura RDX is a snowflake

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -72,7 +72,7 @@ class CarInterface(CarInterfaceBase):
     if ret.flags & HondaFlags.ALLOW_MANUAL_TRANS and all(msg not in fingerprint[CAN.pt] for msg in (0x191, 0x1A3)):
       # Manual transmission support for allowlisted cars only, to prevent silent fall-through on auto-detection failures
       ret.transmissionType = TransmissionType.manual
-    elif 0x191 in fingerprint[CAN.pt]:
+    elif 0x191 in fingerprint[CAN.pt] and candidate != CAR.ACURA_RDX:
       # Traditional CVTs, gearshift position in GEARBOX_CVT
       ret.transmissionType = TransmissionType.cvt
     else:


### PR DESCRIPTION
Acura RDX can't use the common generated gearbox messages, and doesn't have a CVT option. This code path wouldn't be followed in the real world, but fuzzy CI tests can probe past the check, so make its snowflake status official.