### PR TITLE
Tesla: Extend supported model-years for HW4 Model Y

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -284,7 +284,7 @@
 |Tesla|Model 3 (with HW4) 2024-25|All|[Upstream](#upstream)|
 |Tesla|Model X (with HW4) 2024|All|[Dashcam mode](#dashcam)|
 |Tesla|Model Y (with HW3) 2020-23|All|[Upstream](#upstream)|
-|Tesla|Model Y (with HW4) 2024|All|[Upstream](#upstream)|
+|Tesla|Model Y (with HW4) 2024-25|All|[Upstream](#upstream)|
 |Toyota|Alphard 2019-20|All|[Upstream](#upstream)|
 |Toyota|Alphard Hybrid 2021|All|[Upstream](#upstream)|
 |Toyota|Avalon 2016|Toyota Safety Sense P|[Upstream](#upstream)|

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -52,7 +52,7 @@ class CAR(Platforms):
   TESLA_MODEL_Y = TeslaPlatformConfig(
     [
       TeslaCarDocsHW3("Tesla Model Y (with HW3) 2020-23"),
-      TeslaCarDocsHW4("Tesla Model Y (with HW4) 2024"),
+      TeslaCarDocsHW4("Tesla Model Y (with HW4) 2024-25"),
      ],
     CarSpecs(mass=2072., wheelbase=2.890, steerRatio=12.0),
   )


### PR DESCRIPTION
Per @incodemines, there should have been a doc update when fixing #2698.