### PR TITLE
100% Branch Coverage Check Attempt 

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -92,7 +92,8 @@ class CarState(CarStateBase):
       cp.vl["WHL_SPD11"]["WHL_SPD_RL"],
       cp.vl["WHL_SPD11"]["WHL_SPD_RR"],
     )
-    ret.standstill = cp.vl["WHL_SPD11"]["WHL_SPD_FL"] <= STANDSTILL_THRESHOLD and cp.vl["WHL_SPD11"]["WHL_SPD_RR"] <= STANDSTILL_THRESHOLD
+    ret.standstill = cp.vl["WHL_SPD11"]["WHL_SPD_FL"] <= STANDSTILL_THRESHOLD and cp.vl["WHL_SPD11"]["WHL_SPD_RR"] <= STANDSTILL_THRESHOLD \
+      and cp.vl["WHL_SPD11"]["WHL_SPD_FR"] <= STANDSTILL_THRESHOLD and cp.vl["WHL_SPD11"]["WHL_SPD_RL"] <= STANDSTILL_THRESHOLD
 
     self.cluster_speed_counter += 1
     if self.cluster_speed_counter > CLUSTER_SAMPLE_RATE:

--- a/opendbc/safety/modes/chrysler.h
+++ b/opendbc/safety/modes/chrysler.h
@@ -82,7 +82,7 @@ static void chrysler_rx_hook(const CANPacket_t *msg) {
   if ((chrysler_platform != CHRYSLER_PACIFICA) && (msg->bus == 0U) && (msg->addr == chrysler_addrs->ESP_8)) {
     vehicle_moving = ((msg->data[4] << 8) + msg->data[5]) != 0U;
   }
-  if ((chrysler_platform == CHRYSLER_PACIFICA) && (msg->bus == 0U) && (msg->addr == 514U)) {
+  if ((chrysler_platform == CHRYSLER_PACIFICA) && (msg->addr == 514U)) {
     int speed_l = (msg->data[0] << 4) + (msg->data[1] >> 4);
     int speed_r = (msg->data[2] << 4) + (msg->data[3] >> 4);
     vehicle_moving = (speed_l != 0) || (speed_r != 0);

--- a/opendbc/safety/modes/hyundai.h
+++ b/opendbc/safety/modes/hyundai.h
@@ -166,8 +166,11 @@ static void hyundai_rx_hook(const CANPacket_t *msg) {
     // sample wheel speed, averaging opposite corners
     if (msg->addr == 0x386U) {
       uint32_t front_left_speed = GET_BYTES(msg, 0, 2) & 0x3FFFU;
+      uint32_t front_right_speed = GET_BYTES(msg, 2, 2) & 0x3FFFU;
+      uint32_t rear_left_speed = GET_BYTES(msg, 4, 2) & 0x3FFFU;
       uint32_t rear_right_speed = GET_BYTES(msg, 6, 2) & 0x3FFFU;
-      vehicle_moving = (front_left_speed > HYUNDAI_STANDSTILL_THRSLD) || (rear_right_speed > HYUNDAI_STANDSTILL_THRSLD);
+      vehicle_moving = (front_left_speed > HYUNDAI_STANDSTILL_THRSLD) || (rear_right_speed > HYUNDAI_STANDSTILL_THRSLD)
+                      || (front_right_speed > HYUNDAI_STANDSTILL_THRSLD) || (rear_left_speed > HYUNDAI_STANDSTILL_THRSLD);
     }
 
     if (msg->addr == 0x394U) {

--- a/opendbc/safety/modes/hyundai_common.h
+++ b/opendbc/safety/modes/hyundai_common.h
@@ -129,10 +129,9 @@ uint32_t hyundai_common_canfd_compute_checksum(const CANPacket_t *msg) {
 
   if (len == 24) {
     crc ^= 0x819dU;
-  } else if (len == 32) {
-    crc ^= 0x9f5bU;
   } else {
-
+    // 32 bytes message
+    crc ^= 0x9f5bU;
   }
 
   return crc;

--- a/opendbc/safety/modes/subaru_preglobal.h
+++ b/opendbc/safety/modes/subaru_preglobal.h
@@ -37,7 +37,12 @@ static void subaru_preglobal_rx_hook(const CANPacket_t *msg) {
 
     // update vehicle moving with any non-zero wheel speed
     if (msg->addr == MSG_SUBARU_PG_Wheel_Speeds) {
-      vehicle_moving = ((GET_BYTES(msg, 0, 4) >> 12) != 0U) || (GET_BYTES(msg, 4, 4) != 0U);
+      vehicle_moving = (
+        (GET_BYTES(msg, 0, 2) & 0x1FFFU) > 0U ||
+        (GET_BYTES(msg, 2, 2) & 0x1FFFU) > 0U ||
+        (GET_BYTES(msg, 4, 2) & 0x1FFFU) > 0U ||
+        (GET_BYTES(msg, 6, 2) & 0x1FFFU) > 0U
+      );
     }
 
     if (msg->addr == MSG_SUBARU_PG_Brake_Pedal) {

--- a/opendbc/safety/modes/subaru_preglobal.h
+++ b/opendbc/safety/modes/subaru_preglobal.h
@@ -38,11 +38,10 @@ static void subaru_preglobal_rx_hook(const CANPacket_t *msg) {
     // update vehicle moving with any non-zero wheel speed
     if (msg->addr == MSG_SUBARU_PG_Wheel_Speeds) {
       vehicle_moving = (
-        (GET_BYTES(msg, 0, 2) & 0x1FFFU) > 0U ||
-        (GET_BYTES(msg, 2, 2) & 0x1FFFU) > 0U ||
-        (GET_BYTES(msg, 4, 2) & 0x1FFFU) > 0U ||
-        (GET_BYTES(msg, 6, 2) & 0x1FFFU) > 0U
-      );
+        ((GET_BYTES(msg, 0, 2) & 0x1FFFU) > 0U) ||
+        ((GET_BYTES(msg, 2, 2) & 0x1FFFU) > 0U) ||
+        ((GET_BYTES(msg, 4, 2) & 0x1FFFU) > 0U) ||
+        ((GET_BYTES(msg, 6, 2) & 0x1FFFU) > 0U));
     }
 
     if (msg->addr == MSG_SUBARU_PG_Brake_Pedal) {

--- a/opendbc/safety/tests/test_chrysler.py
+++ b/opendbc/safety/tests/test_chrysler.py
@@ -38,7 +38,10 @@ class TestChryslerSafety(common.PandaCarSafetyTest, common.MotorTorqueSteeringSa
     return self.packer.make_can_msg_panda("DAS_3", self.DAS_BUS, values)
 
   def _speed_msg(self, speed):
-    values = {"SPEED_LEFT": speed, "SPEED_RIGHT": speed}
+    return self._wheel_speed_2wheel_msg(speed, speed)
+
+  def _wheel_speed_2wheel_msg(self, wheel_left: float, wheel_right: float):
+    values = {"SPEED_LEFT": wheel_left, "SPEED_RIGHT": wheel_right}
     return self.packer.make_can_msg_panda("SPEED_1", 0, values)
 
   def _user_gas_msg(self, gas):

--- a/opendbc/safety/tests/test_hyundai.py
+++ b/opendbc/safety/tests/test_hyundai.py
@@ -91,12 +91,21 @@ class TestHyundaiSafety(HyundaiButtonBase, common.PandaCarSafetyTest, common.Dri
     return self.packer.make_can_msg_panda("TCS13", 0, values, fix_checksum=checksum)
 
   def _speed_msg(self, speed):
+    return self._wheel_speed_4wheel_msg(speed, speed, speed, speed)
+
+  def _wheel_speed_4wheel_msg(self, wheel_fl: float, wheel_fr: float, wheel_rl: float, wheel_rr: float):
     # panda safety doesn't scale, so undo the scaling
-    values = {"WHL_SPD_%s" % s: speed * 0.03125 for s in ["FL", "FR", "RL", "RR"]}
-    values["WHL_SPD_AliveCounter_LSB"] = (self.cnt_speed % 16) & 0x3
-    values["WHL_SPD_AliveCounter_MSB"] = (self.cnt_speed % 16) >> 2
+    values = {
+      "WHL_SPD_FL": wheel_fl * 0.03125,
+      "WHL_SPD_FR": wheel_fr * 0.03125,
+      "WHL_SPD_RL": wheel_rl * 0.03125,
+      "WHL_SPD_RR": wheel_rr * 0.03125,
+      "WHL_SPD_AliveCounter_LSB": (self.cnt_speed % 16) & 0x3,
+      "WHL_SPD_AliveCounter_MSB": (self.cnt_speed % 16) >> 2,
+    }
     self.__class__.cnt_speed += 1
     return self.packer.make_can_msg_panda("WHL_SPD11", 0, values, fix_checksum=checksum)
+
 
   def _pcm_status_msg(self, enable):
     values = {"ACCMode": enable, "CR_VSM_Alive": self.cnt_cruise % 16}

--- a/opendbc/safety/tests/test_hyundai_canfd.py
+++ b/opendbc/safety/tests/test_hyundai_canfd.py
@@ -57,7 +57,15 @@ class TestHyundaiCanfdBase(HyundaiButtonBase, common.PandaCarSafetyTest, common.
     return self.packer.make_can_msg_panda(self.STEER_MSG, self.STEER_BUS, values)
 
   def _speed_msg(self, speed):
-    values = {f"WHL_Spd{pos}Val": speed * 0.03125 for pos in ["FL", "FR", "RL", "RR"]}
+    return self._wheel_speed_4wheel_msg(speed, speed, speed, speed)
+
+  def _wheel_speed_4wheel_msg(self, wheel_fl: float, wheel_fr: float, wheel_rl: float, wheel_rr: float):
+    values = {
+      "WHL_SpdFLVal": wheel_fl * 0.03125,
+      "WHL_SpdFRVal": wheel_fr * 0.03125,
+      "WHL_SpdRLVal": wheel_rl * 0.03125,
+      "WHL_SpdRRVal": wheel_rr * 0.03125,
+    }
     return self.packer.make_can_msg_panda("WHEEL_SPEEDS", self.PT_BUS, values)
 
   def _user_brake_msg(self, brake):

--- a/opendbc/safety/tests/test_subaru_preglobal.py
+++ b/opendbc/safety/tests/test_subaru_preglobal.py
@@ -40,7 +40,16 @@ class TestSubaruPreglobalSafety(common.PandaCarSafetyTest, common.DriverTorqueSt
 
   def _speed_msg(self, speed):
     # subaru safety doesn't use the scaled value, so undo the scaling
-    values = {s: speed*0.0592 for s in ["FR", "FL", "RR", "RL"]}
+    return self._wheel_speed_4wheel_msg(speed, speed, speed, speed)
+
+
+  def _wheel_speed_4wheel_msg(self, wheel_front_left: float, wheel_front_right: float, wheel_rear_left: float, wheel_rear_right: float):
+    values = {
+      "FL": wheel_front_left * 0.0592,
+      "FR": wheel_front_right * 0.0592,
+      "RL": wheel_rear_left * 0.0592,
+      "RR": wheel_rear_right * 0.0592
+    }
     return self.packer.make_can_msg_panda("Wheel_Speeds", 0, values)
 
   def _user_brake_msg(self, brake):


### PR DESCRIPTION
Attempting to have 100% Branch Coverage Check. Since this is a huge task, this PR will just contain few minor fixes and will depends on other smaller PRs to have 100% branch coverage.

Depends on:
- https://github.com/commaai/opendbc/pull/2583 (Reach 100%)
- https://github.com/commaai/opendbc/pull/2584 (Reach 100%)
- https://github.com/commaai/opendbc/pull/2585
- https://github.com/commaai/opendbc/pull/2587 (Reach 100%)
- https://github.com/commaai/opendbc/pull/2589 (Reach 100%)
- https://github.com/commaai/opendbc/pull/2590

Will update as more fix comes

This PR's work:
 - Added 2/4 wheel update testing. If a car's interface exposes individual wheel speed, it will update the wheel speed and check for speed/standstill.
 - [Chrysler]: Removed redundant bus check for `CHRYSLER_PACIFICA`
 - [Hyundai Common]: Default to 32 bytes message for computing checksum.