### PR TITLE
PSA: allow unpadded tester_present responses for PSA AEE2010_R3 ECUs

### DIFF
--- a/opendbc/car/ecu_addrs.py
+++ b/opendbc/car/ecu_addrs.py
@@ -7,9 +7,11 @@ from opendbc.car.fw_query_definitions import EcuAddrBusType
 
 
 def _is_tester_present_response(msg: CanData, subaddr: int = None) -> bool:
+  # ISO-TP messages may use CAN frame optimization (not always 8 bytes)
   # tester present response is always a single frame
   dat_offset = 1 if subaddr is not None else 0
-  if 3 <= len(msg.dat) <= 8 and 1 <= msg.dat[dat_offset] <= 7:
+  min_length = 4 if subaddr is not None else 3  # bytes: frame len, (pos/neg) sid, (optional negative sid)/0x00 sub-function
+  if min_length <= len(msg.dat) <= 8 and 1 <= msg.dat[dat_offset] <= 7:
     # success response
     if msg.dat[dat_offset + 1] == (uds.SERVICE_TYPE.TESTER_PRESENT + 0x40):
       return True


### PR DESCRIPTION
PSA AEE2010_R3 ECUs send 3-byte (unpadded) responses to tester_present requests, but openpilot expects 8 bytes. This causes ECU discovery to fail and blocks firmware queries.

Fix: Accept variable-length tester_present responses instead of requiring 8 bytes.

Logs of official PSA dongle:
Request:
<img width="337" height="78" alt="image" src="https://github.com/user-attachments/assets/6f450230-7db8-4b10-ad40-8324cedfe4f5" />
Response:
<img width="222" height="72" alt="image" src="https://github.com/user-attachments/assets/6da5c3b7-cdd4-4e79-8876-bed5af1b14c5" />
