### PR TITLE
Clarify that CoPilot-360 must be a version that includes ACC

### DIFF
--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -68,7 +68,7 @@ class Footnote(Enum):
 
 @dataclass
 class FordCarDocs(CarDocs):
-  package: str = "Co-Pilot360 Assist+"
+  package: str = "A version of Co-Pilot360 which includes adaptive cruise control such as Co-Pilot360 Assist or Co-Pilot360 Active"
   hybrid: bool = False
   plug_in_hybrid: bool = False
 


### PR DESCRIPTION
This PR updates the text string that gets displayed on the compatibility page of the website.  The Ford channel on discord continues to frequently see users who are angry because they have bought a Comma for their Ford equipped with Co-Pilot360, only to find out they have the wrong version of Co-Pilot360 and their car is not compatible.
