### PR TITLE
CI: Increase car_diff timeout to 20 minutes

### DIFF
--- a/.github/workflows/car_diff.yml
+++ b/.github/workflows/car_diff.yml
@@ -8,7 +8,7 @@ jobs:
   comment:
     name: comment
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Car_diff needs longer to run, adding time.

See: https://github.com/mvl-boston/opendbc/actions/runs/24632710264/job/72022753334 for a job that needed more than 10 minutes.