### PR TITLE
Increase KIA EV6 torque

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -146,7 +146,8 @@ class CarInterface(CarInterfaceBase):
 
     # Car specific configuration overrides
 
-    if candidate == CAR.KIA_EV6:
+    if ret.flags & HyundaiFlags.CANFD and 0x3aa in fingerprint[CAN.ECAN] and 0x2ba in fingerprint[CAN.ECAN]:
+      ret.flags |= HyundaiFlags.EV6.value
       ret.safetyConfigs[-1].safetyParam |= HyundaiSafetyFlags.EV6.value
 
     if candidate == CAR.KIA_OPTIMA_G4_FL:

--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -146,6 +146,9 @@ class CarInterface(CarInterfaceBase):
 
     # Car specific configuration overrides
 
+    if candidate == CAR.KIA_EV6:
+      ret.safetyConfigs[-1].safetyParam |= HyundaiSafetyFlags.EV6.value
+
     if candidate == CAR.KIA_OPTIMA_G4_FL:
       ret.steerActuatorDelay = 0.2
 

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -32,8 +32,8 @@ class CarControllerParams:
       self.STEER_DELTA_UP = 2
       self.STEER_DELTA_DOWN = 3
 
-      if CP.carFingerprint == CAR.KIA_EV6:
-        self.STEER_MAX = 350
+      if CP.flags & HyundaiFlags.EV6:
+        self.STEER_MAX = 300
         self.STEER_DELTA_UP = 5
         self.STEER_DELTA_DOWN = 10
 
@@ -96,6 +96,8 @@ class HyundaiFlags(IntFlag):
   # these cars use a different gas signal
   HYBRID = 2 ** 10
   EV = 2 ** 11
+
+  EV6 = 2 ** 27
 
   # Static flags
 

--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -32,6 +32,11 @@ class CarControllerParams:
       self.STEER_DELTA_UP = 2
       self.STEER_DELTA_DOWN = 3
 
+      if CP.carFingerprint == CAR.KIA_EV6:
+        self.STEER_MAX = 350
+        self.STEER_DELTA_UP = 5
+        self.STEER_DELTA_DOWN = 10
+
     # To determine the limit for your car, find the maximum value that the stock LKAS will request.
     # If the max stock LKAS request is <384, add your car to this list.
     elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.HYUNDAI_ELANTRA, CAR.HYUNDAI_ELANTRA_GT_I30, CAR.HYUNDAI_IONIQ,
@@ -66,6 +71,7 @@ class HyundaiSafetyFlags(IntFlag):
   CANFD_LKA_STEERING_ALT = 128
   FCEV_GAS = 256
   ALT_LIMITS_2 = 512
+  EV6 = 1024
 
 
 class HyundaiFlags(IntFlag):

--- a/opendbc/safety/modes/hyundai_canfd.h
+++ b/opendbc/safety/modes/hyundai_canfd.h
@@ -154,8 +154,8 @@ static bool hyundai_canfd_tx_hook(const CANPacket_t *msg) {
   };
 
   const TorqueSteeringLimits HYUNDAI_CANFD_STEERING_LIMITS_EV6 = {
-    .max_torque = 350,
-    .max_rt_delta = 348,
+    .max_torque = 300,
+    .max_rt_delta = 299, // 20% margin
     .max_rate_up = 5,
     .max_rate_down = 10,
     .driver_torque_allowance = 250,

--- a/opendbc/safety/modes/hyundai_canfd.h
+++ b/opendbc/safety/modes/hyundai_canfd.h
@@ -153,6 +153,21 @@ static bool hyundai_canfd_tx_hook(const CANPacket_t *msg) {
     .has_steer_req_tolerance = true,
   };
 
+  const TorqueSteeringLimits HYUNDAI_CANFD_STEERING_LIMITS_EV6 = {
+    .max_torque = 350,
+    .max_rt_delta = 348,
+    .max_rate_up = 5,
+    .max_rate_down = 10,
+    .driver_torque_allowance = 250,
+    .driver_torque_multiplier = 2,
+    .type = TorqueDriverLimited,
+
+    .min_valid_request_frames = 89,
+    .max_invalid_request_frames = 2,
+    .min_valid_request_rt_interval = 810000,
+    .has_steer_req_tolerance = true,
+  };
+
   bool tx = true;
 
   // steering
@@ -161,7 +176,8 @@ static bool hyundai_canfd_tx_hook(const CANPacket_t *msg) {
     int desired_torque = (((msg->data[6] & 0xFU) << 7U) | (msg->data[5] >> 1U)) - 1024U;
     bool steer_req = GET_BIT(msg, 52U);
 
-    if (steer_torque_cmd_checks(desired_torque, steer_req, HYUNDAI_CANFD_STEERING_LIMITS)) {
+    const TorqueSteeringLimits limits = hyundai_ev6 ? HYUNDAI_CANFD_STEERING_LIMITS_EV6 : HYUNDAI_CANFD_STEERING_LIMITS;
+    if (steer_torque_cmd_checks(desired_torque, steer_req, limits)) {
       tx = false;
     }
   }

--- a/opendbc/safety/modes/hyundai_common.h
+++ b/opendbc/safety/modes/hyundai_common.h
@@ -42,6 +42,9 @@ bool hyundai_fcev_gas_signal = false;
 extern bool hyundai_alt_limits_2;
 bool hyundai_alt_limits_2 = false;
 
+extern bool hyundai_ev6;
+bool hyundai_ev6 = false;
+
 static uint8_t hyundai_last_button_interaction;  // button messages since the user pressed an enable button
 
 void hyundai_common_init(uint16_t param) {
@@ -52,6 +55,7 @@ void hyundai_common_init(uint16_t param) {
   const uint16_t HYUNDAI_PARAM_ALT_LIMITS = 64; // TODO: shift this down with the rest of the common flags
   const uint16_t HYUNDAI_PARAM_FCEV_GAS = 256;
   const uint16_t HYUNDAI_PARAM_ALT_LIMITS_2 = 512;
+  const uint16_t HYUNDAI_PARAM_EV6 = 1024;
 
   hyundai_ev_gas_signal = GET_FLAG(param, HYUNDAI_PARAM_EV_GAS);
   hyundai_hybrid_gas_signal = !hyundai_ev_gas_signal && GET_FLAG(param, HYUNDAI_PARAM_HYBRID_GAS);
@@ -60,6 +64,7 @@ void hyundai_common_init(uint16_t param) {
   hyundai_alt_limits = GET_FLAG(param, HYUNDAI_PARAM_ALT_LIMITS);
   hyundai_fcev_gas_signal = GET_FLAG(param, HYUNDAI_PARAM_FCEV_GAS);
   hyundai_alt_limits_2 = GET_FLAG(param, HYUNDAI_PARAM_ALT_LIMITS_2);
+  hyundai_ev6 = GET_FLAG(param, HYUNDAI_PARAM_EV6);
 
   hyundai_last_button_interaction = HYUNDAI_PREV_BUTTON_SAMPLES;
 

--- a/opendbc/safety/tests/test_hyundai_canfd.py
+++ b/opendbc/safety/tests/test_hyundai_canfd.py
@@ -174,6 +174,19 @@ class TestHyundaiCanfdLKASteeringEV(TestHyundaiCanfdBase):
     self.safety.init_tests()
 
 
+class TestHyundaiCanfdLKASteeringEV6(TestHyundaiCanfdLKASteeringEV):
+  MAX_RATE_UP = 5
+  MAX_RATE_DOWN = 10
+  MAX_TORQUE_LOOKUP = [0], [350]
+  MAX_RT_DELTA = 348
+
+  def setUp(self):
+    self.packer = CANPackerSafety("hyundai_canfd_generated")
+    self.safety = libsafety_py.libsafety
+    self.safety.set_safety_hooks(CarParams.SafetyModel.hyundaiCanfd, HyundaiSafetyFlags.CANFD_LKA_STEERING | HyundaiSafetyFlags.EV_GAS | HyundaiSafetyFlags.EV6)
+    self.safety.init_tests()
+
+
 # TODO: Handle ICE and HEV configurations once we see cars that use the new messages
 class TestHyundaiCanfdLKASteeringAltEV(TestHyundaiCanfdBase):
 

--- a/opendbc/safety/tests/test_hyundai_canfd.py
+++ b/opendbc/safety/tests/test_hyundai_canfd.py
@@ -177,8 +177,8 @@ class TestHyundaiCanfdLKASteeringEV(TestHyundaiCanfdBase):
 class TestHyundaiCanfdLKASteeringEV6(TestHyundaiCanfdLKASteeringEV):
   MAX_RATE_UP = 5
   MAX_RATE_DOWN = 10
-  MAX_TORQUE_LOOKUP = [0], [350]
-  MAX_RT_DELTA = 348
+  MAX_TORQUE_LOOKUP = [0], [300]
+  MAX_RT_DELTA = 299
 
   def setUp(self):
     self.packer = CANPackerSafety("hyundai_canfd_generated")


### PR DESCRIPTION
Max lat accel measured (roll compensated): -2.3m/s² to +2.2m/s²

EV6 can pair match identification, validated with CommaCarSegments