### PR TITLE
Add car_docs reference for Nissan Leaf IC

### DIFF
--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -66,7 +66,8 @@ class CAR(Platforms):
   )
   # Leaf with ADAS ECU found behind instrument cluster instead of glovebox
   # Currently the only known difference between them is the inverted seatbelt signal.
-  NISSAN_LEAF_IC = NISSAN_LEAF.override(car_docs=[])
+  NISSAN_LEAF_IC = NISSAN_LEAF.override(car_docs=["Nissan Leaf 2018-23 Instrument Cluster"])
+  
   NISSAN_ROGUE = NissanPlatformConfig(
     [NissanCarDocs("Nissan Rogue 2018-20")],
     NissanCarSpecs(mass=1610, wheelbase=2.705)


### PR DESCRIPTION
Updated NISSAN_LEAF_IC configuration to include platform "description".

Currently comma uses fingerprints.py to include the fingerprints, also for platforms with same "description". This works for a manually written file.

In Sunnypilot vehicle selector rewrite the files are autogenerated and put inside "car_list.json". Here the generator does not include a copy of Nissan Leaf IC because they have the same description.