### PR TITLE
Clarify without supercruise for Chevrolet Bolt EUV

### DIFF
--- a/opendbc/car/gm/values.py
+++ b/opendbc/car/gm/values.py
@@ -157,7 +157,7 @@ class CAR(Platforms):
   )
   CHEVROLET_BOLT_EUV = GMPlatformConfig(
     [
-      GMCarDocs("Chevrolet Bolt EUV 2022-23", "Premier or Premier Redline Trim, both without Super Cruise Package", video="https://youtu.be/xvwzGMUA210"),
+      GMCarDocs("Chevrolet Bolt EUV 2022-23", "Premier or Premier Redline Trim, without Super Cruise Package", video="https://youtu.be/xvwzGMUA210"),
       GMCarDocs("Chevrolet Bolt EV 2022-23", "2LT Trim with Adaptive Cruise Control Package"),
     ],
     GMCarSpecs(mass=1669, wheelbase=2.63779, steerRatio=16.8, centerToFrontRatio=0.4, tireStiffnessFactor=1.0),


### PR DESCRIPTION
Some poor prospective user bought Premier with supercruise and thought it was just Premier Redline trim with supercruise that is unworkable.

Add a comma (hey that's the name of the company!) to make it clear.

https://discord.com/channels/469524606043160576/524592892627517450/1432768163921133598