### PR TITLE
Chrysler: fix safety build on clang

### DIFF
--- a/opendbc/safety/modes/chrysler.h
+++ b/opendbc/safety/modes/chrysler.h
@@ -39,8 +39,8 @@ typedef enum {
 } ChryslerPlatform;
 static ChryslerPlatform chrysler_platform;
 
-#define CHRYSLER_ADDR(name) (chrysler_platform == CHRYSLER_RAM_DT ? CHRYSLER_RAM_DT_##name : \
-                             chrysler_platform == CHRYSLER_RAM_HD ? CHRYSLER_RAM_HD_##name : CHRYSLER_##name)
+#define CHRYSLER_ADDR(name) ((uint32_t)((chrysler_platform == CHRYSLER_RAM_DT) ? CHRYSLER_RAM_DT_##name : \
+                                        ((chrysler_platform == CHRYSLER_RAM_HD) ? CHRYSLER_RAM_HD_##name : CHRYSLER_##name)))
 
 static uint32_t chrysler_get_checksum(const CANPacket_t *msg) {
   int checksum_byte = GET_LEN(msg) - 1U;


### PR DESCRIPTION
This was using a GCC-only extension
```bash
clang -o opendbc/safety/tests/libsafety/safety.os -c -Wall -Wextra -Werror -nostdlib -fno-builtin -std=gnu11 -Wfatal-errors -Wno-pointer-to-int-cast -g -O0 -fno-omit-frame-pointer -fprofile-arcs -ftest-coverage -DALLOW_DEBUG -fPIC -I. -Iopendbc/safety/board opendbc/safety/tests/libsafety/safety.c
In file included from opendbc/safety/tests/libsafety/safety.c:13:
In file included from ./opendbc/safety/safety.h:17:
./opendbc/safety/modes/chrysler.h:189:15: fatal error: initializer element is not a compile-time constant
    {.msg = {{CHRYSLER_RAM_DT_ADDRS.EPS_2, 0, 8, 100U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
scons: *** [opendbc/safety/tests/libsafety/safety.os] Error 1
```