### PR TITLE
tesla: tune legacy Model 3/Y steer ratio to 10.3

### DIFF
--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -48,6 +48,11 @@ class CarInterface(CarInterfaceBase):
       ret.flags |= TeslaFlags.FSD_14.value
       ret.safetyConfigs[0].safetyParam |= TeslaSafetyFlags.FSD_14.value
 
+    # Legacy Model 3/Y use 10.3; Highland (Model 3) and Juniper (Model Y)
+    # variants identified by FSD14 EPS FW keep 12.0.
+    if candidate in (CAR.TESLA_MODEL_3, CAR.TESLA_MODEL_Y) and fsd_14:
+      ret.steerRatio = 12.0
+
     ret.dashcamOnly = candidate in (CAR.TESLA_MODEL_X,)  # dashcam only, pending find invalidLkasSetting signal
 
     return ret

--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -48,8 +48,8 @@ class CarInterface(CarInterfaceBase):
       ret.flags |= TeslaFlags.FSD_14.value
       ret.safetyConfigs[0].safetyParam |= TeslaSafetyFlags.FSD_14.value
 
-    # Legacy Model 3/Y use 10.3; Highland (Model 3) and Juniper (Model Y)
-    # variants identified by FSD14 EPS FW keep 12.0.
+    # This PR only retunes legacy Model 3/Y to 10.3.
+    # FSD14-identified variants keep the current 12.0 behavior.
     if candidate in (CAR.TESLA_MODEL_3, CAR.TESLA_MODEL_Y) and fsd_14:
       ret.steerRatio = 12.0
 

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -75,7 +75,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
 )
 
 # Cars with this EPS FW have FSD14 and use TeslaFlags.FSD_14.
-# For Model 3/Y steer ratio, this map is used to keep Highland/Juniper at 12.0.
+# For Model 3/Y steer ratio, this map is used to preserve current 12.0 behavior
+# for FSD14-identified variants in this legacy-only tuning change.
 FSD_14_FW = {
   CAR.TESLA_MODEL_3: [
     b'TeMYG4_Main_0.0.0 (77),E4HP015.04.5',

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -47,7 +47,7 @@ class CAR(Platforms):
       TeslaCarDocsHW3("Tesla Model 3 (with HW3) 2019-23"),
       TeslaCarDocsHW4("Tesla Model 3 (with HW4) 2024-25"),
     ],
-    CarSpecs(mass=1899., wheelbase=2.875, steerRatio=12.0),
+    CarSpecs(mass=1899., wheelbase=2.875, steerRatio=10.3),
     {Bus.party: 'tesla_model3_party', Bus.radar: 'tesla_radar_continental_generated'},
   )
   TESLA_MODEL_Y = TeslaPlatformConfig(
@@ -55,7 +55,7 @@ class CAR(Platforms):
       TeslaCarDocsHW3("Tesla Model Y (with HW3) 2020-23"),
       TeslaCarDocsHW4("Tesla Model Y (with HW4) 2024-25"),
     ],
-    CarSpecs(mass=2072., wheelbase=2.890, steerRatio=12.0),
+    CarSpecs(mass=2072., wheelbase=2.890, steerRatio=10.3),
     {Bus.party: 'tesla_model3_party', Bus.radar: 'tesla_radar_continental_generated'},
   )
   TESLA_MODEL_X = TeslaPlatformConfig(
@@ -74,7 +74,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ]
 )
 
-# Cars with this EPS FW have FSD 14 and use TeslaFlags.FSD_14
+# Cars with this EPS FW have FSD14 and use TeslaFlags.FSD_14.
+# For Model 3/Y steer ratio, this map is used to keep Highland/Juniper at 12.0.
 FSD_14_FW = {
   CAR.TESLA_MODEL_3: [
     b'TeMYG4_Main_0.0.0 (77),E4HP015.04.5',

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -28,6 +28,8 @@ def round_angle(apply_angle, can_offset=0):
 
 class TestTeslaSafetyBase(common.CarSafetyTest, common.AngleSteeringSafetyTest, common.LongitudinalAccelSafetyTest):
   SAFETY_PARAM = 0
+  # Keep in sync with opendbc/safety/modes/tesla.h (TESLA_STEERING_PARAMS.steer_ratio)
+  SAFETY_STEER_RATIO = 12.0
 
   RELAY_MALFUNCTION_ADDRS = {0: (MSG_DAS_steeringControl, MSG_APS_eacMonitor)}
   FWD_BLACKLISTED_ADDRS = {2: [MSG_DAS_steeringControl, MSG_APS_eacMonitor]}
@@ -64,6 +66,7 @@ class TestTeslaSafetyBase(common.CarSafetyTest, common.AngleSteeringSafetyTest, 
 
   def setUp(self):
     self.VM = VehicleModel(get_safety_CP())
+    self.VM.update_params(1.0, self.SAFETY_STEER_RATIO)
     self.packer = CANPackerSafety("tesla_model3_party")
     self.define = CANDefine("tesla_model3_party")
     self.acc_states = {d: v for v, d in self.define.dv["DAS_control"]["DAS_accState"].items()}


### PR DESCRIPTION
## Goal
Tune **legacy (pre-refresh) Tesla Model 3/Y** vehicle model steer ratio from `12.0` to `10.3`, while keeping current behavior for refreshed/FSD14-identified variants.

## Summary
- tune legacy Tesla Model 3/Y steer ratio from `12.0` to `10.3`
- preserve current `12.0` behavior for FSD14-identified variants
- align Tesla safety tests with `opendbc/safety/modes/tesla.h` (`steer_ratio = 12.0`) so test limits stay consistent with safety checks

## Scope
This PR is intentionally limited to **pre-refresh Model 3/Y** tuning.

Refreshed vehicles are reportedly closer to ~10.6, but reliably separating all Model Y pre/post-refresh variants is not straightforward with current signals/firmware grouping. To keep this change low-risk and reviewable, refreshed handling is left unchanged in this PR.

## Validation
- code scope limited to Tesla interface/specs and Tesla safety test setup
- local execution of `opendbc/safety/tests/test_tesla.py` was blocked in this workspace by environment setup (`uv`/python)
- GitHub Actions checks are running for this PR

## Route / Dongle
- N/A for this change (parameter/model tuning only)

## References
- https://www.axecous.com/blogs/auto-living/tesla-model-3-steering-wheel-ergonomics-explained-grip-thickness-control
- https://teslamotorsclub.com/tmc/threads/model-y-steering-ratio-is-10-3-like-a-sports-car.231411/
- https://www.motortrend.com/reviews/exclusive-tesla-model-3-long-range-first-test-review