### PR TITLE
Honda: Fix HONDA_PILOT specs

### DIFF
--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -337,7 +337,7 @@ class CAR(Platforms):
       HondaCarDocs("Honda Pilot 2016-22", min_steer_speed=12. * CV.MPH_TO_MS),
       HondaCarDocs("Honda Passport 2019-25", "All", min_steer_speed=12. * CV.MPH_TO_MS),
     ],
-    HONDA_PILOT_4G.specs,
+    CarSpecs(mass=4278 * CV.LB_TO_KG, wheelbase=2.86, centerToFrontRatio=0.428, steerRatio=16.0, tireStiffnessFactor=0.444),  # as spec
     radar_dbc_dict('acura_ilx_2016_can_generated'),
     flags=HondaFlags.NIDEC_ALT_SCM_MESSAGES | HondaFlags.HAS_ALL_DOOR_STATES,
   )


### PR DESCRIPTION
In April, the original PR for the HONDA_PILOT_4G was merged.

Within that PR, a commit (https://github.com/commaai/opendbc/pull/2118/commits/7dbc832e536e7841c4a3ccb41e2b9b828246ffc1) changed HONDA_PILOT specs to be linked to HONDA_PILOT_4G, specifically, HONDA_PILOT_4G.specs

Then, in August, another commit was merged (https://github.com/commaai/opendbc/commit/d01d4a32a79b8a83c8fa5515f1d705840d033ab6#diff-17c61409dcbc81cf28dfe470a447966a238a5b641910726d04993c4a5b16debe) to updated the specs of HONDA_PILOT_4G. Since HONDA_PILOT specs are linked, its specs are also changed.

This seems odd that a car, which had long been discontinued, would have its specs changed.

This commit is to restore the HONDA_PILOT specs to what it originally was prior to the updates to HONDA_PILOT_4G, while retaining the new specs for HONDA_PILOT_4G