### PR TITLE
Toyota: fix silent frequency truncation

### DIFF
--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -192,7 +192,7 @@ class CarState(CarStateBase):
   def get_can_parsers(CP):
     pt_messages = [
       ("LIGHT_STALK", 1),
-      ("BLINKERS_STATE", 0.15),
+      ("BLINKERS_STATE", 0),
       ("BODY_CONTROL_STATE", 3),
       ("BODY_CONTROL_STATE_2", 2),
       ("ESP_CONTROL", 3),


### PR DESCRIPTION
This got silently truncated to zero with the old CANParser (float -> int), but new one catches this https://github.com/commaai/opendbc/pull/2539.

Will add checks once new CANParser is in.