### PR TITLE
Test: ELM327 GM camera diagnostic address with malformed length

### DIFF
--- a/opendbc/safety/tests/test_elm327.py
+++ b/opendbc/safety/tests/test_elm327.py
@@ -40,6 +40,9 @@ class TestElm327(TestDefaultRxHookBase):
       should_tx = (byte >> 4) <= 3
       self.assertEqual(should_tx, self._tx(common.make_msg(0, GM_CAMERA_DIAG_ADDR, dat=bytes([byte] * 8))))
 
+    # test GM camera diagnostic address with malformed length
+    self.assertEqual(False, self._tx(common.make_msg(0, GM_CAMERA_DIAG_ADDR, dat=bytes([0x00] * 7))))
+
   def test_tx_hook_on_wrong_safety_mode(self):
     # No point, since we allow many diagnostic addresses
     pass


### PR DESCRIPTION
Test ELM327 safety with a malformed length GM camera diagnostic address to increase coverage 