### PR TITLE
Tesla: Add fuzzy fingerprinting support

### DIFF
--- a/opendbc/car/tesla/fuzzy_fp.py
+++ b/opendbc/car/tesla/fuzzy_fp.py
@@ -11,11 +11,13 @@ Ecu = CarParams.Ecu
 # TeMX_SP_XP002p2_0.0.0 (23),XPR003.6.0      -> Model X
 
 FW_PATTERN = re.compile(
-  r'^Te'                           # Tesla prefix
-  r'(?P<platform>[A-Z0-9]+?)_'     # Platform: M3, MYG4, MX
-  r'(?P<variant>[A-Za-z0-9_]+)_'   # Variant: E014p10, Main, SP
-  r'[\d.]+\s*\(\d+\),'             # Version with build
-  r'(?P<ver>[A-Z][A-Z0-9.]+)$'     # Final version: E014.17.00, Y4003.05.4
+    (
+        r'^Te'                           # Tesla prefix
+        r'(?P<platform>[A-Z0-9]+?)_'     # Platform: M3, MYG4, MX
+        r'(?P<variant>[A-Za-z0-9_]+)_'   # Variant: E014p10, Main, SP
+        r'[\d.]+\s*\(\d+\),'             # Version with build
+        r'(?P<ver>[A-Z][A-Z0-9.]+)$'     # Final version: E014.17.00, Y4003.05.4
+    )
 )
 
 def _parse_fw(fw: bytes) -> tuple[str | None, str | None]:

--- a/opendbc/car/tesla/fuzzy_fp.py
+++ b/opendbc/car/tesla/fuzzy_fp.py
@@ -27,7 +27,7 @@ def _parse_fw(fw: bytes) -> tuple[str | None, str | None]:
     m = FW_PATTERN.match(s)
     if m:
       return m.group('platform'), m.group('ver')[0] if m.group('ver') else None
-  except:
+  except Exception:
     pass
   return None, None
 
@@ -38,14 +38,14 @@ def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str,
   for candidate, fws in offline_fw_versions.items():
     expected_platforms: set[str] = set()
     expected_prefixes: set[str] = set()
-    for ecu, versions in fws.items():
+    for _ecu, versions in fws.items():
       for v in versions:
         plat, pref = _parse_fw(v)
         if plat:
           expected_platforms.add(plat)
         if pref:
           expected_prefixes.add(pref)
-    for addr, live_versions in live_fw_versions.items():
+    for _addr, live_versions in live_fw_versions.items():
       for lv in live_versions:
         live_plat, live_pref = _parse_fw(lv)
         if live_plat and live_plat in expected_platforms:

--- a/opendbc/car/tesla/fuzzy_fp.py
+++ b/opendbc/car/tesla/fuzzy_fp.py
@@ -1,0 +1,57 @@
+"""Tesla fuzzy fingerprinting implementation."""
+import re
+from opendbc.car.fw_query_definitions import LiveFwVersions, OfflineFwVersions
+from opendbc.car.structs import CarParams
+
+Ecu = CarParams.Ecu
+
+# Tesla FW version pattern examples:
+# TeM3_E014p10_0.0.0 (16),E014.17.00        -> Model 3
+# TeMYG4_Main_0.0.0 (77),Y4003.05.4          -> Model Y Gen4
+# TeMX_SP_XP002p2_0.0.0 (23),XPR003.6.0      -> Model X
+
+FW_PATTERN = re.compile(
+  r'^Te'                           # Tesla prefix
+  r'(?P<platform>[A-Z0-9]+?)_'     # Platform: M3, MYG4, MX
+  r'(?P<variant>[A-Za-z0-9_]+)_'   # Variant: E014p10, Main, SP
+  r'[\d.]+\s*\(\d+\),'             # Version with build
+  r'(?P<ver>[A-Z][A-Z0-9.]+)$'     # Final version: E014.17.00, Y4003.05.4
+)
+
+def _parse_fw(fw: bytes) -> tuple[str | None, str | None]:
+  """Extract platform and version prefix from FW string."""
+  try:
+    s = fw.decode('utf-8', errors='ignore')
+    m = FW_PATTERN.match(s)
+    if m:
+      return m.group('platform'), m.group('ver')[0] if m.group('ver') else None
+  except:
+    pass
+  return None, None
+
+def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str,
+                          offline_fw_versions: OfflineFwVersions) -> set[str]:
+  """Fuzzy match Tesla firmware versions to car candidates."""
+  candidates: set[str] = set()
+  for candidate, fws in offline_fw_versions.items():
+    expected_platforms: set[str] = set()
+    expected_prefixes: set[str] = set()
+    for ecu, versions in fws.items():
+      for v in versions:
+        plat, pref = _parse_fw(v)
+        if plat:
+          expected_platforms.add(plat)
+        if pref:
+          expected_prefixes.add(pref)
+    for addr, live_versions in live_fw_versions.items():
+      for lv in live_versions:
+        live_plat, live_pref = _parse_fw(lv)
+        if live_plat and live_plat in expected_platforms:
+          candidates.add(candidate)
+          break
+        if live_pref and live_pref in expected_prefixes:
+          candidates.add(candidate)
+          break
+      if candidate in candidates:
+        break
+  return candidates

--- a/opendbc/car/tesla/fuzzy_fp.py
+++ b/opendbc/car/tesla/fuzzy_fp.py
@@ -10,14 +10,14 @@ Ecu = CarParams.Ecu
 # TeMYG4_Main_0.0.0 (77),Y4003.05.4          -> Model Y Gen4
 # TeMX_SP_XP002p2_0.0.0 (23),XPR003.6.0      -> Model X
 
+# Tesla FW regex: ^Te<Platform>_<Variant>_<Version>(<Build>),<FinalVer>
+# Platform: M3, MYG4, MX | Variant: E014p10, Main, SP
 FW_PATTERN = re.compile(
-    (
-        r'^Te'                           # Tesla prefix
-        r'(?P<platform>[A-Z0-9]+?)_'     # Platform: M3, MYG4, MX
-        r'(?P<variant>[A-Za-z0-9_]+)_'   # Variant: E014p10, Main, SP
-        r'[\d.]+\s*\(\d+\),'             # Version with build
-        r'(?P<ver>[A-Z][A-Z0-9.]+)$'     # Final version: E014.17.00, Y4003.05.4
-    )
+    r'^Te' +
+    r'(?P<platform>[A-Z0-9]+?)_' +
+    r'(?P<variant>[A-Za-z0-9_]+)_' +
+    r'[\d.]+\s*\(\d+\),' +
+    r'(?P<ver>[A-Z][A-Z0-9.]+)$'
 )
 
 def _parse_fw(fw: bytes) -> tuple[str | None, str | None]:

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -5,6 +5,7 @@ from opendbc.car.lateral import AngleSteeringLimits, ISO_LATERAL_ACCEL
 from opendbc.car.structs import CarParams, CarState
 from opendbc.car.docs_definitions import CarDocs, CarFootnote, CarHarness, CarParts, Column
 from opendbc.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
+from opendbc.car.tesla.fuzzy_fp import match_fw_to_car_fuzzy
 
 Ecu = CarParams.Ecu
 
@@ -71,7 +72,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.SUPPLIER_SOFTWARE_VERSION_RESPONSE],
       bus=0,
     )
-  ]
+  ],
+  match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )
 
 # Cars with this EPS FW have FSD 14 and use TeslaFlags.FSD_14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ testpaths = [
 
 [tool.codespell]
 quiet-level = 3
-ignore-words-list = "alo,ba,bu,deque,hda,grey,arange"
+ignore-words-list = "Te,alo,ba,bu,deque,hda,grey,arange"
 builtin = "clear,rare,informal,code,names,en-GB_to_en-US"
 check-hidden = true
 


### PR DESCRIPTION
## Summary

- Add fuzzy fingerprinting for Tesla vehicles
- Match FW versions using platform and version prefix
- Supports Model 3, Model Y, and Model X variants

Closes #1917