### PR TITLE
gm: Refactor to make branches clearer and remove unreachable `else`

### DIFF
--- a/opendbc/safety/modes/gm.h
+++ b/opendbc/safety/modes/gm.h
@@ -198,13 +198,12 @@ static safety_config gm_init(uint16_t param) {
   static const CanMsg GM_CAM_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true},  // pt bus
                                           {0x1E1, 2, 7, .check_relay = false}, {0x184, 2, 8, .check_relay = true}};  // camera bus
 
-  gm_hw = GET_FLAG(param, GM_PARAM_HW_CAM) ? GM_CAM : GM_ASCM;
-
-  if (gm_hw == GM_ASCM) {
-    gm_long_limits = &GM_ASCM_LONG_LIMITS;
-  } else if (gm_hw == GM_CAM) {
+  if (GET_FLAG(param, GM_PARAM_HW_CAM)) {
+    gm_hw = GM_CAM;
     gm_long_limits = &GM_CAM_LONG_LIMITS;
   } else {
+    gm_hw = GM_ASCM;
+    gm_long_limits = &GM_ASCM_LONG_LIMITS;
   }
 
   bool gm_cam_long = false;


### PR DESCRIPTION
## Description
This makes incremental progress towards #2944. In this PR, the logic in *opendbc/safety/modes/gm.h* is simplified to remove the need for an empty `else` block. This gets us improved coverage and decreased complexity for free.

## Verification
`opendbc/safety/tests/test.sh --report` (with branch coverage enabled) on master:
<img width="1029" height="23" alt="image" src="https://github.com/user-attachments/assets/62d9fbeb-2152-412f-ae29-a42d4a080a63" />

`opendbc/safety/tests/test.sh --report` on this branch:
<img width="1029" height="23" alt="image" src="https://github.com/user-attachments/assets/16206049-3e54-433d-9f5b-7f09eb3395f7" />