### PR TITLE
safety: move CAN ignition hook from panda into opendbc + tests

### DIFF
--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -263,6 +263,12 @@ extern bool acc_main_on; // referred to as "ACC off" in ISO 15622:2018
 extern int cruise_button_prev;
 extern bool safety_rx_checks_invalid;
 
+// CAN-based ignition detection (used by panda)
+extern bool ignition_can;
+extern uint32_t ignition_can_cnt;
+void ignition_can_reset(void);
+void ignition_can_hook(const CANPacket_t *msg);
+
 // for safety modes with torque steering control
 extern int desired_torque_last;       // last desired steer torque
 extern int rt_torque_last;            // last desired torque for real time check

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -70,12 +70,19 @@ void set_timer(uint32_t t);
 void safety_tick_current_safety_config();
 bool safety_config_valid();
 
-void init_tests(void);
+  void init_tests(void);
 
-void set_honda_fwd_brake(bool c);
-bool get_honda_fwd_brake(void);
-void set_honda_alt_brake_msg(bool c);
-void set_honda_bosch_long(bool c);
+  void ignition_can_reset(void);
+  void ignition_can_hook(CANPacket_t *msg);
+  void set_ignition_can(bool c);
+  bool get_ignition_can(void);
+  void set_ignition_can_cnt(uint32_t c);
+  uint32_t get_ignition_can_cnt(void);
+
+  void set_honda_fwd_brake(bool c);
+  bool get_honda_fwd_brake(void);
+  void set_honda_alt_brake_msg(bool c);
+  void set_honda_bosch_long(bool c);
 int get_honda_hw(void);
 """)
 

--- a/opendbc/safety/tests/libsafety/safety.c
+++ b/opendbc/safety/tests/libsafety/safety.c
@@ -89,6 +89,22 @@ bool get_vehicle_moving(void){
   return vehicle_moving;
 }
 
+void set_ignition_can(bool c) {
+  ignition_can = c;
+}
+
+bool get_ignition_can(void) {
+  return ignition_can;
+}
+
+void set_ignition_can_cnt(uint32_t c) {
+  ignition_can_cnt = c;
+}
+
+uint32_t get_ignition_can_cnt(void) {
+  return ignition_can_cnt;
+}
+
 bool get_acc_main_on(void){
   return acc_main_on;
 }
@@ -198,6 +214,7 @@ void init_tests(void){
   ts_steer_req_mismatch_last = 0;
   valid_steer_req_count = 0;
   invalid_steer_req_count = 0;
+  ignition_can_reset();
 
   // assumes autopark on safety mode init to avoid a fault. get rid of that for testing
   tesla_autopark = false;

--- a/opendbc/safety/tests/misra/main.c
+++ b/opendbc/safety/tests/misra/main.c
@@ -12,3 +12,7 @@ SAFETY_UNUSED(safety_tx_hook);
 SAFETY_UNUSED(safety_fwd_hook);
 SAFETY_UNUSED(safety_tick);
 SAFETY_UNUSED(set_safety_hooks);
+
+// Called by panda and via libsafety tests (FFI)
+SAFETY_UNUSED(ignition_can_reset);
+SAFETY_UNUSED(ignition_can_hook);

--- a/opendbc/safety/tests/test_ignition_can.py
+++ b/opendbc/safety/tests/test_ignition_can.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+import unittest
+
+from opendbc.safety.tests.libsafety import libsafety_py
+
+
+class TestIgnitionCan(unittest.TestCase):
+  def setUp(self):
+    self.safety = libsafety_py.libsafety
+    self.safety.init_tests()
+    self.safety.ignition_can_reset()
+
+  def _rx_ign(self, addr: int, bus: int, data):
+    msg = libsafety_py.make_CANPacket(addr, bus, data)
+    self.safety.ignition_can_hook(msg)
+    return msg
+
+  def test_reset(self):
+    self.safety.set_ignition_can(True)
+    self.safety.set_ignition_can_cnt(123)
+    self.safety.ignition_can_reset()
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+  def test_bus_not_zero_noop(self):
+    self.safety.set_ignition_can(True)
+    self.safety.set_ignition_can_cnt(123)
+    self._rx_ign(0x1F1, 1, [0x0] * 8)
+    self.assertTrue(self.safety.get_ignition_can())
+    self.assertEqual(123, self.safety.get_ignition_can_cnt())
+
+  def test_gm_1f1(self):
+    self.safety.set_ignition_can(False)
+    self.safety.set_ignition_can_cnt(5)
+    self._rx_ign(0x1F1, 0, [0x2] + ([0x0] * 7))
+    self.assertTrue(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+    self.safety.set_ignition_can_cnt(7)
+    self._rx_ign(0x1F1, 0, [0x0] * 8)
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+  def test_mazda_9e(self):
+    # (data[0] >> 5) == 0x6
+    self.safety.set_ignition_can(False)
+    self.safety.set_ignition_can_cnt(9)
+    self._rx_ign(0x9E, 0, [0xC0] + ([0x0] * 7))
+    self.assertTrue(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+    self.safety.set_ignition_can_cnt(11)
+    self._rx_ign(0x9E, 0, [0x00] * 8)
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+  def test_rivian_152_sequential_counter_sets(self):
+    self.safety.set_ignition_can(False)
+    self._rx_ign(0x152, 0, [0x0, 0x0] + ([0x0] * 5) + [0x10])
+    self.assertFalse(self.safety.get_ignition_can())
+
+    self.safety.set_ignition_can_cnt(42)
+    self._rx_ign(0x152, 0, [0x0, 0x1] + ([0x0] * 5) + [0x10])
+    self.assertTrue(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+    self.safety.set_ignition_can_cnt(7)
+    self._rx_ign(0x152, 0, [0x0, 0x2] + ([0x0] * 5) + [0x00])
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+  def test_rivian_152_skipped_counter_no_update(self):
+    self.safety.ignition_can_reset()
+    self.safety.set_ignition_can(False)
+    self._rx_ign(0x152, 0, [0x0, 0x0] + ([0x0] * 5) + [0x10])
+    self.assertFalse(self.safety.get_ignition_can())
+
+    # Skip counter, should not update ignition state
+    self.safety.set_ignition_can_cnt(99)
+    self._rx_ign(0x152, 0, [0x0, 0x2] + ([0x0] * 5) + [0x10])
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(99, self.safety.get_ignition_can_cnt())
+
+  def test_tesla_221_sequential_counter_sets(self):
+    self.safety.set_ignition_can(False)
+    # First message initializes counter state, should not update
+    self._rx_ign(0x221, 0, [0x60] + ([0x0] * 5) + [0x00, 0x00])
+    self.assertFalse(self.safety.get_ignition_can())
+
+    self.safety.set_ignition_can_cnt(8)
+    # power_state == 3 (bits 6..5 == 0b11)
+    self._rx_ign(0x221, 0, [0x60] + ([0x0] * 5) + [0x10, 0x00])
+    self.assertTrue(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+    self.safety.set_ignition_can_cnt(12)
+    # power_state != 3, update to false
+    self._rx_ign(0x221, 0, [0x00] + ([0x0] * 5) + [0x20, 0x00])
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(0, self.safety.get_ignition_can_cnt())
+
+  def test_tesla_221_skipped_counter_no_update(self):
+    self.safety.ignition_can_reset()
+    self.safety.set_ignition_can(False)
+    self._rx_ign(0x221, 0, [0x60] + ([0x0] * 5) + [0x00, 0x00])
+    self.assertFalse(self.safety.get_ignition_can())
+
+    self.safety.set_ignition_can_cnt(77)
+    # Skip counter, should not update ignition state
+    self._rx_ign(0x221, 0, [0x60] + ([0x0] * 5) + [0x30, 0x00])
+    self.assertFalse(self.safety.get_ignition_can())
+    self.assertEqual(77, self.safety.get_ignition_can_cnt())
+
+
+if __name__ == "__main__":
+  unittest.main()
+

--- a/opendbc/safety/tests/test_ignition_can.py
+++ b/opendbc/safety/tests/test_ignition_can.py
@@ -5,6 +5,10 @@ from opendbc.safety.tests.libsafety import libsafety_py
 
 
 class TestIgnitionCan(unittest.TestCase):
+  # Required by SafetyTest.test_tx_hook_on_wrong_safety_mode, which imports all
+  # test_*.py modules and expects any `Test*` class to define TX_MSGS.
+  TX_MSGS = None
+
   def setUp(self):
     self.safety = libsafety_py.libsafety
     self.safety.init_tests()
@@ -114,4 +118,3 @@ class TestIgnitionCan(unittest.TestCase):
 
 if __name__ == "__main__":
   unittest.main()
-


### PR DESCRIPTION
## Goal
Move CAN ignition detection from panda-side implementation into `opendbc/safety`, and add deterministic CI tests to ensure ignition hooks do not regress or trip incorrectly across supported platforms.

## Summary
Moves CAN ignition detection logic into `opendbc/safety` and adds dedicated safety tests so behavior is validated in CI.

## Changes
- Added ignition state declarations and public hook/reset APIs in safety declarations.
- Moved ignition CAN hook implementation into `opendbc/safety/safety.h`.
- Exposed ignition getters/setters/reset helpers through `libsafety` test bridge.
- Added `test_ignition_can.py` covering:
  - reset behavior
  - bus filtering (non-bus0 no-op)
  - GM `0x1F1`
  - Mazda `0x9E`
  - Rivian `0x152` sequential and skipped-counter behavior
  - Tesla `0x221` sequential and skipped-counter behavior
- Marked ignition helpers as used in MISRA test entrypoint.

## Validation
- Built libsafety test target (`scons -j8 -D`)
- Ran ignition tests: `pytest -n8 test_ignition_can.py` (8 passed)
- Full PR CI currently passing (test models, safety, mutation tests, test.sh, car diff).

Closes #1834
