### PR TITLE
Docs: Add missing Youtube icon to `SETUP_VIDEO`

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -393,7 +393,7 @@ class CarDocs:
       item = star_icon.format(item.value)
     elif column == Column.MODEL and len(self.years):
       item += f" {self.years}"
-    elif column == Column.VIDEO and len(item) > 0:
+    elif column in (Column.VIDEO, Column.SETUP_VIDEO) and len(item) > 0:
       item = video_icon.format(item)
 
     footnotes = get_footnotes(self.footnotes, column)


### PR DESCRIPTION
```python
Column.VIDEO: self.video or "",  # replaced with an image and link from template in get_column
Column.SETUP_VIDEO: self.setup_video or "",  # replaced with an image and link from template in get_column
```
- `SETUP_VIDEO` [comment](https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py#L330) says it should look like `VIDEO` but it shows as text link in current openpilot's [CARS.md](https://github.com/commaai/openpilot/blob/master/docs/CARS.md)
<br>
<img width="2798" height="1598" alt="openpilot-cars-docs" src="https://github.com/user-attachments/assets/16697e07-c2c2-4886-ac21-125ae28456c2" />
