### PR TITLE
Subaru: fix FR/RR wheel speed signals swapped

### DIFF
--- a/opendbc/dbc/generator/subaru/_subaru_global.dbc
+++ b/opendbc/dbc/generator/subaru/_subaru_global.dbc
@@ -78,8 +78,8 @@ BO_ 315 G_Sensor: 8 XXX
 BO_ 314 Wheel_Speeds: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ FR : 12|13@1+ (0.057,0) [0|255] "kph" XXX
- SG_ RR : 25|13@1+ (0.057,0) [0|255] "kph" XXX
+ SG_ RR : 12|13@1+ (0.057,0) [0|255] "kph" XXX
+ SG_ FR : 25|13@1+ (0.057,0) [0|255] "kph" XXX
  SG_ FL : 51|13@1+ (0.057,0) [0|255] "kph" XXX
  SG_ RL : 38|13@1+ (0.057,0) [0|255] "kph" XXX
 


### PR DESCRIPTION
Verified using BRZ 6MT drift data - during a left turn, what was labeled FR matched inside (slower) wheel behavior and RR matched outside (faster), which is backwards.

https://connect.comma.ai/057d1cd62625d62c/00000125--d050b42387/595/695