### PR TITLE
Rivian: 90° fault prevention

### DIFF
--- a/opendbc/car/rivian/carcontroller.py
+++ b/opendbc/car/rivian/carcontroller.py
@@ -6,7 +6,7 @@ from opendbc.car.interfaces import CarControllerBase
 from opendbc.car.rivian.riviancan import create_lka_steering, create_longitudinal, create_wheel_touch, create_adas_status
 from opendbc.car.rivian.values import CarControllerParams
 
-# EPS faults after 90 frames of >90 degree steering
+# EPS faults after 90 frames of >90 degree steering angle
 MAX_ANGLE = 90
 MAX_ANGLE_FRAMES = 89
 MAX_ANGLE_CONSECUTIVE_FRAMES = 2

--- a/opendbc/car/rivian/carcontroller.py
+++ b/opendbc/car/rivian/carcontroller.py
@@ -6,7 +6,7 @@ from opendbc.car.interfaces import CarControllerBase
 from opendbc.car.rivian.riviancan import create_lka_steering, create_longitudinal, create_wheel_touch, create_adas_status
 from opendbc.car.rivian.values import CarControllerParams
 
-# EPS faults if you apply torque while the steering angle is above 90 degrees for more than 1 second
+# EPS faults after 90 frames of >90 degree steering
 MAX_ANGLE = 90
 MAX_ANGLE_FRAMES = 89
 MAX_ANGLE_CONSECUTIVE_FRAMES = 2

--- a/opendbc/car/rivian/carcontroller.py
+++ b/opendbc/car/rivian/carcontroller.py
@@ -1,10 +1,15 @@
 import numpy as np
 from opendbc.can import CANPacker
 from opendbc.car import Bus
-from opendbc.car.lateral import apply_driver_steer_torque_limits
+from opendbc.car.lateral import apply_driver_steer_torque_limits, common_fault_avoidance
 from opendbc.car.interfaces import CarControllerBase
 from opendbc.car.rivian.riviancan import create_lka_steering, create_longitudinal, create_wheel_touch, create_adas_status
 from opendbc.car.rivian.values import CarControllerParams
+
+# EPS faults if you apply torque while the steering angle is above 90 degrees for more than 1 second
+MAX_ANGLE = 90
+MAX_ANGLE_FRAMES = 89
+MAX_ANGLE_CONSECUTIVE_FRAMES = 2
 
 
 class CarController(CarControllerBase):
@@ -12,6 +17,7 @@ class CarController(CarControllerBase):
     super().__init__(dbc_names, CP)
     self.apply_torque_last = 0
     self.packer = CANPacker(dbc_names[Bus.pt])
+    self.angle_limit_counter = 0
 
     self.cancel_frames = 0
 
@@ -27,9 +33,17 @@ class CarController(CarControllerBase):
       apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last,
                                                       CS.out.steeringTorque, CarControllerParams, steer_max)
 
+    # >90 degree steering fault prevention
+    self.angle_limit_counter, apply_steer_req = common_fault_avoidance(abs(CS.out.steeringAngleDeg) >= MAX_ANGLE, CC.latActive,
+                                                                       self.angle_limit_counter, MAX_ANGLE_FRAMES,
+                                                                       MAX_ANGLE_CONSECUTIVE_FRAMES)
+    torque_fault = CC.latActive and not apply_steer_req
+    if not CC.latActive or torque_fault:
+      apply_torque = 0
+
     # send steering command
     self.apply_torque_last = apply_torque
-    can_sends.append(create_lka_steering(self.packer, self.frame, CS.acm_lka_hba_cmd, apply_torque, CC.enabled, CC.latActive))
+    can_sends.append(create_lka_steering(self.packer, self.frame, CS.acm_lka_hba_cmd, apply_torque, CC.enabled, apply_steer_req))
 
     if self.frame % 5 == 0:
       can_sends.append(create_wheel_touch(self.packer, CS.sccm_wheel_touch, CC.enabled))

--- a/opendbc/safety/modes/rivian.h
+++ b/opendbc/safety/modes/rivian.h
@@ -107,6 +107,11 @@ static bool rivian_tx_hook(const CANPacket_t *msg) {
     .driver_torque_multiplier = 2,
     .driver_torque_allowance = 100,
     .type = TorqueDriverLimited,
+
+    .min_valid_request_frames = 89,
+    .max_invalid_request_frames = 2,
+    .min_valid_request_rt_interval = 810000,  // 810ms; a ~10% buffer on cutting every 90 frames
+    .has_steer_req_tolerance = true,
   };
 
   const LongitudinalLimits RIVIAN_LONG_LIMITS = {


### PR DESCRIPTION
The fault avoidance is essentially the same pattern as  Hyundai using common_fault_avoidance.
Rivian-specific requirement: torque (ACM_lkaStrToqReq) must be 0 during the fault avoidance cut frames, just cutting the request bit alone isn't enough                                           
Based on fault avoidance work by @Uncle-Tony on Gen1

Validation
* Dongle ID: c70d59e4150956fc
* Route: [c70d59e4150956fc/00000028--cfee21f0db](https://connect.comma.ai/c70d59e4150956fc/00000028--cfee21f0db)
