### PR TITLE
doco/website: Add footnote to VW-group cars to prevent user confusion about where harness connects (option 2 - brand-specific footnote)

### DIFF
--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -214,20 +214,31 @@ class Footnote(Enum):
     "Model-years 2022 and beyond may have a combined CAN gateway and BCM, which is supported by openpilot " +
     "in software, but doesn't yet have a harness available from the comma store.",
     Column.HARDWARE)
+  VW_J533_HARNESS_CONNECTION_LOCATION = CarFootnote(
+    "The J533 harness used in this model is not a windshield camera harness but one that plugs" +
+    "into the J533 gateway box, usually located in the driver footwell area.",
+    Column.MODEL)
 
 
 @dataclass
 class VWCarDocs(CarDocs):
   package: str = "Adaptive Cruise Control (ACC) & Lane Assist"
-  car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.vw_j533]))
 
   def init_make(self, CP: structs.CarParams):
-    self.footnotes.append(Footnote.VW_EXP_LONG)
-    if "SKODA" in CP.carFingerprint:
-      self.footnotes.append(Footnote.SKODA_HEATED_WINDSHIELD)
+    harness = CarHarness.vw_j533          # Var used in preparation for multi-harness future (e.g. MEB platform)
 
     if CP.carFingerprint in (CAR.VOLKSWAGEN_CRAFTER_MK2, CAR.VOLKSWAGEN_TRANSPORTER_T61):
-      self.car_parts = CarParts([Device.threex_angled_mount, CarHarness.vw_j533])
+      self.car_parts = CarParts([Device.threex_angled_mount, harness])
+    else:
+      self.car_parts = CarParts([Device.threex, harness])
+
+    self.footnotes.append(Footnote.VW_EXP_LONG)
+
+    if harness == CarHarness.vw_j533:
+      self.footnotes.append(Footnote.VW_J533_HARNESS_CONNECTION_LOCATION)
+
+    if "SKODA" in CP.carFingerprint:
+      self.footnotes.append(Footnote.SKODA_HEATED_WINDSHIELD)
 
     if abs(CP.minSteerSpeed - CarControllerParams.DEFAULT_MIN_STEER_SPEED) < 1e-3:
       self.min_steer_speed = 0


### PR DESCRIPTION
Follow-up from https://github.com/commaai/openpilot/pull/36325

The Comma website is missing information for VW car users informing them that the J533 harness doesn't connect to the usual location on the windshield camera as advertised on the Comma website. This omission caused users to be confused and their Comma installation delayed when the harness connector didn't match the camera connector which they expected to plug into. People think they got the wrong connector, have to go to Discord etc.

This change fixes the customer experience by adding a footnote that directs the users to connect to the correct module under the dash.

---

The brand-specific copy solution option here leads to creation of more footnotes in CARS.md as more footnotes are added into respective brands' `values.py` files, but it gives the customer a clearer guidance about where to plug the harness, likely reducing some Discord back-and-forths, consumers sending devices back etc. The CARS.md would end up with one footnote for each brand, but this might be a good tradeoff for getting greater end-customer clarity on the website.
The brand-agnostic, more generic copy alternative is in PR https://github.com/commaai/opendbc/pull/2841