### PR TITLE
Nissan Altima 2024 uses harness A, which is different from B

### DIFF
--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -72,7 +72,12 @@ class CAR(Platforms):
     NissanCarSpecs(mass=1610, wheelbase=2.705)
   )
   NISSAN_ALTIMA = NissanPlatformConfig(
-    [NissanCarDocs("Nissan Altima 2019-20, 2024", car_parts=CarParts.common([CarHarness.nissan_b]))],
+    [NissanCarDocs("Nissan Altima 2019-20", car_parts=CarParts.common([CarHarness.nissan_b]))],
+    NissanCarSpecs(mass=1492, wheelbase=2.824)
+  )
+
+  NISSAN_ALTIMA_2024 = NissanPlatformConfig(
+    [NissanCarDocs("Nissan Altima 2024")],
     NissanCarSpecs(mass=1492, wheelbase=2.824)
   )
 


### PR DESCRIPTION
Nissan Altima 2024 uses harness A, which is different from the pre-facelift harness B

I've moved the new Altima to a separate platform

