### PR TITLE
perf: reduce pytest collection node explosion in car tests

### DIFF
--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -134,14 +134,18 @@ def _run_car_interface_test(car_name: str, data):
 
 class TestCarInterfaces(unittest.TestCase):
   def test_car_interfaces(self):
+
+    def make_run_case(car_name):
+      @settings(max_examples=MAX_EXAMPLES, deadline=None,
+                phases=(Phase.reuse, Phase.generate, Phase.shrink))
+      @given(data=st.data())
+      def run_case(data):
+        _run_car_interface_test(car_name, data)
+      return run_case
+
     for car_name in sorted(PLATFORMS):
       with self.subTest(car_model=car_name):
-        @settings(max_examples=MAX_EXAMPLES, deadline=None,
-                  phases=(Phase.reuse, Phase.generate, Phase.shrink))
-        @given(data=st.data())
-        def run_case(data, car_name=car_name):
-          _run_car_interface_test(car_name, data)
-
+        run_case = make_run_case(car_name)
         run_case()
 
   def test_interface_attrs(self):

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -139,7 +139,7 @@ class TestCarInterfaces(unittest.TestCase):
         @settings(max_examples=MAX_EXAMPLES, deadline=None,
                   phases=(Phase.reuse, Phase.generate, Phase.shrink))
         @given(data=st.data())
-        def run_case(data):
+        def run_case(data, car_name=car_name):
           _run_car_interface_test(car_name, data)
 
         run_case()

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -9,18 +9,11 @@ from typing import Any
 
 from opendbc.car import DT_CTRL, CanData, structs
 from opendbc.car.car_helpers import interfaces
-from opendbc.car.fingerprints import FW_VERSIONS
-from opendbc.car.fw_versions import FW_QUERY_CONFIGS
 from opendbc.car.interfaces import CarInterfaceBase, get_interface_attr
 from opendbc.car.mock.values import CAR as MOCK
 from opendbc.car.values import PLATFORMS
 
 DrawType = Callable[[st.SearchStrategy], Any]
-
-ALL_ECUS = {ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()}
-ALL_ECUS |= {ecu for config in FW_QUERY_CONFIGS.values() for ecu in config.extra_ecus}
-
-ALL_REQUESTS = {tuple(r.request) for config in FW_QUERY_CONFIGS.values() for r in config.requests}
 
 # From panda/python/__init__.py
 DLC_TO_LEN = [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64]
@@ -29,7 +22,20 @@ MAX_EXAMPLES = int(os.environ.get('MAX_EXAMPLES', '15'))
 
 
 @cache
+def get_fw_strategy_inputs() -> tuple[list, list]:
+  from opendbc.car.fingerprints import FW_VERSIONS
+  from opendbc.car.fw_versions import FW_QUERY_CONFIGS
+
+  all_ecus = {ecu for ecus in FW_VERSIONS.values() for ecu in ecus.keys()}
+  all_ecus |= {ecu for config in FW_QUERY_CONFIGS.values() for ecu in config.extra_ecus}
+  all_requests = {tuple(r.request) for config in FW_QUERY_CONFIGS.values() for r in config.requests}
+  return sorted(all_ecus), sorted(all_requests)
+
+
+@cache
 def get_fuzzy_strategy():
+  all_ecus, all_requests = get_fw_strategy_inputs()
+
   # Fuzzy CAN fingerprints and FW versions to test more states of the CarInterface
   fingerprint_strategy = st.fixed_dictionaries({0: st.dictionaries(st.integers(min_value=0, max_value=0x800),
                                                                    st.sampled_from(DLC_TO_LEN))})
@@ -37,8 +43,8 @@ def get_fuzzy_strategy():
   # only pick from possible ecus to reduce search space
   car_fw_strategy = st.lists(st.builds(
     lambda fw, req: structs.CarParams.CarFw(ecu=fw[0], address=fw[1], subAddress=fw[2] or 0, request=req),
-    st.sampled_from(sorted(ALL_ECUS)),
-    st.sampled_from(sorted(ALL_REQUESTS)),
+    st.sampled_from(all_ecus),
+    st.sampled_from(all_requests),
   ))
 
   params_strategy = st.fixed_dictionaries({
@@ -61,78 +67,83 @@ def get_fuzzy_car_interface(car_name: str, draw: DrawType) -> CarInterfaceBase:
   return CarInterface(car_params)
 
 
-def _make_car_test(car_name):
+def _run_car_interface_test(car_name: str, data):
   # FIXME: Due to the lists used in carParams, Phase.target is very slow and will cause
   #  many generated examples to overrun when max_examples > ~20, don't use it
-  @settings(max_examples=MAX_EXAMPLES, deadline=None,
-            phases=(Phase.reuse, Phase.generate, Phase.shrink))
-  @given(data=st.data())
-  def test(self, data):
-    car_interface = get_fuzzy_car_interface(car_name, data.draw)
-    car_params = car_interface.CP.as_reader()
+  car_interface = get_fuzzy_car_interface(car_name, data.draw)
+  car_params = car_interface.CP.as_reader()
 
-    assert car_params.mass > 1
-    assert car_params.wheelbase > 0
-    # centerToFront is center of gravity to front wheels, assert a reasonable range
-    assert car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7
-    assert car_params.maxLateralAccel > 0
+  assert car_params.mass > 1
+  assert car_params.wheelbase > 0
+  # centerToFront is center of gravity to front wheels, assert a reasonable range
+  assert car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7
+  assert car_params.maxLateralAccel > 0
 
-    # Longitudinal sanity checks
-    assert len(car_params.longitudinalTuning.kpV) == len(car_params.longitudinalTuning.kpBP)
-    assert len(car_params.longitudinalTuning.kiV) == len(car_params.longitudinalTuning.kiBP)
+  # Longitudinal sanity checks
+  assert len(car_params.longitudinalTuning.kpV) == len(car_params.longitudinalTuning.kpBP)
+  assert len(car_params.longitudinalTuning.kiV) == len(car_params.longitudinalTuning.kiBP)
 
-    # Lateral sanity checks
-    if car_params.steerControlType != structs.CarParams.SteerControlType.angle:
-      tune = car_params.lateralTuning
-      if tune.which() == 'pid':
-        if car_name != MOCK.MOCK:
-          assert not math.isnan(tune.pid.kf) and tune.pid.kf > 0
-          assert len(tune.pid.kpV) > 0 and len(tune.pid.kpV) == len(tune.pid.kpBP)
-          assert len(tune.pid.kiV) > 0 and len(tune.pid.kiV) == len(tune.pid.kiBP)
+  # Lateral sanity checks
+  if car_params.steerControlType != structs.CarParams.SteerControlType.angle:
+    tune = car_params.lateralTuning
+    if tune.which() == 'pid':
+      if car_name != MOCK.MOCK:
+        assert not math.isnan(tune.pid.kf) and tune.pid.kf > 0
+        assert len(tune.pid.kpV) > 0 and len(tune.pid.kpV) == len(tune.pid.kpBP)
+        assert len(tune.pid.kiV) > 0 and len(tune.pid.kiV) == len(tune.pid.kiBP)
 
-      elif tune.which() == 'torque':
-        assert not math.isnan(tune.torque.latAccelFactor) and tune.torque.latAccelFactor > 0
-        assert not math.isnan(tune.torque.friction) and tune.torque.friction > 0
+    elif tune.which() == 'torque':
+      assert not math.isnan(tune.torque.latAccelFactor) and tune.torque.latAccelFactor > 0
+      assert not math.isnan(tune.torque.friction) and tune.torque.friction > 0
 
-    # Run car interface
-    # TODO: use hypothesis to generate random messages
-    now_nanos = 0
-    CC = structs.CarControl().as_reader()
-    for _ in range(10):
-      car_interface.update([])
-      car_interface.apply(CC, now_nanos)
-      now_nanos += DT_CTRL * 1e9  # 10 ms
+  # Run car interface
+  # TODO: use hypothesis to generate random messages
+  now_nanos = 0
+  CC = structs.CarControl().as_reader()
+  for _ in range(10):
+    car_interface.update([])
+    car_interface.apply(CC, now_nanos)
+    now_nanos += DT_CTRL * 1e9  # 10 ms
 
-    CC = structs.CarControl()
-    CC.enabled = True
-    CC.latActive = True
-    CC.longActive = True
-    CC = CC.as_reader()
-    for _ in range(10):
-      car_interface.update([])
-      car_interface.apply(CC, now_nanos)
-      now_nanos += DT_CTRL * 1e9  # 10ms
+  CC = structs.CarControl()
+  CC.enabled = True
+  CC.latActive = True
+  CC.longActive = True
+  CC = CC.as_reader()
+  for _ in range(10):
+    car_interface.update([])
+    car_interface.apply(CC, now_nanos)
+    now_nanos += DT_CTRL * 1e9  # 10ms
 
-    # Test radar interface
-    radar_interface = car_interface.RadarInterface(car_params)
-    assert radar_interface
+  # Test radar interface
+  radar_interface = car_interface.RadarInterface(car_params)
+  assert radar_interface
 
-    # Run radar interface once
-    radar_interface.update([])
-    if not car_params.radarUnavailable and radar_interface.rcp is not None and \
-       hasattr(radar_interface, '_update') and hasattr(radar_interface, 'trigger_msg'):
-      radar_interface._update([radar_interface.trigger_msg])
+  # Run radar interface once
+  radar_interface.update([])
+  if not car_params.radarUnavailable and radar_interface.rcp is not None and \
+     hasattr(radar_interface, '_update') and hasattr(radar_interface, 'trigger_msg'):
+    radar_interface._update([radar_interface.trigger_msg])
 
-    # Test radar fault
-    if not car_params.radarUnavailable and radar_interface.rcp is not None:
-      cans = [(0, [CanData(0, b'', 0) for _ in range(5)])]
-      rr = radar_interface.update(cans)
-      assert rr is None or len(rr.errors) > 0
-
-  return test
+  # Test radar fault
+  if not car_params.radarUnavailable and radar_interface.rcp is not None:
+    cans = [(0, [CanData(0, b'', 0) for _ in range(5)])]
+    rr = radar_interface.update(cans)
+    assert rr is None or len(rr.errors) > 0
 
 
 class TestCarInterfaces(unittest.TestCase):
+  def test_car_interfaces(self):
+    for car_name in sorted(PLATFORMS):
+      with self.subTest(car_model=car_name):
+        @settings(max_examples=MAX_EXAMPLES, deadline=None,
+                  phases=(Phase.reuse, Phase.generate, Phase.shrink))
+        @given(data=st.data())
+        def run_case(data):
+          _run_car_interface_test(car_name, data)
+
+        run_case()
+
   def test_interface_attrs(self):
     """Asserts basic behavior of interface attribute getter"""
     num_brands = len(get_interface_attr('CAR'))
@@ -157,7 +168,3 @@ class TestCarInterfaces(unittest.TestCase):
     ret = get_interface_attr('FINGERPRINTS', ignore_none=True)
     none_brands_in_ret = none_brands.intersection(ret)
     assert len(none_brands_in_ret) == 0, f'Brands with None values in ignore_none=True result: {none_brands_in_ret}'
-
-
-for car_name in sorted(PLATFORMS):
-  setattr(TestCarInterfaces, f'test_car_interfaces_{car_name}', _make_car_test(car_name))

--- a/opendbc/car/tests/test_lateral_limits.py
+++ b/opendbc/car/tests/test_lateral_limits.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import unittest
 import importlib
-from opendbc.testing import parameterized_class
+from functools import cache
 
 from opendbc.car import DT_CTRL
 from opendbc.car.car_helpers import interfaces
@@ -18,31 +18,28 @@ MAX_LAT_JERK_UP_TOLERANCE = 0.5  # m/s^3
 JERK_MEAS_T = 0.5
 
 
-@parameterized_class('car_model', [(c,) for c in sorted(PLATFORMS)])
+@cache
+def get_lateral_case(car_model: str):
+  CarInterface = interfaces[car_model]
+  CP = CarInterface.get_non_essential_params(car_model)
+
+  if car_model == 'MOCK':
+    return None
+
+  # TODO: test all platforms
+  if CP.steerControlType != 'torque':
+    return None
+
+  if CP.notCar:
+    return None
+
+  CarControllerParams = importlib.import_module(f'opendbc.car.{CP.brand}.values').CarControllerParams
+  control_params = CarControllerParams(CP)
+  torque_params = get_torque_params()[car_model]
+  return control_params, torque_params
+
+
 class TestLateralLimits(unittest.TestCase):
-  car_model: str
-
-  @classmethod
-  def setUpClass(cls):
-    if 'car_model' not in cls.__dict__:
-      raise unittest.SkipTest('Base class')
-
-    CarInterface = interfaces[cls.car_model]
-    CP = CarInterface.get_non_essential_params(cls.car_model)
-
-    if cls.car_model == 'MOCK':
-      raise unittest.SkipTest('Mock car')
-
-    # TODO: test all platforms
-    if CP.steerControlType != 'torque':
-      raise unittest.SkipTest
-
-    if CP.notCar:
-      raise unittest.SkipTest
-
-    CarControllerParams = importlib.import_module(f'opendbc.car.{CP.brand}.values').CarControllerParams
-    cls.control_params = CarControllerParams(CP)
-    cls.torque_params = get_torque_params()[cls.car_model]
 
   @staticmethod
   def calculate_0_5s_jerk(control_params, torque_params):
@@ -61,9 +58,21 @@ class TestLateralLimits(unittest.TestCase):
     return accel_up_0_5_sec / JERK_MEAS_T, accel_down_0_5_sec / JERK_MEAS_T
 
   def test_jerk_limits(self):
-    up_jerk, down_jerk = self.calculate_0_5s_jerk(self.control_params, self.torque_params)
-    assert up_jerk <= MAX_LAT_JERK_UP + MAX_LAT_JERK_UP_TOLERANCE
-    assert down_jerk <= MAX_LAT_JERK_DOWN
+    for car_model in sorted(PLATFORMS):
+      with self.subTest(car_model=car_model):
+        case = get_lateral_case(car_model)
+        if case is None:
+          continue
+        control_params, torque_params = case
+        up_jerk, down_jerk = self.calculate_0_5s_jerk(control_params, torque_params)
+        self.assertLessEqual(up_jerk, MAX_LAT_JERK_UP + MAX_LAT_JERK_UP_TOLERANCE)
+        self.assertLessEqual(down_jerk, MAX_LAT_JERK_DOWN)
 
   def test_max_lateral_accel(self):
-    assert self.torque_params["MAX_LAT_ACCEL_MEASURED"] <= ISO_LATERAL_ACCEL
+    for car_model in sorted(PLATFORMS):
+      with self.subTest(car_model=car_model):
+        case = get_lateral_case(car_model)
+        if case is None:
+          continue
+        _, torque_params = case
+        self.assertLessEqual(torque_params["MAX_LAT_ACCEL_MEASURED"], ISO_LATERAL_ACCEL)


### PR DESCRIPTION
## Summary
Reduce pytest collection overhead in `opendbc/car/tests/` by eliminating large per-platform test expansion.

## Root cause
Collection time was dominated by pytest node explosion from large parameterized / generated per-platform tests.

## What changed

### `test_car_interfaces.py`
- Replace per-platform generated tests with a single loop using `self.subTest(car_model=...)`
- Keep Hypothesis-driven data generation inside each case
- Cache FW strategy inputs to avoid repeated heavy setup at import time

### `test_lateral_limits.py`
- Replace parameterized class expansion with a loop using `self.subTest(car_model=...)`

## Why this is different from earlier attempts
This keeps platform coverage deterministic.

Instead of drawing a platform from Hypothesis, the refactored tests iterate through all platforms explicitly via `subTest(...)`. So the collection-time reduction does not come from sampling fewer platforms; it comes from avoiding pytest node explosion.

Hypothesis is still used where applicable for per-case generated inputs.

## Results
Local `--collect-only` runs after this change:
- 31 tests collected in 0.31s
- 31 tests collected in 0.15s
- 31 tests collected in 0.15s
- 31 tests collected in 0.23s

Profiler:
- pyinstrument duration: ~0.32s

Compared to the original structure:
- collected nodes dropped from ~763 to 31
- collection became consistently faster

## Correctness / Safety
- All original platform cases are still executed explicitly
- Failures still report the relevant `car_model` through `subTest(...)`
- No test logic was removed; only the collection/execution structure changed

## Tradeoffs
This change targets collection time, not runtime.

After removing node explosion, the remaining collection cost appears to be mostly import / pytest overhead:
- pytest assertion rewriting
- import chains
- numpy / capnp / crypto imports

So this removes the largest avoidable collection cost without changing test intent.

## Validation
- `pytest -q opendbc/car/tests/test_lateral_limits.py`
  - 2 passed, 490 subtests passed
- `pytest -q opendbc/car/tests/test_car_interfaces.py`
  - 2 passed, 245 subtests passed

Dongle ID: N/A  
Route: N/A