### PR TITLE
Fix Ioniq 5 EU unknown vehicle variant (force vision-only config)

### DIFF
--- a/opendbc/car/hyundai/interface.py
+++ b/opendbc/car/hyundai/interface.py
@@ -132,6 +132,14 @@ class CarInterface(CarInterfaceBase):
     ret.vEgoStarting = 0.1
     ret.startAccel = 1.0
     ret.longitudinalActuatorDelay = 0.5
+    #  FIX IONIQ 5 EU VARIANT
+    if candidate == CAR.HYUNDAI_IONIQ_5:
+      # Force vision-only config
+      ret.radarUnavailable = True
+      ret.openpilotLongitudinalControl = False
+      ret.pcmCruise = True
+      if len(ret.safetyConfigs) > 0:
+        ret.safetyConfigs[-1].safetyParam &= ~HyundaiSafetyFlags.LONG.value   
 
     if ret.openpilotLongitudinalControl:
       ret.safetyConfigs[-1].safetyParam |= HyundaiSafetyFlags.LONG.value


### PR DESCRIPTION
Fix for Hyundai Ioniq 5 EU variant showing "unknown vehicle variant".

Issue:
Although the car is correctly fingerprinted, openpilot attempts to enable radar-based longitudinal control, which is not compatible with this EU configuration.

Solution:
Force vision-only configuration:
- radarUnavailable = True
- disable openpilot longitudinal control
- use stock ACC (pcmCruise = True)
- clear LONG safety flag to avoid conflicts

This aligns behavior with actual vehicle capabilities and resolves the error.

* Dongle ID: 41f768082eeec626
* Route: 41f768082eeec626%7C0000000b--c698908b49
