### PR TITLE
Tesla long: more closely match stock setSpeed

### DIFF
--- a/opendbc/car/tesla/teslacan.py
+++ b/opendbc/car/tesla/teslacan.py
@@ -29,12 +29,7 @@ class TeslaCAN:
     return self.packer.make_can_msg("DAS_steeringControl", CANBUS.party, values)
 
   def create_longitudinal_command(self, acc_state, accel, counter, v_ego, active):
-    from opendbc.car.interfaces import V_CRUISE_MAX
-
-    set_speed = max(v_ego * CV.MS_TO_KPH, 0)
-    if active:
-      # TODO: this causes jerking after gas override when above set speed
-      set_speed = 0 if accel < 0 else V_CRUISE_MAX
+    set_speed = min(max(v_ego + accel, 0) * CV.MS_TO_KPH, 400)
 
     values = {
       "DAS_setSpeed": set_speed,


### PR DESCRIPTION
This alone doesn't do anything from what I can tell, but with https://github.com/commaai/opendbc/pull/3249, this fixes brake jerk after override