### PR TITLE
CI: bugfix of tests by pinning pycapnp to 2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
   "numpy",
   "crcmod",
   "tqdm",
-  "pycapnp",
+  "pycapnp==2.1.0",
   "pycryptodome",
 ]
 


### PR DESCRIPTION
Pipelines broke since last night https://github.com/commaai/opendbc/actions/runs/17701582104/job/50307962453 

(also seen in sunnypilot) due to a pycapnp update from `2.1.0` to `2.2.0`, this pins so we are back to "working order" but probably we should embrace the change? i'm unfamiliar with the change tho.