### PR TITLE
CANParser: auto-detect frequency

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -50,7 +50,6 @@ env = Environment(
     "-Wshadow",
     "-Wno-vla-cxx-extension",
     "-Wno-unknown-warning-option",  # for compatibility across compiler versions
-    "-fmax-errors=1",
   ] + ccflags_asan,
   LDFLAGS=ldflags_asan,
   LINKFLAGS=ldflags_asan,
@@ -63,6 +62,8 @@ env = Environment(
   CYTHONCFILESUFFIX=".cpp",
   tools=["default", "cython", "compilation_db"]
 )
+if arch != "Darwin":
+  env.Append(CCFLAGS=["-fmax-errors=1", ])
 
 env.CompilationDatabase('compile_commands.json')
 

--- a/SConstruct
+++ b/SConstruct
@@ -50,6 +50,7 @@ env = Environment(
     "-Wshadow",
     "-Wno-vla-cxx-extension",
     "-Wno-unknown-warning-option",  # for compatibility across compiler versions
+    "-fmax-errors=1",
   ] + ccflags_asan,
   LDFLAGS=ldflags_asan,
   LINKFLAGS=ldflags_asan,

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <deque>
 #include <cstring>
 #include <map>
 #include <set>
@@ -69,6 +70,7 @@ public:
   std::vector<double> vals;
   std::vector<std::vector<double>> all_vals;
 
+  std::deque<uint64_t> timestamps;
   uint64_t last_seen_nanos;
   uint64_t check_threshold;
 

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -72,7 +72,8 @@ public:
 
   uint8_t counter;
   uint8_t counter_fail = 0;
-  uint64_t check_threshold;
+  double frequency = 0.0f;
+  uint64_t check_threshold = 0;
   std::deque<uint64_t> timestamps;
 
   bool ignore_checksum = false;

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -18,7 +18,6 @@
 #define DEBUG(...)
 //#define DEBUG printf
 
-#define MAX_BAD_COUNTER 5
 #define CAN_INVALID_CNT 5
 
 // Car specific functions
@@ -70,12 +69,9 @@ public:
   std::vector<double> vals;
   std::vector<std::vector<double>> all_vals;
 
-  std::deque<uint64_t> timestamps;
-  uint64_t last_seen_nanos;
-  uint64_t check_threshold;
-
   uint8_t counter;
-  uint8_t counter_fail;
+  uint64_t check_threshold;
+  std::deque<uint64_t> timestamps;
 
   bool ignore_checksum = false;
   bool ignore_counter = false;
@@ -101,7 +97,8 @@ public:
   int can_invalid_cnt = CAN_INVALID_CNT;
 
   CANParser(int abus, const std::string& dbc_name,
-            const std::vector<std::pair<uint32_t, int>> &messages);
+            const std::vector<std::pair<uint32_t, int>> &messages,
+            bool ignore_checksum, bool ignore_counter);
   CANParser(int abus, const std::string& dbc_name, bool ignore_checksum, bool ignore_counter);
   std::set<uint32_t> update(const std::vector<CanData> &can_data);
   MessageState *getMessageState(uint32_t address) { return &message_states.at(address); }

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -18,6 +18,7 @@
 #define DEBUG(...)
 //#define DEBUG printf
 
+#define MAX_BAD_COUNTER 5
 #define CAN_INVALID_CNT 5
 
 // Car specific functions
@@ -70,13 +71,14 @@ public:
   std::vector<std::vector<double>> all_vals;
 
   uint8_t counter;
+  uint8_t counter_fail = 0;
   uint64_t check_threshold;
   std::deque<uint64_t> timestamps;
 
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
-  bool valid(uint64_t current_nanos, bool bus_timeout);
+  bool valid(uint64_t current_nanos, bool bus_timeout) const;
   bool parse(uint64_t nanos, const std::vector<uint8_t> &dat);
   bool update_counter(int64_t v, int cnt_size);
 

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -80,8 +80,11 @@ public:
   bool ignore_checksum = false;
   bool ignore_counter = false;
 
+  bool valid(uint64_t current_nanos, bool bus_timeout);
   bool parse(uint64_t nanos, const std::vector<uint8_t> &dat);
   bool update_counter(int64_t v, int cnt_size);
+
+  uint64_t first_seen_nanos = 0;
 };
 
 class CANParser {
@@ -93,10 +96,9 @@ private:
 public:
   bool can_valid = false;
   bool bus_timeout = false;
-  uint64_t first_nanos = 0;
   uint64_t last_nonempty_nanos = 0;
   uint64_t bus_timeout_threshold = 0;
-  uint64_t can_invalid_cnt = CAN_INVALID_CNT;
+  int can_invalid_cnt = CAN_INVALID_CNT;
 
   CANParser(int abus, const std::string& dbc_name,
             const std::vector<std::pair<uint32_t, int>> &messages);

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -73,7 +73,7 @@ public:
   uint8_t counter;
   uint8_t counter_fail = 0;
   double frequency = 0.0f;
-  uint64_t check_threshold = 0;
+  uint64_t timeout_threshold = 0;
   std::deque<uint64_t> timestamps;
 
   bool ignore_checksum = false;

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -100,8 +100,7 @@ public:
   int can_invalid_cnt = CAN_INVALID_CNT;
 
   CANParser(int abus, const std::string& dbc_name,
-            const std::vector<std::pair<uint32_t, int>> &messages,
-            bool ignore_checksum, bool ignore_counter);
+            const std::vector<std::pair<uint32_t, int>> &messages);
   CANParser(int abus, const std::string& dbc_name, bool ignore_checksum, bool ignore_counter);
   std::set<uint32_t> update(const std::vector<CanData> &can_data);
   MessageState *getMessageState(uint32_t address) { return &message_states.at(address); }

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -96,7 +96,6 @@ public:
   bool can_valid = false;
   bool bus_timeout = false;
   uint64_t last_nonempty_nanos = 0;
-  uint64_t bus_timeout_threshold = 0;
   int can_invalid_cnt = CAN_INVALID_CNT;
 
   CANParser(int abus, const std::string& dbc_name,

--- a/opendbc/can/common.h
+++ b/opendbc/can/common.h
@@ -76,6 +76,7 @@ public:
   uint64_t timeout_threshold = 0;
   std::deque<uint64_t> timestamps;
 
+  bool ignore_alive = false;
   bool ignore_checksum = false;
   bool ignore_counter = false;
 

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -8,6 +8,7 @@ from libcpp.set cimport set
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 from libcpp.unordered_map cimport unordered_map
+from libcpp.deque cimport deque
 
 
 ctypedef unsigned int (*calc_checksum_type)(uint32_t, const Signal&, const vector[uint8_t] &)
@@ -67,7 +68,7 @@ cdef extern from "common.h":
     vector[Signal] signals
     vector[double] vals
     vector[vector[double]] all_vals
-    uint64_t last_seen_nanos
+    deque[uint64_t] timestamps
 
   cdef struct CanFrame:
     long src

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -82,7 +82,7 @@ cdef extern from "common.h":
   cdef cppclass CANParser:
     bool can_valid
     bool bus_timeout
-    CANParser(int, string, vector[pair[uint32_t, int]], bool, bool) except + nogil
+    CANParser(int, string, vector[pair[uint32_t, int]]) except + nogil
     set[uint32_t] update(vector[CanData]&) except + nogil
     MessageState *getMessageState(uint32_t address) nogil
 

--- a/opendbc/can/common.pxd
+++ b/opendbc/can/common.pxd
@@ -82,7 +82,7 @@ cdef extern from "common.h":
   cdef cppclass CANParser:
     bool can_valid
     bool bus_timeout
-    CANParser(int, string, vector[pair[uint32_t, int]]) except + nogil
+    CANParser(int, string, vector[pair[uint32_t, int]], bool, bool) except + nogil
     set[uint32_t] update(vector[CanData]&) except + nogil
     MessageState *getMessageState(uint32_t address) nogil
 

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -209,8 +209,6 @@ std::set<uint32_t> CANParser::update(const std::vector<CanData> &can_data) {
 }
 
 void CANParser::UpdateCans(const CanData &can, std::set<uint32_t> &updated_addresses) {
-  //DEBUG("got %zu messages\n", can.frames.size());
-
   bool bus_empty = true;
 
   for (const auto &frame : can.frames) {
@@ -259,14 +257,11 @@ void CANParser::UpdateValid(uint64_t nanos) {
 
   for (auto& kv : message_states) {
     const auto& state = kv.second;
-
     if (state.counter_fail >= MAX_BAD_COUNTER) {
       counters_valid = false;
     }
-
     if (!state.valid(nanos, bus_timeout)) {
       valid = false;
-      LOGE("INVALID %s %d %.2f %zu", state.name.c_str(), state.address, state.frequency, state.timestamps.size());
     }
   }
 

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -80,6 +80,17 @@ bool MessageState::parse(uint64_t nanos, const std::vector<uint8_t> &dat) {
     timestamps.pop_front();
   }
 
+  // learn message frequency
+  if (frequency < 1e-5) {
+    double dt = (timestamps.back() - timestamps.front())*1e-9;
+    if (timestamps.size() >= 4 && (dt > 1.0f)) {
+      frequency = timestamps.size() / dt;
+      uint64_t new_thresh = (1000000000ULL / frequency) * 10;
+      printf("0x%X %s got %.2fHz, old %.2f new %.2f", address, name.c_str(), frequency, (double)check_threshold*1e-6, (double)new_thresh*1e-6);
+      check_threshold = (1000000000ULL / frequency) * 10;
+    }
+  }
+
   return true;
 }
 

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -114,6 +114,10 @@ bool MessageState::valid(uint64_t current_nanos, bool bus_timeout) const {
     cases get caught here too.
   */
 
+  if (ignore_alive) {
+    return true;
+  }
+
   const bool print = true; //!bus_timeout && ((current_nanos - first_seen_nanos) > 7e9);
   if (timestamps.empty()) {
     if (print) LOGE_100("0x%X '%s' NOT SEEN", address, name.c_str());
@@ -145,6 +149,7 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
     state.address = address;
     state.ignore_counter = ignore_counter;
     state.ignore_checksum = ignore_checksum;
+    state.ignore_alive = (frequency == 0);
 
     const Msg *msg = dbc->addr_to_msg.at(address);
     state.name = msg->name;

--- a/opendbc/can/parser.cc
+++ b/opendbc/can/parser.cc
@@ -132,7 +132,7 @@ bool MessageState::valid(uint64_t current_nanos, bool bus_timeout) const {
 
 // ***** CANParser *****
 
-CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<std::pair<uint32_t, int>> &messages, bool ignore_counter, bool ignore_checksum)
+CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<std::pair<uint32_t, int>> &messages)
   : bus(abus) {
   dbc = dbc_lookup(dbc_name);
   assert(dbc);
@@ -147,8 +147,6 @@ CANParser::CANParser(int abus, const std::string& dbc_name, const std::vector<st
 
     MessageState &state = message_states[address];
     state.address = address;
-    state.ignore_counter = ignore_counter;
-    state.ignore_checksum = ignore_checksum;
     state.ignore_alive = (frequency == 0);
 
     const Msg *msg = dbc->addr_to_msg.at(address);

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -26,7 +26,7 @@ cdef class CANParser:
     string dbc_name
     uint32_t bus
 
-  def __init__(self, dbc_name, messages, bus=0, ignore_counter=False, ignore_checksum=False):
+  def __init__(self, dbc_name, messages, bus=0):
     self.dbc_name = dbc_name
     self.bus = bus
     self.dbc = dbc_lookup(dbc_name)
@@ -67,10 +67,8 @@ cdef class CANParser:
     else:
       cpp_dbc_name = dbc_name  # Assume bytes
     cdef int cpp_bus = bus
-    cdef bint cpp_ign_counter = ignore_counter
-    cdef bint cpp_ign_checksum = ignore_checksum
     with nogil:
-      self.can = new cpp_CANParser(cpp_bus, cpp_dbc_name, message_v, cpp_ign_counter, cpp_ign_checksum)
+      self.can = new cpp_CANParser(cpp_bus, cpp_dbc_name, message_v)
 
   def __dealloc__(self):
     if self.can:

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -26,7 +26,7 @@ cdef class CANParser:
     string dbc_name
     uint32_t bus
 
-  def __init__(self, dbc_name, messages, bus=0):
+  def __init__(self, dbc_name, messages, bus=0, ignore_counter=False, ignore_checksum=False):
     self.dbc_name = dbc_name
     self.bus = bus
     self.dbc = dbc_lookup(dbc_name)
@@ -67,8 +67,10 @@ cdef class CANParser:
     else:
       cpp_dbc_name = dbc_name  # Assume bytes
     cdef int cpp_bus = bus
+    cdef bint cpp_ign_counter = ignore_counter
+    cdef bint cpp_ign_checksum = ignore_checksum
     with nogil:
-      self.can = new cpp_CANParser(cpp_bus, cpp_dbc_name, message_v)
+      self.can = new cpp_CANParser(cpp_bus, cpp_dbc_name, message_v, cpp_ign_counter, cpp_ign_checksum)
 
   def __dealloc__(self):
     if self.can:

--- a/opendbc/can/parser_pyx.pyx
+++ b/opendbc/can/parser_pyx.pyx
@@ -117,7 +117,7 @@ cdef class CANParser:
         name = <unicode>state.signals[i].name
         vl[name] = state.vals[i]
         vl_all[name] = state.all_vals[i]
-        ts_nanos[name] = state.last_seen_nanos
+        ts_nanos[name] = state.timestamps.back() if not state.timestamps.empty() else 0
 
     return updated_addrs
 

--- a/opendbc/can/tests/test_checksums.py
+++ b/opendbc/can/tests/test_checksums.py
@@ -66,7 +66,7 @@ class TestCanChecksums:
     # TODO: refactor to use self.verify_checksum()
     dbc_file = "honda_accord_2018_can_generated"
     msgs = [("LKAS_HUD", 0), ("LKAS_HUD_A", 0)]
-    parser = CANParser(dbc_file, msgs, 0, ignore_counter=True)
+    parser = CANParser(dbc_file, msgs, 0)
     packer = CANPacker(dbc_file)
 
     values = {

--- a/opendbc/can/tests/test_checksums.py
+++ b/opendbc/can/tests/test_checksums.py
@@ -66,7 +66,7 @@ class TestCanChecksums:
     # TODO: refactor to use self.verify_checksum()
     dbc_file = "honda_accord_2018_can_generated"
     msgs = [("LKAS_HUD", 0), ("LKAS_HUD_A", 0)]
-    parser = CANParser(dbc_file, msgs, 0)
+    parser = CANParser(dbc_file, msgs, 0, ignore_counter=True)
     packer = CANPacker(dbc_file)
 
     values = {


### PR DESCRIPTION
Our frequency checks are currently relatively lax. While it would be nice (in theory) to make them stricter, I can't recall an issue the extra strictness would have caught.

And this lets us ship a significant red diff (https://github.com/commaai/opendbc/pull/2521) to car ports.

---

A sample from running `test_models` on this branch:
```bash
0x444 TRACK_14 got 21.00Hz, old 500.00 new 476.20
0x445 TRACK_15 got 21.00Hz, old 500.00 new 476.20
0x156 STEERING_SENSORS got 100.00Hz, old 100.00 new 100.00
0x1A4 VSA_STATUS got 50.99Hz, old 200.00 new 196.10
0x1B0 STANDSTILL got 50.99Hz, old 200.00 new 196.10
0x158 ENGINE_DATA got 100.00Hz, old 100.00 new 100.00
0x17C POWERTRAIN_DATA got 100.00Hz, old 100.00 new 100.00
0x188 GEARBOX_AUTO got 100.00Hz, old 200.00 new 100.00
0x1D0 WHEEL_SPEEDS got 50.99Hz, old 200.00 new 196.10
0x18F STEER_STATUS got 100.00Hz, old 100.00 new 100.00
0x194 STEERING_CONTROL got 100.00Hz, old 100.00 new 100.00
0x1FA BRAKE_COMMAND got 50.99Hz, old 200.00 new 196.10
0x1A6 SCM_BUTTONS got 50.99Hz, old 400.00 new 196.10
0x324 CRUISE got 11.00Hz, old 1000.00 new 909.15
0x294 SCM_FEEDBACK got 25.74Hz, old 1000.00 new 388.50
0x30C ACC_HUD got 11.00Hz, old 1000.00 new 909.21
0x33D LKAS_HUD got 11.00Hz, old 1000.00 new 909.21
0x305 SEATBELT_STATUS got 11.00Hz, old 1000.00 new 909.21
0x309 CAR_SPEED got 10.89Hz, old 1000.00 new 918.22
```