### PR TITLE
Fix Subaru message definitions for HighBeamAssist and static messages

### DIFF
--- a/opendbc/safety/modes/subaru.h
+++ b/opendbc/safety/modes/subaru.h
@@ -35,9 +35,9 @@
 
 #define MSG_SUBARU_ES_UDS_Request        0x787U
 
-#define MSG_SUBARU_ES_HighBeamAssist     0x121U
-#define MSG_SUBARU_ES_STATIC_1           0x22aU
-#define MSG_SUBARU_ES_STATIC_2           0x325U
+#define MSG_SUBARU_ES_HighBeamAssist     0x22AU
+#define MSG_SUBARU_ES_STATIC_1           0x325U
+#define MSG_SUBARU_ES_STATIC_2           0x121U
 
 #define SUBARU_MAIN_BUS 0U
 #define SUBARU_ALT_BUS  1U

--- a/opendbc/safety/tests/test_subaru.py
+++ b/opendbc/safety/tests/test_subaru.py
@@ -25,9 +25,9 @@ class SubaruMsg(enum.IntEnum):
   ES_LKAS_State     = 0x322
   ES_Infotainment   = 0x323
   ES_UDS_Request    = 0x787
-  ES_HighBeamAssist = 0x121
-  ES_STATIC_1       = 0x22a
-  ES_STATIC_2       = 0x325
+  ES_HighBeamAssist = 0x22A
+  ES_STATIC_1       = 0x325
+  ES_STATIC_2       = 0x121
 
 
 SUBARU_MAIN_BUS = 0


### PR DESCRIPTION
<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.
-->
Validation
* Dongle ID: 
* Route: 

I think these were wrong previously. My car has these messages in these different addresses

<img width="423" height="55" alt="image" src="https://github.com/user-attachments/assets/5cd3b706-a614-463c-bc74-ab99f622ef53" />

<img width="431" height="99" alt="image" src="https://github.com/user-attachments/assets/41555567-f505-4ad2-ba68-24bdc37dbe8b" />
