### PR TITLE
Honda: Disable more routes causing failing CI

### DIFF
--- a/opendbc/car/tests/routes.py
+++ b/opendbc/car/tests/routes.py
@@ -30,6 +30,7 @@ non_tested_cars = [
   HONDA.ACURA_TLX_2G,
   HONDA.HONDA_NBOX_2G,
   HONDA.ACURA_MDX_4G_MMR,
+  HONDA.HONDA_CITY_7G
 ]
 
 
@@ -116,7 +117,7 @@ routes = [
   CarTestRoute("b1c832ad56b6bc9d/00000010--debfcf5867", HONDA.HONDA_CIVIC_2022),  # 2025 Civic Hatch Hybrid with new eCVT transmission
   CarTestRoute("f9c43864cf057d05/2024-01-15--23-01-20", HONDA.HONDA_PILOT_4G),  # TODO: Replace with a newer route
   CarTestRoute("f39cf149898833ff/0000002b--54f3fae045", HONDA.HONDA_ACCORD_11G),
-  CarTestRoute("56b2cf1dacdcd033/00000017--d24ffdb376", HONDA.HONDA_CITY_7G),  # Brazilian model
+  # CarTestRoute("56b2cf1dacdcd033/00000017--d24ffdb376", HONDA.HONDA_CITY_7G),  # Brazilian model
   CarTestRoute("2dc4489d7e1410ca/00000001--bbec3f5117", HONDA.HONDA_CRV_6G),
   CarTestRoute("a703d058f4e05aeb/00000008--f169423024", HONDA.HONDA_PASSPORT_4G),
 


### PR DESCRIPTION
There is a missing route (`56b2cf1dacdcd033/00000048--3267801001`) currently causing CI failures on multiple sunnypilot PRs ([Source 1](https://github.com/sunnypilot/opendbc/actions/runs/19123671685/job/54649250007?pr=359) [Source 2](https://github.com/sunnypilot/opendbc/actions/runs/19092590155/job/54647368247?pr=362)). This PR comments out the missing route, hopefully enabling CI to pass again (pending commaai/openpilot#36098, which would ideally fix/avoid this permanently).

~~Note that the Source 2 run also failed on another route (`63568e3e2f56c8ad/0000000a--a254e90429`), but I do not see that in the current master. Perhaps that is an artifact of sunnypilot/opendbc being out of date.~~ Upon further investigation, I was able to find [a commit](https://github.com/sunnypilot/opendbc/commit/1fe1026d8797720240f2c9164f6fbeb0e6dd6ff9) that my branch was missing which commented out the second failing route temporarily. That failure can be disregarded.