### PR TITLE
car: add max planned speed actuator field

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -368,6 +368,7 @@ struct CarControl {
     # longitudinal commands
     accel @4: Float32;  # m/s^2
     longControlState @5: LongControlState;
+    maxPlannedSpeed @9: Float32;  # m/s, max desired speed over the current planning horizon
 
     # these are only for logging the actual values sent to the car over CAN
     gas @0: Float32;   # [0.0, 1.0]


### PR DESCRIPTION
prerequisite of: 
- #2764 
- https://github.com/commaai/openpilot/pull/37800

**TLDR**
this type of MQB has no rollback protection and slow brakes.
knowing how fast the planner wants to go a few seconds from now lets the carcontroller make smarter decisions about how to comply with openpilot's requests

<details>
<summary>the long winded version</summary>

I'm going to do my best to explain why such a property is necessary, but it does require a bit of context.

### the first problem, for context

In order to hold at standstill forever, we must use TSK braking at low speeds. normally, MQB cars do not use the TSK below vEgoStopping. A few side effects:
- when using the TSK, we have no "native" rollback protection, unlike EPB cars which handle this at the ESP level
- the MQB TSK will only ever command brake or gas, never both
- the brake force commanded by the TSK is jerk-limited and takes about a second to accumulate
- releasing the brake is always instant

therefore: if we approach a stop on a hill, we may start rolling backward before the car has time to apply the brake.

### the solution to the first problem, for context
the solution is actually fairly simple:

estimate the amount of brake torque needed to hold the car at a stop.
use that to determine how long the TSK will take to accumulate the required brake torque.
and then use that to determine the slowest speed we can travel before rollback becomes a risk. 

This speed is our "safe speed". Above this speed momentum will keep the car moving long enough to apply brake. Below that speed, we must stop (or risk rollback).

### why this property needs to exist

poof! we have now fixed the first problem. now, consider the following scenario:
1. the car is stopped on a steep hill, with a car in front and behind
2. openpilot, for any reason, decides it would like to be just a little closer to the car in front of it
3. openpilot sends positive acceleration
4. the TSK complies in the only way it can: instantly release all brake pressure and apply engine torque to accelerate.
5. the car is now moving at a very slow speed uphill.

we have now put ourselves into a rather dangerous situation!

if we force openpilot to accelerate, we may hit the lead car!
if openpilot tries to stop, our jerk limited brake force **_cannot_** stop the car before we roll backward significantly! we may hit the car behind us!
any attempt to 'balance' the acceleration against gravity will earn the wrath of the check engine light

there's not really a good way out of this scenario. it's critical that we avoid it entirely!

initially, I tried to guess openpilot's intent based on its current commanded acceleration. this is awful for obvious reasons.
a much better solution is to use openpilot's plan directly, and only allow the car to release the brake if openpilot is actually planning on driving above our "safe speed".

I'm absolutely open to alternative approaches, though I've tried a few and this seems to be broadly the best approach.
</details>