### PR TITLE
Toyota: whitelist hybrids for standstill resume behaviour

### DIFF
--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -183,13 +183,13 @@ class CarController(CarControllerBase):
       # brakes can take a while to ramp up causing a lurch forward. prevent resume press until planner wants to move.
       # don't use CC.cruiseControl.resume since it is gated on CS.cruiseState.standstill which goes false for 3s after resume press
       # whitelist hybrids as they do not have this issue and can stay stopped after resume press
-      toyota_hybrid = self.CP.flags & ToyotaFlags.HYBRID
-      should_resume = actuators.accel > 0
-      if should_resume or toyota_hybrid:
-        self.standstill_req = False
+      if not self.CP.flags & ToyotaFlags.HYBRID.value:
+        should_resume = actuators.accel > 0
+        if should_resume:
+          self.standstill_req = False
 
-      if not should_resume and CS.out.cruiseState.standstill and not toyota_hybrid:
-        self.standstill_req = True
+        if not should_resume and CS.out.cruiseState.standstill:
+          self.standstill_req = True
 
     self.last_standstill = CS.out.standstill
 


### PR DESCRIPTION
Implements TODO to whitelist Toyota hybrid vehicles, which do not exhibit the standstill resume lurch seen on non-hybrids.

UPDATED: better hybrid check logic to ensure correct standstill behaviour

No functional change for non-hybrid vehicles.

Dongle ID: N/A
Route: N/A
