### PR TITLE
Honda: Refactor create_ui_commands

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -237,6 +237,7 @@ class CarController(CarControllerBase):
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud, CS.lkas_hud))
 
       if self.CP.openpilotLongitudinalControl:
+        # TODO: combine with create_acc_hud block above, changes message order and will need replay logs regenerated
         if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS):
           can_sends.append(hondacan.create_radar_hud(self.packer, self.CAN.pt))
         if self.CP.carFingerprint == CAR.HONDA_CIVIC_BOSCH:

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -237,7 +237,7 @@ class CarController(CarControllerBase):
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud, CS.lkas_hud))
 
       if self.CP.openpilotLongitudinalControl:
-        # TODO: combine with create_acc_hud block above, changes message order and will need replay logs regenerated
+        # TODO: combining with create_acc_hud block above will change message order and will need replay logs regenerated
         if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS):
           can_sends.append(hondacan.create_radar_hud(self.packer, self.CAN.pt))
         if self.CP.carFingerprint == CAR.HONDA_CIVIC_BOSCH:

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -1,5 +1,4 @@
 import numpy as np
-from collections import namedtuple
 
 from opendbc.can import CANPacker
 from opendbc.car import Bus, DT_CTRL, rate_limit, make_tester_present_msg, structs
@@ -87,10 +86,6 @@ def process_hud_alert(hud_alert):
     alert_steer_required = True
 
   return alert_fcw, alert_steer_required
-
-
-HUDData = namedtuple("HUDData",
-                     ["pcm_accel", "v_cruise"])
 
 
 class CarController(CarControllerBase):
@@ -223,11 +218,10 @@ class CarController(CarControllerBase):
 
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
-      hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)))
-
       if self.CP.openpilotLongitudinalControl:
         # On Nidec, this also controls longitudinal positive acceleration
-        can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, hud_control, hud, CS.is_metric, CS.acc_hud))
+        can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, pcm_accel,
+                                                 hud_control, hud_v_cruise, CS.is_metric, CS.acc_hud))
 
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud_control, alert_steer_required, CS.lkas_hud))
 

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -90,8 +90,7 @@ def process_hud_alert(hud_alert):
 
 
 HUDData = namedtuple("HUDData",
-                     ["pcm_accel", "v_cruise", "lead_visible",
-                      "fcw", "lead_distance_bars"])
+                     ["pcm_accel", "v_cruise"])
 
 
 class CarController(CarControllerBase):
@@ -224,12 +223,11 @@ class CarController(CarControllerBase):
 
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
-      hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
-                    alert_fcw, hud_control.leadDistanceBars)
+      hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)))
 
       if self.CP.openpilotLongitudinalControl:
-        # On Nidec, this controls longitudinal positive acceleration
-        can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud))
+        # On Nidec, this also controls longitudinal positive acceleration
+        can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, hud_control, hud, CS.is_metric, CS.acc_hud))
 
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud_control, alert_steer_required, CS.lkas_hud))
 

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -91,7 +91,7 @@ def process_hud_alert(hud_alert):
 
 HUDData = namedtuple("HUDData",
                      ["pcm_accel", "v_cruise", "lead_visible",
-                      "lanes_visible", "fcw", "steer_required", "lead_distance_bars"])
+                      "fcw", "lead_distance_bars"])
 
 
 class CarController(CarControllerBase):
@@ -225,13 +225,13 @@ class CarController(CarControllerBase):
     # Send dashboard UI commands.
     if self.frame % 10 == 0:
       hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
-                    hud_control.lanesVisible, alert_fcw, alert_steer_required, hud_control.leadDistanceBars)
+                    alert_fcw, hud_control.leadDistanceBars)
 
       if self.CP.openpilotLongitudinalControl:
         # On Nidec, this controls longitudinal positive acceleration
         can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud))
 
-      can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud, CS.lkas_hud))
+      can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud_control, alert_steer_required, CS.lkas_hud))
 
       if self.CP.openpilotLongitudinalControl:
         # TODO: combining with create_acc_hud block above will change message order and will need replay logs regenerated

--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -226,25 +226,24 @@ class CarController(CarControllerBase):
           self.brake = apply_brake / self.params.NIDEC_BRAKE_MAX
 
     # Send dashboard UI commands.
-    # On Nidec, this controls longitudinal positive acceleration
     if self.frame % 10 == 0:
       hud = HUDData(int(pcm_accel), int(round(hud_v_cruise)), hud_control.leadVisible,
                     hud_control.lanesVisible, fcw_display, acc_alert, steer_required, hud_control.leadDistanceBars)
 
       if self.CP.openpilotLongitudinalControl:
+        # On Nidec, this controls longitudinal positive acceleration
         can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, hud, CS.is_metric, CS.acc_hud))
 
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud, CS.lkas_hud))
 
-      if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and self.CP.openpilotLongitudinalControl:
-        can_sends.append(hondacan.create_radar_hud(self.packer, self.CAN.pt))
-
-      if self.CP.carFingerprint == CAR.HONDA_CIVIC_BOSCH:
-        can_sends.append(hondacan.create_legacy_brake_command(self.packer, self.CAN.pt))
-
-      if self.CP.openpilotLongitudinalControl and self.CP.carFingerprint not in HONDA_BOSCH:
-        self.speed = pcm_speed
-        self.gas = pcm_accel / self.params.NIDEC_GAS_MAX
+      if self.CP.openpilotLongitudinalControl:
+        if self.CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS):
+          can_sends.append(hondacan.create_radar_hud(self.packer, self.CAN.pt))
+        if self.CP.carFingerprint == CAR.HONDA_CIVIC_BOSCH:
+          can_sends.append(hondacan.create_legacy_brake_command(self.packer, self.CAN.pt))
+        if self.CP.carFingerprint not in HONDA_BOSCH:
+          self.speed = pcm_speed
+          self.gas = pcm_accel / self.params.NIDEC_GAS_MAX
 
     new_actuators = actuators.as_builder()
     new_actuators.speed = self.speed

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -131,14 +131,14 @@ def create_bosch_supplemental_1(packer, CAN):
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_1", CAN.lkas, values)
 
 
-def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud, is_metric, acc_hud):
+def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud_control, hud, is_metric, acc_hud):
   acc_hud_values = {
     'CRUISE_SPEED': hud.v_cruise,
     'ENABLE_MINI_CAR': 1 if enabled else 0,
     # only moves the lead car without ACC_ON
-    'HUD_DISTANCE': hud.lead_distance_bars,  # wraps to 0 at 4 bars
+    'HUD_DISTANCE': hud_control.leadDistanceBars,  # wraps to 0 at 4 bars
     'IMPERIAL_UNIT': int(not is_metric),
-    'HUD_LEAD': 2 if enabled and hud.lead_visible else 1 if enabled else 0,
+    'HUD_LEAD': 2 if enabled and hud_control.leadVisible else 1 if enabled else 0,
     'SET_ME_X01_2': 1,
   }
 

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -1,6 +1,6 @@
 from opendbc.car import CanBusBase
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.honda.values import HondaFlags, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_BOSCH_CANFD, CAR, CarControllerParams
+from opendbc.car.honda.values import HondaFlags, HONDA_BOSCH, HONDA_BOSCH_RADARLESS, HONDA_BOSCH_CANFD, CarControllerParams
 
 # CAN bus layout with relay
 # 0 = ACC-CAN - radar side
@@ -131,36 +131,36 @@ def create_bosch_supplemental_1(packer, CAN):
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_1", CAN.lkas, values)
 
 
-def create_ui_commands(packer, CAN, CP, enabled, pcm_speed, hud, is_metric, acc_hud, lkas_hud):
+def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud, is_metric, acc_hud):
+  acc_hud_values = {
+    'CRUISE_SPEED': hud.v_cruise,
+    'ENABLE_MINI_CAR': 1 if enabled else 0,
+    # only moves the lead car without ACC_ON
+    'HUD_DISTANCE': hud.lead_distance_bars,  # wraps to 0 at 4 bars
+    'IMPERIAL_UNIT': int(not is_metric),
+    'HUD_LEAD': 2 if enabled and hud.lead_visible else 1 if enabled else 0,
+    'SET_ME_X01_2': 1,
+  }
+
+  if CP.carFingerprint in HONDA_BOSCH:
+    acc_hud_values['ACC_ON'] = int(enabled)
+    acc_hud_values['FCM_OFF'] = 1
+    acc_hud_values['FCM_OFF_2'] = 1
+  else:
+    # Shows the distance bars, TODO: stock camera shows updates temporarily while disabled
+    acc_hud_values['ACC_ON'] = int(enabled)
+    acc_hud_values['PCM_SPEED'] = pcm_speed * CV.MS_TO_KPH
+    acc_hud_values['PCM_GAS'] = hud.pcm_accel
+    acc_hud_values['SET_ME_X01'] = 1
+    acc_hud_values['FCM_OFF'] = acc_hud['FCM_OFF']
+    acc_hud_values['FCM_OFF_2'] = acc_hud['FCM_OFF_2']
+    acc_hud_values['FCM_PROBLEM'] = acc_hud['FCM_PROBLEM']
+    acc_hud_values['ICONS'] = acc_hud['ICONS']
+  return packer.make_can_msg("ACC_HUD", bus, acc_hud_values)
+
+
+def create_lkas_hud(packer, bus, CP, hud, lkas_hud):
   commands = []
-  radar_disabled = CP.carFingerprint in (HONDA_BOSCH - HONDA_BOSCH_RADARLESS) and CP.openpilotLongitudinalControl
-
-  if CP.openpilotLongitudinalControl:
-    acc_hud_values = {
-      'CRUISE_SPEED': hud.v_cruise,
-      'ENABLE_MINI_CAR': 1 if enabled else 0,
-      # only moves the lead car without ACC_ON
-      'HUD_DISTANCE': hud.lead_distance_bars,  # wraps to 0 at 4 bars
-      'IMPERIAL_UNIT': int(not is_metric),
-      'HUD_LEAD': 2 if enabled and hud.lead_visible else 1 if enabled else 0,
-      'SET_ME_X01_2': 1,
-    }
-
-    if CP.carFingerprint in HONDA_BOSCH:
-      acc_hud_values['ACC_ON'] = int(enabled)
-      acc_hud_values['FCM_OFF'] = 1
-      acc_hud_values['FCM_OFF_2'] = 1
-    else:
-      # Shows the distance bars, TODO: stock camera shows updates temporarily while disabled
-      acc_hud_values['ACC_ON'] = int(enabled)
-      acc_hud_values['PCM_SPEED'] = pcm_speed * CV.MS_TO_KPH
-      acc_hud_values['PCM_GAS'] = hud.pcm_accel
-      acc_hud_values['SET_ME_X01'] = 1
-      acc_hud_values['FCM_OFF'] = acc_hud['FCM_OFF']
-      acc_hud_values['FCM_OFF_2'] = acc_hud['FCM_OFF_2']
-      acc_hud_values['FCM_PROBLEM'] = acc_hud['FCM_PROBLEM']
-      acc_hud_values['ICONS'] = acc_hud['ICONS']
-    commands.append(packer.make_can_msg("ACC_HUD", CAN.pt, acc_hud_values))
 
   lkas_hud_values = {
     'LKAS_READY': 1,
@@ -184,22 +184,25 @@ def create_ui_commands(packer, CAN, CP, enabled, pcm_speed, hud, is_metric, acc_
     lkas_hud_values['LANE_ASSIST_BEEP_OFF'] = 1
 
   if CP.flags & HondaFlags.BOSCH_EXT_HUD and not CP.openpilotLongitudinalControl:
-    commands.append(packer.make_can_msg('LKAS_HUD_A', CAN.lkas, lkas_hud_values))
-    commands.append(packer.make_can_msg('LKAS_HUD_B', CAN.lkas, lkas_hud_values))
+    commands.append(packer.make_can_msg('LKAS_HUD_A', bus, lkas_hud_values))
+    commands.append(packer.make_can_msg('LKAS_HUD_B', bus, lkas_hud_values))
   else:
-    commands.append(packer.make_can_msg('LKAS_HUD', CAN.lkas, lkas_hud_values))
-
-  if radar_disabled:
-    radar_hud_values = {
-      'CMBS_OFF': 0x01,
-      'SET_TO_1': 0x01,
-    }
-    commands.append(packer.make_can_msg('RADAR_HUD', CAN.pt, radar_hud_values))
-
-    if CP.carFingerprint == CAR.HONDA_CIVIC_BOSCH:
-      commands.append(packer.make_can_msg("LEGACY_BRAKE_COMMAND", CAN.pt, {}))
+    commands.append(packer.make_can_msg('LKAS_HUD', bus, lkas_hud_values))
 
   return commands
+
+
+def create_radar_hud(packer, bus):
+  radar_hud_values = {
+    'CMBS_OFF': 0x01,
+    'SET_TO_1': 0x01,
+  }
+
+  return packer.make_can_msg('RADAR_HUD', bus, radar_hud_values)
+
+
+def create_legacy_brake_command(packer, bus):
+  return packer.make_can_msg("LEGACY_BRAKE_COMMAND", bus, {})
 
 
 def spam_buttons_command(packer, CAN, button_val, car_fingerprint):

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -160,20 +160,20 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud, is_metric, acc_hud)
   return packer.make_can_msg("ACC_HUD", bus, acc_hud_values)
 
 
-def create_lkas_hud(packer, bus, CP, hud, lkas_hud):
+def create_lkas_hud(packer, bus, CP, hud_control, alert_steer_required, lkas_hud):
   commands = []
 
   lkas_hud_values = {
     'LKAS_READY': 1,
     'LKAS_STATE_CHANGE': 1,
-    'STEERING_REQUIRED': hud.steer_required,
-    'SOLID_LANES': hud.lanes_visible,
+    'STEERING_REQUIRED': alert_steer_required,
+    'SOLID_LANES': hud_control.lanesVisible,
     'BEEP': 0,
   }
 
   if CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_CANFD):
     lkas_hud_values['LANE_LINES'] = 3
-    lkas_hud_values['DASHED_LANES'] = hud.lanes_visible
+    lkas_hud_values['DASHED_LANES'] = hud_control.lanesVisible
 
     # car likely needs to see LKAS_PROBLEM fall within a specific time frame, so forward from camera
     # TODO: needed for Bosch CAN FD?

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -131,9 +131,9 @@ def create_bosch_supplemental_1(packer, CAN):
   return packer.make_can_msg("BOSCH_SUPPLEMENTAL_1", CAN.lkas, values)
 
 
-def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud_control, hud, is_metric, acc_hud):
+def create_acc_hud(packer, bus, CP, enabled, pcm_speed, pcm_accel, hud_control, hud_v_cruise, is_metric, acc_hud):
   acc_hud_values = {
-    'CRUISE_SPEED': hud.v_cruise,
+    'CRUISE_SPEED': hud_v_cruise,
     'ENABLE_MINI_CAR': 1 if enabled else 0,
     # only moves the lead car without ACC_ON
     'HUD_DISTANCE': hud_control.leadDistanceBars,  # wraps to 0 at 4 bars
@@ -150,7 +150,7 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud_control, hud, is_met
     # Shows the distance bars, TODO: stock camera shows updates temporarily while disabled
     acc_hud_values['ACC_ON'] = int(enabled)
     acc_hud_values['PCM_SPEED'] = pcm_speed * CV.MS_TO_KPH
-    acc_hud_values['PCM_GAS'] = hud.pcm_accel
+    acc_hud_values['PCM_GAS'] = pcm_accel
     acc_hud_values['SET_ME_X01'] = 1
     acc_hud_values['FCM_OFF'] = acc_hud['FCM_OFF']
     acc_hud_values['FCM_OFF_2'] = acc_hud['FCM_OFF_2']

--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -156,6 +156,7 @@ def create_acc_hud(packer, bus, CP, enabled, pcm_speed, hud, is_metric, acc_hud)
     acc_hud_values['FCM_OFF_2'] = acc_hud['FCM_OFF_2']
     acc_hud_values['FCM_PROBLEM'] = acc_hud['FCM_PROBLEM']
     acc_hud_values['ICONS'] = acc_hud['ICONS']
+
   return packer.make_can_msg("ACC_HUD", bus, acc_hud_values)
 
 


### PR DESCRIPTION
Null effect refactor, prep for #2473 or its spiritual successor.

`create_ui_commands()` is too big, it builds up to five messages, the argument list is unwieldy, and the LKAS_HUD message is about to get more arguments.

* Break `create_ui_commands()` into several pieces.
* Start moving more of the bus and car logic up into carcontroller