### PR TITLE
Honda: Accord 11G updates

### DIFF
--- a/opendbc/car/honda/fingerprints.py
+++ b/opendbc/car/honda/fingerprints.py
@@ -953,24 +953,12 @@ FW_VERSIONS = {
     ],
   },
   CAR.HONDA_ACCORD_11G: {
-    (Ecu.eps, 0x18da30f1, None): [
-      b'39991-30B-A060\x00\x00',
-    ],
-    (Ecu.gateway, 0x18daeff1, None): [
-      b'5J802-30B-AA10\x00\x00',
-    ],
-    (Ecu.srs, 0x18da53f1, None): [
-      b'77959-30B-A750\x00\x00',
-    ],
     (Ecu.fwdRadar, 0x18dab0f1, None): [
       b'8S302-30A-A040\x00\x00',
     ],
     (Ecu.fwdCamera, 0x18dab5f1, None): [
       b'8S102-30A-A050\x00\x00',
       b'8S102-30A-A060\x00\x00',
-    ],
-    (Ecu.vsa, 0x18da28f1, None): [
-      b'57114-30B-A030\x00\x00',
     ],
   },
 }

--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -169,7 +169,10 @@ class CAR(Platforms):
     {Bus.pt: 'honda_accord_2018_can_generated'},
   )
   HONDA_ACCORD_11G = HondaBoschCANFDPlatformConfig(
-    [HondaCarDocs("Honda Accord 2023-25", "All")],
+    [
+      HondaCarDocs("Honda Accord 2023-25", "All"),
+      HondaCarDocs("Honda Accord Hybrid 2023-25", "All"),
+  ],
     CarSpecs(mass=3477 * CV.LB_TO_KG, wheelbase=2.83, steerRatio=16.0, centerToFrontRatio=0.39),
   )
   HONDA_CIVIC_BOSCH = HondaBoschPlatformConfig(


### PR DESCRIPTION
* Drop extra firmware due to #2632
* Fingerprints re-verified (no change)
* Add the Accord Hybrid, since we list those separately and they've been tested