### PR TITLE
CI: use tags for cppcheck update

### DIFF
--- a/.github/workflows/update-cppcheck.yml
+++ b/.github/workflows/update-cppcheck.yml
@@ -17,7 +17,11 @@ jobs:
       - name: Get latest cppcheck version
         id: version
         run: |
-          LATEST=$(curl -fsSL https://api.github.com/repos/danmar/cppcheck/releases/latest | jq -r .tag_name)
+          # Tags are sorted by time (newest first), so get the first version-like tag
+          LATEST=$(curl -fsSL "https://api.github.com/repos/danmar/cppcheck/tags?per_page=20" | \
+            jq -r '.[].name' | \
+            grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | \
+            head -n 1)
           echo "vers=$LATEST" >> "$GITHUB_OUTPUT"
       - name: Update VERS in install.sh
         run: |


### PR DESCRIPTION
cppcheck doesn't always create a release for each tag