### PR TITLE
Honda: Remove future-platform FW from ACURA_RDX_3G, part 2

### DIFF
--- a/opendbc/car/honda/fingerprints.py
+++ b/opendbc/car/honda/fingerprints.py
@@ -730,7 +730,6 @@ FW_VERSIONS = {
     ],
     (Ecu.shiftByWire, 0x18da0bf1, None): [
       b'54008-TJB-A520\x00\x00',
-      b'54008-TJB-A530\x00\x00',
     ],
     (Ecu.transmission, 0x18da1ef1, None): [
       b'28102-5YK-A610\x00\x00',


### PR DESCRIPTION
Missed one in #2778.