### PR TITLE
Re-open: HKG: 2021 Kia Xceed PHEV

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -565,14 +565,17 @@ FW_VERSIONS = {
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00CD__ SCC F-CUP      1.00 1.00 99110-J7500         ',
       b'\xf1\x00CD__ SCC F-CUP      1.00 1.02 99110-J7000         ',
+      b'\xf1\x00CDph SCC F-CUP      1.00 1.01 99110-CR100         ',
     ],
     (Ecu.eps, 0x7d4, None): [
       b'\xf1\x00CD  MDPS C 1.00 1.06 56310-XX000 4CDEC106',
       b'\xf1\x00CDT MDPS C 1.00 1.00 56310-XX000 4CDTC100',
+      b'\xf1\x00CDe MDPS C 1.00 1.01 56310-XX000 4CDHC101',
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00CD  LKAS AT EUR LHD 1.00 1.01 99211-J7000 B40',
       b'\xf1\x00CDT LKAS AT EUR LHD 1.00 1.01 99211-J7210 521',
+      b'\xf1\x00CD2 LKAS AT EUR LHD 1.00 1.01 99211-CR010 621',
     ],
     (Ecu.abs, 0x7d1, None): [
       b'\xf1\x00CD ESC \x03 102\x18\x08\x05 58920-J7350',

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -506,7 +506,7 @@ class CAR(Platforms):
   KIA_CEED = HyundaiPlatformConfig(
     [HyundaiCarDocs("Kia Ceed 2019-21", car_parts=CarParts.common([CarHarness.hyundai_e]))],
     CarSpecs(mass=1450, wheelbase=2.65, steerRatio=13.75, tireStiffnessFactor=0.5),
-    flags=HyundaiFlags.LEGACY,
+    flags=HyundaiFlags.LEGACY | HyundaiFlags.HYBRID,
   )
   KIA_EV6 = HyundaiCanFDPlatformConfig(
     [


### PR DESCRIPTION
**From:** https://github.com/commaai/opendbc/pull/2708
_______________________________________________________________________________________________________________________
### Closed by accident

**Earlier comments:**
[jyoung8607](https://github.com/jyoung8607): _Kia Ceed and XCeed are indeed very close: https://en.wikipedia.org/wiki/Kia_Ceed#XCeed_

_We need to rework how the HYBRID flag is set for HKG in general first, otherwise we'll end up having to add a bunch of unnecessary platform permutations.__ (https://github.com/commaai/opendbc/pull/2708#pullrequestreview-3323517469)

[jyoung8607](https://github.com/jyoung8607): _Xceed will need an additional CarDocs entry at a minimum_ (https://github.com/commaai/opendbc/pull/2708#discussion_r2420205063)

[jyoung8607](https://github.com/jyoung8607): _We can't just add the HYBRID flag for all Ceed, that will break the non-hybrid cars. We could potentially add XCeed/Hybrid permutations, but ideally HYBRID should be auto-detected instead._ (https://github.com/commaai/opendbc/pull/2708#discussion_r2420210041)

_______________________________________________________________________________________________________________________

I added kia xceed fingerprint to the kia ceed port, since they have the same CD platform. everything works as expected, also added the "hybrid" flag in values.py in order to get it to work.

Used Harness B for my car.

Validation

Dongle ID: 22703002ddbe2a08
Route: 22703002ddbe2a08/0000000e--083b76c42c/0

if you need anything from me, tell me