### PR TITLE
packaging: move direct-URL deps to dependency-groups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
 
 [project.optional-dependencies]
 testing = [
-  "comma-car-segments @ https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl",
   "cffi",
   "tree-sitter",
   "tree-sitter-c",
@@ -33,13 +32,21 @@ testing = [
   "lefthook",
   "cpplint",
   "codespell",
-  "cppcheck @ git+https://github.com/commaai/dependencies.git@release-cppcheck#subdirectory=cppcheck",
 ]
 docs = [
   "Jinja2",
 ]
 examples = [
   "inputs",
+]
+
+# Dependency groups (PEP 735) are not included in the published wheel.
+# Direct URL dependencies must live here because PyPI rejects uploads whose
+# `Requires-Dist` contains direct URLs.
+[dependency-groups]
+testing = [
+  "comma-car-segments @ https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl",
+  "cppcheck @ git+https://github.com/commaai/dependencies.git@release-cppcheck#subdirectory=cppcheck",
 ]
 
 [build-system]

--- a/setup.sh
+++ b/setup.sh
@@ -18,5 +18,5 @@ if ! command -v uv &>/dev/null; then
 fi
 
 export UV_PROJECT_ENVIRONMENT="$BASEDIR/.venv"
-uv sync --all-extras --inexact
+uv sync --all-extras --all-groups --inexact
 source "$PYTHONPATH/.venv/bin/activate"

--- a/uv.lock
+++ b/uv.lock
@@ -401,8 +401,6 @@ examples = [
 testing = [
     { name = "cffi" },
     { name = "codespell" },
-    { name = "comma-car-segments" },
-    { name = "cppcheck" },
     { name = "cpplint" },
     { name = "gcovr" },
     { name = "hypothesis" },
@@ -415,12 +413,16 @@ testing = [
     { name = "zstandard" },
 ]
 
+[package.dev-dependencies]
+testing = [
+    { name = "comma-car-segments" },
+    { name = "cppcheck" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "cffi", marker = "extra == 'testing'" },
     { name = "codespell", marker = "extra == 'testing'" },
-    { name = "comma-car-segments", marker = "extra == 'testing'", url = "https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl" },
-    { name = "cppcheck", marker = "extra == 'testing'", git = "https://github.com/commaai/dependencies.git?subdirectory=cppcheck&rev=release-cppcheck" },
     { name = "cpplint", marker = "extra == 'testing'" },
     { name = "gcovr", marker = "extra == 'testing'" },
     { name = "hypothesis", marker = "extra == 'testing'", specifier = "==6.47.*" },
@@ -439,6 +441,12 @@ requires-dist = [
     { name = "zstandard", marker = "extra == 'testing'" },
 ]
 provides-extras = ["testing", "docs", "examples"]
+
+[package.metadata.requires-dev]
+testing = [
+    { name = "comma-car-segments", url = "https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl" },
+    { name = "cppcheck", git = "https://github.com/commaai/dependencies.git?subdirectory=cppcheck&rev=release-cppcheck" },
+]
 
 [[package]]
 name = "pycapnp"


### PR DESCRIPTION
For https://github.com/commaai/opendbc/issues/3140

## Summary
- PyPI rejected the 0.3.0 upload with `400 Bad Request` because the wheel's `Requires-Dist` contained direct-URL entries, which PyPI disallows on upload.
- Moves `comma-car-segments` and `cppcheck` from `[project.optional-dependencies].testing` to a PEP 735 `[dependency-groups].testing`. Dependency groups are not shipped in the wheel.
- Updates `setup.sh` to pick them up via `--all-groups`.

## Test plan
- [x] Local wheel build: `uvx --from build python -m build --wheel` — resulting `Requires-Dist` no longer contains `@ https://` or `@ git+https://` entries.
- [x] `twine check` passes on the new wheel.