### PR TITLE
HKG: add KIA_SPORTAGE_5TH_GEN (NQ5) to CANFD_FUZZY_WHITELIST

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -687,6 +687,7 @@ PART_NUMBER_FW_PATTERN = re.compile(b'(?<=[0-9][.,][0-9]{2} )([0-9]{5}[-/]?[A-Z]
 
 # We've seen both ICE and hybrid for these platforms, and they have hybrid descriptors (e.g. MQ4 vs MQ4H)
 CANFD_FUZZY_WHITELIST = {CAR.KIA_SORENTO_4TH_GEN, CAR.KIA_SORENTO_HEV_4TH_GEN, CAR.KIA_K8_HEV_1ST_GEN,
+                         CAR.KIA_SPORTAGE_5TH_GEN,
                          # TODO: the hybrid variant is not out yet
                          CAR.KIA_CARNIVAL_4TH_GEN}
 


### PR DESCRIPTION
## Description

Adds `CAR.KIA_SPORTAGE_5TH_GEN` to `CANFD_FUZZY_WHITELIST` in `opendbc/car/hyundai/values.py`.

## Problem

The KIA Sportage 5th Gen (NQ5) is a CAN-FD car that is currently blacklisted from fuzzy fingerprinting. Cars with firmware versions not present in the exact fingerprint database cannot be matched at all — both exact and fuzzy matching fail, resulting in "unsupported car" on the device.

## Fix

Adding the NQ5 to `CANFD_FUZZY_WHITELIST` enables platform code-based fuzzy matching. This is safe because:

- Both ICE and Hybrid variants share the same platform (`KIA_SPORTAGE_5TH_GEN`) and platform code (`NQ5`)
- The same approach is already used for other Kia CAN-FD platforms (Sorento 4th Gen, K8, Carnival)

## Testing

Tested on a KIA NQ5 Sportage that was previously showing as unsupported.