### PR TITLE
Test: Improve Tesla LKAS Passthru Test Coverage

### DIFF
--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -296,8 +296,6 @@ class TestTeslaSafetyBase(common.PandaCarSafetyTest, common.AngleSteeringSafetyT
     self.assertEqual(-1, self.safety.safety_fwd_hook(2, lkas_msg_cam.addr))
     self.assertFalse(self._tx(lkas_msg_cam))
 
-
-
   def test_angle_cmd_when_enabled(self):
     # We properly test lateral acceleration and jerk below
     pass


### PR DESCRIPTION
- Cover test that make sure CAN is not blocked during autopark
- Cover test for rising edge LKAS forwarding
- Cover test for stock LKAS is not allowed when OP are enabled