### PR TITLE
Remove `STEER_ERROR_MAX` dead code in Mazda `values.py`

### DIFF
--- a/opendbc/car/mazda/values.py
+++ b/opendbc/car/mazda/values.py
@@ -19,7 +19,6 @@ class CarControllerParams:
   STEER_DRIVER_ALLOWANCE = 15     # allowed driver torque before start limiting
   STEER_DRIVER_MULTIPLIER = 1     # weight driver torque
   STEER_DRIVER_FACTOR = 1         # from dbc
-  STEER_ERROR_MAX = 350           # max delta between torque cmd and torque motor
   STEER_STEP = 1  # 100 Hz
 
   def __init__(self, CP):


### PR DESCRIPTION
Mazdas use TorqueDriverLimited torque steering limits and not TorqueMotorLimited.

`STEER_ERROR_MAX` appears to only be relevant for Toyota and Chrysler since they call `apply_meas_steer_torque_limits()` (which calls `apply_dist_to_meas_limits()` that uses `LIMITS.STEER_ERROR_MAX`) via their car controller classes. Mazda car controller calls `apply_driver_steer_torque_limits()` instead.