### PR TITLE
doco/website: Add footnote to VW-group and Tesla cars to prevent user confusion about where harness connects (option 1 - brand-agnostic footnote)

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -189,6 +189,10 @@ CarFootnote = namedtuple("CarFootnote", ["text", "column", "docs_only", "setup_n
 
 
 class CommonFootnote(Enum):
+  NON_CAMERA_HARNESS = CarFootnote(
+    "The harness used in this model is not a windshield camera harness but one that plugs" +
+    "into a car gateway box, usually located in the driver footwell area.",
+    Column.MODEL)
   EXP_LONG_AVAIL = CarFootnote(
     "openpilot Longitudinal Control (Alpha) is available behind a toggle; " +
     "the toggle is only available in non-release branches such as `devel` or `nightly-dev`.",

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -3,7 +3,7 @@ from enum import Enum, IntFlag
 from opendbc.car import ACCELERATION_DUE_TO_GRAVITY, Bus, CarSpecs, DbcDict, PlatformConfig, Platforms
 from opendbc.car.lateral import AngleSteeringLimits, ISO_LATERAL_ACCEL
 from opendbc.car.structs import CarParams, CarState
-from opendbc.car.docs_definitions import CarDocs, CarFootnote, CarHarness, CarParts, Column
+from opendbc.car.docs_definitions import CommonFootnote, CarFootnote, CarDocs, CarHarness, CarParts, Column
 from opendbc.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
 Ecu = CarParams.Ecu
@@ -25,14 +25,14 @@ class Footnote(Enum):
 class TeslaCarDocsHW3(CarDocs):
   package: str = "All"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.tesla_a]))
-  footnotes: list[Enum] = field(default_factory=lambda: [Footnote.HW_TYPE, Footnote.SETUP])
+  footnotes: list[Enum] = field(default_factory=lambda: [CommonFootnote.NON_CAMERA_HARNESS, Footnote.HW_TYPE, Footnote.SETUP])
 
 
 @dataclass
 class TeslaCarDocsHW4(CarDocs):
   package: str = "All"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.tesla_b]))
-  footnotes: list[Enum] = field(default_factory=lambda: [Footnote.HW_TYPE, Footnote.SETUP])
+  footnotes: list[Enum] = field(default_factory=lambda: [CommonFootnote.NON_CAMERA_HARNESS, Footnote.HW_TYPE, Footnote.SETUP])
 
 
 @dataclass

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -5,7 +5,7 @@ from enum import Enum, IntFlag, StrEnum
 from opendbc.car import Bus, CanBusBase, CarSpecs, DbcDict, PlatformConfig, Platforms, structs, uds
 from opendbc.can import CANDefine
 from opendbc.car.common.conversions import Conversions as CV
-from opendbc.car.docs_definitions import CarFootnote, CarHarness, CarDocs, CarParts, Column, \
+from opendbc.car.docs_definitions import CommonFootnote, CarFootnote, CarHarness, CarDocs, CarParts, Column, \
                                                      Device
 from opendbc.car.fw_query_definitions import EcuAddrSubAddr, FwQueryConfig, Request, p16
 from opendbc.car.vin import Vin
@@ -219,15 +219,22 @@ class Footnote(Enum):
 @dataclass
 class VWCarDocs(CarDocs):
   package: str = "Adaptive Cruise Control (ACC) & Lane Assist"
-  car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.vw_j533]))
 
   def init_make(self, CP: structs.CarParams):
-    self.footnotes.append(Footnote.VW_EXP_LONG)
-    if "SKODA" in CP.carFingerprint:
-      self.footnotes.append(Footnote.SKODA_HEATED_WINDSHIELD)
+    harness = CarHarness.vw_j533          # Var used in preparation for multi-harness future (e.g. MEB platform)
 
     if CP.carFingerprint in (CAR.VOLKSWAGEN_CRAFTER_MK2, CAR.VOLKSWAGEN_TRANSPORTER_T61):
-      self.car_parts = CarParts([Device.threex_angled_mount, CarHarness.vw_j533])
+      self.car_parts = CarParts([Device.threex_angled_mount, harness])
+    else:
+      self.car_parts = CarParts([Device.threex, harness])
+
+    self.footnotes.append(Footnote.VW_EXP_LONG)
+
+    if harness == CarHarness.vw_j533:
+      self.footnotes.append(CommonFootnote.NON_CAMERA_HARNESS)
+
+    if "SKODA" in CP.carFingerprint:
+      self.footnotes.append(Footnote.SKODA_HEATED_WINDSHIELD)
 
     if abs(CP.minSteerSpeed - CarControllerParams.DEFAULT_MIN_STEER_SPEED) < 1e-3:
       self.min_steer_speed = 0


### PR DESCRIPTION
Follow-up from https://github.com/commaai/openpilot/pull/36325

The Comma website is missing information for VW car users informing them that the J533 harness doesn't connect to the usual location on the windshield camera as advertised on the Comma website. This omission caused users to be confused and their Comma installation delayed when the harness connector didn't match the camera connector which they expected to plug into. People think they got the wrong connector, have to go to Discord etc.

This change fixes the customer experience by adding a footnote that directs the users to connect to the correct module under the dash. The copy of the note is generic so that it can potentially be reused for other cars whose harness doesn't plug into the windshield camera, starting with Tesla already in this PR.

---

The generic, brand-agnostic copy solution option here has the benefit of not creating too many footnotes in CARS.md, but is slightly less specific which may lead to continued user confusion queries in brand-specific Discords. But perhaps a lot of footnotes in CARS.md is a non-issue (no-one reads that file?), and having more specific instructions about the harness location on the website is more important (that is what the alternative option PR https://github.com/commaai/opendbc/pull/2842 does).

Thoughts?