### PR TITLE
Ford Docs: Update package for individual models

### DIFF
--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -170,7 +170,7 @@ class CAR(Platforms):
   FORD_MAVERICK_MK1 = FordPlatformConfig(
     [
       FordCarDocs("Ford Maverick 2022", hybrid=True),
-      FordCarDocs("Ford Maverick 2023-24", "Co-Pilot360 Assist", hybrid=True),
+      FordCarDocs("Ford Maverick 2023-24", hybrid=True),
     ],
     CarSpecs(mass=1650, wheelbase=3.076, steerRatio=17.0),
   )

--- a/opendbc/car/ford/values.py
+++ b/opendbc/car/ford/values.py
@@ -132,7 +132,7 @@ class CAR(Platforms):
   FORD_ESCAPE_MK4 = FordPlatformConfig(
     [
       FordCarDocs("Ford Escape 2020-22", hybrid=True, plug_in_hybrid=True),
-      FordCarDocs("Ford Kuga 2020-23", "Adaptive Cruise Control with Lane Centering", hybrid=True, plug_in_hybrid=True),
+      FordCarDocs("Ford Kuga 2020-23", hybrid=True, plug_in_hybrid=True),
     ],
     CarSpecs(mass=1750, wheelbase=2.71, steerRatio=16.7),
   )
@@ -164,12 +164,12 @@ class CAR(Platforms):
     CarSpecs(mass=2948, wheelbase=3.70, steerRatio=16.9),
   )
   FORD_FOCUS_MK4 = FordPlatformConfig(
-    [FordCarDocs("Ford Focus 2018", "Adaptive Cruise Control with Lane Centering", footnotes=[Footnote.FOCUS], hybrid=True)],  # mHEV only
+    [FordCarDocs("Ford Focus 2018", footnotes=[Footnote.FOCUS], hybrid=True)],  # mHEV only
     CarSpecs(mass=1350, wheelbase=2.7, steerRatio=15.0),
   )
   FORD_MAVERICK_MK1 = FordPlatformConfig(
     [
-      FordCarDocs("Ford Maverick 2022", "LARIAT Luxury", hybrid=True),
+      FordCarDocs("Ford Maverick 2022", hybrid=True),
       FordCarDocs("Ford Maverick 2023-24", "Co-Pilot360 Assist", hybrid=True),
     ],
     CarSpecs(mass=1650, wheelbase=3.076, steerRatio=17.0),
@@ -179,7 +179,7 @@ class CAR(Platforms):
     CarSpecs(mass=2200, wheelbase=2.984, steerRatio=17.0),  # TODO: check steer ratio
   )
   FORD_RANGER_MK2 = FordCANFDPlatformConfig(
-    [FordCarDocs("Ford Ranger 2024", "Adaptive Cruise Control with Lane Centering", setup_video="https://www.youtube.com/watch?v=2oJlXCKYOy0")],
+    [FordCarDocs("Ford Ranger 2024", setup_video="https://www.youtube.com/watch?v=2oJlXCKYOy0")],
     CarSpecs(mass=2000, wheelbase=3.27, steerRatio=17.0),
   )
 


### PR DESCRIPTION
Context on convo found on Discord [here](https://discord.com/channels/469524606043160576/539096103468007424/1402903379247763497)


### Remove packages already covered by the default footnote (dependent on PR #2592)
Default footnote from that PR looks like 
```
package: str = "Co-Pilot360 Assist+ or Co-Pilot360 Assist 2.0 or Co-Pilot360 Active"
```
PR#2593 lists out exactly which Co-Pilot360 is compatible, which makes the below packages redundant
- "LARIAT Luxury" 
- "Adaptive Cruise Control with Lane Centering"
<br>

 "Ford Maverick 2023-24" should use default footnote from PR #2592. since current window sticker would still say a Co-Pilot360 version as noted by this Discord message [here](https://discord.com/channels/469524606043160576/539096103468007424/1402994070531477660) from DrAskew



If we get any of these packages wrong, we will know sooner from users(since we are more explicit about which package)  rather than later on what to change or tweak, which will then get Ford to a better UX faster, for the future new users



Related open PRs:
Clearer `notecard` structure for required package:  #129 https://github.com/commaai/website/pull/129