### PR TITLE
CarDocs: Update car package name

### DIFF
--- a/opendbc/car/extra_cars.py
+++ b/opendbc/car/extra_cars.py
@@ -55,8 +55,8 @@ class CAR(Platforms):
 
   EXTRA_HYUNDAI = ExtraPlatformConfig(
     [
-      CommunityCarDocs("Hyundai Palisade 2023-24", package="HDA2"),
-      CommunityCarDocs("Kia Telluride 2023-24", package="HDA2"),
+      CommunityCarDocs("Hyundai Palisade 2023-24", "Highway Driving Assist II"),
+      CommunityCarDocs("Kia Telluride 2023-24", "Highway Driving Assist II"),
     ],
   )
 


### PR DESCRIPTION
- HDA II = Highway Driving Assist II
- All cars using HDA II don't use the abbreviation for `package` 

Example in [CARS.md](https://github.com/commaai/opendbc/blob/master/docs/CARS.md): 

<img width="2124" height="296" alt="cars-md-example" src="https://github.com/user-attachments/assets/109c622a-57b0-4369-a11a-0a87a149c6d4" />
