### PR TITLE
VW: Rename aux bus to alt

### DIFF
--- a/opendbc/car/__init__.py
+++ b/opendbc/car/__init__.py
@@ -80,7 +80,6 @@ DbcDict = dict[StrEnum, str]
 
 class Bus(StrEnum):
   pt = auto()
-  aux = auto()
   cam = auto()
   radar = auto()
   adas = auto()


### PR DESCRIPTION
The VW carport by default maps internal panda bus 1 to "aux", when this is added to the CANParser in carstate it causes a crash unless it is defined here, another solution would be just renaming the bus inside values.py if we don't want to update init.

<img width="443" height="486" alt="image" src="https://github.com/user-attachments/assets/1fa2f5e4-baaf-4a0b-a1cd-b379f4c21821" />

