### PR TITLE
Replace libsafety cffi shim with a C extension

### DIFF
--- a/opendbc/safety/tests/libsafety/_libsafety_c_ext.c
+++ b/opendbc/safety/tests/libsafety/_libsafety_c_ext.c
@@ -1,0 +1,622 @@
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <dlfcn.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "opendbc/safety/can.h"
+
+typedef struct {
+  PyObject_HEAD
+  CANPacket_t packet;
+} CANPacketObject;
+
+typedef struct {
+  PyObject_HEAD
+} LibSafetyObject;
+
+static PyTypeObject CANPacketType;
+static PyTypeObject LibSafetyType;
+static LibSafetyObject *g_libsafety = NULL;
+static void *g_handle = NULL;
+
+typedef bool (*bool_packet_fn)(CANPacket_t *msg);
+typedef int (*int_int_int_fn)(int, int);
+typedef int (*int_u16_u16_fn)(uint16_t, uint16_t);
+typedef void (*void_bool_fn)(bool);
+typedef bool (*bool_void_fn)(void);
+typedef void (*void_int_fn)(int);
+typedef int (*int_void_fn)(void);
+typedef void (*void_int_int_fn)(int, int);
+typedef void (*void_u32_fn)(uint32_t);
+typedef float (*float_void_fn)(void);
+
+static bool_packet_fn fn_safety_rx_hook = NULL;
+static bool_packet_fn fn_safety_tx_hook = NULL;
+static int_int_int_fn fn_safety_fwd_hook = NULL;
+static int_u16_u16_fn fn_set_safety_hooks = NULL;
+static void_bool_fn fn_set_controls_allowed = NULL;
+static bool_void_fn fn_get_controls_allowed = NULL;
+static bool_void_fn fn_get_longitudinal_allowed = NULL;
+static void_int_fn fn_set_alternative_experience = NULL;
+static int_void_fn fn_get_alternative_experience = NULL;
+static void_bool_fn fn_set_relay_malfunction = NULL;
+static bool_void_fn fn_get_relay_malfunction = NULL;
+static bool_void_fn fn_get_gas_pressed_prev = NULL;
+static void_bool_fn fn_set_gas_pressed_prev = NULL;
+static bool_void_fn fn_get_brake_pressed_prev = NULL;
+static bool_void_fn fn_get_regen_braking_prev = NULL;
+static bool_void_fn fn_get_steering_disengage_prev = NULL;
+static bool_void_fn fn_get_acc_main_on = NULL;
+static float_void_fn fn_get_vehicle_speed_min = NULL;
+static float_void_fn fn_get_vehicle_speed_max = NULL;
+static int_void_fn fn_get_current_safety_mode = NULL;
+static int_void_fn fn_get_current_safety_param = NULL;
+static void_int_int_fn fn_set_torque_meas = NULL;
+static int_void_fn fn_get_torque_meas_min = NULL;
+static int_void_fn fn_get_torque_meas_max = NULL;
+static void_int_int_fn fn_set_torque_driver = NULL;
+static int_void_fn fn_get_torque_driver_min = NULL;
+static int_void_fn fn_get_torque_driver_max = NULL;
+static void_int_fn fn_set_desired_torque_last = NULL;
+static void_int_fn fn_set_rt_torque_last = NULL;
+static void_int_fn fn_set_desired_angle_last = NULL;
+static int_void_fn fn_get_desired_angle_last = NULL;
+static void_int_int_fn fn_set_angle_meas = NULL;
+static int_void_fn fn_get_angle_meas_min = NULL;
+static int_void_fn fn_get_angle_meas_max = NULL;
+static bool_void_fn fn_get_cruise_engaged_prev = NULL;
+static void_bool_fn fn_set_cruise_engaged_prev = NULL;
+static bool_void_fn fn_get_vehicle_moving = NULL;
+static void_u32_fn fn_set_timer = NULL;
+static void (*fn_safety_tick_current_safety_config)(void) = NULL;
+static bool_void_fn fn_safety_config_valid = NULL;
+static void (*fn_init_tests)(void) = NULL;
+static void_bool_fn fn_set_honda_fwd_brake = NULL;
+static bool_void_fn fn_get_honda_fwd_brake = NULL;
+static void_bool_fn fn_set_honda_alt_brake_msg = NULL;
+static void_bool_fn fn_set_honda_bosch_long = NULL;
+static int_void_fn fn_get_honda_hw = NULL;
+static void_int_fn fn_mutation_set_active_mutant = NULL;
+static int_void_fn fn_mutation_get_active_mutant = NULL;
+
+static int require_loaded(void) {
+  if (g_handle == NULL) {
+    PyErr_SetString(PyExc_RuntimeError, "libsafety is not loaded");
+    return 0;
+  }
+  return 1;
+}
+
+static int require_symbol(const void *fn, const char *name) {
+  if (fn == NULL) {
+    PyErr_Format(PyExc_RuntimeError, "missing symbol: %s", name);
+    return 0;
+  }
+  return 1;
+}
+
+static void *load_symbol(const char *name, int required) {
+  void *sym = dlsym(g_handle, name);
+  if ((sym == NULL) && required) {
+    PyErr_Format(PyExc_RuntimeError, "failed to load symbol %s: %s", name, dlerror());
+  }
+  return sym;
+}
+
+static int load_symbols(void) {
+  fn_safety_rx_hook = (bool_packet_fn)load_symbol("safety_rx_hook", 1);
+  fn_safety_tx_hook = (bool_packet_fn)load_symbol("safety_tx_hook", 1);
+  fn_safety_fwd_hook = (int_int_int_fn)load_symbol("safety_fwd_hook", 1);
+  fn_set_safety_hooks = (int_u16_u16_fn)load_symbol("set_safety_hooks", 1);
+  fn_set_controls_allowed = (void_bool_fn)load_symbol("set_controls_allowed", 1);
+  fn_get_controls_allowed = (bool_void_fn)load_symbol("get_controls_allowed", 1);
+  fn_get_longitudinal_allowed = (bool_void_fn)load_symbol("get_longitudinal_allowed", 1);
+  fn_set_alternative_experience = (void_int_fn)load_symbol("set_alternative_experience", 1);
+  fn_get_alternative_experience = (int_void_fn)load_symbol("get_alternative_experience", 1);
+  fn_set_relay_malfunction = (void_bool_fn)load_symbol("set_relay_malfunction", 1);
+  fn_get_relay_malfunction = (bool_void_fn)load_symbol("get_relay_malfunction", 1);
+  fn_get_gas_pressed_prev = (bool_void_fn)load_symbol("get_gas_pressed_prev", 1);
+  fn_set_gas_pressed_prev = (void_bool_fn)load_symbol("set_gas_pressed_prev", 1);
+  fn_get_brake_pressed_prev = (bool_void_fn)load_symbol("get_brake_pressed_prev", 1);
+  fn_get_regen_braking_prev = (bool_void_fn)load_symbol("get_regen_braking_prev", 1);
+  fn_get_steering_disengage_prev = (bool_void_fn)load_symbol("get_steering_disengage_prev", 1);
+  fn_get_acc_main_on = (bool_void_fn)load_symbol("get_acc_main_on", 1);
+  fn_get_vehicle_speed_min = (float_void_fn)load_symbol("get_vehicle_speed_min", 1);
+  fn_get_vehicle_speed_max = (float_void_fn)load_symbol("get_vehicle_speed_max", 1);
+  fn_get_current_safety_mode = (int_void_fn)load_symbol("get_current_safety_mode", 1);
+  fn_get_current_safety_param = (int_void_fn)load_symbol("get_current_safety_param", 1);
+  fn_set_torque_meas = (void_int_int_fn)load_symbol("set_torque_meas", 1);
+  fn_get_torque_meas_min = (int_void_fn)load_symbol("get_torque_meas_min", 1);
+  fn_get_torque_meas_max = (int_void_fn)load_symbol("get_torque_meas_max", 1);
+  fn_set_torque_driver = (void_int_int_fn)load_symbol("set_torque_driver", 1);
+  fn_get_torque_driver_min = (int_void_fn)load_symbol("get_torque_driver_min", 1);
+  fn_get_torque_driver_max = (int_void_fn)load_symbol("get_torque_driver_max", 1);
+  fn_set_desired_torque_last = (void_int_fn)load_symbol("set_desired_torque_last", 1);
+  fn_set_rt_torque_last = (void_int_fn)load_symbol("set_rt_torque_last", 1);
+  fn_set_desired_angle_last = (void_int_fn)load_symbol("set_desired_angle_last", 1);
+  fn_get_desired_angle_last = (int_void_fn)load_symbol("get_desired_angle_last", 1);
+  fn_set_angle_meas = (void_int_int_fn)load_symbol("set_angle_meas", 1);
+  fn_get_angle_meas_min = (int_void_fn)load_symbol("get_angle_meas_min", 1);
+  fn_get_angle_meas_max = (int_void_fn)load_symbol("get_angle_meas_max", 1);
+  fn_get_cruise_engaged_prev = (bool_void_fn)load_symbol("get_cruise_engaged_prev", 1);
+  fn_set_cruise_engaged_prev = (void_bool_fn)load_symbol("set_cruise_engaged_prev", 1);
+  fn_get_vehicle_moving = (bool_void_fn)load_symbol("get_vehicle_moving", 1);
+  fn_set_timer = (void_u32_fn)load_symbol("set_timer", 1);
+  fn_safety_tick_current_safety_config = (void (*)(void))load_symbol("safety_tick_current_safety_config", 1);
+  fn_safety_config_valid = (bool_void_fn)load_symbol("safety_config_valid", 1);
+  fn_init_tests = (void (*)(void))load_symbol("init_tests", 1);
+  fn_set_honda_fwd_brake = (void_bool_fn)load_symbol("set_honda_fwd_brake", 1);
+  fn_get_honda_fwd_brake = (bool_void_fn)load_symbol("get_honda_fwd_brake", 1);
+  fn_set_honda_alt_brake_msg = (void_bool_fn)load_symbol("set_honda_alt_brake_msg", 1);
+  fn_set_honda_bosch_long = (void_bool_fn)load_symbol("set_honda_bosch_long", 1);
+  fn_get_honda_hw = (int_void_fn)load_symbol("get_honda_hw", 1);
+  fn_mutation_set_active_mutant = (void_int_fn)load_symbol("mutation_set_active_mutant", 0);
+  fn_mutation_get_active_mutant = (int_void_fn)load_symbol("mutation_get_active_mutant", 0);
+
+  return !PyErr_Occurred();
+}
+
+static CANPacketObject *packet_from_object(PyObject *obj) {
+  if (!PyObject_TypeCheck(obj, &CANPacketType)) {
+    PyErr_SetString(PyExc_TypeError, "expected CANPacket");
+    return NULL;
+  }
+  return (CANPacketObject *)obj;
+}
+
+static PyObject *CANPacket_new(PyTypeObject *type, PyObject *args, PyObject *kwargs) {
+  CANPacketObject *self = (CANPacketObject *)type->tp_alloc(type, 0);
+  if (self != NULL) {
+    memset(&self->packet, 0, sizeof(self->packet));
+  }
+  return (PyObject *)self;
+}
+
+static PyObject *CANPacket_subscript(PyObject *self, PyObject *item) {
+  long index = PyLong_AsLong(item);
+  if ((index == -1) && PyErr_Occurred()) return NULL;
+  if (index != 0) {
+    PyErr_SetString(PyExc_IndexError, "CANPacket only supports index 0");
+    return NULL;
+  }
+  Py_INCREF(self);
+  return self;
+}
+
+static PyMappingMethods CANPacket_mapping = {
+  .mp_length = 0,
+  .mp_subscript = CANPacket_subscript,
+  .mp_ass_subscript = 0,
+};
+
+static PyObject *get_data_view(CANPacketObject *self, void *closure) {
+  (void)closure;
+  return PyMemoryView_FromMemory((char *)self->packet.data, CANPACKET_DATA_SIZE_MAX, PyBUF_WRITE);
+}
+
+static PyObject *get_uint_attr(unsigned int value) {
+  return PyLong_FromUnsignedLong(value);
+}
+
+static int parse_small_uint(PyObject *value, unsigned int max_value, const char *name, unsigned int *out) {
+  unsigned long v;
+  if (value == NULL) {
+    PyErr_Format(PyExc_AttributeError, "cannot delete %s", name);
+    return -1;
+  }
+  v = PyLong_AsUnsignedLong(value);
+  if ((v == (unsigned long)-1) && PyErr_Occurred()) return -1;
+  if (v > max_value) {
+    PyErr_Format(PyExc_ValueError, "%s out of range", name);
+    return -1;
+  }
+  *out = (unsigned int)v;
+  return 0;
+}
+
+static PyObject *packet_get_fd(CANPacketObject *self, void *closure) { (void)closure; return get_uint_attr(self->packet.fd); }
+static int packet_set_fd(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned int v;
+  (void)closure;
+  if (parse_small_uint(value, 1U, "fd", &v) < 0) return -1;
+  self->packet.fd = v;
+  return 0;
+}
+static PyObject *packet_get_bus(CANPacketObject *self, void *closure) { (void)closure; return get_uint_attr(self->packet.bus); }
+static int packet_set_bus(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned int v;
+  (void)closure;
+  if (parse_small_uint(value, 7U, "bus", &v) < 0) return -1;
+  self->packet.bus = v;
+  return 0;
+}
+static PyObject *packet_get_dlc(CANPacketObject *self, void *closure) { (void)closure; return get_uint_attr(self->packet.data_len_code); }
+static int packet_set_dlc(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned int v;
+  (void)closure;
+  if (parse_small_uint(value, 15U, "data_len_code", &v) < 0) return -1;
+  self->packet.data_len_code = v;
+  return 0;
+}
+static PyObject *packet_get_rejected(CANPacketObject *self, void *closure) { (void)closure; return get_uint_attr(self->packet.rejected); }
+static int packet_set_rejected(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned int v;
+  (void)closure;
+  if (parse_small_uint(value, 1U, "rejected", &v) < 0) return -1;
+  self->packet.rejected = v;
+  return 0;
+}
+static PyObject *packet_get_returned(CANPacketObject *self, void *closure) { (void)closure; return get_uint_attr(self->packet.returned); }
+static int packet_set_returned(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned int v;
+  (void)closure;
+  if (parse_small_uint(value, 1U, "returned", &v) < 0) return -1;
+  self->packet.returned = v;
+  return 0;
+}
+static PyObject *packet_get_extended(CANPacketObject *self, void *closure) { (void)closure; return get_uint_attr(self->packet.extended); }
+static int packet_set_extended(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned int v;
+  (void)closure;
+  if (parse_small_uint(value, 1U, "extended", &v) < 0) return -1;
+  self->packet.extended = v;
+  return 0;
+}
+static PyObject *packet_get_addr(CANPacketObject *self, void *closure) { (void)closure; return PyLong_FromUnsignedLong(self->packet.addr); }
+static int packet_set_addr(CANPacketObject *self, PyObject *value, void *closure) {
+  unsigned long v;
+  (void)closure;
+  if (value == NULL) {
+    PyErr_SetString(PyExc_AttributeError, "cannot delete addr");
+    return -1;
+  }
+  v = PyLong_AsUnsignedLong(value);
+  if ((v == (unsigned long)-1) && PyErr_Occurred()) return -1;
+  if (v > 0x1FFFFFFFU) {
+    PyErr_SetString(PyExc_ValueError, "addr out of range");
+    return -1;
+  }
+  self->packet.addr = (unsigned int)v;
+  return 0;
+}
+
+static PyGetSetDef CANPacket_getset[] = {
+  {"fd", (getter)packet_get_fd, (setter)packet_set_fd, NULL, NULL},
+  {"bus", (getter)packet_get_bus, (setter)packet_set_bus, NULL, NULL},
+  {"data_len_code", (getter)packet_get_dlc, (setter)packet_set_dlc, NULL, NULL},
+  {"rejected", (getter)packet_get_rejected, (setter)packet_set_rejected, NULL, NULL},
+  {"returned", (getter)packet_get_returned, (setter)packet_set_returned, NULL, NULL},
+  {"extended", (getter)packet_get_extended, (setter)packet_set_extended, NULL, NULL},
+  {"addr", (getter)packet_get_addr, (setter)packet_set_addr, NULL, NULL},
+  {"data", (getter)get_data_view, NULL, NULL, NULL},
+  {NULL, NULL, NULL, NULL, NULL},
+};
+
+#define LIBSAFETY_BOOL_PACKET_WRAPPER(py_name, fn_ptr) \
+static PyObject *py_name(LibSafetyObject *self, PyObject *arg) { \
+  CANPacketObject *packet; \
+  (void)self; \
+  if (!require_loaded() || !require_symbol((const void *)fn_ptr, #fn_ptr)) return NULL; \
+  packet = packet_from_object(arg); \
+  if (packet == NULL) return NULL; \
+  if (fn_ptr(&packet->packet)) Py_RETURN_TRUE; \
+  Py_RETURN_FALSE; \
+}
+
+#define LIBSAFETY_BOOL_VOID_WRAPPER(py_name, fn_ptr) \
+static PyObject *py_name(LibSafetyObject *self, PyObject *Py_UNUSED(ignored)) { \
+  (void)self; \
+  if (!require_loaded() || !require_symbol((const void *)fn_ptr, #fn_ptr)) return NULL; \
+  if (fn_ptr()) Py_RETURN_TRUE; \
+  Py_RETURN_FALSE; \
+}
+
+#define LIBSAFETY_INT_VOID_WRAPPER(py_name, fn_ptr) \
+static PyObject *py_name(LibSafetyObject *self, PyObject *Py_UNUSED(ignored)) { \
+  (void)self; \
+  if (!require_loaded() || !require_symbol((const void *)fn_ptr, #fn_ptr)) return NULL; \
+  return PyLong_FromLong(fn_ptr()); \
+}
+
+#define LIBSAFETY_FLOAT_VOID_WRAPPER(py_name, fn_ptr) \
+static PyObject *py_name(LibSafetyObject *self, PyObject *Py_UNUSED(ignored)) { \
+  (void)self; \
+  if (!require_loaded() || !require_symbol((const void *)fn_ptr, #fn_ptr)) return NULL; \
+  return PyFloat_FromDouble((double)fn_ptr()); \
+}
+
+#define LIBSAFETY_VOID_BOOL_WRAPPER(py_name, fn_ptr) \
+static PyObject *py_name(LibSafetyObject *self, PyObject *arg) { \
+  int truthy; \
+  (void)self; \
+  if (!require_loaded() || !require_symbol((const void *)fn_ptr, #fn_ptr)) return NULL; \
+  truthy = PyObject_IsTrue(arg); \
+  if (truthy < 0) return NULL; \
+  fn_ptr(truthy != 0); \
+  Py_RETURN_NONE; \
+}
+
+#define LIBSAFETY_VOID_INT_WRAPPER(py_name, fn_ptr) \
+static PyObject *py_name(LibSafetyObject *self, PyObject *arg) { \
+  long value; \
+  (void)self; \
+  if (!require_loaded() || !require_symbol((const void *)fn_ptr, #fn_ptr)) return NULL; \
+  value = PyLong_AsLong(arg); \
+  if ((value == -1) && PyErr_Occurred()) return NULL; \
+  fn_ptr((int)value); \
+  Py_RETURN_NONE; \
+}
+
+LIBSAFETY_BOOL_PACKET_WRAPPER(LibSafety_safety_rx_hook, fn_safety_rx_hook)
+LIBSAFETY_BOOL_PACKET_WRAPPER(LibSafety_safety_tx_hook, fn_safety_tx_hook)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_controls_allowed, fn_get_controls_allowed)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_longitudinal_allowed, fn_get_longitudinal_allowed)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_relay_malfunction, fn_get_relay_malfunction)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_gas_pressed_prev, fn_get_gas_pressed_prev)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_brake_pressed_prev, fn_get_brake_pressed_prev)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_regen_braking_prev, fn_get_regen_braking_prev)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_steering_disengage_prev, fn_get_steering_disengage_prev)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_acc_main_on, fn_get_acc_main_on)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_cruise_engaged_prev, fn_get_cruise_engaged_prev)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_vehicle_moving, fn_get_vehicle_moving)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_safety_config_valid, fn_safety_config_valid)
+LIBSAFETY_BOOL_VOID_WRAPPER(LibSafety_get_honda_fwd_brake, fn_get_honda_fwd_brake)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_alternative_experience, fn_get_alternative_experience)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_current_safety_mode, fn_get_current_safety_mode)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_current_safety_param, fn_get_current_safety_param)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_torque_meas_min, fn_get_torque_meas_min)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_torque_meas_max, fn_get_torque_meas_max)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_torque_driver_min, fn_get_torque_driver_min)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_torque_driver_max, fn_get_torque_driver_max)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_desired_angle_last, fn_get_desired_angle_last)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_angle_meas_min, fn_get_angle_meas_min)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_angle_meas_max, fn_get_angle_meas_max)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_get_honda_hw, fn_get_honda_hw)
+LIBSAFETY_INT_VOID_WRAPPER(LibSafety_mutation_get_active_mutant, fn_mutation_get_active_mutant)
+LIBSAFETY_FLOAT_VOID_WRAPPER(LibSafety_get_vehicle_speed_min, fn_get_vehicle_speed_min)
+LIBSAFETY_FLOAT_VOID_WRAPPER(LibSafety_get_vehicle_speed_max, fn_get_vehicle_speed_max)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_controls_allowed, fn_set_controls_allowed)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_relay_malfunction, fn_set_relay_malfunction)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_gas_pressed_prev, fn_set_gas_pressed_prev)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_cruise_engaged_prev, fn_set_cruise_engaged_prev)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_honda_fwd_brake, fn_set_honda_fwd_brake)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_honda_alt_brake_msg, fn_set_honda_alt_brake_msg)
+LIBSAFETY_VOID_BOOL_WRAPPER(LibSafety_set_honda_bosch_long, fn_set_honda_bosch_long)
+LIBSAFETY_VOID_INT_WRAPPER(LibSafety_set_alternative_experience, fn_set_alternative_experience)
+LIBSAFETY_VOID_INT_WRAPPER(LibSafety_set_desired_torque_last, fn_set_desired_torque_last)
+LIBSAFETY_VOID_INT_WRAPPER(LibSafety_set_rt_torque_last, fn_set_rt_torque_last)
+LIBSAFETY_VOID_INT_WRAPPER(LibSafety_set_desired_angle_last, fn_set_desired_angle_last)
+LIBSAFETY_VOID_INT_WRAPPER(LibSafety_mutation_set_active_mutant, fn_mutation_set_active_mutant)
+
+static PyObject *LibSafety_safety_fwd_hook(LibSafetyObject *self, PyObject *args) {
+  int bus_num, addr;
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_safety_fwd_hook, "safety_fwd_hook")) return NULL;
+  if (!PyArg_ParseTuple(args, "ii", &bus_num, &addr)) return NULL;
+  return PyLong_FromLong(fn_safety_fwd_hook(bus_num, addr));
+}
+
+static PyObject *LibSafety_set_safety_hooks(LibSafetyObject *self, PyObject *args) {
+  unsigned int mode, param;
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_set_safety_hooks, "set_safety_hooks")) return NULL;
+  if (!PyArg_ParseTuple(args, "II", &mode, &param)) return NULL;
+  return PyLong_FromLong(fn_set_safety_hooks((uint16_t)mode, (uint16_t)param));
+}
+
+static PyObject *LibSafety_set_torque_meas(LibSafetyObject *self, PyObject *args) {
+  int min_value, max_value;
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_set_torque_meas, "set_torque_meas")) return NULL;
+  if (!PyArg_ParseTuple(args, "ii", &min_value, &max_value)) return NULL;
+  fn_set_torque_meas(min_value, max_value);
+  Py_RETURN_NONE;
+}
+
+static PyObject *LibSafety_set_torque_driver(LibSafetyObject *self, PyObject *args) {
+  int min_value, max_value;
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_set_torque_driver, "set_torque_driver")) return NULL;
+  if (!PyArg_ParseTuple(args, "ii", &min_value, &max_value)) return NULL;
+  fn_set_torque_driver(min_value, max_value);
+  Py_RETURN_NONE;
+}
+
+static PyObject *LibSafety_set_angle_meas(LibSafetyObject *self, PyObject *args) {
+  int min_value, max_value;
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_set_angle_meas, "set_angle_meas")) return NULL;
+  if (!PyArg_ParseTuple(args, "ii", &min_value, &max_value)) return NULL;
+  fn_set_angle_meas(min_value, max_value);
+  Py_RETURN_NONE;
+}
+
+static PyObject *LibSafety_set_timer(LibSafetyObject *self, PyObject *arg) {
+  unsigned long value;
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_set_timer, "set_timer")) return NULL;
+  value = PyLong_AsUnsignedLong(arg);
+  if ((value == (unsigned long)-1) && PyErr_Occurred()) return NULL;
+  fn_set_timer((uint32_t)value);
+  Py_RETURN_NONE;
+}
+
+static PyObject *LibSafety_safety_tick_current_safety_config(LibSafetyObject *self, PyObject *Py_UNUSED(ignored)) {
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_safety_tick_current_safety_config, "safety_tick_current_safety_config")) return NULL;
+  fn_safety_tick_current_safety_config();
+  Py_RETURN_NONE;
+}
+
+static PyObject *LibSafety_init_tests(LibSafetyObject *self, PyObject *Py_UNUSED(ignored)) {
+  (void)self;
+  if (!require_loaded() || !require_symbol((const void *)fn_init_tests, "init_tests")) return NULL;
+  fn_init_tests();
+  Py_RETURN_NONE;
+}
+
+static PyMethodDef LibSafety_methods[] = {
+  {"safety_rx_hook", (PyCFunction)LibSafety_safety_rx_hook, METH_O, NULL},
+  {"safety_tx_hook", (PyCFunction)LibSafety_safety_tx_hook, METH_O, NULL},
+  {"safety_fwd_hook", (PyCFunction)LibSafety_safety_fwd_hook, METH_VARARGS, NULL},
+  {"set_safety_hooks", (PyCFunction)LibSafety_set_safety_hooks, METH_VARARGS, NULL},
+  {"set_controls_allowed", (PyCFunction)LibSafety_set_controls_allowed, METH_O, NULL},
+  {"get_controls_allowed", (PyCFunction)LibSafety_get_controls_allowed, METH_NOARGS, NULL},
+  {"get_longitudinal_allowed", (PyCFunction)LibSafety_get_longitudinal_allowed, METH_NOARGS, NULL},
+  {"set_alternative_experience", (PyCFunction)LibSafety_set_alternative_experience, METH_O, NULL},
+  {"get_alternative_experience", (PyCFunction)LibSafety_get_alternative_experience, METH_NOARGS, NULL},
+  {"set_relay_malfunction", (PyCFunction)LibSafety_set_relay_malfunction, METH_O, NULL},
+  {"get_relay_malfunction", (PyCFunction)LibSafety_get_relay_malfunction, METH_NOARGS, NULL},
+  {"get_gas_pressed_prev", (PyCFunction)LibSafety_get_gas_pressed_prev, METH_NOARGS, NULL},
+  {"set_gas_pressed_prev", (PyCFunction)LibSafety_set_gas_pressed_prev, METH_O, NULL},
+  {"get_brake_pressed_prev", (PyCFunction)LibSafety_get_brake_pressed_prev, METH_NOARGS, NULL},
+  {"get_regen_braking_prev", (PyCFunction)LibSafety_get_regen_braking_prev, METH_NOARGS, NULL},
+  {"get_steering_disengage_prev", (PyCFunction)LibSafety_get_steering_disengage_prev, METH_NOARGS, NULL},
+  {"get_acc_main_on", (PyCFunction)LibSafety_get_acc_main_on, METH_NOARGS, NULL},
+  {"get_vehicle_speed_min", (PyCFunction)LibSafety_get_vehicle_speed_min, METH_NOARGS, NULL},
+  {"get_vehicle_speed_max", (PyCFunction)LibSafety_get_vehicle_speed_max, METH_NOARGS, NULL},
+  {"get_current_safety_mode", (PyCFunction)LibSafety_get_current_safety_mode, METH_NOARGS, NULL},
+  {"get_current_safety_param", (PyCFunction)LibSafety_get_current_safety_param, METH_NOARGS, NULL},
+  {"set_torque_meas", (PyCFunction)LibSafety_set_torque_meas, METH_VARARGS, NULL},
+  {"get_torque_meas_min", (PyCFunction)LibSafety_get_torque_meas_min, METH_NOARGS, NULL},
+  {"get_torque_meas_max", (PyCFunction)LibSafety_get_torque_meas_max, METH_NOARGS, NULL},
+  {"set_torque_driver", (PyCFunction)LibSafety_set_torque_driver, METH_VARARGS, NULL},
+  {"get_torque_driver_min", (PyCFunction)LibSafety_get_torque_driver_min, METH_NOARGS, NULL},
+  {"get_torque_driver_max", (PyCFunction)LibSafety_get_torque_driver_max, METH_NOARGS, NULL},
+  {"set_desired_torque_last", (PyCFunction)LibSafety_set_desired_torque_last, METH_O, NULL},
+  {"set_rt_torque_last", (PyCFunction)LibSafety_set_rt_torque_last, METH_O, NULL},
+  {"set_desired_angle_last", (PyCFunction)LibSafety_set_desired_angle_last, METH_O, NULL},
+  {"get_desired_angle_last", (PyCFunction)LibSafety_get_desired_angle_last, METH_NOARGS, NULL},
+  {"set_angle_meas", (PyCFunction)LibSafety_set_angle_meas, METH_VARARGS, NULL},
+  {"get_angle_meas_min", (PyCFunction)LibSafety_get_angle_meas_min, METH_NOARGS, NULL},
+  {"get_angle_meas_max", (PyCFunction)LibSafety_get_angle_meas_max, METH_NOARGS, NULL},
+  {"get_cruise_engaged_prev", (PyCFunction)LibSafety_get_cruise_engaged_prev, METH_NOARGS, NULL},
+  {"set_cruise_engaged_prev", (PyCFunction)LibSafety_set_cruise_engaged_prev, METH_O, NULL},
+  {"get_vehicle_moving", (PyCFunction)LibSafety_get_vehicle_moving, METH_NOARGS, NULL},
+  {"set_timer", (PyCFunction)LibSafety_set_timer, METH_O, NULL},
+  {"safety_tick_current_safety_config", (PyCFunction)LibSafety_safety_tick_current_safety_config, METH_NOARGS, NULL},
+  {"safety_config_valid", (PyCFunction)LibSafety_safety_config_valid, METH_NOARGS, NULL},
+  {"init_tests", (PyCFunction)LibSafety_init_tests, METH_NOARGS, NULL},
+  {"set_honda_fwd_brake", (PyCFunction)LibSafety_set_honda_fwd_brake, METH_O, NULL},
+  {"get_honda_fwd_brake", (PyCFunction)LibSafety_get_honda_fwd_brake, METH_NOARGS, NULL},
+  {"set_honda_alt_brake_msg", (PyCFunction)LibSafety_set_honda_alt_brake_msg, METH_O, NULL},
+  {"set_honda_bosch_long", (PyCFunction)LibSafety_set_honda_bosch_long, METH_O, NULL},
+  {"get_honda_hw", (PyCFunction)LibSafety_get_honda_hw, METH_NOARGS, NULL},
+  {"mutation_set_active_mutant", (PyCFunction)LibSafety_mutation_set_active_mutant, METH_O, NULL},
+  {"mutation_get_active_mutant", (PyCFunction)LibSafety_mutation_get_active_mutant, METH_NOARGS, NULL},
+  {NULL, NULL, 0, NULL},
+};
+
+static PyObject *module_load(PyObject *module, PyObject *arg) {
+  const char *path;
+  (void)module;
+  if (!PyUnicode_Check(arg)) {
+    PyErr_SetString(PyExc_TypeError, "path must be a string");
+    return NULL;
+  }
+  path = PyUnicode_AsUTF8(arg);
+  if (path == NULL) return NULL;
+
+  if (g_handle != NULL) {
+    dlclose(g_handle);
+    g_handle = NULL;
+  }
+
+  g_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+  if (g_handle == NULL) {
+    PyErr_Format(PyExc_RuntimeError, "dlopen failed: %s", dlerror());
+    return NULL;
+  }
+
+  if (!load_symbols()) {
+    dlclose(g_handle);
+    g_handle = NULL;
+    return NULL;
+  }
+
+  Py_INCREF((PyObject *)g_libsafety);
+  return (PyObject *)g_libsafety;
+}
+
+static PyObject *module_make_CANPacket(PyObject *module, PyObject *args) {
+  unsigned long addr;
+  unsigned long bus;
+  unsigned long dlc;
+  const unsigned char *data;
+  Py_ssize_t data_len;
+  CANPacketObject *packet;
+  (void)module;
+
+  if (!PyArg_ParseTuple(args, "kkky#", &addr, &bus, &dlc, &data, &data_len)) return NULL;
+  if (data_len < 0 || data_len > CANPACKET_DATA_SIZE_MAX) {
+    PyErr_SetString(PyExc_ValueError, "invalid CAN packet length");
+    return NULL;
+  }
+
+  packet = (CANPacketObject *)CANPacket_new(&CANPacketType, NULL, NULL);
+  if (packet == NULL) return NULL;
+
+  packet->packet.extended = addr >= 0x800U;
+  packet->packet.addr = (unsigned int)addr;
+  packet->packet.data_len_code = (unsigned int)dlc;
+  packet->packet.bus = (unsigned char)bus;
+  memcpy(packet->packet.data, data, (size_t)data_len);
+
+  return (PyObject *)packet;
+}
+
+static PyMethodDef module_methods[] = {
+  {"load", (PyCFunction)module_load, METH_O, NULL},
+  {"make_CANPacket", (PyCFunction)module_make_CANPacket, METH_VARARGS, NULL},
+  {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef moduledef = {
+  PyModuleDef_HEAD_INIT,
+  .m_name = "_libsafety_c_ext",
+  .m_doc = NULL,
+  .m_size = -1,
+  .m_methods = module_methods,
+};
+
+PyMODINIT_FUNC PyInit__libsafety_c_ext(void) {
+  PyObject *module;
+
+  CANPacketType = (PyTypeObject){
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_libsafety_c_ext.CANPacket",
+    .tp_basicsize = sizeof(CANPacketObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_new = CANPacket_new,
+    .tp_as_mapping = &CANPacket_mapping,
+    .tp_getset = CANPacket_getset,
+  };
+
+  LibSafetyType = (PyTypeObject){
+    PyVarObject_HEAD_INIT(NULL, 0)
+    .tp_name = "_libsafety_c_ext.LibSafety",
+    .tp_basicsize = sizeof(LibSafetyObject),
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_methods = LibSafety_methods,
+  };
+
+  if (PyType_Ready(&CANPacketType) < 0) return NULL;
+  if (PyType_Ready(&LibSafetyType) < 0) return NULL;
+
+  module = PyModule_Create(&moduledef);
+  if (module == NULL) return NULL;
+
+  Py_INCREF(&CANPacketType);
+  if (PyModule_AddObject(module, "CANPacket", (PyObject *)&CANPacketType) < 0) return NULL;
+
+  Py_INCREF(&LibSafetyType);
+  if (PyModule_AddObject(module, "LibSafety", (PyObject *)&LibSafetyType) < 0) return NULL;
+
+  g_libsafety = PyObject_New(LibSafetyObject, &LibSafetyType);
+  if (g_libsafety == NULL) return NULL;
+  if (PyModule_AddObject(module, "libsafety", (PyObject *)g_libsafety) < 0) return NULL;
+
+  return module;
+}

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -1,9 +1,9 @@
+import importlib.util
 import os
 import subprocess
+import sysconfig
 import tempfile
 from pathlib import Path
-
-from cffi import FFI
 
 from opendbc.safety import LEN_TO_DLC
 
@@ -11,7 +11,6 @@ libsafety_dir = os.path.dirname(os.path.abspath(__file__))
 
 
 def _build_libsafety() -> str:
-  """Compile libsafety.so to a temp file and return its path."""
   root = str(Path(libsafety_dir).parents[3])
   safety_c = os.path.join(libsafety_dir, "safety.c")
   safety_os = os.path.join(libsafety_dir, "safety.os")
@@ -35,89 +34,45 @@ def _build_libsafety() -> str:
   return libsafety_so
 
 
-ffi = FFI()
+def _build_extension():
+  root = str(Path(libsafety_dir).parents[3])
+  ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
+  include_flags = sysconfig.get_config_var("INCLUDEPY")
+  platinclude = sysconfig.get_config_var("PLATINCLUDE")
+  source = os.path.join(libsafety_dir, "_libsafety_c_ext.c")
 
-ffi.cdef("""
-typedef struct {
-  unsigned char fd : 1;
-  unsigned char bus : 3;
-  unsigned char data_len_code : 4;
-  unsigned char rejected : 1;
-  unsigned char returned : 1;
-  unsigned char extended : 1;
-  unsigned int addr : 29;
-  unsigned char checksum;
-  unsigned char data[64];
-} CANPacket_t;
-""", packed=True)
-class CANPacket:
-  pass
+  fd, ext_path = tempfile.mkstemp(suffix=ext_suffix)
+  os.close(fd)
 
-ffi.cdef("""
-bool safety_rx_hook(CANPacket_t *msg);
-bool safety_tx_hook(CANPacket_t *msg);
-int safety_fwd_hook(int bus_num, int addr);
-int set_safety_hooks(uint16_t mode, uint16_t param);
+  cmd = ['cc', '-shared', '-fPIC', '-O3', '-I', root]
+  if include_flags:
+    cmd.extend(['-I', include_flags])
+  if platinclude and platinclude != include_flags:
+    cmd.extend(['-I', platinclude])
+  cmd.extend([source, '-o', ext_path])
+  subprocess.check_call(cmd)
+  return ext_path
 
-void set_controls_allowed(bool c);
-bool get_controls_allowed(void);
-bool get_longitudinal_allowed(void);
-void set_alternative_experience(int mode);
-int get_alternative_experience(void);
-void set_relay_malfunction(bool c);
-bool get_relay_malfunction(void);
-bool get_gas_pressed_prev(void);
-void set_gas_pressed_prev(bool);
-bool get_brake_pressed_prev(void);
-bool get_regen_braking_prev(void);
-bool get_steering_disengage_prev(void);
-bool get_acc_main_on(void);
-float get_vehicle_speed_min(void);
-float get_vehicle_speed_max(void);
-int get_current_safety_mode(void);
-int get_current_safety_param(void);
 
-void set_torque_meas(int min, int max);
-int get_torque_meas_min(void);
-int get_torque_meas_max(void);
-void set_torque_driver(int min, int max);
-int get_torque_driver_min(void);
-int get_torque_driver_max(void);
-void set_desired_torque_last(int t);
-void set_rt_torque_last(int t);
-void set_desired_angle_last(int t);
-int get_desired_angle_last();
-void set_angle_meas(int min, int max);
-int get_angle_meas_min(void);
-int get_angle_meas_max(void);
+def _load_extension():
+  spec = importlib.util.spec_from_file_location("_libsafety_c_ext", _build_extension())
+  if spec is None or spec.loader is None:
+    raise ImportError("failed to load libsafety C extension")
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
 
-bool get_cruise_engaged_prev(void);
-void set_cruise_engaged_prev(bool engaged);
-bool get_vehicle_moving(void);
-void set_timer(uint32_t t);
 
-void safety_tick_current_safety_config();
-bool safety_config_valid();
-
-void init_tests(void);
-
-void set_honda_fwd_brake(bool c);
-bool get_honda_fwd_brake(void);
-void set_honda_alt_brake_msg(bool c);
-void set_honda_bosch_long(bool c);
-int get_honda_hw(void);
-
-void mutation_set_active_mutant(int id);
-int mutation_get_active_mutant(void);
-""")
-
-class LibSafety:
-  pass
+_ext = _load_extension()
+CANPacket = _ext.CANPacket
+LibSafety = _ext.LibSafety
 libsafety: LibSafety
+
 
 def load(path):
   global libsafety
-  libsafety = ffi.dlopen(str(path))
+  libsafety = _ext.load(str(path))
+
 
 def __getattr__(name):
   if name == "libsafety":
@@ -125,11 +80,6 @@ def __getattr__(name):
     return libsafety
   raise AttributeError(name)
 
+
 def make_CANPacket(addr: int, bus: int, dat):
-  ret = ffi.new('CANPacket_t *')
-  ret[0].extended = 1 if addr >= 0x800 else 0
-  ret[0].addr = addr
-  ret[0].data_len_code = LEN_TO_DLC[len(dat)]
-  ret[0].bus = bus
-  ret[0].data = bytes(dat)
-  return ret
+  return _ext.make_CANPacket(addr, bus, LEN_TO_DLC[len(dat)], bytes(dat))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
 [project.optional-dependencies]
 testing = [
   "comma-car-segments @ https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl",
-  "cffi",
   "tree-sitter",
   "tree-sitter-c",
   "gcovr",

--- a/uv.lock
+++ b/uv.lock
@@ -21,42 +21,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cffi"
-version = "2.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
-    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
-    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
-    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
-    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
-    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
-    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
-]
-
-[[package]]
 name = "charset-normalizer"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -395,7 +359,6 @@ examples = [
     { name = "inputs" },
 ]
 testing = [
-    { name = "cffi" },
     { name = "codespell" },
     { name = "comma-car-segments" },
     { name = "cppcheck" },
@@ -413,7 +376,6 @@ testing = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cffi", marker = "extra == 'testing'" },
     { name = "codespell", marker = "extra == 'testing'" },
     { name = "comma-car-segments", marker = "extra == 'testing'", url = "https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl" },
     { name = "cppcheck", marker = "extra == 'testing'", git = "https://github.com/commaai/dependencies.git?subdirectory=cppcheck&rev=releases" },
@@ -466,15 +428,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/5b/68090013128d7853f34c43828dd4dc80a7c8516fd1b56057b134e1e4c2c0/pycapnp-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c151edf78155b6416e7cb31e2e333d302d742ba52bb37d4dbdf71e75cc999d46", size = 6295279, upload-time = "2025-09-05T03:49:12.712Z" },
     { url = "https://files.pythonhosted.org/packages/5b/52/7d85212b4fcf127588888f71d3dbf5558ee7dc302eba760b12b1b325f9a3/pycapnp-2.1.0-cp312-cp312-win32.whl", hash = "sha256:c09b28419321dafafc644d60c57ff8ccaf3c3e686801b6060c612a7a3c580944", size = 1038995, upload-time = "2025-09-05T03:49:14.165Z" },
     { url = "https://files.pythonhosted.org/packages/f2/12/25d283ebf5c28717364647672e7494dc46196ca7a662f5420e4866f45687/pycapnp-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:560cb69cc02b0347e85b0629e4c2f0a316240900aa905392f9df6bab0a359989", size = 1176620, upload-time = "2025-09-05T03:49:15.545Z" },
-]
-
-[[package]]
-name = "pycparser"
-version = "3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Replace the Python `libsafety` test shim from `cffi` to a minimal CPython C extension while keeping the existing packet-facing test API.

## Why
`ctypes` was measurably slower on this boundary. Moving packet construction and hook dispatch into a tiny native shim keeps us testing the real `libsafety.so` while cutting Python FFI overhead.

## Benchmarks
Median of 5 runs on this machine:

| benchmark | cffi | C extension |
| --- | ---: | ---: |
| `make_CANPacket` | 1.81M ops/s | 3.94M ops/s |
| `safety_rx_hook` loop | 4.23M ops/s | 7.04M ops/s |

## Validation
- `pytest -n0 opendbc/safety/tests/test_defaults.py opendbc/safety/tests/test_body.py -q`
- `pytest -n0 opendbc/safety/tests/test_tesla.py -q`
