### PR TITLE
Tesla: fuzzy fingerprinting

### DIFF
--- a/opendbc/car/tesla/tests/test_tesla_fuzzy_fingerprint.py
+++ b/opendbc/car/tesla/tests/test_tesla_fuzzy_fingerprint.py
@@ -1,0 +1,176 @@
+"""
+Tests for Tesla fuzzy fingerprinting.
+Place in: opendbc/car/tesla/tests/test_tesla_fuzzy_fingerprint.py
+
+These tests verify that Tesla's fuzzy fingerprinting correctly identifies
+car models based on the model identifier code in EPS firmware strings,
+even for firmware versions not in the database.
+"""
+import unittest
+
+from opendbc.car.tesla.values import (
+    CAR,
+    TESLA_FW_PATTERN,
+    get_platform_codes,
+    match_fw_to_car_fuzzy,
+)
+from opendbc.car.tesla.fingerprints import FW_VERSIONS
+from opendbc.car.structs import CarParams
+
+Ecu = CarParams.Ecu
+EPS_ADDR = (0x730, None)
+
+
+class TestTeslaFwPattern(unittest.TestCase):
+    """Test that the firmware regex pattern matches all known Tesla EPS firmware versions."""
+
+    def test_pattern_matches_all_known_fw(self):
+        for car_model, ecus in FW_VERSIONS.items():
+            for ecu, versions in ecus.items():
+                for fw in versions:
+                    with self.subTest(car_model=car_model, fw=fw):
+                        match = TESLA_FW_PATTERN.match(fw)
+                        self.assertIsNotNone(match, f"Pattern failed to match: {fw}")
+
+
+class TestGetPlatformCodes(unittest.TestCase):
+    """Test platform code extraction from firmware version strings."""
+
+    def test_model_3_codes_are_E(self):
+        codes = get_platform_codes(FW_VERSIONS[CAR.TESLA_MODEL_3][(Ecu.eps, 0x730, None)])
+        model_letters = {code[0] for code in codes}
+        self.assertEqual(model_letters, {b'E'})
+
+    def test_model_y_codes_are_Y(self):
+        codes = get_platform_codes(FW_VERSIONS[CAR.TESLA_MODEL_Y][(Ecu.eps, 0x730, None)])
+        model_letters = {code[0] for code in codes}
+        self.assertEqual(model_letters, {b'Y'})
+
+    def test_model_x_codes_are_X(self):
+        codes = get_platform_codes(FW_VERSIONS[CAR.TESLA_MODEL_X][(Ecu.eps, 0x730, None)])
+        model_letters = {code[0] for code in codes}
+        self.assertEqual(model_letters, {b'X'})
+
+    def test_no_model_letter_overlap(self):
+        m3 = {c[0] for c in get_platform_codes(FW_VERSIONS[CAR.TESLA_MODEL_3][(Ecu.eps, 0x730, None)])}
+        my = {c[0] for c in get_platform_codes(FW_VERSIONS[CAR.TESLA_MODEL_Y][(Ecu.eps, 0x730, None)])}
+        mx = {c[0] for c in get_platform_codes(FW_VERSIONS[CAR.TESLA_MODEL_X][(Ecu.eps, 0x730, None)])}
+        self.assertFalse(m3 & my, "Model 3 and Model Y share model letters")
+        self.assertFalse(m3 & mx, "Model 3 and Model X share model letters")
+        self.assertFalse(my & mx, "Model Y and Model X share model letters")
+
+    def test_empty_input(self):
+        self.assertEqual(get_platform_codes([]), set())
+        self.assertEqual(get_platform_codes(set()), set())
+
+    def test_garbage_input(self):
+        self.assertEqual(get_platform_codes([b'garbage']), set())
+        self.assertEqual(get_platform_codes([b'']), set())
+
+
+class TestTeslaFuzzyMatch(unittest.TestCase):
+    """Test the fuzzy fingerprinting function for Tesla vehicles."""
+
+    @property
+    def offline_fw(self):
+        """Build offline FW dict in the format match_fw_to_car_fuzzy expects."""
+        return {car.value: ecus for car, ecus in FW_VERSIONS.items()}
+
+    def test_known_fw_matches_correct_model(self):
+        """Every known FW version should fuzzy-match to its own model."""
+        for car_model, ecus in FW_VERSIONS.items():
+            for ecu, versions in ecus.items():
+                for fw in versions:
+                    with self.subTest(car_model=car_model, fw=fw):
+                        live = {EPS_ADDR: {fw}}
+                        result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+                        self.assertIn(car_model.value, result)
+
+    def test_known_fw_does_not_cross_match(self):
+        """Model 3 FW should not match Model Y or X, etc."""
+        model_map = {
+            CAR.TESLA_MODEL_3: [CAR.TESLA_MODEL_Y, CAR.TESLA_MODEL_X],
+            CAR.TESLA_MODEL_Y: [CAR.TESLA_MODEL_3, CAR.TESLA_MODEL_X],
+            CAR.TESLA_MODEL_X: [CAR.TESLA_MODEL_3, CAR.TESLA_MODEL_Y],
+        }
+        for car_model, ecus in FW_VERSIONS.items():
+            for ecu, versions in ecus.items():
+                for fw in versions:
+                    live = {EPS_ADDR: {fw}}
+                    result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+                    for wrong_model in model_map[car_model]:
+                        with self.subTest(car_model=car_model, wrong=wrong_model, fw=fw):
+                            self.assertNotIn(wrong_model.value, result)
+
+    def test_unknown_model_3_fw(self):
+        """Simulated future Model 3 firmware should still match."""
+        unknown_fws = [
+            b'TeMYG4_Main_0.0.0 (99),E4H016.01.0',
+            b'TeMYG4_NewBuild_0.0.0 (1),E5017.01.0',
+            b'TeM3_E014p12_0.0.0 (30),E014.20.00',
+        ]
+        for fw in unknown_fws:
+            with self.subTest(fw=fw):
+                live = {EPS_ADDR: {fw}}
+                result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+                self.assertIn(CAR.TESLA_MODEL_3.value, result)
+                self.assertNotIn(CAR.TESLA_MODEL_Y.value, result)
+
+    def test_unknown_model_y_fw(self):
+        """Simulated future Model Y firmware should still match."""
+        unknown_fws = [
+            b'TeMYG4_Main_0.0.0 (99),Y4004.01.0',
+            b'TeMYG4_Legacy3Y_0.0.0 (10),Y4003.10.0',
+            b'TeM3_E014p10_0.0.0 (20),YP003.01.00',
+        ]
+        for fw in unknown_fws:
+            with self.subTest(fw=fw):
+                live = {EPS_ADDR: {fw}}
+                result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+                self.assertIn(CAR.TESLA_MODEL_Y.value, result)
+                self.assertNotIn(CAR.TESLA_MODEL_3.value, result)
+
+    def test_unknown_model_x_fw(self):
+        """Simulated future Model X firmware should still match."""
+        unknown_fws = [
+            b'TeM3_SP_XP002p3_0.0.0 (50),XPR004.1.0',
+            b'TeM3_SP_XP003p1_0.0.0 (1),XPR005.01.0',
+        ]
+        for fw in unknown_fws:
+            with self.subTest(fw=fw):
+                live = {EPS_ADDR: {fw}}
+                result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+                self.assertIn(CAR.TESLA_MODEL_X.value, result)
+                self.assertNotIn(CAR.TESLA_MODEL_3.value, result)
+
+    def test_malformed_fw_no_match(self):
+        """Garbage firmware data should not produce any matches."""
+        garbage = [b'garbage_data', b'', b'NotATesla_FW_1.0.0 (1),Z999.01.0', b'random bytes']
+        for fw in garbage:
+            with self.subTest(fw=fw):
+                live = {EPS_ADDR: {fw}}
+                result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+                self.assertEqual(len(result), 0)
+
+    def test_empty_live_fw(self):
+        result = match_fw_to_car_fuzzy({}, "", self.offline_fw)
+        self.assertEqual(len(result), 0)
+
+    def test_wrong_ecu_address(self):
+        live = {(0x999, None): {b'TeMYG4_Main_0.0.0 (77),E4H015.04.5'}}
+        result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+        self.assertEqual(len(result), 0)
+
+    def test_multiple_fw_at_same_address(self):
+        """Multiple firmware responses at the same ECU address should work."""
+        live = {EPS_ADDR: {
+            b'TeMYG4_Main_0.0.0 (77),E4H015.04.5',
+            b'TeMYG4_Main_0.0.0 (78),E4HP015.05.0',
+        }}
+        result = match_fw_to_car_fuzzy(live, "", self.offline_fw)
+        self.assertIn(CAR.TESLA_MODEL_3.value, result)
+        self.assertNotIn(CAR.TESLA_MODEL_Y.value, result)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -4,9 +4,24 @@ from opendbc.car import ACCELERATION_DUE_TO_GRAVITY, Bus, CarSpecs, DbcDict, Pla
 from opendbc.car.lateral import AngleSteeringLimits, ISO_LATERAL_ACCEL
 from opendbc.car.structs import CarParams, CarState
 from opendbc.car.docs_definitions import CarDocs, CarFootnote, CarHarness, CarParts, Column
-from opendbc.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
+from opendbc.car.fw_query_definitions import FwQueryConfig, LiveFwVersions, OfflineFwVersions, Request, StdQueries
+import re
 
 Ecu = CarParams.Ecu
+
+# Tesla EPS firmware version pattern:
+#   <platform>_<build>_<version> (<build_num>),<model_code><part_version>
+# The model_code after the comma uniquely identifies the vehicle model:
+#   E... = Model 3, Y... = Model Y, X... = Model X
+TESLA_FW_PATTERN = re.compile(
+  rb'^(?P<platform>\w+)_(?P<build>[\w]+)_(?P<version>\d+\.\d+\.\d+) '
+  rb'\((?P<build_num>\d+)\),'
+  rb'(?P<model_code>[A-Z][A-Z0-9]*?)'
+  rb'(?P<part_version>\d{3}[\d.]*[\d]*)$'
+)
+
+# ECUs expected to have parseable platform codes for fuzzy matching
+PLATFORM_CODE_ECUS = (Ecu.eps,)
 
 
 class Footnote(Enum):
@@ -64,6 +79,48 @@ class CAR(Platforms):
   )
 
 
+def get_platform_codes(fw_versions: list[bytes] | set[bytes]) -> set[tuple[bytes, bytes]]:
+  """Extract (model_letter, platform_prefix) tuples from Tesla EPS firmware versions."""
+  codes = set()
+  for fw in fw_versions:
+    match = TESLA_FW_PATTERN.match(fw)
+    if match is not None:
+      model_letter = match.group('model_code')[:1]
+      platform = match.group('platform')
+      codes.add((model_letter, platform))
+  return codes
+
+
+def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str,
+                          offline_fw_versions: OfflineFwVersions) -> set[str]:
+  """Fuzzy fingerprint matching for Tesla vehicles using model identifier codes."""
+  candidates: set[str] = set()
+
+  for candidate, fws in offline_fw_versions.items():
+    for ecu, expected_versions in fws.items():
+      addr = ecu[1:]
+      if ecu[0] not in PLATFORM_CODE_ECUS:
+        continue
+
+      found_versions = live_fw_versions.get(addr, set())
+      if not found_versions:
+        continue
+
+      expected_codes = get_platform_codes(expected_versions)
+      found_codes = get_platform_codes(found_versions)
+
+      if not expected_codes or not found_codes:
+        continue
+
+      expected_model_letters = {code[0] for code in expected_codes}
+      found_model_letters = {code[0] for code in found_codes}
+
+      if expected_model_letters & found_model_letters:
+        candidates.add(candidate)
+
+  return candidates
+
+
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     Request(
@@ -71,7 +128,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [StdQueries.TESTER_PRESENT_RESPONSE, StdQueries.SUPPLIER_SOFTWARE_VERSION_RESPONSE],
       bus=0,
     )
-  ]
+  ],
+  match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )
 
 # Cars with this EPS FW have FSD 14 and use TeslaFlags.FSD_14


### PR DESCRIPTION
# Tesla: fuzzy fingerprinting

Closes #1917

## Summary

Implements fuzzy fingerprinting for Tesla vehicles by extracting the **model identifier code** from EPS firmware version strings. Tesla EPS firmware follows a consistent format:

```
<platform>_<build>_<version> (<build_num>),<model_code><part_version>
```

The `<model_code>` after the comma uniquely and reliably identifies the vehicle model:
- **`E...`** = Model 3 (variants: `E`, `EL`, `ES`, `E4`, `E4L`, `E4H`, `E4HP`, `E4S`)
- **`Y...`** = Model Y (variants: `Y`, `YP`, `YS`, `Y4`, `Y4P`, `Y4S`)
- **`X...`** = Model X (variants: `XPR`)

This approach is analogous to Ford's `platform_hint` extraction, adapted for Tesla's firmware format.

## Changes

**`opendbc/car/tesla/values.py`:**
- Added `TESLA_FW_PATTERN` regex to parse EPS firmware strings
- Added `PLATFORM_CODE_ECUS` constant (just `Ecu.eps` for Tesla)
- Added `get_platform_codes()` to extract model letter + platform prefix
- Added `match_fw_to_car_fuzzy()` implementing the fuzzy matching logic
- Updated `FW_QUERY_CONFIG` to register the fuzzy matching function

**`opendbc/car/tesla/tests/test_tesla_fuzzy_fingerprint.py`:**
- `TestTeslaFwPattern`: Validates regex matches ALL 33 known firmware versions
- `TestGetPlatformCodes`: Verifies model letter extraction (E/Y/X) with no overlap
- `TestTeslaFuzzyMatch`: 
  - Known FW correctly matches its own model
  - Known FW does NOT cross-match to wrong models
  - **Simulated future/unknown FW still matches correctly** (the whole point!)
  - Malformed/garbage data produces no matches
  - Edge cases: empty data, wrong ECU address, multiple FW responses

## Bounty Questions

### Has Tesla ever changed the APIs used?

Tesla queries the EPS ECU at address `0x730` using the standard UDS `SUPPLIER_SOFTWARE_VERSION` request. Based on the firmware database spanning HW3 (2019+) through HW4 (2024-25), the query mechanism has remained consistent. The firmware **format** has evolved (e.g., `TeM3_` prefix for HW3 era → `TeMYG4_` for HW4 era), but the model identifier pattern in the response (first letter after comma = model) has been stable across all known versions.

### Are there any variants of supported cars that won't work?

**Potential gaps to consider:**
- **Model S**: Not yet in the database. When added, we'd expect firmware codes starting with `S...` based on the pattern. The regex and matching logic already handle this — just needs firmware data.
- **International variants**: The firmware variations we see (e.g., `E4L` vs `E4H` vs `E4HP`) appear to be build-track variants rather than regional ones. The model letter (`E`/`Y`/`X`) stays the same regardless of variant, which is exactly what makes fuzzy matching work.
- **Very old HW2.5 Teslas**: These aren't supported by openpilot and would have different firmware formats entirely.

## Test Plan

- [ ] `pytest opendbc/car/tesla/tests/test_tesla_fuzzy_fingerprint.py` — all tests pass
- [ ] `pytest opendbc/car/tests/test_fw_fingerprint.py` — existing `test_custom_fuzzy_match` now exercises Tesla
- [ ] Verified no false positives: Model 3 FW never matches Model Y/X and vice versa
- [ ] Verified forward compatibility: simulated future firmware versions still match correctly