### PR TITLE
cleanup CARS.md generation

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -338,15 +338,15 @@
 |Toyota|RAV4 Hybrid 2019-21|All|[Upstream](#upstream)|
 |Toyota|RAV4 Hybrid 2022|All|[Upstream](#upstream)|
 |Toyota|RAV4 Hybrid 2023-25|All|[Upstream](#upstream)|
-|Toyota|RAV4 Prime 2021-23|All|[Community](#community)|
+|Toyota|RAV4 Prime 2021-23|All|[Custom](#secoc-cars-with-recoverable-keys)|
 |Toyota|RAV4 Prime 2024-25|Any|[Not compatible](#can-bus-security)|
 |Toyota|Sequoia 2023-25|Any|[Not compatible](#can-bus-security)|
 |Toyota|Sienna 2018-20|All|[Upstream](#upstream)|
-|Toyota|Sienna 2021-23|All|[Community](#community)|
+|Toyota|Sienna 2021-23|All|[Custom](#secoc-cars-with-recoverable-keys)|
 |Toyota|Sienna 2024-25|Any|[Not compatible](#can-bus-security)|
 |Toyota|Tundra 2022-25|Any|[Not compatible](#can-bus-security)|
 |Toyota|Venza 2021-25|Any|[Not compatible](#can-bus-security)|
-|Toyota|Yaris (Non-US only) 2020, 2023|All|[Community](#community)|
+|Toyota|Yaris (Non-US only) 2020, 2023|All|[Custom](#secoc-cars-with-recoverable-keys)|
 |Volkswagen|Arteon 2018-23|Adaptive Cruise Control (ACC) & Lane Assist|[Upstream](#upstream)|
 |Volkswagen|Arteon eHybrid 2020-23|Adaptive Cruise Control (ACC) & Lane Assist|[Upstream](#upstream)|
 |Volkswagen|Arteon R 2020-23|Adaptive Cruise Control (ACC) & Lane Assist|[Upstream](#upstream)|
@@ -412,7 +412,14 @@ openpilot is installed, but custom forks may allow their use.
 
 Vehicles in this category are not considered plug-and-play. Software support is included in upstream openpilot, but
 these vehicles might not have a harness in the comma store, or the physical install might be at an unusual or cumbersome
-location, or they might need unusual configuration after install.
+location, or they might need unusual configuration after install. These vehicles will not work with release builds of
+openpilot, but depending on the situation, development builds or custom forks may allow their use.
+
+### SecOC cars with recoverable keys
+
+For a small subset of SecOC-protected vehicles, tools may be available in the community to recover the SecOC keys. These
+tools, and the recovery process, are not part of openpilot. If supplied with a valid SecOC key, development builds or
+custom forks may work with these vehicles. Release builds of openpilot don't support SecOC.
 
 ## Dashcam
 

--- a/opendbc/car/CARS_template.md
+++ b/opendbc/car/CARS_template.md
@@ -32,7 +32,14 @@ openpilot is installed, but custom forks may allow their use.
 
 Vehicles in this category are not considered plug-and-play. Software support is included in upstream openpilot, but
 these vehicles might not have a harness in the comma store, or the physical install might be at an unusual or cumbersome
-location, or they might need unusual configuration after install.
+location, or they might need unusual configuration after install. These vehicles will not work with release builds of
+openpilot, but depending on the situation, development builds or custom forks may allow their use.
+
+### SecOC cars with recoverable keys
+
+For a small subset of SecOC-protected vehicles, tools may be available in the community to recover the SecOC keys. These
+tools, and the recovery process, are not part of openpilot. If supplied with a valid SecOC key, development builds or
+custom forks may work with these vehicles. Release builds of openpilot don't support SecOC.
 
 ## Dashcam
 

--- a/opendbc/car/docs.py
+++ b/opendbc/car/docs.py
@@ -32,7 +32,7 @@ def get_params_for_docs(platform) -> CarParams:
   cp_platform = platform if platform in interfaces else MOCK.MOCK
   CP: CarParams = interfaces[cp_platform].get_params(cp_platform, fingerprint=gen_empty_fingerprint(),
                                                      car_fw=[CarParams.CarFw(ecu=CarParams.Ecu.unknown)],
-                                                     alpha_long=True, is_release=False, docs=True)
+                                                     alpha_long=True, is_release=True, docs=True)
   return CP
 
 

--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -256,11 +256,9 @@ class CarDocs:
     self.longitudinal_control = CP.openpilotLongitudinalControl and not CP.alphaLongitudinalAvailable
 
     if self.merged and CP.dashcamOnly:
-      if self.support_type != SupportType.REVIEW:
+      if self.support_type not in (SupportType.CUSTOM, SupportType.REVIEW):
         self.support_type = SupportType.DASHCAM
         self.support_link = "#dashcam"
-      else:
-        self.support_link = "#under-review"
 
     # longitudinal column
     op_long = "Stock"

--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -97,9 +97,9 @@ class ToyotaCarDocs(CarDocs):
 
 
 @dataclass
-class ToyotaCommunityCarDocs(ToyotaCarDocs):
-  support_type: SupportType = SupportType.COMMUNITY
-  support_link: str = "#community"
+class ToyotaSecOcCarDocs(ToyotaCarDocs):
+  support_type: SupportType = SupportType.CUSTOM
+  support_link: str = "#secoc-cars-with-recoverable-keys"
 
 
 @dataclass
@@ -288,11 +288,11 @@ class CAR(Platforms):
     flags=ToyotaFlags.RADAR_ACC | ToyotaFlags.ANGLE_CONTROL,
   )
   TOYOTA_RAV4_PRIME = ToyotaSecOCPlatformConfig(
-    [ToyotaCommunityCarDocs("Toyota RAV4 Prime 2021-23", min_enable_speed=MIN_ACC_SPEED)],
+    [ToyotaSecOcCarDocs("Toyota RAV4 Prime 2021-23", min_enable_speed=MIN_ACC_SPEED)],
     CarSpecs(mass=4372. * CV.LB_TO_KG, wheelbase=2.68, steerRatio=16.88, tireStiffnessFactor=0.5533),
   )
   TOYOTA_YARIS = ToyotaSecOCPlatformConfig(
-    [ToyotaCommunityCarDocs("Toyota Yaris (Non-US only) 2020, 2023", min_enable_speed=MIN_ACC_SPEED)],
+    [ToyotaSecOcCarDocs("Toyota Yaris (Non-US only) 2020, 2023", min_enable_speed=MIN_ACC_SPEED)],
     CarSpecs(mass=1170, wheelbase=2.55, steerRatio=14.80, tireStiffnessFactor=0.5533),
     flags=ToyotaFlags.RADAR_ACC,
   )
@@ -307,7 +307,7 @@ class CAR(Platforms):
     flags=ToyotaFlags.NO_STOP_TIMER,
   )
   TOYOTA_SIENNA_4TH_GEN = ToyotaSecOCPlatformConfig(
-    [ToyotaCommunityCarDocs("Toyota Sienna 2021-23", min_enable_speed=MIN_ACC_SPEED)],
+    [ToyotaSecOcCarDocs("Toyota Sienna 2021-23", min_enable_speed=MIN_ACC_SPEED)],
     CarSpecs(mass=4625. * CV.LB_TO_KG, wheelbase=3.06, steerRatio=17.8, tireStiffnessFactor=0.444),
   )
 


### PR DESCRIPTION
Require `is_release = True` for cars to appear in openpilot CARS.md, so that dashcam-mode car ports can be released to operate on development builds without appearing in docs and in the comma shop.

Toyota SecOC cars were the only ones currently set up this way. This change made their opendbc CARS.md appearance more wrong than it already was, so add some docs around pseudo-supported SecOC cars.