### PR TITLE
CANParser: Improved error logging

### DIFF
--- a/opendbc/can/parser.py
+++ b/opendbc/can/parser.py
@@ -204,7 +204,7 @@ class CANParser:
     for state in self.message_states.values():
       if state.counter_fail >= MAX_BAD_COUNTER:
         counters_valid = False
-        state.rate_limited_log(self._last_update_nanos, f"counter_fail >= {MAX_BAD_COUNTER}")
+        state.rate_limited_log(self._last_update_nanos, f"counter invalid, {state.counter_fail=} {MAX_BAD_COUNTER=}")
       if not state.valid(self._last_update_nanos, bus_timeout):
         valid = False
         state.rate_limited_log(self._last_update_nanos, "not valid (timeout or missing)")


### PR DESCRIPTION
After the recent CANParser rewrite, we lost logging of missing messages that cause canValid == False, which makes debugging not very fun.

Added that logging back, did some other minor cleanup, and rate-limited error logging to once per second per message so we don't massively inflate the logs.

Example:

```
CANParser: 0x296 SCM_BUTTONS not valid (timeout or missing)
CANParser: 0x296 SCM_BUTTONS not valid (timeout or missing)
CANParser: 0x309 CAR_SPEED not valid (timeout or missing)
CANParser: 0x309 CAR_SPEED not valid (timeout or missing)
CANParser: 0x158 ENGINE_DATA not valid (timeout or missing)
CANParser: 0x158 ENGINE_DATA not valid (timeout or missing)
```