### PR TITLE
Honda: Add DBC signals for driver regen braking control

### DIFF
--- a/opendbc/dbc/generator/honda/_gearbox_common.dbc
+++ b/opendbc/dbc/generator/honda/_gearbox_common.dbc
@@ -22,7 +22,7 @@ BO_ 419 GEARBOX_AUTO: 8 PCM
  SG_ AUTO_UNKNOWN_1 : 27|2@0+ (1,0) [0|3] "" XXX
  SG_ AUTO_UNKNOWN_2 : 29|1@0+ (1,0) [0|1] "" XXX
  SG_ GEAR_SHIFTER : 35|4@0+ (1,0) [0|15] "" EON
- SG_ REGEN_UNKNOWN_2 : 50|2@0+ (1,0) [0|3] "" XXX
+ SG_ REGEN_UNKNOWN : 50|2@0+ (1,0) [0|3] "" XXX
  SG_ CHECKSUM : 59|4@0+ (1,0) [0|3] "" EON
  SG_ COUNTER : 61|2@0+ (1,0) [0|3] "" EON
  SG_ AUTO_UNKNOWN_3 : 62|1@0+ (1,0) [0|1] "" XXX
@@ -32,7 +32,7 @@ CM_ SG_ 401 CVT_UNKNOWN_2 "Probably target/commanded CVT ratio";
 CM_ SG_ 419 TRANS_SHIFT_ACTIVITY "Tracks but trails TRANS_TARGET_GEAR with extra activity, probable solenoid activations or TC lockup";
 CM_ SG_ 419 REGEN_STAGE_SELECTION "Driver-selected regenerative braking threshold";
 CM_ SG_ 419 REGEN_MEMORY "Driver-selected persistence setting, M shown in instrument cluster";
-CM_ SG_ 419 REGEN_UNKNOWN_2 "Both bits set when user enables regen, otherwise zero";
+CM_ SG_ 419 REGEN_UNKNOWN "Both bits set when user enables regen, otherwise zero";
 
 VAL_ 401 GEAR_SHIFTER 1 "P" 2 "R" 3 "N" 4 "D" 7 "L" 10 "S";
 VAL_ 419 GEAR_SHIFTER 1 "P" 2 "R" 3 "N" 4 "D" 7 "L" 10 "S";


### PR DESCRIPTION
Prerequisite for opendbc car/safety to treat the regen paddles as driver braking.

Stock ACC disengages on these paddles.

Routes for future reference:
`f39cf149898833ff/0000003a--497a0c8b70`
`f39cf149898833ff/0000003b--d79f28818e`