### PR TITLE
Simplify GM siglin to use tanh

### DIFF
--- a/opendbc/car/gm/interface.py
+++ b/opendbc/car/gm/interface.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from math import fabs, exp
+from math import fabs, tanh
 import numpy as np
 
 from opendbc.car import get_safety_config, structs
@@ -55,7 +55,7 @@ class CarInterface(CarInterfaceBase):
       assert non_linear_torque_params, "The params are not defined"
       a, b, c, d = non_linear_torque_params
       sig_input = a * lateral_acceleration
-      sig = np.sign(sig_input) * (1 / (1 + exp(-fabs(sig_input))) - 0.5)
+      sig = 0.5 * tanh(0.5 * sig_input)
       steer_torque = (sig * b) + (lateral_acceleration * c) + d
       return float(steer_torque)
 


### PR DESCRIPTION
[it's literally the exact same mathematical function](https://www.wolframalpha.com/input?i=plot+sign%28x%29+*+%281%2F+%281+%2B+exp%28-abs%28x%29%29%29+-+0.5%29%2C+0.5+*+tanh%280.5+*+x%29), expressed with 32 fewer characters and using a familiar transcendental function. was there ever a reason to use abs/sign?

$$
\mathrm{sign}(x) \left(\frac{1}{1 + \exp|x|} - \frac{1}{2}\right) = \frac{1}{2} \tanh \left(\frac{x}{2}\right)
$$