### PR TITLE
Subaru: Add FW for 2020 Subaru Legacy

### DIFF
--- a/opendbc/car/subaru/fingerprints.py
+++ b/opendbc/car/subaru/fingerprints.py
@@ -57,6 +57,7 @@ FW_VERSIONS = {
       b'\xa1  \x02\x02',
       b'\xa1  \x03\x02',
       b'\xa1  \x03\x03',
+      b'\xa1  \x04\x00',
       b'\xa1  \x04\x01',
       b'\xa1  \x04\x02',
     ],
@@ -65,10 +66,12 @@ FW_VERSIONS = {
       b'\x9b\xc0\x11\x02',
     ],
     (Ecu.fwdCamera, 0x787, None): [
+      b'\x00\x00eJ\x00\x1f@ \x19\x00',
       b'\x00\x00e\x80\x00\x1f@ \x19\x00',
       b'\x00\x00e\x9a\x00\x00\x00\x00\x00\x00',
     ],
     (Ecu.engine, 0x7e0, None): [
+      b'\xbc"a@\x07',
       b'\xde"a0\x07',
       b'\xde,\xa0@\x07',
       b'\xe2"a0\x07',


### PR DESCRIPTION
Add various missing firmware for the 2020 Subaru Legacy. Resolves #3088.

**Route:** `5fb61bbf18cab256/00000000--0177160c2b`

Thanks to Legacy owner @cwwindyhill620-ctrl!