### PR TITLE
Toyota: prevent roll in ICE after pressing resume while wanting to stay stopped

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -181,17 +181,14 @@ class CarController(CarControllerBase):
     else:
       # if user engages at a stop with foot on brake, PCM starts in a special cruise standstill mode. on resume press,
       # brakes can take a while to ramp up causing a lurch forward. prevent resume press until planner wants to move.
+      # don't use CC.cruiseControl.resume since it is gated on CS.cruiseState.standstill which goes false for 3s after resume press
       # TODO: hybrids do not have this issue and can stay stopped after resume press, whitelist them
-      #should_resume = CC.cruiseControl.resume or actuators.accel > 0
       should_resume = actuators.accel > 0
       if should_resume:
         self.standstill_req = False
 
       if not should_resume and CS.out.cruiseState.standstill:
         self.standstill_req = True
-
-      # if CS.out.standstill and CS.out.cruiseState.standstill and CC.enabled and not self.last_enabled:
-      #   self.standstill_req = True
 
     self.last_standstill = CS.out.standstill
 


### PR DESCRIPTION
Closes https://github.com/commaai/openpilot/issues/36684

This allows the planner 3s to go after user presses resume without rolling forward if it doesn't, just like stock!