### PR TITLE
Honda: Disengage stock ACC on regen paddle

### DIFF
--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -131,8 +131,7 @@ class CarState(CarStateBase):
     else:
       gear_position = self.shifter_values.get(cp.vl[self.gearbox_msg]["GEAR_SHIFTER"], None)
       ret.gearShifter = self.parse_gear_shifter(gear_position)
-      if self.CP.transmissionType == TransmissionType.auto:
-        ret.regenBraking = cp.vl["GEARBOX_AUTO"]["REGEN_STAGE_SELECTION"] > 0
+      ret.regenBraking = cp.vl[self.gearbox_msg].get("REGEN_STAGE_SELECTION", 0) > 0
 
     ret.gasPressed = cp.vl["POWERTRAIN_DATA"]["PEDAL_GAS"] > 1e-5
 

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -131,6 +131,8 @@ class CarState(CarStateBase):
     else:
       gear_position = self.shifter_values.get(cp.vl[self.gearbox_msg]["GEAR_SHIFTER"], None)
       ret.gearShifter = self.parse_gear_shifter(gear_position)
+      if self.CP.transmissionType == TransmissionType.auto:
+        ret.regenBraking = cp.vl["GEARBOX_AUTO"]["REGEN_STAGE_SELECTION"] > 0
 
     ret.gasPressed = cp.vl["POWERTRAIN_DATA"]["PEDAL_GAS"] > 1e-5
 


### PR DESCRIPTION
Act on the regen paddle signals added in #2622. Resolves occurrences of #1100 with stock ACC.

Leaving that bug open, as some safety refactoring is needed to solve it for alpha OP long.

**Before:** `f39cf149898833ff/0000003e--1fd6c210b4`
**After:** `f39cf149898833ff/0000003f--f8fa7f2c17`

Requires commaai/openpilot#35929.