### PR TITLE
car dynamic parsing fixups

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -300,8 +300,14 @@ class CarState(CarStateBase):
     return ret
 
   def get_can_parsers_canfd(self, CP):
+    msgs = []
+    if not (CP.flags & HyundaiFlags.CANFD_ALT_BUTTONS):
+      # TODO: this can be removed once we add dynamic support to vl_all
+      msgs += [
+        ("CRUISE_BUTTONS", 50)
+      ]
     return {
-      Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], [("CRUISE_BUTTONS", 50), ], CanBus(CP).ECAN),
+      Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], msgs, CanBus(CP).ECAN),
       Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CanBus(CP).CAM),
     }
 

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -141,8 +141,8 @@ class CarState(CarStateBase):
       cluster_set_speed = cp.vl["PCM_CRUISE_SM"]["UI_SET_SPEED"]
 
     # UI_SET_SPEED is always non-zero when main is on, hide until first enable
+    is_metric = cp.vl["BODY_CONTROL_STATE_2"]["UNITS"] in (1, 2)
     if ret.cruiseState.speed != 0:
-      is_metric = cp.vl["BODY_CONTROL_STATE_2"]["UNITS"] in (1, 2)
       conversion_factor = CV.KPH_TO_MS if is_metric else CV.MPH_TO_MS
       ret.cruiseState.speedCluster = cluster_set_speed * conversion_factor
 

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -256,12 +256,19 @@ class CarState(CarStateBase):
     if CP.flags & VolkswagenFlags.PQ:
       return CarState.get_can_parsers_pq(CP)
 
+    # another case of the 1-50Hz
+    cam_messages = []
+    if CP.flags & VolkswagenFlags.STOCK_HCA_PRESENT:
+      cam_messages += [
+        ("HCA_01", 1),  # From R242 Driver assistance camera, 50Hz if steering/1Hz if not
+      ]
+
     return {
       Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], [
         # the 50->1Hz is currently too much for the CANParser to figure out
         ("Blinkmodi_02", 1),  # From J519 BCM (sent at 1Hz when no lights active, 50Hz when active)
       ], CANBUS.pt),
-      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], CANBUS.cam),
+      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], cam_messages, CANBUS.cam),
     }
 
   @staticmethod


### PR DESCRIPTION
There are a few warts of the new dynamic CANParser:
* if a message is read conditionally, it will make `canValid` drop to False briefly once it is read  
  * longer term, this is fixed by *parsing* all messages in a DBC all the time (pending performance improvements) but only considering them for the `canValid` flag once you've read from it
* VW's variable 1-50Hz messages need manual handling for now; long term solution needs some thought

That being said, I think the line savings are definitely worth the trade-offs (>100 lines gone from Hyundai's carstate.py!).