### PR TITLE
safety: remove redundant checks in psa, rivian, and toyota

### DIFF
--- a/opendbc/safety/modes/psa.h
+++ b/opendbc/safety/modes/psa.h
@@ -27,14 +27,7 @@ static uint8_t psa_get_counter(const CANPacket_t *msg) {
 }
 
 static uint32_t psa_get_checksum(const CANPacket_t *msg) {
-  uint8_t chksum = 0;
-  if (msg->addr == PSA_HS2_DAT_MDD_CMD_452) {
-    chksum = msg->data[5] & 0xFU;
-  } else if (msg->addr == PSA_HS2_DYN_ABR_38D) {
-    chksum = msg->data[5] & 0xFU;
-  } else {
-  }
-  return chksum;
+  return msg->data[5] & 0xFU;
 }
 
 static uint8_t _psa_compute_checksum(const CANPacket_t *msg, uint8_t chk_ini, int chk_pos) {

--- a/opendbc/safety/modes/rivian.h
+++ b/opendbc/safety/modes/rivian.h
@@ -3,22 +3,13 @@
 #include "opendbc/safety/declarations.h"
 
 static uint8_t rivian_get_counter(const CANPacket_t *msg) {
-  uint8_t cnt = 0;
-  if ((msg->addr == 0x208U) || (msg->addr == 0x150U)) {
-    // Signal: ESP_Status_Counter, VDM_PropStatus_Counter
-    cnt = msg->data[1] & 0xFU;
-  }
-  return cnt;
+  // Signal: ESP_Status_Counter, VDM_PropStatus_Counter
+  return msg->data[1] & 0xFU;
 }
 
 static uint32_t rivian_get_checksum(const CANPacket_t *msg) {
-  uint8_t chksum = 0;
-  if ((msg->addr == 0x208U) || (msg->addr == 0x150U)) {
-    // Signal: ESP_Status_Checksum, VDM_PropStatus_Checksum
-    chksum = msg->data[0];
-  } else {
-  }
-  return chksum;
+  // Signal: ESP_Status_Checksum, VDM_PropStatus_Checksum
+  return msg->data[0];
 }
 
 static uint8_t _rivian_compute_checksum(const CANPacket_t *msg, uint8_t poly, uint8_t xor_output) {

--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -77,12 +77,7 @@ static uint32_t toyota_get_checksum(const CANPacket_t *msg) {
 }
 
 static bool toyota_get_quality_flag_valid(const CANPacket_t *msg) {
-
-  bool valid = false;
-  if (msg->addr == 0x260U) {
-    valid = !GET_BIT(msg, 3U);  // STEER_ANGLE_INITIALIZING
-  }
-  return valid;
+  return !GET_BIT(msg, 3U);  // STEER_ANGLE_INITIALIZING
 }
 
 static void toyota_rx_hook(const CANPacket_t *msg) {


### PR DESCRIPTION
## Description
This makes incremental progress towards #2944. In this PR, the logic in *opendbc/safety/modes/{psa,rivian,toyota}.h* is simplified by removing redundant address checks in rivian_get_counter, toyota_get_quality_flag_valid, and {psa,rivian}_get_checksum as these functions are securely guarded by the safety whitelist. This gets us improved coverage and decreased complexity for free.

## Validation:
`opendbc/safety/modes/tests/test.sh --report` on master:
<img width="1029" height="122" alt="image" src="https://github.com/user-attachments/assets/fd7d4d8e-8da3-4ac8-963d-ccb418dc05cd" />
Overall branch coverage: 92.1%

`opendbc/safety/modes/tests/test.sh --report` on this branch:
<img width="1029" height="122" alt="image" src="https://github.com/user-attachments/assets/9e11a8cc-e97e-4ca5-a8af-2dc82caa134a" />
Overall branch coverage: 92.4%