### PR TITLE
use parent env in dbc/SConscript

### DIFF
--- a/opendbc/dbc/SConscript
+++ b/opendbc/dbc/SConscript
@@ -1,7 +1,5 @@
-import os
+Import("env")
 from pathlib import Path
-
-env = Environment(ENV=os.environ)
 
 generator = File("generator/generator.py")
 


### PR DESCRIPTION
else scons doesn't find `opendbc` in `openpilot/Dockerfile.openpilot`