### PR TITLE
Tesla: Replace 6 byte Model Y test route

### DIFF
--- a/opendbc/car/tests/routes.py
+++ b/opendbc/car/tests/routes.py
@@ -321,7 +321,7 @@ routes = [
   CarTestRoute("bc095dc92e101734/000000db--ee9fe46e57", RIVIAN.RIVIAN_R1_GEN1),
 
   CarTestRoute("7dc058789994da80/00000112--adb970f6a8", TESLA.TESLA_MODEL_3),
-  CarTestRoute("46cdc864ec865f4b/00000007--42f94db730", TESLA.TESLA_MODEL_Y),
+  CarTestRoute("c8a98e58647765ad/00000000--ad27d31c4d", TESLA.TESLA_MODEL_Y),
   CarTestRoute("2c912ca5de3b1ee9/0000025d--6eb6bcbca4", TESLA.TESLA_MODEL_Y, segment=4),
   CarTestRoute("bdda168c0c35fad7/00000001--5c5a36ec06", TESLA.TESLA_MODEL_X), # openpilot longitudinal
 

--- a/opendbc/car/tests/routes.py
+++ b/opendbc/car/tests/routes.py
@@ -321,7 +321,7 @@ routes = [
   CarTestRoute("bc095dc92e101734/000000db--ee9fe46e57", RIVIAN.RIVIAN_R1_GEN1),
 
   CarTestRoute("7dc058789994da80/00000112--adb970f6a8", TESLA.TESLA_MODEL_3),
-  CarTestRoute("c8a98e58647765ad/00000000--ad27d31c4d", TESLA.TESLA_MODEL_Y),
+  CarTestRoute("c8a98e58647765ad/00000002--84e4746136", TESLA.TESLA_MODEL_Y),
   CarTestRoute("2c912ca5de3b1ee9/0000025d--6eb6bcbca4", TESLA.TESLA_MODEL_Y, segment=4),
   CarTestRoute("bdda168c0c35fad7/00000001--5c5a36ec06", TESLA.TESLA_MODEL_X), # openpilot longitudinal
 


### PR DESCRIPTION
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
The current test route is using older firmware which only shows 6 bytes but newer vehicle firmwares show 8 bytes for the message sizes on the bus for certain messages including the display message for current touch points on display, which is used  by certain forks.

This new route is on newer firmware which has the correct 8 bytes per message for these specific messages which should fix the failing tests downstream.

Validation
* Dongle ID: c8a98e58647765ad
* Route: https://connect.comma.ai/c8a98e58647765ad/00000002--84e4746136

Note: This route is not mine directly, it was provided by @incodemines

This fixes #2698
