### PR TITLE
Tja_D_Stat value of 7 indicates hands free bluecruise is active.

### DIFF
--- a/opendbc/dbc/ford_lincoln_base_pt.dbc
+++ b/opendbc/dbc/ford_lincoln_base_pt.dbc
@@ -12615,7 +12615,7 @@ VAL_ 394 AccStopStat_D_Dsply 3 "PressResume" 2 "Stopped" 1 "ResumeReady" 0 "NoDi
 VAL_ 394 AccTrgDist2_D_Dsply 15 "DIST_ACTIVE_13_Farthest" 14 "DIST_ACTIVE_12" 13 "DIST_ACTIVE_11" 12 "DIST_ACTIVE_10" 11 "DIST_ACTIVE_9" 10 "DIST_ACTIVE_8" 9 "DIST_ACTIVE_7" 8 "DIST_ACTIVE_6" 7 "DIST_ACTIVE_5" 6 "DIST_ACTIVE_4" 5 "DIST_ACTIVE_3" 4 "DIST_ACTIVE_2" 3 "DIST_ACTIVE_1_Closest" 2 "DIST_ACTIVE_No_Target" 1 "DIST_STANDBY" 0 "DIST_OFF";
 VAL_ 394 AccStopRes_B_Dsply 1 "Yes" 0 "No";
 VAL_ 394 TjaWarn_D_Rq 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "HardTakeOverLevel2" 2 "HardTakeOverLevel1" 1 "TrafficJamAssistCancel" 0 "NoWarning";
-VAL_ 394 Tja_D_Stat 7 "NotUsed_1" 6 "ActiveWarningRight" 5 "ActiveWarningLeft" 4 "ActiveInterventionRight" 3 "ActiveInterventionLeft" 2 "Active" 1 "Standby" 0 "Off";
+VAL_ 394 Tja_D_Stat 7 "HandsFreeActive" 6 "ActiveWarningRight" 5 "ActiveWarningLeft" 4 "ActiveInterventionRight" 3 "ActiveInterventionLeft" 2 "Active" 1 "Standby" 0 "Off";
 VAL_ 394 TjaMsgTxt_D_Dsply 7 "NotUsed_4" 6 "NotUsed_3" 5 "NotUsed_2" 4 "NotUsed_1" 3 "TurnOnAdaptCruiseControl" 2 "TrafficJamAssistSelected" 1 "TrafficJamAssistUnavailabl" 0 "NoMessage";
 VAL_ 394 IaccLamp_D_Rq 3 "NotUsed_2" 2 "NotUsed_1" 1 "DisplayIaccIcon" 0 "DoNotDisplayIaccIcon";
 VAL_ 394 AccMsgTxt_D2_Rq 15 "NotUsed_1" 14 "NCC_Enabled_Warning" 13 "IACC_TJA_Selected" 12 "ACC_TJA_Selected" 11 "IACC_Selected" 10 "Press_Brake_To_Hold" 9 "Only_Following_In_Low_Spd" 8 "TJA_Unavailable" 7 "Shift_Down" 6 "IACC_Unavailable" 5 "ACC_Selected" 4 "ACC_Overridden" 3 "Brake_Capacity_Warning" 2 "ACC_Cancelled" 1 "ACC_Unavailable" 0 "No_Text";


### PR DESCRIPTION
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 
* Route: 

24574459dd7fb3e0/2024-05-20--11-24-02

Segments of this route where Tja_D_Stat is equal to 7 line up perfectly with BlueCruise active on the cluster.