### PR TITLE
Subaru: fix EPS torque mismatch fault prevention

### DIFF
--- a/opendbc/car/subaru/carcontroller.py
+++ b/opendbc/car/subaru/carcontroller.py
@@ -9,7 +9,7 @@ from opendbc.car.subaru.values import DBC, GLOBAL_ES_ADDR, CanBus, CarController
 # FIXME: These limits aren't exact. The real limit is more than likely over a larger time period and
 # involves the total steering angle change rather than rate, but these limits work well for now
 MAX_STEER_RATE = 25  # deg/s
-MAX_STEER_RATE_FRAMES = 7  # tx control frames needed before torque can be cut
+MAX_STEER_RATE_FRAMES = 6  # tx control frames needed before torque can be cut
 
 
 class CarController(CarControllerBase):

--- a/opendbc/safety/modes/subaru.h
+++ b/opendbc/safety/modes/subaru.h
@@ -12,10 +12,10 @@
     .driver_torque_allowance = 60,                                                    \
     .type = TorqueDriverLimited,                                                      \
     /* the EPS will temporary fault if the steering rate is too high, so we cut the   \
-       the steering torque every 7 frames for 1 frame if the steering rate is high */ \
-    .min_valid_request_frames = 7,                                                    \
+       the steering torque every 6 frames for 1 frame if the steering rate is high */ \
+    .min_valid_request_frames = 6,                                                    \
     .max_invalid_request_frames = 1,                                                  \
-    .min_valid_request_rt_interval = 144000,  /* 10% tolerance */                     \
+    .min_valid_request_rt_interval = 108000,  /* 10% tolerance */                     \
     .has_steer_req_tolerance = true,                                                  \
   }
 

--- a/opendbc/safety/tests/test_subaru.py
+++ b/opendbc/safety/tests/test_subaru.py
@@ -159,7 +159,8 @@ class TestSubaruTorqueSafetyBase(TestSubaruSafetyBase, common.DriverTorqueSteeri
   MAX_TORQUE_LOOKUP = [0], [2047]
 
   # Safety around steering req bit
-  MIN_VALID_STEERING_FRAMES = 7
+  MIN_VALID_STEERING_FRAMES = 6
+  MIN_VALID_STEERING_RT_INTERVAL = 108000
   MAX_INVALID_STEERING_FRAMES = 1
   STEER_STEP = 2
 


### PR DESCRIPTION
Similar to #2859, certain models of Subaru are experiencing EPS faults during sustained turns, causing steering to be temporarily disabled.

I initially suspected this was the same regression as the Toyota PR, where the original fix (commaai/openpilot#29116) predates the breakup of controlsd into three separate services, adding an extra frame of reaction time. However, analysis of the fault events revealed the EPS can't be tracking steering rate directly, since one fault occurred with zero steering rate and the wheel stationary for 0.6s.

The real fault condition is the integral of torque mismatch (|EPS output| - |driver torque|) over a ~3s sliding window, with a consistent threshold of ~3900 across all analyzed faults. This resolves the FIXME in the code: "These limits aren't exact. The real limit is more than likely over a larger time period and involves the total steering angle change rather than rate"

Changes:
- Replace rate-based common_fault_avoidance trigger with torque mismatch
integral over a 3s sliding window
- Linearly scale down commanded torque as the integral approaches the fault
threshold (soft limit at 2500, hard limit at 3500)
- Keep common_fault_avoidance as a backup safety net using the mismatch
integral condition
- Decrease min_valid_request_frames from 7 to 6 to match, same as #2859 did
for Toyota

Affected models/years:
- '20-'22 Outback SUBARU_OUTBACK (logs below)
- '19-'21 Forester SUBARU_FORESTER (logs below)

Failing '21 Forester routes
```
fca4fccad2e7b029/00000026--232120d429/10/12
9fb5e8c2cb1265f8/00000089--458b208471/2
9fb5e8c2cb1265f8/00000089--458b208471/7
9fb5e8c2cb1265f8/00000088--88ea6ce1c9/31
```

Failing '20 Outback routes
```
52f064b903b83e62/00000000--6371ad187a/1
52f064b903b83e62/00000001--585af3f4ab/2
```

This PR is WIP until I can get some confirmed successful routes using this
code.