### PR TITLE
crcmod -> crcmod-plus

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ urls = { "homepage" = "https://github.com/commaai/opendbc" }
 dependencies = [
   "scons",
   "numpy",
-  "crcmod",
+  "crcmod-plus",
   "tqdm",
   "pycapnp==2.1.0",
   "pycryptodome",


### PR DESCRIPTION
Started getting errors during uv install because `crcmod` hasn't been updated since 2010

`crcmod-plus` is designed to be drop in: https://github.com/commaai/opendbc