### PR TITLE
Honda - add pitch compensation to Nidec

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -12,8 +12,8 @@ from opendbc.car.interfaces import CarControllerBase
 VisualAlert = structs.CarControl.HUDControl.VisualAlert
 LongCtrlState = structs.CarControl.Actuators.LongControlState
 
-
 MAX_PITCH_COMPENSATION = 1.5  # m/s^2
+
 
 def compute_gb_honda_bosch(accel, speed):
   # TODO returns 0s, is unused


### PR DESCRIPTION
Honda Nidecs benefit from pitch compensation for gas and brake.   Have been testing this for a month on an openpilot fork.

Adding this change in a similar manner as the Bosch change in earlier versions of https://github.com/commaai/opendbc/pull/2488

Todo:
- [x] Await upstream of https://github.com/commaai/opendbc/pull/2488
- [x] Rebaseline with any further changes in https://github.com/commaai/opendbc/pull/2488
- [ ] Separate PR needed to fix gas control, to make the impact of this fix more obvious in a test route
- [ ] Create pre and post testroutes with this fix