### PR TITLE
Chrysler: reliable fuzzy fingerprinting

### DIFF
--- a/opendbc/car/chrysler/tests/test_chrysler.py
+++ b/opendbc/car/chrysler/tests/test_chrysler.py
@@ -1,0 +1,124 @@
+import random
+import unittest
+
+from hypothesis import settings, given, strategies as st
+
+from opendbc.car.structs import CarParams
+from opendbc.car.fw_versions import build_fw_dict
+from opendbc.car.chrysler.values import CAR, FW_QUERY_CONFIG, FW_PATTERN, PLATFORM_CODE_ECUS, get_platform_codes
+from opendbc.car.chrysler.fingerprints import FW_VERSIONS
+from opendbc.testing import parameterized
+
+Ecu = CarParams.Ecu
+
+
+class TestChryslerFW(unittest.TestCase):
+  # Validates that every platform code ECU in the database has at least some
+  # parseable FW versions. Not all FW may parse (e.g. RAM radar b'22DTRHD_AA'),
+  # but each ECU should have at least one standard XXXXXXXXYY format entry.
+  @parameterized("car_model, fw_versions", FW_VERSIONS.items())
+  def test_fw_versions(self, car_model, fw_versions):
+    for (ecu, addr, subaddr), fws in fw_versions.items():
+      if ecu not in PLATFORM_CODE_ECUS:
+        continue
+
+      assert len(get_platform_codes(fws)) > 0, \
+        f"No FW versions for Ecu.{ecu} could be parsed for platform codes"
+
+  # Fuzz test: get_platform_codes should never raise on arbitrary byte strings
+  @settings(max_examples=100)
+  @given(data=st.data())
+  def test_platform_codes_fuzzy_fw(self, data):
+    fw_strategy = st.lists(st.binary())
+    fws = data.draw(fw_strategy)
+    get_platform_codes(fws)
+
+  # Spot-check that known FW versions parse to the expected part numbers
+  def test_platform_codes_spot_check(self):
+    results = get_platform_codes([
+      b'68227902AF',   # Pacifica combinationMeter
+      b'68222747AG',   # Pacifica ABS
+      b'04672758AA',   # Pacifica fwdRadar (Delphi supplier prefix)
+      b'68288891AE',   # Pacifica EPS
+    ])
+    assert results == {b'68227902', b'68222747', b'04672758', b'68288891'}
+
+  # Engine ECUs often have a trailing space — make sure we still parse those
+  def test_platform_codes_with_trailing_space(self):
+    results = get_platform_codes([b'68267018AO '])
+    assert results == {b'68267018'}
+
+    results = get_platform_codes([b'68267018AO'])
+    assert results == {b'68267018'}
+
+  # Non-standard formats should return empty (no crash, no false positives)
+  def test_platform_codes_unparseable(self):
+    results = get_platform_codes([b'22DTRHD_AA', b'', b'short'])
+    assert results == set()
+
+  # Every supported platform needs at least 2 ECUs with parseable part numbers
+  # to make fuzzy matching reliable (avoids single-ECU false positives)
+  def test_platform_code_ecus_available(self):
+    for car_model, fw_by_addr in FW_VERSIONS.items():
+      with self.subTest(car_model=car_model.value):
+        ecus_with_codes = {ecu for ecu, fws in fw_by_addr.items()
+                          if ecu[0] in PLATFORM_CODE_ECUS and len(get_platform_codes(fws)) > 0}
+        assert len(ecus_with_codes) >= 2, \
+          f"{car_model}: Only {len(ecus_with_codes)} ECUs have parseable platform codes"
+
+  # Core fuzzy matching test: with exact (database) FW versions, every platform
+  # should uniquely match to itself across 20 random FW selections per platform
+  def test_fuzzy_match(self):
+    for platform, fw_by_addr in FW_VERSIONS.items():
+      for _ in range(20):
+        car_fw = []
+        for ecu, fw_versions in fw_by_addr.items():
+          ecu_name, addr, sub_addr = ecu
+          fw = random.choice(fw_versions)
+          car_fw.append(CarParams.CarFw(ecu=ecu_name, fwVersion=fw, address=addr,
+                                        subAddress=0 if sub_addr is None else sub_addr))
+
+        CP = CarParams(carFw=car_fw)
+        matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw), CP.carVin, FW_VERSIONS)
+        assert matches == {platform}, f"{platform}: expected {{platform}}, got {matches}"
+
+  # The whole point of fuzzy matching: unseen revision codes (e.g. from a firmware
+  # update) should still identify the correct platform via part number matching
+  def test_fuzzy_match_mutated_revisions(self):
+    revisions = [b'AA', b'ZZ', b'XY', b'QQ']
+    for platform, fw_by_addr in FW_VERSIONS.items():
+      for _ in range(10):
+        car_fw = []
+        for ecu, fw_versions in fw_by_addr.items():
+          ecu_name, addr, sub_addr = ecu
+          fw = random.choice(fw_versions)
+          # Swap the revision code on platform code ECUs to simulate an update
+          match = FW_PATTERN.match(fw)
+          if match and ecu[0] in PLATFORM_CODE_ECUS:
+            fw = match.group('part_number') + random.choice(revisions)
+          car_fw.append(CarParams.CarFw(ecu=ecu_name, fwVersion=fw, address=addr,
+                                        subAddress=0 if sub_addr is None else sub_addr))
+
+        CP = CarParams(carFw=car_fw)
+        matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw), CP.carVin, FW_VERSIONS)
+        assert matches == {platform}, f"{platform}: expected {{platform}}, got {matches}"
+
+  # Fabricated part numbers should never match any platform
+  def test_fuzzy_match_wrong_part_numbers(self):
+    live_fw = {
+      (0x742, None): {b'99999999AA'},
+      (0x747, None): {b'99999998BB'},
+      (0x753, None): {b'99999997CC'},
+      (0x75a, None): {b'99999996DD'},
+    }
+    matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(live_fw, '', FW_VERSIONS)
+    assert len(matches) == 0
+
+  # No FW at all should obviously not match anything
+  def test_fuzzy_match_empty_input(self):
+    matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy({}, '', FW_VERSIONS)
+    assert len(matches) == 0
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/car/chrysler/tests/test_chrysler.py
+++ b/opendbc/car/chrysler/tests/test_chrysler.py
@@ -5,7 +5,7 @@ from hypothesis import settings, given, strategies as st
 
 from opendbc.car.structs import CarParams
 from opendbc.car.fw_versions import build_fw_dict
-from opendbc.car.chrysler.values import CAR, FW_QUERY_CONFIG, FW_PATTERN, PLATFORM_CODE_ECUS, get_platform_codes
+from opendbc.car.chrysler.values import FW_QUERY_CONFIG, FW_PATTERN, PLATFORM_CODE_ECUS, get_platform_codes
 from opendbc.car.chrysler.fingerprints import FW_VERSIONS
 from opendbc.testing import parameterized
 
@@ -18,7 +18,7 @@ class TestChryslerFW(unittest.TestCase):
   # but each ECU should have at least one standard XXXXXXXXYY format entry.
   @parameterized("car_model, fw_versions", FW_VERSIONS.items())
   def test_fw_versions(self, car_model, fw_versions):
-    for (ecu, addr, subaddr), fws in fw_versions.items():
+    for (ecu, _addr, _subaddr), fws in fw_versions.items():
       if ecu not in PLATFORM_CODE_ECUS:
         continue
 

--- a/opendbc/car/chrysler/values.py
+++ b/opendbc/car/chrysler/values.py
@@ -164,7 +164,7 @@ def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str, offline_fw
   """Match live firmware to a car platform using part numbers (revision-agnostic).
 
   For each candidate platform, checks that every checkable ECU's live part number
-  appears in the database for that platform. ECUs with unparseable FW (non-standard
+  appears in the database for that platform. ECUs with unparsable FW (non-standard
   format) are skipped rather than treated as a mismatch. Requires at least 2 ECUs
   to match to avoid false positives from single shared part numbers.
   """

--- a/opendbc/car/chrysler/values.py
+++ b/opendbc/car/chrysler/values.py
@@ -1,10 +1,11 @@
+import re
 from enum import IntFlag
 from dataclasses import dataclass, field
 
 from opendbc.car import Bus, CarSpecs, DbcDict, PlatformConfig, Platforms, uds
 from opendbc.car.structs import CarParams
 from opendbc.car.docs_definitions import CarHarness, CarDocs, CarParts
-from opendbc.car.fw_query_definitions import FwQueryConfig, Request, p16
+from opendbc.car.fw_query_definitions import FwQueryConfig, LiveFwVersions, OfflineFwVersions, Request, p16
 
 Ecu = CarParams.Ecu
 
@@ -129,6 +130,77 @@ RAM_CARS = RAM_DT | RAM_HD
 CUSW_CARS = {CAR.JEEP_CHEROKEE_5TH_GEN, }
 
 
+# Chrysler/Dodge/Jeep/Ram FW versions follow the format: XXXXXXXXYY
+#   XXXXXXXX = 8-digit part number (identifies the hardware/platform)
+#   YY       = 2-character revision code (changes with software updates)
+# Examples:
+#   b'68227902AF' -> part number 68227902, revision AF
+#   b'04672758AA' -> part number 04672758, revision AA
+#   b'68267018AO ' -> part number 68267018, revision AO (trailing space on some engine ECUs)
+# Some ECUs have non-standard formats (e.g. b'22DTRHD_AA' on RAM radar) which won't parse
+FW_PATTERN = re.compile(b'^(?P<part_number>[A-Z0-9]{8})(?P<revision>[A-Z]{2})\\s*$')
+
+# These ECUs carry platform-specific part numbers suitable for fuzzy matching.
+# Engine/transmission/hybrid ECUs are excluded since their part numbers vary
+# by powertrain option (V6 vs V8, gas vs hybrid) within the same platform.
+PLATFORM_CODE_ECUS = (Ecu.combinationMeter, Ecu.abs, Ecu.fwdRadar, Ecu.eps)
+
+
+def get_platform_codes(fw_versions: list[bytes] | set[bytes]) -> set[bytes]:
+  """Extract 8-digit part numbers from FW versions, ignoring the 2-char revision suffix.
+
+  Returns a set of part number bytes. FW versions that don't match the expected
+  XXXXXXXXYY format (e.g. non-standard radar responses) are silently skipped.
+  """
+  codes = set()
+  for fw in fw_versions:
+    match = FW_PATTERN.match(fw)
+    if match is not None:
+      codes.add(match.group('part_number'))
+  return codes
+
+
+def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str, offline_fw_versions: OfflineFwVersions) -> set[str]:
+  """Match live firmware to a car platform using part numbers (revision-agnostic).
+
+  For each candidate platform, checks that every checkable ECU's live part number
+  appears in the database for that platform. ECUs with unparseable FW (non-standard
+  format) are skipped rather than treated as a mismatch. Requires at least 2 ECUs
+  to match to avoid false positives from single shared part numbers.
+  """
+  candidates: set[str] = set()
+
+  for candidate, fws in offline_fw_versions.items():
+    valid_found_ecus = set()
+    valid_expected_ecus = set()
+    for ecu, expected_versions in fws.items():
+      addr = ecu[1:]
+      if ecu[0] not in PLATFORM_CODE_ECUS:
+        continue
+
+      expected_part_numbers = get_platform_codes(expected_versions)
+      found_part_numbers = get_platform_codes(live_fw_versions.get(addr, set()))
+
+      # If live FW can't be parsed for this ECU, skip it — it gives us no signal.
+      # This handles non-standard formats like b'22DTRHD_AA' on some RAM radars.
+      if not found_part_numbers:
+        continue
+
+      valid_expected_ecus.add(addr)
+
+      # At least one live part number must exist in the database for this platform
+      if not any(found in expected_part_numbers for found in found_part_numbers):
+        break
+
+      valid_found_ecus.add(addr)
+    else:
+      # Every checkable ECU must match, and we need at least 2 to be confident
+      if len(valid_found_ecus) >= 2 and valid_expected_ecus.issubset(valid_found_ecus):
+        candidates.add(candidate)
+
+  return candidates
+
+
 CHRYSLER_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
   p16(0xf132)
 CHRYSLER_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
@@ -166,6 +238,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[
     (Ecu.abs, 0x7e4, None),  # alt address for abs on hybrids, NOTE: not on all hybrid platforms
   ],
+  match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION
Adds fuzzy fingerprinting for Chrysler/Dodge/Jeep/Ram, same approach as Ford and Hyundai — match on the 8-digit part number, ignore the 2-char revision suffix that changes with software updates.

Uses `combinationMeter`, `abs`, `fwdRadar`, and `eps` for matching (engine/transmission vary by powertrain within a platform so those are excluded). Needs at least 2 ECU matches to avoid false positives. Some RAM radars return non-standard FW (`22DTRHD_AA`) — these are skipped gracefully.

Tested against the FW from #3328 (Trackhawk) — correctly doesn't match since the Trackhawk has genuinely new part numbers in cluster/eps. Once those get added to the DB, future Trackhawks with updated revisions will fuzzy match.

```
python -m pytest opendbc/car/chrysler/tests/test_chrysler.py  # 10 passed
python -m pytest opendbc/car/tests/test_fw_fingerprint.py     # 14 passed, 2483 subtests passed
```

Closes #1092

Validation
* Dongle ID: N/A (code-only change, no new car)
* Route: N/A