### PR TITLE
add 2026 kia carnival SX fingerprints

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1211,6 +1211,7 @@ FW_VERSIONS = {
       b'\xf1\x00KA4 MFC  AT USA LHD 1.00 1.01 99210-R0100 230710',
       b'\xf1\x00KA4 MFC  AT USA LHD 1.00 1.05 99210-R0000 201221',
       b'\xf1\x00KA4 MFC  AT USA LHD 1.00 1.06 99210-R0000 220221',
+      b'\xf1\x00KA4HMFC  AT USA LHD 1.00 1.00 99210-R0700 250324',
       b'\xf1\x00KA4CMFC  AT CHN LHD 1.00 1.01 99211-I4000 210525',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
@@ -1219,6 +1220,7 @@ FW_VERSIONS = {
       b'\xf1\x00KA4_ SCC FHCUP      1.00 1.02 99110-R0000         ',
       b'\xf1\x00KA4_ SCC FHCUP      1.00 1.03 99110-R0000         ',
       b'\xf1\x00KA4c SCC FHCUP      1.00 1.01 99110-I4000         ',
+      b'\xf1\x00KAhe RDR -----      1.00 1.01 99110-ES500         ',
     ],
   },
   CAR.KIA_K8_HEV_1ST_GEN: {


### PR DESCRIPTION
Adding fingerprints for 2026 kia carnival

Validation
* Dongle ID:  aacf80047c4955eb
* Route:  00000003--edd34f68ce
