### PR TITLE
parser: optimize MessageState buffer management

### DIFF
--- a/opendbc/can/parser.py
+++ b/opendbc/can/parser.py
@@ -9,7 +9,6 @@ from opendbc.can.dbc import DBC, Signal
 
 MAX_BAD_COUNTER = 5
 CAN_INVALID_CNT = 5
-MESSAGE_HISTORY_SIZE = 500
 
 
 
@@ -41,7 +40,7 @@ class MessageState:
   timeout_threshold: float = 1e5  # default to 1Hz threshold
   vals: list[float] = field(default_factory=list)
   all_vals: list[list[float]] = field(default_factory=list)
-  timestamps: deque[int] = field(default_factory=lambda: deque(maxlen=MESSAGE_HISTORY_SIZE))
+  timestamps: deque[int] = field(default_factory=lambda: deque(maxlen=500))
   counter: int = 0
   counter_fail: int = 0
   first_seen_nanos: int = 0
@@ -86,7 +85,7 @@ class MessageState:
 
     if self.frequency < 1e-5 and len(self.timestamps) >= 3:
       dt = (self.timestamps[-1] - self.timestamps[0]) * 1e-9
-      if (dt > 1.0 or len(self.timestamps) >= MESSAGE_HISTORY_SIZE) and dt != 0:
+      if (dt > 1.0 or len(self.timestamps) >= self.timestamps.maxlen) and dt != 0:
         self.frequency = min(len(self.timestamps) / dt, 100.0)
         self.timeout_threshold = (1_000_000_000 / self.frequency) * 10
     return True


### PR DESCRIPTION
using `deque(maxlen=MESSAGE_HISTORY_SIZE) `instead of manual buffer size checks and popping.