### PR TITLE
ty: Fix typo in ignored rule causing failing CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,7 @@ call-non-callable = "ignore"
 invalid-argument-type = "ignore"
 
 # Dynamic type patterns (e.g., values converted from Number to list in __init__)
-non-subscriptable = "ignore"
+not-subscriptable = "ignore"
 unsupported-operator = "ignore"
 
 # Return types with complex callable signatures


### PR DESCRIPTION
This bug/typo, introduced in #2993 ([source](https://github.com/commaai/opendbc/pull/2993/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R154)), causes CI to fail on both macOS and Ubuntu. I'm a bit unclear as to why this didn't fail in any of the three ty PRs merged 2 days ago.

### Example of failing CI
Visible in #2996 and #2947
<img width="695" height="105" alt="image" src="https://github.com/user-attachments/assets/de255a54-310f-4f05-9fb9-d4d219a56503" />

### Example of CI passing on this branch
<img width="680" height="82" alt="image" src="https://github.com/user-attachments/assets/8f95fe86-b377-442f-8fbb-53f93b7178ab" />

### ty failures within CI run
3 instances of this error:
<img width="795" height="281" alt="image" src="https://github.com/user-attachments/assets/e7b372ef-9555-4d73-b597-5c94ec907c84" />
a single instance of this:
<img width="753" height="204" alt="image" src="https://github.com/user-attachments/assets/f75e47c0-d088-43b4-bc3e-6b79c224ef89" />
