### PR TITLE
Nissan: add new fingerprint for Nissan Leaf 2021 UK 

### DIFF
--- a/opendbc/car/nissan/fingerprints.py
+++ b/opendbc/car/nissan/fingerprints.py
@@ -60,6 +60,7 @@ FW_VERSIONS = {
       b'476605SH1D',
       b'476605SH7D',
       b'476605SK2A',
+      b'476605SH7E',
     ],
     (Ecu.eps, 0x742, None): [
       b'5SH2A\x99A\x05\x02N123F\x15\x81\x00\x00\x00\x00\x00\x00\x00\x80',

--- a/opendbc/car/nissan/fingerprints.py
+++ b/opendbc/car/nissan/fingerprints.py
@@ -59,8 +59,8 @@ FW_VERSIONS = {
       b'476605SD2E',
       b'476605SH1D',
       b'476605SH7D',
-      b'476605SK2A',
       b'476605SH7E',
+      b'476605SK2A',
     ],
     (Ecu.eps, 0x742, None): [
       b'5SH2A\x99A\x05\x02N123F\x15\x81\x00\x00\x00\x00\x00\x00\x00\x80',


### PR DESCRIPTION
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 74c81c1645dda5fd
* Route: 74c81c1645dda5fd/00000000--c4f4545110

All Log Files
[74c81c1645dda5fd_00000000--c4f4545110--0--rlog.zst.zip](https://github.com/user-attachments/files/21820189/74c81c1645dda5fd_00000000--c4f4545110--0--rlog.zst.zip)


Model: Nissan Leaf 2021 UK
