### PR TITLE
Honda - fix docs to remove experimental footnote for Bosch C

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -48,7 +48,7 @@ class CarInterface(CarInterfaceBase):
       # If Bosch radarless, this blocks ACC messages from the camera
       # TODO: get radar disable working on Bosch CANFD
       ret.alphaLongitudinalAvailable = candidate not in HONDA_BOSCH_CANFD
-      ret.openpilotLongitudinalControl = alpha_long
+      ret.openpilotLongitudinalControl = alpha_long if candidate not in HONDA_BOSCH_CANFD else False
       ret.pcmCruise = not ret.openpilotLongitudinalControl
     else:
       ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.hondaNidec)]


### PR DESCRIPTION
Website has improper description of experimental mode for canfd cars.

Footnotes are triggered by:
if CP.openpilotLongitudinalControl and not CP.alphaLongitudinalAvailable:

This sets openpilotLongitudinalControl to False for canfd to remove the website description