### PR TITLE
Honda - add back removed 2020 RDX fingerprint

### DIFF
--- a/opendbc/car/honda/fingerprints.py
+++ b/opendbc/car/honda/fingerprints.py
@@ -758,6 +758,7 @@ FW_VERSIONS = {
     (Ecu.eps, 0x18da30f1, None): [
       b'39990-TJB-A030\x00\x00',
       b'39990-TJB-A040\x00\x00',
+      b'39990-TJB-A130\x00\x00',
     ],
   },
   CAR.HONDA_RIDGELINE: {


### PR DESCRIPTION
add back 2020 RDX fingerprint removed in https://github.com/commaai/opendbc/pull/2778

source: https://github.com/commaai/openpilot/commit/8c2bec03af58add66dd2ab72ca852d30879cb06f