### PR TITLE
HONDA - fix alt_radar standstill lane blinking

### DIFF
--- a/opendbc/car/honda/carcontroller.py
+++ b/opendbc/car/honda/carcontroller.py
@@ -224,7 +224,7 @@ class CarController(CarControllerBase):
         can_sends.append(hondacan.create_acc_hud(self.packer, self.CAN.pt, self.CP, CC.enabled, pcm_speed, pcm_accel,
                                                  hud_control, hud_v_cruise, CS.is_metric, CS.acc_hud))
 
-      steering_available = CS.out.cruiseState.available and CS.out.vEgo > self.CP.minSteerSpeed
+      steering_available = CS.out.cruiseState.available and CS.out.vEgo > max(self.params.STEER_GLOBAL_MIN_SPEED, self.CP.minSteerSpeed)
       can_sends.extend(hondacan.create_lkas_hud(self.packer, self.CAN.lkas, self.CP, hud_control, CC.latActive,
                                                 steering_available, alert_steer_required, CS.lkas_hud))
 


### PR DESCRIPTION
Stops alt_radar cars from blinking lane lines at standstill

minsteerspeed was zero and vEgo noise at standstill had blinked the lines.

see lkas_hud - dashed_lanes

before: 619b464263ab23f2|0000002a--733b774118
after: 619b464263ab23f2/00000039--beccb905ef