### PR TITLE
Replace libsafety cffi wrapper with ctypes

### DIFF
--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -1,99 +1,185 @@
+import ctypes
 import os
-from cffi import FFI
 
 from opendbc.safety import LEN_TO_DLC
 
 libsafety_dir = os.path.dirname(os.path.abspath(__file__))
+libsafety_fn = os.path.join(libsafety_dir, "libsafety.so")
 
-ffi = FFI()
 
-ffi.cdef("""
-typedef struct {
-  unsigned char fd : 1;
-  unsigned char bus : 3;
-  unsigned char data_len_code : 4;
-  unsigned char rejected : 1;
-  unsigned char returned : 1;
-  unsigned char extended : 1;
-  unsigned int addr : 29;
-  unsigned char checksum;
-  unsigned char data[64];
-} CANPacket_t;
-""", packed=True)
-class CANPacket:
-  pass
+class CANPacket(ctypes.Structure):
+  _pack_ = 1
+  _fields_ = [
+    ("fd_bus_dlc", ctypes.c_uint8),
+    ("flags_addr", ctypes.c_uint32),
+    ("checksum", ctypes.c_uint8),
+    ("data", ctypes.c_uint8 * 64),
+    ("_padding", ctypes.c_uint8 * 2),
+  ]
 
-ffi.cdef("""
-bool safety_rx_hook(CANPacket_t *msg);
-bool safety_tx_hook(CANPacket_t *msg);
-int safety_fwd_hook(int bus_num, int addr);
-int set_safety_hooks(uint16_t mode, uint16_t param);
+  @property
+  def fd(self) -> int:
+    return self.fd_bus_dlc & 0x1
 
-void set_controls_allowed(bool c);
-bool get_controls_allowed(void);
-bool get_longitudinal_allowed(void);
-void set_alternative_experience(int mode);
-int get_alternative_experience(void);
-void set_relay_malfunction(bool c);
-bool get_relay_malfunction(void);
-bool get_gas_pressed_prev(void);
-void set_gas_pressed_prev(bool);
-bool get_brake_pressed_prev(void);
-bool get_regen_braking_prev(void);
-bool get_steering_disengage_prev(void);
-bool get_acc_main_on(void);
-float get_vehicle_speed_min(void);
-float get_vehicle_speed_max(void);
-int get_current_safety_mode(void);
-int get_current_safety_param(void);
+  @fd.setter
+  def fd(self, value: int) -> None:
+    self.fd_bus_dlc = (self.fd_bus_dlc & ~0x1) | (value & 0x1)
 
-void set_torque_meas(int min, int max);
-int get_torque_meas_min(void);
-int get_torque_meas_max(void);
-void set_torque_driver(int min, int max);
-int get_torque_driver_min(void);
-int get_torque_driver_max(void);
-void set_desired_torque_last(int t);
-void set_rt_torque_last(int t);
-void set_desired_angle_last(int t);
-int get_desired_angle_last();
-void set_angle_meas(int min, int max);
-int get_angle_meas_min(void);
-int get_angle_meas_max(void);
+  @property
+  def bus(self) -> int:
+    return (self.fd_bus_dlc >> 1) & 0x7
 
-bool get_cruise_engaged_prev(void);
-void set_cruise_engaged_prev(bool engaged);
-bool get_vehicle_moving(void);
-void set_timer(uint32_t t);
+  @bus.setter
+  def bus(self, value: int) -> None:
+    self.fd_bus_dlc = (self.fd_bus_dlc & ~0xE) | ((value & 0x7) << 1)
 
-void safety_tick_current_safety_config();
-bool safety_config_valid();
+  @property
+  def data_len_code(self) -> int:
+    return (self.fd_bus_dlc >> 4) & 0xF
 
-void init_tests(void);
+  @data_len_code.setter
+  def data_len_code(self, value: int) -> None:
+    self.fd_bus_dlc = (self.fd_bus_dlc & ~0xF0) | ((value & 0xF) << 4)
 
-void set_honda_fwd_brake(bool c);
-bool get_honda_fwd_brake(void);
-void set_honda_alt_brake_msg(bool c);
-void set_honda_bosch_long(bool c);
-int get_honda_hw(void);
+  @property
+  def rejected(self) -> int:
+    return self.flags_addr & 0x1
 
-void mutation_set_active_mutant(int id);
-int mutation_get_active_mutant(void);
-""")
+  @rejected.setter
+  def rejected(self, value: int) -> None:
+    self.flags_addr = (self.flags_addr & ~0x1) | (value & 0x1)
+
+  @property
+  def returned(self) -> int:
+    return (self.flags_addr >> 1) & 0x1
+
+  @returned.setter
+  def returned(self, value: int) -> None:
+    self.flags_addr = (self.flags_addr & ~0x2) | ((value & 0x1) << 1)
+
+  @property
+  def extended(self) -> int:
+    return (self.flags_addr >> 2) & 0x1
+
+  @extended.setter
+  def extended(self, value: int) -> None:
+    self.flags_addr = (self.flags_addr & ~0x4) | ((value & 0x1) << 2)
+
+  @property
+  def addr(self) -> int:
+    return (self.flags_addr >> 3) & 0x1FFFFFFF
+
+  @addr.setter
+  def addr(self, value: int) -> None:
+    self.flags_addr = (self.flags_addr & 0x7) | ((value & 0x1FFFFFFF) << 3)
+
+
+class CANPacketHandle:
+  def __init__(self):
+    self._packet = CANPacket()
+    self._pointer = ctypes.pointer(self._packet)
+
+  @property
+  def _as_parameter_(self):
+    return self._pointer
+
+  def __getitem__(self, index: int) -> CANPacket:
+    return self._pointer[index]
+
+  def __getattr__(self, name: str):
+    return getattr(self._packet, name)
+
+
+CANPacketPtr = ctypes.POINTER(CANPacket)
+
 
 class LibSafety:
   pass
-libsafety: LibSafety = ffi.dlopen(os.path.join(libsafety_dir, "libsafety.so"))
+
+
+def _set_sig(libsafety, name: str, argtypes, restype) -> None:
+  fn = getattr(libsafety, name)
+  fn.argtypes = argtypes
+  fn.restype = restype
+
+
+def _set_sig_if_present(libsafety, name: str, argtypes, restype) -> None:
+  if hasattr(libsafety, name):
+    _set_sig(libsafety, name, argtypes, restype)
+
+
+def _configure(libsafety):
+  _set_sig(libsafety, "safety_rx_hook", [CANPacketPtr], ctypes.c_bool)
+  _set_sig(libsafety, "safety_tx_hook", [CANPacketPtr], ctypes.c_bool)
+  _set_sig(libsafety, "safety_fwd_hook", [ctypes.c_int, ctypes.c_int], ctypes.c_int)
+  _set_sig(libsafety, "set_safety_hooks", [ctypes.c_uint16, ctypes.c_uint16], ctypes.c_int)
+
+  _set_sig(libsafety, "set_controls_allowed", [ctypes.c_bool], None)
+  _set_sig(libsafety, "get_controls_allowed", [], ctypes.c_bool)
+  _set_sig(libsafety, "get_longitudinal_allowed", [], ctypes.c_bool)
+  _set_sig(libsafety, "set_alternative_experience", [ctypes.c_int], None)
+  _set_sig(libsafety, "get_alternative_experience", [], ctypes.c_int)
+  _set_sig(libsafety, "set_relay_malfunction", [ctypes.c_bool], None)
+  _set_sig(libsafety, "get_relay_malfunction", [], ctypes.c_bool)
+  _set_sig(libsafety, "get_gas_pressed_prev", [], ctypes.c_bool)
+  _set_sig(libsafety, "set_gas_pressed_prev", [ctypes.c_bool], None)
+  _set_sig(libsafety, "get_brake_pressed_prev", [], ctypes.c_bool)
+  _set_sig(libsafety, "get_regen_braking_prev", [], ctypes.c_bool)
+  _set_sig(libsafety, "get_steering_disengage_prev", [], ctypes.c_bool)
+  _set_sig(libsafety, "get_acc_main_on", [], ctypes.c_bool)
+  _set_sig(libsafety, "get_vehicle_speed_min", [], ctypes.c_float)
+  _set_sig(libsafety, "get_vehicle_speed_max", [], ctypes.c_float)
+  _set_sig(libsafety, "get_current_safety_mode", [], ctypes.c_int)
+  _set_sig(libsafety, "get_current_safety_param", [], ctypes.c_int)
+
+  _set_sig(libsafety, "set_torque_meas", [ctypes.c_int, ctypes.c_int], None)
+  _set_sig(libsafety, "get_torque_meas_min", [], ctypes.c_int)
+  _set_sig(libsafety, "get_torque_meas_max", [], ctypes.c_int)
+  _set_sig(libsafety, "set_torque_driver", [ctypes.c_int, ctypes.c_int], None)
+  _set_sig(libsafety, "get_torque_driver_min", [], ctypes.c_int)
+  _set_sig(libsafety, "get_torque_driver_max", [], ctypes.c_int)
+  _set_sig(libsafety, "set_desired_torque_last", [ctypes.c_int], None)
+  _set_sig(libsafety, "set_rt_torque_last", [ctypes.c_int], None)
+  _set_sig(libsafety, "set_desired_angle_last", [ctypes.c_int], None)
+  _set_sig(libsafety, "get_desired_angle_last", [], ctypes.c_int)
+  _set_sig(libsafety, "set_angle_meas", [ctypes.c_int, ctypes.c_int], None)
+  _set_sig(libsafety, "get_angle_meas_min", [], ctypes.c_int)
+  _set_sig(libsafety, "get_angle_meas_max", [], ctypes.c_int)
+
+  _set_sig(libsafety, "get_cruise_engaged_prev", [], ctypes.c_bool)
+  _set_sig(libsafety, "set_cruise_engaged_prev", [ctypes.c_bool], None)
+  _set_sig(libsafety, "get_vehicle_moving", [], ctypes.c_bool)
+  _set_sig(libsafety, "set_timer", [ctypes.c_uint32], None)
+
+  _set_sig(libsafety, "safety_tick_current_safety_config", [], None)
+  _set_sig(libsafety, "safety_config_valid", [], ctypes.c_bool)
+  _set_sig(libsafety, "init_tests", [], None)
+
+  _set_sig(libsafety, "set_honda_fwd_brake", [ctypes.c_bool], None)
+  _set_sig(libsafety, "get_honda_fwd_brake", [], ctypes.c_bool)
+  _set_sig(libsafety, "set_honda_alt_brake_msg", [ctypes.c_bool], None)
+  _set_sig(libsafety, "set_honda_bosch_long", [ctypes.c_bool], None)
+  _set_sig(libsafety, "get_honda_hw", [], ctypes.c_int)
+
+  _set_sig_if_present(libsafety, "mutation_set_active_mutant", [ctypes.c_int], None)
+  _set_sig_if_present(libsafety, "mutation_get_active_mutant", [], ctypes.c_int)
+
+  return libsafety
+
+
+libsafety: LibSafety = _configure(ctypes.CDLL(libsafety_fn))
+
 
 def load(path):
   global libsafety
-  libsafety = ffi.dlopen(str(path))
+  libsafety = _configure(ctypes.CDLL(str(path)))
+
 
 def make_CANPacket(addr: int, bus: int, dat):
-  ret = ffi.new('CANPacket_t *')
+  ret = CANPacketHandle()
   ret[0].extended = 1 if addr >= 0x800 else 0
   ret[0].addr = addr
   ret[0].data_len_code = LEN_TO_DLC[len(dat)]
   ret[0].bus = bus
-  ret[0].data = bytes(dat)
+  ret[0].data[:len(dat)] = dat
   return ret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
 [project.optional-dependencies]
 testing = [
   "comma-car-segments @ https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl",
-  "cffi",
   "tree-sitter",
   "tree-sitter-c",
   "gcovr",

--- a/uv.lock
+++ b/uv.lock
@@ -21,42 +21,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -375,7 +339,6 @@ examples = [
     { name = "inputs" },
 ]
 testing = [
-    { name = "cffi" },
     { name = "codespell" },
     { name = "comma-car-segments" },
     { name = "cppcheck" },
@@ -397,7 +360,6 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cffi", marker = "extra == 'testing'" },
     { name = "codespell", marker = "extra == 'testing'" },
     { name = "comma-car-segments", marker = "extra == 'testing'", url = "https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl" },
     { name = "cppcheck", marker = "extra == 'testing'", git = "https://github.com/commaai/dependencies.git?subdirectory=cppcheck&rev=releases" },
@@ -482,15 +444,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/5b/68090013128d7853f34c43828dd4dc80a7c8516fd1b56057b134e1e4c2c0/pycapnp-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c151edf78155b6416e7cb31e2e333d302d742ba52bb37d4dbdf71e75cc999d46", size = 6295279, upload-time = "2025-09-05T03:49:12.712Z" },
     { url = "https://files.pythonhosted.org/packages/5b/52/7d85212b4fcf127588888f71d3dbf5558ee7dc302eba760b12b1b325f9a3/pycapnp-2.1.0-cp312-cp312-win32.whl", hash = "sha256:c09b28419321dafafc644d60c57ff8ccaf3c3e686801b6060c612a7a3c580944", size = 1038995, upload-time = "2025-09-05T03:49:14.165Z" },
     { url = "https://files.pythonhosted.org/packages/f2/12/25d283ebf5c28717364647672e7494dc46196ca7a662f5420e4866f45687/pycapnp-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:560cb69cc02b0347e85b0629e4c2f0a316240900aa905392f9df6bab0a359989", size = 1176620, upload-time = "2025-09-05T03:49:15.545Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- replace the Python `libsafety` wrapper from `cffi` to `ctypes`
- preserve the existing pointer-style `CANPacket` test API with a packed byte-level struct wrapper
- drop `cffi` from the testing dependency set and lockfile

## Benchmarks
Median of 5 runs on this machine against the same `libsafety.so` loop:

| benchmark | cffi baseline | ctypes branch | delta |
| --- | ---: | ---: | ---: |
| `make_CANPacket` | 1.96M ops/s | 0.61M ops/s | 3.22x slower |
| `safety_rx_hook` | 4.22M ops/s | 1.68M ops/s | 2.51x slower |

Commands were run from detached baseline and feature worktrees after building `opendbc/safety/tests/libsafety/libsafety.so` in each.

## Validation
- `scons -j4 opendbc/safety/tests/libsafety/libsafety.so`
- `pytest -n0 opendbc/safety/tests/test_defaults.py opendbc/safety/tests/test_body.py -q`

## Notes
- I attempted the broader local `opendbc/safety/tests` suite, but this checkout is missing generated DBC files such as `opendbc/dbc/toyota_nodsu_pt_generated.dbc`, so the full suite is not a meaningful local gate here.
