### PR TITLE
[50 bounty] Move CAN ignition hooks and add test

### DIFF
--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -57,6 +57,10 @@ bool acc_main_on = false;  // referred to as "ACC off" in ISO 15622:2018
 int cruise_button_prev = 0;
 bool safety_rx_checks_invalid = false;
 
+// Ignition detected from CAN messages
+bool ignition_can = false;
+uint32_t ignition_can_cnt = 0U;
+
 // for safety modes with torque steering control
 int desired_torque_last = 0;       // last desired steer torque
 int rt_torque_last = 0;            // last desired torque for real time check
@@ -184,6 +188,9 @@ static bool rx_msg_safety_check(const CANPacket_t *msg,
 }
 
 bool safety_rx_hook(const CANPacket_t *msg) {
+  // Check for CAN ignition signal
+  ignition_can_hook(msg);
+
   bool controls_allowed_prev = controls_allowed;
 
   bool valid = rx_msg_safety_check(msg, &current_safety_config, current_hooks);
@@ -240,6 +247,55 @@ bool safety_tx_hook(CANPacket_t *msg) {
   }
 
   return !relay_malfunction && whitelisted && safety_allowed;
+}
+
+void ignition_can_hook(const CANPacket_t *msg) {
+  if (msg->bus == 0U) {
+    int len = GET_LEN(msg);
+
+    // GM exception
+    if ((msg->addr == 0x1F1U) && (len == 8)) {
+      // SystemPowerMode (2=Run, 3=Crank Request)
+      ignition_can = (msg->data[0] & 0x2U) != 0U;
+      ignition_can_cnt = 0U;
+    }
+
+    // Rivian R1S/T GEN1 exception
+    if ((msg->addr == 0x152U) && (len == 8)) {
+      // 0x152 overlaps with Subaru pre-global which has this bit as the high beam
+      int counter = msg->data[1] & 0xFU;  // max is only 14
+
+      static int prev_counter_rivian = -1;
+      if ((counter == ((prev_counter_rivian + 1) % 15)) && (prev_counter_rivian != -1)) {
+        // VDM_OutputSignals->VDM_EpasPowerMode
+        ignition_can = ((msg->data[7] >> 4U) & 0x3U) == 1U;  // VDM_EpasPowerMode_Drive_On=1
+        ignition_can_cnt = 0U;
+      }
+      prev_counter_rivian = counter;
+    }
+
+    // Tesla Model 3/Y exception
+    if ((msg->addr == 0x221U) && (len == 8)) {
+      // 0x221 overlaps with Rivian which has random data on byte 0
+      int counter = msg->data[6] >> 4;
+
+      static int prev_counter_tesla = -1;
+      if ((counter == ((prev_counter_tesla + 1) % 16)) && (prev_counter_tesla != -1)) {
+        // VCFRONT_LVPowerState->VCFRONT_vehiclePowerState
+        int power_state = (msg->data[0] >> 5U) & 0x3U;
+        ignition_can = power_state == 0x3;  // VEHICLE_POWER_STATE_DRIVE=3
+        ignition_can_cnt = 0U;
+      }
+      prev_counter_tesla = counter;
+    }
+
+    // Mazda exception
+    if ((msg->addr == 0x9EU) && (len == 8)) {
+      ignition_can = (msg->data[0] >> 5) == 0x6U;
+      ignition_can_cnt = 0U;
+    }
+
+  }
 }
 
 static int get_fwd_bus(int bus_num) {

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -77,6 +77,8 @@ bool get_honda_fwd_brake(void);
 void set_honda_alt_brake_msg(bool c);
 void set_honda_bosch_long(bool c);
 int get_honda_hw(void);
+bool get_ignition_can(void);
+uint32_t get_ignition_can_cnt(void);
 """)
 
 class LibSafety:

--- a/opendbc/safety/tests/libsafety/safety.c
+++ b/opendbc/safety/tests/libsafety/safety.c
@@ -202,3 +202,11 @@ void init_tests(void){
   // assumes autopark on safety mode init to avoid a fault. get rid of that for testing
   tesla_autopark = false;
 }
+
+bool get_ignition_can(void) {
+  return ignition_can;
+}
+
+uint32_t get_ignition_can_cnt(void) {
+  return ignition_can_cnt;
+}

--- a/opendbc/safety/tests/test_ignition_can.py
+++ b/opendbc/safety/tests/test_ignition_can.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import unittest
+from opendbc.safety.tests.common import make_msg, libsafety_py as libsafety
+
+class TestIgnitionCan(unittest.TestCase):
+  def setUp(self):
+    libsafety.libsafety.init_tests()
+    # Reset ignition state before each test
+    libsafety.libsafety.set_safety_hooks(0, 0)  # DEFAULT safety mode
+
+  def test_gm_ignition(self):
+    # GM: 0x1F1, bus 0, len 8, data[0] bit 1 set = ignition on
+    msg = make_msg(0, 0x1F1, 8, b'\x02\x00\x00\x00\x00\x00\x00\x00')
+    libsafety.libsafety.safety_rx_hook(msg)
+    self.assertTrue(libsafety.libsafety.get_ignition_can())
+    self.assertEqual(libsafety.libsafety.get_ignition_can_cnt(), 0)
+
+    # Test ignition off
+    msg = make_msg(0, 0x1F1, 8, b'\x00\x00\x00\x00\x00\x00\x00\x00')
+    libsafety.libsafety.safety_rx_hook(msg)
+    self.assertFalse(libsafety.libsafety.get_ignition_can())
+
+  def test_rivian_ignition(self):
+    # Rivian: 0x152, bus 0, len 8, counter increments correctly, data[7] high 4 bits = 1
+    # First msg to set counter
+    msg1 = make_msg(0, 0x152, 8, b'\x00\x00\x00\x00\x00\x00\x00\x10')
+    libsafety.libsafety.safety_rx_hook(msg1)
+    # Second msg with counter +1
+    msg2 = make_msg(0, 0x152, 8, b'\x00\x01\x00\x00\x00\x00\x00\x10')
+    libsafety.libsafety.safety_rx_hook(msg2)
+    self.assertTrue(libsafety.libsafety.get_ignition_can())
+
+    # Test power mode off
+    msg3 = make_msg(0, 0x152, 8, b'\x00\x02\x00\x00\x00\x00\x00\x00')
+    libsafety.libsafety.safety_rx_hook(msg3)
+    self.assertFalse(libsafety.libsafety.get_ignition_can())
+
+  def test_tesla_ignition(self):
+    # Tesla: 0x221, bus 0, len 8, counter increments correctly, data[0] high 3 bits = 3
+    # First msg to set counter
+    msg1 = make_msg(0, 0x221, 8, b'\xE0\x00\x00\x00\x00\x00\x00\x00')  # data[0] = 0xE0 = 0b11100000, high 3 bits 3
+    libsafety.libsafety.safety_rx_hook(msg1)
+    # Second msg with counter +1 (data[6] high 4 bits = 1)
+    msg2 = make_msg(0, 0x221, 8, b'\xE0\x00\x00\x00\x00\x00\x10\x00')
+    libsafety.libsafety.safety_rx_hook(msg2)
+    self.assertTrue(libsafety.libsafety.get_ignition_can())
+
+    # Test power mode off
+    msg3 = make_msg(0, 0x221, 8, b'\x00\x00\x00\x00\x00\x00\x20\x00')
+    libsafety.libsafety.safety_rx_hook(msg3)
+    self.assertFalse(libsafety.libsafety.get_ignition_can())
+
+  def test_mazda_ignition(self):
+    # Mazda: 0x9E, bus 0, len 8, data[0] high 3 bits = 6
+    msg = make_msg(0, 0x9E, 8, b'\xC0\x00\x00\x00\x00\x00\x00\x00')  # 0xC0 = 0b11000000, high 3 bits 6
+    libsafety.libsafety.safety_rx_hook(msg)
+    self.assertTrue(libsafety.libsafety.get_ignition_can())
+
+    # Test ignition off
+    msg = make_msg(0, 0x9E, 8, b'\x00\x00\x00\x00\x00\x00\x00\x00')
+    libsafety.libsafety.safety_rx_hook(msg)
+    self.assertFalse(libsafety.libsafety.get_ignition_can())
+
+  def test_no_false_positives(self):
+    # Test random other messages don't trigger ignition
+    test_addrs = [0x100, 0x200, 0x300, 0x400, 0x500]
+    for addr in test_addrs:
+      msg = make_msg(0, addr, 8, b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF')
+      libsafety.libsafety.safety_rx_hook(msg)
+      self.assertFalse(libsafety.libsafety.get_ignition_can())
+
+    # Test bus != 0, even matching addr shouldn't trigger
+    msg = make_msg(1, 0x1F1, 8, b'\x02\x00\x00\x00\x00\x00\x00\x00')
+    libsafety.libsafety.safety_rx_hook(msg)
+    self.assertFalse(libsafety.libsafety.get_ignition_can())
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Resolves #1834

## Changes:
- Move ignition_can/ignition_can_cnt global variables from panda repo to opendbc safety layer
- Port full ignition_can_hook() implementation, 100% compatible with original panda code, no logic changes
- Automatically call ignition_can_hook() from safety_rx_hook() on all incoming CAN messages, same as panda behavior
- Add complete test coverage:
  * GM ignition signal (0x1F1) test
  * Rivian R1S/T GEN1 ignition signal (0x152 + counter validation) test
  * Tesla Model 3/Y ignition signal (0x221 + counter validation) test
  * Mazda ignition signal (0x9E) test
  * Negative test: ensure non-matching messages / non-bus 0 messages do not trigger false positives

All functionality matches existing panda implementation exactly, no breaking changes to any existing features or safety logic.