### PR TITLE
TOYOTA: Remove stale BRAKE_POSITION comment from toyota_new_mc_pt.dbc

### DIFF
--- a/opendbc/dbc/generator/toyota/toyota_new_mc_pt.dbc
+++ b/opendbc/dbc/generator/toyota/toyota_new_mc_pt.dbc
@@ -15,7 +15,6 @@ BO_ 1178 BRAKE_RELATED: 8 XXX
  SG_ BRAKE_PRESSED : 48|1@0+ (1,0) [0|1] "" XXX
 
 CM_ SG_ 548 BRAKE_PRESSURE "seems prop to pedal force";
-CM_ SG_ 548 BRAKE_POSITION "seems proportional to pedal displacement, unclear the max value of 0x1c8";
 CM_ SG_ 610 TYPE "seems 1 on Corolla, 0 on all others";
 
 VAL_ 610 IPAS_STATE 5 "override" 3 "enabled" 1 "disabled";


### PR DESCRIPTION
Hi, thank you for the great tool. This is a minor fix.

### Summary  

Remove an orphan comment referencing BRAKE_POSITION in toyota_new_mc_pt.dbc. The signal is not defined in this variant and the generated DBC already omits it.


### Background  
The line `CM_ SG_ 548 BRAKE_POSITION ...` remained after earlier template/copy operations. Other Toyota variants legitimately define BRAKE_POSITION; this variant does not. The comment misleads contributors into searching for a non‑existent signal.

### Change  
- Delete one stale comment line. No message or signal definitions modified.