### PR TITLE
Honda: Adjust TJA flag behavior

### DIFF
--- a/opendbc/car/honda/hondacan.py
+++ b/opendbc/car/honda/hondacan.py
@@ -121,7 +121,7 @@ def create_steering_control(packer, CAN, apply_torque, lkas_active, tja_control)
   }
 
   if tja_control:
-    values["STEER_DOWN_TO_ZERO"] = 1
+    values["STEER_DOWN_TO_ZERO"] = lkas_active
 
   return packer.make_can_msg("STEERING_CONTROL", CAN.lkas, values)
 


### PR DESCRIPTION
The fix in #2832 contained an unintended behavior change, setting the TJA flag all the time on supported cars rather than only when lkas_active. I'm not sure it matters, but it's only been tested with lkas_active, so change that back.