### PR TITLE
Honda: Static minimum steer speed handling

### DIFF
--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -39,6 +39,7 @@ class CarState(CarStateBase):
 
     self.brake_switch_prev = False
     self.brake_switch_active = False
+    self.low_speed_alert = False
 
     self.dynamic_v_cruise_units = self.CP.carFingerprint in (HONDA_BOSCH_RADARLESS | HONDA_BOSCH_ALT_RADAR | HONDA_BOSCH_CANFD)
     self.cruise_setting = 0
@@ -174,6 +175,17 @@ class CarState(CarStateBase):
     ret.brake = cp.vl["VSA_STATUS"]["USER_BRAKE"]
     ret.cruiseState.enabled = cp.vl["POWERTRAIN_DATA"]["ACC_STATUS"] != 0
     ret.cruiseState.available = bool(cp.vl[self.car_state_scm_msg]["MAIN_ON"])
+
+    # Low speed steer alert hysteresis logic
+    # All Honda EPS cut off slightly above standstill; don't alert under 3mph
+    # TODO: verify actual above-standstill cutoff speed, it's almost certainly metric
+    # TODO: handle asymmetric enable/disable speeds
+    # TODO: nerf the HUD steering-required VisualAlert because it's continuous and obnoxious
+    if 3 * CV.MPH_TO_MS < ret.vEgo < (self.CP.minSteerSpeed + 1.):
+      self.low_speed_alert = True
+    elif ret.standstill or ret.vEgo > (self.CP.minSteerSpeed + 2.):
+      self.low_speed_alert = False
+    ret.lowSpeedAlert = self.low_speed_alert
 
     # Gets rid of Pedal Grinding noise when brake is pressed at slow speeds for some models
     if self.CP.carFingerprint in (CAR.HONDA_PILOT, CAR.HONDA_RIDGELINE):


### PR DESCRIPTION
Prerequisite for merging Honda ALT_RADAR cars.

As of this writing, this alert will only affect the recently-merged Honda City. The rest of the cars with non-zero minimum steer speeds are all set on CarDocs only.