### PR TITLE
Honda - update to 8 degree mount for passport

### DIFF
--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -109,7 +109,7 @@ class HondaCarDocs(CarDocs):
     else:
       harness = CarHarness.nidec
 
-    if CP.carFingerprint in (CAR.HONDA_PILOT_4G,):
+    if CP.carFingerprint in (CAR.HONDA_PILOT_4G, CAR.HONDA_PASSPORT_4G):
       self.car_parts = CarParts([Device.threex_angled_mount, harness])
     else:
       self.car_parts = CarParts.common([harness])


### PR DESCRIPTION
HONDA_PASSPORT_4G test route a703d058f4e05aeb/00000008--f169423024 shows a 9 degree calibration.

Thus 8-degree-mount should be used similar to HONDA_PILOT_4G.