### PR TITLE
volkswagen: fix brake pressure normalization and add EPB parking brak…

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -79,11 +79,11 @@ class CarState(CarStateBase):
       if self.CP.flags & VolkswagenFlags.STOCK_HCA_PRESENT:
         ret.carFaultedNonCritical = bool(cam_cp.vl["HCA_01"]["EA_Ruckfreigabe"]) or cam_cp.vl["HCA_01"]["EA_ACC_Sollstatus"] > 0  # EA
 
-      ret.brake = pt_cp.vl["ESP_05"]["ESP_Bremsdruck"] / 250.0  # FIXME: this is pressure in Bar, not sure what OP expects
+      ret.brake = max(0, pt_cp.vl["ESP_05"]["ESP_Bremsdruck"]) / 250.0
       brake_pedal_pressed = bool(pt_cp.vl["Motor_14"]["MO_Fahrer_bremst"])
       brake_pressure_detected = bool(pt_cp.vl["ESP_05"]["ESP_Fahrer_bremst"])
       ret.brakePressed = brake_pedal_pressed or brake_pressure_detected
-      ret.parkingBrake = bool(pt_cp.vl["Kombi_01"]["KBI_Handbremse"])  # FIXME: need to include an EPB check as well
+      ret.parkingBrake = bool(pt_cp.vl["Kombi_01"]["KBI_Handbremse"]) or pt_cp.vl["EPB_01"]["EPB_Status"] == 1
 
       ret.doorOpen = any([pt_cp.vl["Gateway_72"]["ZV_FT_offen"],
                           pt_cp.vl["Gateway_72"]["ZV_BT_offen"],
@@ -157,7 +157,7 @@ class CarState(CarStateBase):
 
     # Update gas, brakes, and gearshift.
     ret.gasPressed = pt_cp.vl["Motor_3"]["MO3_Pedalwert"] > 0
-    ret.brake = pt_cp.vl["Bremse_5"]["BR5_Bremsdruck"] / 250.0  # FIXME: this is pressure in Bar, not sure what OP expects
+    ret.brake = pt_cp.vl["Bremse_5"]["BR5_Bremsdruck"] / 250.0
     ret.brakePressed = bool(pt_cp.vl["Motor_2"]["MO2_BLS"])
     ret.parkingBrake = bool(pt_cp.vl["Kombi_1"]["Bremsinfo"])
 


### PR DESCRIPTION
Description
Two FIXMEs in the VW MQB carstate:

ret.brake (MQB): ESP_Bremsdruck has offset=-30 in the DBC, which can produce negative values before the first CAN message. Added max(0, ...) clamp. The /250.0 normalization was already correct (maps Bar pressure to 0.0–1.0 as expected by CarState).
ret.parkingBrake (MQB): Added EPB check via EPB_01.EPB_Status == 1 (brake closed). EPB_01 is defined in both MQB and MQBEvo DBCs. On cars without EPB the signal defaults to 0 ("offen"), so no regression.
ret.brake (PQ): The /250.0 was already correct (BR5_Bremsdruck has offset=0, range [0, 250] Bar). Removed the FIXME comment.

Verification
Verified against DBC signal definitions in vw_mqb_2010.dbc and vw_pq35.dbc.
Validation

Dongle ID: N/A — no hardware available
Route: N/A — changes verified against DBC signal definitions (ESP_Bremsdruck offset=-30, EPB_01.EPB_Status values 0=offen, 1=closed, 2=actuating, 3=error)

