### PR TITLE
Revert "Honda: Disengage stock ACC on regen paddle"

### DIFF
--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -131,7 +131,6 @@ class CarState(CarStateBase):
     else:
       gear_position = self.shifter_values.get(cp.vl[self.gearbox_msg]["GEAR_SHIFTER"], None)
       ret.gearShifter = self.parse_gear_shifter(gear_position)
-      ret.regenBraking = cp.vl[self.gearbox_msg].get("REGEN_STAGE_SELECTION", 0) > 0
 
     ret.gasPressed = cp.vl["POWERTRAIN_DATA"]["PEDAL_GAS"] > 1e-5
 


### PR DESCRIPTION
Reverts commaai/opendbc#2624.

When engaged, this acted correctly to disengage instead of throwing an immediate disengage alert. But when disengaged, if the driver had regen braking active, we'd reject and cancel the first engagement attempt before the platform ACC could disable regen braking on its own.

This wasn't intentional, or a good UX tradeoff, so reverting for release. Will work on a proper fix later.