### PR TITLE
Car diff: fix PR comment

### DIFF
--- a/.github/workflows/car_diff.yml
+++ b/.github/workflows/car_diff.yml
@@ -1,0 +1,42 @@
+name: car diff
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  comment:
+    name: comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
+    steps:
+    - name: Wait for car diff
+      uses: lewagon/wait-on-check-action@v1.3.4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        check-name: car diff
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        allowed-conclusions: success
+        wait-interval: 20
+    - name: Download car diff
+      uses: dawidd6/action-download-artifact@v6
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow: tests.yml
+        workflow_conclusion: ''
+        pr: ${{ github.event.number }}
+        name: car_diff_${{ github.event.number }}
+        path: .
+        allow_forks: true
+    - name: Comment car diff on PR
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        filePath: diff.txt
+        comment_tag: car_diff
+        pr_number: ${{ github.event.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,11 +77,12 @@ jobs:
     - name: Test car diff
       if: github.event_name == 'pull_request'
       run: source setup.sh && python opendbc/car/tests/car_diff.py | tee diff.txt
-    - name: Comment PR
+    - name: Upload diff
       if: always() && github.event_name == 'pull_request'
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: '[ -s diff.txt ] && gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} -F diff.txt || true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: car_diff_${{ github.event.number }}
+        path: diff.txt
     - name: Update refs
       if: github.repository == 'commaai/opendbc' && github.ref == 'refs/heads/master'
       run: source setup.sh && python opendbc/car/tests/car_diff.py --update-refs

--- a/opendbc/car/tests/car_diff.py
+++ b/opendbc/car/tests/car_diff.py
@@ -262,7 +262,7 @@ def main(platform=None, segments_per_platform=10, update_refs=False, all_platfor
     platforms = get_changed_platforms(cwd, database, interfaces)
 
   if not platforms:
-    print("No car changes detected", file=sys.stderr)
+    print("No car changes detected")
     return 0
 
   segments = {p: database.get(p, [])[:segments_per_platform] for p in platforms}


### PR DESCRIPTION
This fixes the PR comment from car_diff on external PRs.
The car diff and comment part are separated to prevent RCE.
