### PR TITLE
fix tesla dbc formatting for plotjuggler

### DIFF
--- a/opendbc/dbc/tesla_model3_party.dbc
+++ b/opendbc/dbc/tesla_model3_party.dbc
@@ -293,30 +293,30 @@ BO_ 923 DAS_status: 8 PARTY
  SG_ DAS_autopilotState : 0|4@1+ (1,0) [0|15] ""  aps
 
 BO_ 325 ESP_status: 8 PARTY
- SG_ ESP_absBrakeEvent2: 22|2@1+ (1,0) [0|0] "" X
- SG_ ESP_absFaultLamp: 17|1@1+ (1,0) [0|0] "" X
- SG_ ESP_brakeApply: 31|1@1+ (1,0) [0|0] "" X
- SG_ ESP_brakeDiscWipingActive: 28|1@1+ (1,0) [0|0] "" X
- SG_ ESP_brakeLamp: 21|1@1+ (1,0) [0|0] "" X
- SG_ ESP_brakeTorqueTarget: 51|13@1+ (2,0) [0|0] "Nm" X
- SG_ ESP_btcTargetState: 38|2@1+ (1,0) [0|0] "" X
- SG_ ESP_cdpStatus: 34|2@1+ (1,0) [0|0] "" X
- SG_ ESP_driverBrakeApply: 29|2@1+ (1,0) [0|0] "" X
- SG_ ESP_ebdFaultLamp: 16|1@1+ (1,0) [0|0] "" X
- SG_ ESP_ebrStandstillSkid: 48|1@1+ (1,0) [0|0] "" X
- SG_ ESP_ebrStatus: 49|2@1+ (1,0) [0|0] "" X
- SG_ ESP_espFaultLamp: 18|1@1+ (1,0) [0|0] "" X
- SG_ ESP_espLampFlash: 20|1@1+ (1,0) [0|0] "" X
- SG_ ESP_espModeActive: 12|2@1+ (1,0) [0|0] "" X
- SG_ ESP_hydraulicBoostEnabled: 19|1@1+ (1,0) [0|0] "" X
- SG_ ESP_lateralAccelQF: 25|1@1+ (1,0) [0|0] "" X
- SG_ ESP_longitudinalAccelQF: 24|1@1+ (1,0) [0|0] "" X
- SG_ ESP_ptcTargetState: 36|2@1+ (1,0) [0|0] "" X
- SG_ ESP_stabilityControlSts2: 14|2@1+ (1,0) [0|0] "" X
- SG_ ESP_statusChecksum: 0|8@1+ (1,0) [0|0] "" X
- SG_ ESP_statusCounter: 8|4@1+ (1,0) [0|0] "" X
- SG_ ESP_steeringAngleQF: 27|1@1+ (1,0) [0|0] "" X
- SG_ ESP_yawRateQF: 26|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_absBrakeEvent2 : 22|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_absFaultLamp : 17|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_brakeApply : 31|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_brakeDiscWipingActive : 28|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_brakeLamp : 21|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_brakeTorqueTarget : 51|13@1+ (2,0) [0|0] "Nm" X
+ SG_ ESP_btcTargetState : 38|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_cdpStatus : 34|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_driverBrakeApply : 29|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_ebdFaultLamp : 16|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_ebrStandstillSkid : 48|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_ebrStatus : 49|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_espFaultLamp : 18|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_espLampFlash : 20|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_espModeActive : 12|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_hydraulicBoostEnabled : 19|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_lateralAccelQF : 25|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_longitudinalAccelQF : 24|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_ptcTargetState : 36|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_stabilityControlSts2 : 14|2@1+ (1,0) [0|0] "" X
+ SG_ ESP_statusChecksum : 0|8@1+ (1,0) [0|0] "" X
+ SG_ ESP_statusCounter : 8|4@1+ (1,0) [0|0] "" X
+ SG_ ESP_steeringAngleQF : 27|1@1+ (1,0) [0|0] "" X
+ SG_ ESP_yawRateQF : 26|1@1+ (1,0) [0|0] "" X
 
 CM_ BO_ 605 "Bytes change when toggling between FSD and AP, as well as Traffic Light and Stop Sign Control in TACC";
 


### PR DESCRIPTION
Solves this error:

```
op juggle 2a251bf8a265ff32/00000035--ed4ea771ee/0
Checking system → [✔]
Running command → tools/plotjuggler/juggle.py 2a251bf8a265ff32/00000035--ed4ea771ee/0 │
──────────────────────────────────────────────────────────────────────────────────────┘

QStandardPaths: wrong permissions on runtime directory /mnt/wslg/runtime-dir, 0777 instead of 0700
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:08<00:00,  8.31s/it]
QStandardPaths: wrong permissions on runtime directory /mnt/wslg/runtime-dir, 0777 instead of 0700
Loading compatible plugins from directory:  "/home/dzid_/sunnypilot/tools/plotjuggler/bin"
"libcapnp-0.7.0.so" :  "Failed to extract plugin meta data from '/home/dzid_/sunnypilot/tools/plotjuggler/bin/libcapnp-0.7.0.so'"
"libcapnp-json-0.7.0.so" :  "Failed to extract plugin meta data from '/home/dzid_/sunnypilot/tools/plotjuggler/bin/libcapnp-json-0.7.0.so'"
"libcapnp-rpc-0.7.0.so" :  "Failed to extract plugin meta data from '/home/dzid_/sunnypilot/tools/plotjuggler/bin/libcapnp-rpc-0.7.0.so'"
"libcapnpc-0.7.0.so" :  "Failed to extract plugin meta data from '/home/dzid_/sunnypilot/tools/plotjuggler/bin/libcapnpc-0.7.0.so'"
"libDataLoadCSV.so is a DataLoader plugin"
"libDataLoadRlog.so is a DataLoader plugin"
"libDataLoadULog.so is a DataLoader plugin"
terminate called after throwing an instance of 'std::runtime_error'
  what():  [tesla_model3_party.dbc:296] bad SG: SG_ ESP_absBrakeEvent2: 22|2@1+ (1,0) [0|0] "" X
Stack trace (most recent call last):
#22   Object "", at 0xffffffffffffffff, in 
#21   Object "/home/dzid_/sunnypilot/tools/plotjuggler/bin/plotjuggler", at 0x64560b67233d, in _start
#20   Source "../csu/libc-start.c", line 360, in __libc_start_main_impl [0x733c44c2a28a]
#19   Source "../sysdeps/nptl/libc_start_call_main.h", line 58, in __libc_start_call_main [0x733c44c2a1c9]
#18   Source "/tmp/plotjuggler/plotjuggler_app/main.cpp", line 422, in main [0x64560b6708d7]
#17   Source "/tmp/plotjuggler/plotjuggler_app/mainwindow.cpp", line 247, in MainWindow [0x64560b6c5103]
#16   Source "/tmp/plotjuggler/plotjuggler_app/mainwindow.cpp", line 589, in loadAllPlugins [0x64560b6bbc9e]
#15   Source "/tmp/plotjuggler/plotjuggler_app/mainwindow.cpp", line 621, in initializePlugins [0x64560b6b9953]
#14   Object "/usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.13", at 0x733c456cd85d, in 
#13   Source "/tmp/plotjuggler/build/plotjuggler_plugins/DataStreamCereal/DataStreamCereal_autogen/EWIEGA46WW/moc_datastream_cereal.cpp", line 186, in qt_plugin_instance [0x733c385250dc]
#12   Source "/tmp/plotjuggler/plotjuggler_plugins/DataStreamCereal/datastream_cereal.cpp", line 32, in DataStreamCereal [0x733c385273b0]
#11   Source "/tmp/plotjuggler/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp", line 18, in RlogMessageParser [0x733c3853300b]
#10   Source "/tmp/plotjuggler/plotjuggler_plugins/DataLoadRlog/rlog_parser.cpp", line 47, in loadDBC [0x733c38532a58]
#9    Source "/tmp/plotjuggler/3rdparty/opendbc/can/dbc.cc", line 238, in dbc_lookup [0x733c3853e4bb]
#8    Source "/tmp/plotjuggler/3rdparty/opendbc/can/dbc.cc", line 214, in dbc_parse [0x733c3853ddda]
#7    Source "/tmp/plotjuggler/3rdparty/opendbc/can/dbc.cc", line 145, in dbc_parse_from_stream [0x733c3851efc6]
#6    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x733c450bb127, in __cxa_throw
#5    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x733c450a5a48, in std::terminate()
#4    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x733c450bae9b, in 
#3    Object "/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.33", at 0x733c450a5ffd, in 
#2    Source "./stdlib/abort.c", line 79, in abort [0x733c44c288fe]
#1    Source "../sysdeps/posix/raise.c", line 26, in raise [0x733c44c4527d]
#0  | Source "./nptl/pthread_kill.c", line 89, in __pthread_kill_internal
    | Source "./nptl/pthread_kill.c", line 78, in __pthread_kill_implementation
      Source "./nptl/pthread_kill.c", line 44, in __pthread_kill [0x733c44c9eb2c]
Aborted (Signal sent by tkill() 31257 1000)
Aborted (core dumped)
```