### PR TITLE
Honda: Steer control status refactor, part 2

### DIFF
--- a/opendbc/dbc/generator/honda/_steering_control_b.dbc
+++ b/opendbc/dbc/generator/honda/_steering_control_b.dbc
@@ -5,3 +5,13 @@ BO_ 404 STEERING_CONTROL: 4 EON
  SG_ SET_ME_X00_2 : 22|7@0+ (1,0) [0|127] "" EPS
  SG_ COUNTER : 29|2@0+ (1,0) [0|15] "" EPS
  SG_ CHECKSUM : 27|4@0+ (1,0) [0|3] "" EPS
+
+BO_ 399 STEER_STATUS: 6 EPS
+ SG_ STEER_TORQUE_SENSOR : 7|12@0- (-1,0) [-2047.5|2047.5] "tbd"  EON
+ SG_ STEER_ANGLE_RATE : 23|16@0- (-0.1,0) [-31000|31000] "deg/s" EON
+ SG_ STEER_CONTROL_ACTIVE : 36|1@0+ (1,0) [0|1] ""  EON
+ SG_ STEER_STATUS : 35|4@0+ (1,0) [0|15] ""  EON
+ SG_ COUNTER : 45|2@0+ (1,0) [0|3] ""  EON
+ SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] ""  EON
+
+VAL_ 399 STEER_STATUS 7 "permanent_fault" 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 1 "driver_steering" 0 "normal" ;

--- a/opendbc/dbc/generator/honda/acura_rdx_2018_can.dbc
+++ b/opendbc/dbc/generator/honda/acura_rdx_2018_can.dbc
@@ -10,14 +10,5 @@ BO_ 392 GEARBOX_AUTO: 6 XXX
  SG_ GEAR_SHIFTER : 27|4@0+ (1,0) [0|15] "" EON
  SG_ GEAR : 36|5@0+ (1,0) [0|31] "" EON
 
-BO_ 399 STEER_STATUS: 6 EPS
- SG_ STEER_TORQUE_SENSOR : 7|12@0- (-1,0) [-2047.5|2047.5] "tbd" EON
- SG_ STEER_ANGLE_RATE : 23|16@0- (-0.1,0) [-31000|31000] "deg/s" EON
- SG_ STEER_STATUS : 35|4@0+ (1,0) [0|15] "" EON
- SG_ STEER_CONTROL_ACTIVE : 36|1@0+ (1,0) [0|1] "" EON
- SG_ COUNTER : 45|2@0+ (1,0) [0|3] "" EON
- SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] "" EON
-
 VAL_ 392 GEAR_SHIFTER 0 "S" 1 "P" 2 "R" 4 "N" 8 "D" ;
 VAL_ 392 GEAR 26 "S" 4 "D" 3 "N" 2 "R" 1 "P" ;
-VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;

--- a/opendbc/dbc/generator/honda/honda_crv_executive_2016_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_crv_executive_2016_can.dbc
@@ -4,13 +4,3 @@ CM_ "IMPORT _nidec_scm_group_a.dbc";
 CM_ "IMPORT _steering_control_b.dbc";
 CM_ "IMPORT _steering_sensors_b.dbc";
 CM_ "IMPORT _gearbox_common.dbc";
-
-BO_ 399 STEER_STATUS: 6 EPS
- SG_ STEER_TORQUE_SENSOR : 7|12@0- (-1,0) [-2047.5|2047.5] "tbd"  EON
- SG_ STEER_TORQUE_MOTOR : 23|16@0- (-1,0) [-31000|31000] "tbd"  EON
- SG_ STEER_CONTROL_ACTIVE : 36|1@0+ (1,0) [0|1] ""  EON
- SG_ STEER_STATUS : 35|4@0+ (1,0) [0|15] ""  EON
- SG_ COUNTER : 45|2@0+ (1,0) [0|3] ""  EON
- SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] ""  EON
-
-VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;

--- a/opendbc/dbc/generator/honda/honda_crv_touring_2016_can.dbc
+++ b/opendbc/dbc/generator/honda/honda_crv_touring_2016_can.dbc
@@ -4,13 +4,3 @@ CM_ "IMPORT _nidec_scm_group_a.dbc";
 CM_ "IMPORT _steering_sensors_b.dbc";
 CM_ "IMPORT _steering_control_b.dbc";
 CM_ "IMPORT _gearbox_common.dbc";
-
-BO_ 399 STEER_STATUS: 6 EPS
- SG_ STEER_TORQUE_SENSOR : 7|12@0- (-1,0) [-2047.5|2047.5] "tbd"  EON
- SG_ STEER_ANGLE_RATE : 23|16@0- (-0.1,0) [-31000|31000] "deg/s" EON
- SG_ STEER_CONTROL_ACTIVE : 36|1@0+ (1,0) [0|1] ""  EON
- SG_ STEER_STATUS : 35|4@0+ (1,0) [0|15] ""  EON
- SG_ COUNTER : 45|2@0+ (1,0) [0|3] ""  EON
- SG_ CHECKSUM : 43|4@0+ (1,0) [0|15] ""  EON
-
-VAL_ 399 STEER_STATUS 6 "tmp_fault" 5 "fault_1" 4 "no_torque_alert_2" 3 "low_speed_lockout" 2 "no_torque_alert_1" 0 "normal" ;


### PR DESCRIPTION
Clean up and consolidate the length 6 variants, and add some new fault enums.

There was one difference in the very oldest DBC, treating `STEER_ANGLE_RATE` as `STEER_MOTOR_TORQUE` which disagrees with every other Honda DBC. This would be easy to confuse during early reverse engineering. I'm cleaning this up without specific validation, but openpilot doesn't make use of this signal anyway. It uses the angle-rate from `STEERING_SENSORS` and doesn't read EPS motor torque at all anymore.