### PR TITLE
Honda City 7G: set STEER_MAX to 4096

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -200,6 +200,10 @@ class CarInterface(CarInterfaceBase):
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 3840], [0, 3840]]
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
 
+    elif candidate == CAR.HONDA_CITY_7G:
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]
+      CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
+
     else:
       ret.steerActuatorDelay = 0.15
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 2560], [0, 2560]]


### PR DESCRIPTION
## Summary

The Honda City 7G (Brazil 2023, Bosch Radarless, EPS `39990-T14-B030`) currently falls through to the default `else` block with `STEER_MAX=2560`. This adds a dedicated block with `STEER_MAX=4096`, matching sibling Bosch EPS cars (Civic Bosch, Civic 2022, Accord, CRV Hybrid, Insight, Honda E) that already use 4096.

## Change

```python
elif candidate == CAR.HONDA_CITY_7G:
    ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]
    CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
```

+4 lines in `interface.py`. No other files changed. Stays on the standard Torque controller with online learning.

## Test Route

**Route:** `56b2cf1dacdcd033|0000000a--3249198b0c` (34 segments, ~34 min)

### Car Params (from route)
- `carFingerprint`: HONDA_CITY_7G
- `lateralTuning`: torque (online learning)
- `torqueBP`: [0, 4096]
- `torqueV`: [0, 4096]
- `steerRatio`: 19.00
- `latAccelFactor`: 1.200 (seed)

### Torque Analysis
| Metric | Value |
|--------|-------|
| Control samples | 203,221 |
| Engaged | 81.9% |
| Max commanded torque | **4096 / 4096 (100%)** |
| P95 | 4096 |
| Samples > 2048 (50%) | 22,527 (11.1%) |
| Samples > 3686 (90%) | 14,245 (7.0%) |
| **Saturation events** | **7,191 (3.5%)** |
| EPS faults | **0** |

### Saturation Detail
14 of 34 segments hit the 4096 ceiling. Saturation occurred across the full speed range (0-100 km/h) and at steering angles from -22.5° to +26.4°. With the default 2560, approximately 11% of engaged driving would be under-torqued.

| Segment | Samples | Speed | Angle range |
|---------|---------|-------|-------------|
| 3-4 | 1,740 | 0-61 km/h | -21.5° to 26.4° |
| 8-11 | 1,807 | 80-100 km/h | -11.9° to 16.2° |
| 19 | 365 | 74-85 km/h | -14.0° to -11.0° |
| 26-28 | 1,400 | 50-63 km/h | -22.5° to 19.1° |
| 30-31 | 1,598 | 59-61 km/h | -20.1° to 25.2° |

### Why 4096 is appropriate
1. Same Bosch EPS platform as Civic Bosch/Accord/CRV Hybrid (all 4096 upstream)
2. 3.5% saturation at 4096 proves the car uses the full range on normal roads
3. Zero EPS faults across the entire route
4. 7 prior tuning iterations at 4096 with zero faults