### PR TITLE
VW MQB: Add missing AWV (ACC_10) & LH_EPS_03 Signals

### DIFF
--- a/opendbc/dbc/vw_mqb.dbc
+++ b/opendbc/dbc/vw_mqb.dbc
@@ -58,6 +58,7 @@ BO_ 290 ACC_06: 8 XXX
 BO_ 279 ACC_10: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] ""  XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] ""  XXX
+ SG_ AWV_AWA_Status_EPS : 12|4@1+ (1,0) [0|7] ""  XXX
  SG_ AWV1_Anf_Prefill : 16|1@1+ (1,0) [0|1] ""  XXX
  SG_ ANB_CM_Info : 17|1@1+ (1,0) [0|1] ""  XXX
  SG_ AWV2_Freigabe : 18|1@1+ (1,0) [0|1] ""  XXX
@@ -1329,6 +1330,7 @@ BO_ 159 LH_EPS_03: 8 XXX
  SG_ EPS_BLW_QBit : 30|1@1+ (1,0) [0|1] ""  XXX
  SG_ EPS_VZ_BLW : 31|1@1+ (1,0) [0|1] ""  XXX
  SG_ EPS_HCA_Status : 32|4@1+ (1,0) [0|15] ""  XXX
+ SG_ EPS_AWA_Status : 36|4@1+ (1,0) [0|14] ""  XXX
  SG_ EPS_Lenkmoment : 40|10@1+ (1,0) [0|8] "Unit_centiNewtoMeter"  XXX
  SG_ EPS_Lenkmoment_QBit : 54|1@1+ (1,0) [0|1] ""  XXX
  SG_ EPS_VZ_Lenkmoment : 55|1@1+ (1,0) [0|1] ""  XXX
@@ -1673,7 +1675,9 @@ CM_ SG_ 1720 KBI_Variante_USA "In diesem Signal wird die HW-Variante des Kombis 
 
 
 VAL_ 159 EPS_HCA_Status 0 "disabled" 1 "initializing" 2 "fault" 3 "ready" 4 "rejected" 5 "active" 8 "preempted" ;
+VAL_ 159 EPS_AWA_Status 0 "AWA_deaktiviert" 1 "AWA_Anf_nicht_ausfuehrbar" 2 "Kom_AWA_gestoert" 3 "EPS_bzgl_AWA_funktionsbereit" 4 "AWA_Anf_abgewiesen" 5 "AWA_Momeingriff_1_aktiv" 7 "AWA_Momeingriff_2_aktiv" 8 "AWA_abgewiesen_Momentenpriorisierung" 9 "Anf_abgewiesen_Bedienueblich" 14 "Init" ;
 VAL_ 173 GE_Fahrstufe 5 "P" 6 "R" 7 "N" 8 "D" 9 "S" 10 "E" 13 "T" 14 "T" ;
+VAL_ 279 AWV_AWA_Status_EPS 0 "AWA_deactivated" 1 "AWA_request_not_executable" 2 "EPS_communication_disturbed" 3 "AWA_ready" 5 "AWA_torque_intervention_1" 7 "AWA_torque_intervention_2" ;
 VAL_ 288 TSK_Status 0 "init" 1 "disabled" 2 "enabled" 3 "regulating" 4 "accel_pedal_override" 5 "brake_only" 6 "temp_fault" 7 "perm_fault" ;
 VAL_ 288 TSK_v_Begrenzung_aktiv 0 "inaktiv" 1 "aktiv" ;
 VAL_ 288 TSK_Standby_Anf_ESP 0 "keine_Standby_Anforderung" 1 "Standby_Anforderung" ;


### PR DESCRIPTION
This PR adds missing AWV signals for VW MQB in the ACC_10 message, these signals are used for the `AWA` function which is apart of the `AWV` function, and provides Evasive Steering Assistance as apart of the Front Assist package by using the signals added in this PR to command steering to the EPS, it is important to note this is only a DBC edit, as for the EPS to accept these signals it needs to be parameterized by ODIS to support `AWA`. 

`AWA` = `Ausweichassistent` = `Evasive Steering Assistant`