### PR TITLE
Honda: Cleanup LKAS_HUD signal overlaps

### DIFF
--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -179,7 +179,8 @@ def create_ui_commands(packer, CAN, CP, enabled, pcm_speed, hud, is_metric, acc_
       lkas_hud_values['LKAS_PROBLEM'] = lkas_hud['LKAS_PROBLEM']
 
   if not (CP.flags & HondaFlags.BOSCH_EXT_HUD):
-    lkas_hud_values['SET_ME_X48'] = 0x48
+    lkas_hud_values['LDW_OFF'] = 1
+    lkas_hud_values['SET_ME_X1'] = 1
 
   if CP.flags & HondaFlags.BOSCH_EXT_HUD and not CP.openpilotLongitudinalControl:
     commands.append(packer.make_can_msg('LKAS_HUD_A', CAN.lkas, lkas_hud_values))

--- a/opendbc/dbc/generator/honda/_bosch_adas_2018.dbc
+++ b/opendbc/dbc/generator/honda/_bosch_adas_2018.dbc
@@ -42,7 +42,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" XXX
+ SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" BDY
  SG_ COUNTER : 37|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 35|4@0+ (1,0) [0|15] "" BDY
 

--- a/opendbc/dbc/generator/honda/_bosch_adas_2018.dbc
+++ b/opendbc/dbc/generator/honda/_bosch_adas_2018.dbc
@@ -42,7 +42,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X48 : 31|8@0+ (1,0) [0|255] "" BDY
+ SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" XXX
  SG_ COUNTER : 37|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 35|4@0+ (1,0) [0|15] "" BDY
 

--- a/opendbc/dbc/generator/honda/_nidec_common.dbc
+++ b/opendbc/dbc/generator/honda/_nidec_common.dbc
@@ -63,7 +63,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" XXX
+ SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" BDY
  SG_ COUNTER : 37|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 35|4@0+ (1,0) [0|15] "" BDY
 

--- a/opendbc/dbc/generator/honda/_nidec_common.dbc
+++ b/opendbc/dbc/generator/honda/_nidec_common.dbc
@@ -63,7 +63,7 @@ BO_ 829 LKAS_HUD: 5 ADAS
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X48 : 31|8@0+ (1,0) [0|255] "" BDY
+ SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" XXX
  SG_ COUNTER : 37|2@0+ (1,0) [0|3] "" BDY
  SG_ CHECKSUM : 35|4@0+ (1,0) [0|15] "" BDY
 

--- a/opendbc/dbc/generator/honda/honda_civic_ex_2022_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_civic_ex_2022_can.dbc
@@ -33,27 +33,26 @@ BO_ 495 SPEED_LIMIT_DASH_DISPLAY: 8 ADAS
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
 
-BO_ 829 LKAS_HUD: 8 ADAS
- SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" BDY
- SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ BOH : 6|7@0+ (1,0) [0|127] "" BDY
- SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" BDY
- SG_ DTC : 13|1@0+ (1,0) [0|1] "" BDY
- SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" BDY
- SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" BDY
- SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" BDY
- SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" BDY
- SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" BDY
- SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" BDY
- SG_ BEEP : 17|2@0+ (1,0) [0|1] "" BDY
- SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" BDY
- SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" BDY
- SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" BDY
- SG_ SET_ME_X48 : 31|8@0+ (1,0) [0|255] "" BDY
- SG_ LANE_LINES : 36|2@0+ (1,0) [0|3] "" BDY
- SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" BDY
- SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" BDY
+BO_ 829 LKAS_HUD: 8 XXX
+ SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" XXX
+ SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" XXX
+ SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" XXX
+ SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" XXX
+ SG_ SOLID_LANES : 10|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKAS_OFF : 11|1@0+ (1,0) [0|1] "" XXX
+ SG_ LKAS_PROBLEM : 12|1@0+ (1,0) [0|1] "" XXX
+ SG_ DTC : 13|1@0+ (1,0) [0|1] "" XXX
+ SG_ DASHED_LANES : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ BEEP : 17|2@0+ (1,0) [0|1] "" XXX
+ SG_ LDW_PROBLEM : 21|1@0+ (1,0) [0|1] "" XXX
+ SG_ BOH_2 : 23|2@0+ (1,0) [0|4] "" XXX
+ SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" XXX
+ SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" XXX
+ SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" XXX
+ SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" XXX
+ SG_ LANE_LINES : 36|2@0+ (1,0) [0|3] "" XXX
+ SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
+ SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX
 
 BO_ 254913108 LKAS_HUD_2: 8 ADAS
  SG_ COUNTER_2 : 7|2@0+ (1,0) [0|3] "" XXX

--- a/opendbc/dbc/generator/honda/honda_common_canfd.dbc
+++ b/opendbc/dbc/generator/honda/honda_common_canfd.dbc
@@ -32,7 +32,6 @@ BO_ 495 ACC_CONTROL_ON: 8 XXX
 
 BO_ 829 LKAS_HUD: 8 XXX
  SG_ SET_ME_X41 : 6|7@0+ (1,0) [0|127] "" XXX
- SG_ BOH : 6|7@0+ (1,0) [0|127] "" XXX
  SG_ CAM_TEMP_HIGH : 7|1@0+ (1,0) [0|255] "" XXX
  SG_ STEERING_REQUIRED : 8|1@0+ (1,0) [0|1] "" XXX
  SG_ LDW_RIGHT : 9|1@0+ (1,0) [0|1] "" XXX
@@ -47,7 +46,7 @@ BO_ 829 LKAS_HUD: 8 XXX
  SG_ CLEAN_WINDSHIELD : 26|1@0+ (1,0) [0|1] "" XXX
  SG_ LDW_OFF : 27|1@0+ (1,0) [0|1] "" XXX
  SG_ LDW_ON : 28|1@0+ (1,0) [0|1] "" XXX
- SG_ SET_ME_X48 : 31|8@0+ (1,0) [0|255] "" XXX
+ SG_ SET_ME_X1 : 30|1@0+ (1,0) [0|1] "" XXX
  SG_ LANE_LINES : 36|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|15] "" XXX
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" XXX


### PR DESCRIPTION
Fix some signal overlaps, "don't know" placeholders overlapping things that were apparently learned later.

The Bosch messages are identical and could be put in a generator template, but I'll take a look at that when we're ready for a round of Bosch DBC consolidation.

<img width="1456" height="1730" alt="image" src="https://github.com/user-attachments/assets/e8d7a9c9-2fa2-4b07-9453-09c61ad38f88" />
