### PR TITLE
Tesla - add HW3 detection to avoid false detection of FSD14

### DIFF
--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -124,13 +124,13 @@ class CarState(CarStateBase):
       # 1. If in Autosteer or FSD, already caught by invalidLkasSetting
       # 2. If in TACC and DAS ever sends ANGLE_CONTROL (1), we can infer it's trying to do LKAS on FSD 14+
       angle_control = cp_ap_party.vl["DAS_steeringControl"]["DAS_steeringControlType"] == 1  # ANGLE_CONTROL
-      if not ret.invalidLkasSetting and angle_control and not self.CP.flags & TeslaFlags.FSD_14 and not self.CP.flags & TeslaFlags.HW3:
+      if not ret.invalidLkasSetting and angle_control and not self.CP.flags & TeslaFlags.FSD_14 and not self.CP.flags & TeslaFlags.NON_FSD_14_SELFDRIVE:
         self.suspected_fsd14 = True
 
       if self.suspected_fsd14:
         ret.invalidLkasSetting = True
         if not self.fsd14_error_logged:
-          carlog.error("FSD 14 detected, but FW not in FSD_14_FW or HW3_FW set")
+          carlog.error("possible FSD 14 detected, but FW did not match FSD 14 rules.")
           self.fsd14_error_logged = True
 
     # Buttons # ToDo: add Gap adjust button

--- a/opendbc/car/tesla/carstate.py
+++ b/opendbc/car/tesla/carstate.py
@@ -124,13 +124,13 @@ class CarState(CarStateBase):
       # 1. If in Autosteer or FSD, already caught by invalidLkasSetting
       # 2. If in TACC and DAS ever sends ANGLE_CONTROL (1), we can infer it's trying to do LKAS on FSD 14+
       angle_control = cp_ap_party.vl["DAS_steeringControl"]["DAS_steeringControlType"] == 1  # ANGLE_CONTROL
-      if not ret.invalidLkasSetting and angle_control and not self.CP.flags & TeslaFlags.FSD_14:
+      if not ret.invalidLkasSetting and angle_control and not self.CP.flags & TeslaFlags.FSD_14 and not self.CP.flags & TeslaFlags.HW3:
         self.suspected_fsd14 = True
 
       if self.suspected_fsd14:
         ret.invalidLkasSetting = True
         if not self.fsd14_error_logged:
-          carlog.error("FSD 14 detected, but FW not in FSD_14_FW set")
+          carlog.error("FSD 14 detected, but FW not in FSD_14_FW or HW3_FW set")
           self.fsd14_error_logged = True
 
     # Buttons # ToDo: add Gap adjust button

--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -2,7 +2,7 @@ from opendbc.car import Bus, get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.tesla.carcontroller import CarController
 from opendbc.car.tesla.carstate import CarState
-from opendbc.car.tesla.values import TeslaSafetyFlags, TeslaFlags, CANBUS, CAR, DBC, FSD_14_FW, Ecu
+from opendbc.car.tesla.values import TeslaSafetyFlags, TeslaFlags, CANBUS, CAR, DBC, FSD_14_FW, HW3_FW, Ecu
 from opendbc.car.tesla.radar_interface import RadarInterface, RADAR_START_ADDR
 
 
@@ -47,6 +47,10 @@ class CarInterface(CarInterfaceBase):
     if fsd_14:
       ret.flags |= TeslaFlags.FSD_14.value
       ret.safetyConfigs[0].safetyParam |= TeslaSafetyFlags.FSD_14.value
+
+    hw3 = any(fw.ecu == Ecu.eps and fw.fwVersion in HW3_FW.get(candidate, []) for fw in car_fw)
+    if hw3:
+      ret.flags |= TeslaFlags.HW3.value
 
     ret.dashcamOnly = candidate in (CAR.TESLA_MODEL_X,)  # dashcam only, pending find invalidLkasSetting signal
 

--- a/opendbc/car/tesla/interface.py
+++ b/opendbc/car/tesla/interface.py
@@ -2,7 +2,7 @@ from opendbc.car import Bus, get_safety_config, structs
 from opendbc.car.interfaces import CarInterfaceBase
 from opendbc.car.tesla.carcontroller import CarController
 from opendbc.car.tesla.carstate import CarState
-from opendbc.car.tesla.values import TeslaSafetyFlags, TeslaFlags, CANBUS, CAR, DBC, FSD_14_FW, HW3_FW, Ecu
+from opendbc.car.tesla.values import TeslaSafetyFlags, TeslaFlags, CANBUS, CAR, DBC, FSD_14_FW_RULES, NON_FSD_14_SELFDRIVE_FW_RULES, Ecu, match_rules
 from opendbc.car.tesla.radar_interface import RadarInterface, RADAR_START_ADDR
 
 
@@ -43,14 +43,15 @@ class CarInterface(CarInterfaceBase):
       ret.vEgoStarting = 0.1
       ret.stoppingDecelRate = 0.3
 
-    fsd_14 = any(fw.ecu == Ecu.eps and fw.fwVersion in FSD_14_FW.get(candidate, []) for fw in car_fw)
+    fsd_14 = any(fw.ecu == Ecu.eps and match_rules(FSD_14_FW_RULES.get(candidate, []), fw.fwVersion) for fw in car_fw)
     if fsd_14:
       ret.flags |= TeslaFlags.FSD_14.value
       ret.safetyConfigs[0].safetyParam |= TeslaSafetyFlags.FSD_14.value
 
-    hw3 = any(fw.ecu == Ecu.eps and fw.fwVersion in HW3_FW.get(candidate, []) for fw in car_fw)
-    if hw3:
-      ret.flags |= TeslaFlags.HW3.value
+    non_fsd_14_selfdrive = any(fw.ecu == Ecu.eps and match_rules(NON_FSD_14_SELFDRIVE_FW_RULES.get(candidate, []), fw.fwVersion) for fw in car_fw)
+    if non_fsd_14_selfdrive:
+      ret.flags |= TeslaFlags.NON_FSD_14_SELFDRIVE.value
+      ret.safetyConfigs[0].safetyParam |= TeslaSafetyFlags.NON_FSD_14_SELFDRIVE.value
 
     ret.dashcamOnly = candidate in (CAR.TESLA_MODEL_X,)  # dashcam only, pending find invalidLkasSetting signal
 

--- a/opendbc/car/tesla/tests/test_tesla.py
+++ b/opendbc/car/tesla/tests/test_tesla.py
@@ -51,10 +51,70 @@ PLATFORM_TO_CAR = {
 #   M3: variant_code starts with '4H',  ends with '015'
 #   MY: variant_code starts with '4',   ends with '003'
 # Older series (M3 '014', MY '002') are never FSD 14.
-FSD_14_FW_RULE = {
-  CAR.TESLA_MODEL_3: (b'4H', b'015'),
-  CAR.TESLA_MODEL_Y: (b'4',  b'003'),
+# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
+FSD_14_FW_RULES = {
+  CAR.TESLA_MODEL_3: [
+    (b'^4H.*015$', 4, 1),
+  ],
+  CAR.TESLA_MODEL_Y: [
+    (b'^4.*003$', 4, 1),
+  ],
 }
+
+# Non FSD 14 HW4 and HW3 cars with recent FW (2026.8.6+) in which Tesla uses
+# "Self-Driving" as name for its ADAS.
+# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
+NON_FSD_14_SELFDRIVE_FW_RULES = {
+  CAR.TESLA_MODEL_3: [
+    (b'^(L|S)?014$', 20, 1),
+  ],
+  CAR.TESLA_MODEL_Y: [
+    (b'^(P|S)?002$', 21, 1),
+  ],
+}
+
+# Non FSD 14 HW4 and HW3 cars with older FW (2026.8.3-) in which Tesla uses
+# "Autopilot" as name for its ADAS.
+# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
+NON_FSD_14_AUTOPILOT_FW_RULES = {
+  CAR.TESLA_MODEL_3: [
+    (b'^(L|S)?014$', 19, 0),
+    (b'^4.*014$', 0, 1),
+    (b'^4.*015$', 3, 0),
+  ],
+  CAR.TESLA_MODEL_Y: [
+    (b'^(P|S)?002$', 20, 0),
+    (b'^4.*002$', 0, 1),
+    (b'^4.*003$', 3, 0),
+  ],
+}
+
+def compile_rules_dict(rules_dict):
+  compiled = {}
+  for car_model, rules in rules_dict.items():
+    compiled[car_model] = []
+    for rule in rules:
+      regex_str = rule[0]
+      compiled_rule = (re.compile(regex_str), rule[1], rule[2])
+      compiled[car_model].append(compiled_rule)
+  return compiled
+
+def match_rules(rules, fw) -> bool:
+  decoded_fw = FW_RE.match(fw)
+  assert decoded_fw is not None, f"Unparsable FW: {fw}"
+  any_rule_matches = False
+  for rule in rules:
+    variant_regex, software_major, software_major_geq = rule
+    any_rule_matches |= (
+      variant_regex.match(decoded_fw['variant_code']) is not None
+      and ((software_major_geq and int(decoded_fw['software_major']) >= software_major)
+      or (not software_major_geq and int(decoded_fw['software_major']) <= software_major))
+    )
+  return any_rule_matches
+
+FSD_14_FW_RULES = compile_rules_dict(FSD_14_FW_RULES)
+NON_FSD_14_SELFDRIVE_FW_RULES = compile_rules_dict(NON_FSD_14_SELFDRIVE_FW_RULES)
+NON_FSD_14_AUTOPILOT_FW_RULES = compile_rules_dict(NON_FSD_14_AUTOPILOT_FW_RULES)
 
 
 class TestTeslaFingerprint(unittest.TestCase):
@@ -69,21 +129,29 @@ class TestTeslaFingerprint(unittest.TestCase):
 
   def test_fsd_14_fw(self):
     for car_model, ecus in FW_VERSIONS.items():
-      if car_model not in FSD_14_FW_RULE:
+      if car_model not in FSD_14_FW_RULES:
         continue
 
-      variant_prefix, variant_suffix = FSD_14_FW_RULE[car_model]
-      for fw in ecus.get((Ecu.eps, 0x730, None), []):
-        m = FW_RE.match(fw)
-        assert m is not None, f"Unparsable FW: {fw}"
+      for rule in FSD_14_FW_RULES[car_model]:
+        variant_regex, software_major, software_major_geq = rule
+        for fw in ecus.get((Ecu.eps, 0x730, None), []):
+          is_fsd_14 = fw in FSD_14_FW.get(car_model, [])
+          expected = match_rules(FSD_14_FW_RULES[car_model], fw)
+          assert is_fsd_14 == expected, f"{fw}"
 
-        is_fsd_14 = fw in FSD_14_FW.get(car_model, [])
-        expected = (
-          m['variant_code'].startswith(variant_prefix)
-          and m['variant_code'].endswith(variant_suffix)
-          and int(m['software_major']) >= 4
-        )
-        assert is_fsd_14 == expected, f"{fw}"
+  def test_rules_uniqueness(self):
+    # check if rules lead to exactly one match
+    for car_model, ecus in FW_VERSIONS.items():
+      if car_model not in FSD_14_FW_RULES:
+        continue
+
+      for fw in ecus.get((Ecu.eps, 0x730, None), []):
+        matches = [
+          match_rules(FSD_14_FW_RULES[car_model], fw),
+          match_rules(NON_FSD_14_SELFDRIVE_FW_RULES[car_model], fw),
+          match_rules(NON_FSD_14_AUTOPILOT_FW_RULES[car_model], fw),
+        ]
+        assert sum(matches) == 1, f"{fw}: matched {sum(matches)} rule sets"
 
   def test_radar_detection(self):
     # Test radar availability detection for cars with radar DBC defined

--- a/opendbc/car/tesla/tests/test_tesla.py
+++ b/opendbc/car/tesla/tests/test_tesla.py
@@ -1,76 +1,15 @@
-import re
 import unittest
 
 from opendbc.car import gen_empty_fingerprint
-from opendbc.car.structs import CarParams
 from opendbc.car.tesla.interface import CarInterface
 from opendbc.car.tesla.fingerprints import FW_VERSIONS
 from opendbc.car.tesla.radar_interface import RADAR_START_ADDR
-from opendbc.car.tesla.values import CAR, FSD_14_FW
-
-Ecu = CarParams.Ecu
-
-# Fields prefixed unknown_* we observe structurally but don't know the meaning of.
-# Only `platform` has evidence-backed semantic meaning (matches car_model in FW_VERSIONS).
-#
-# unknown_prefix is everything before the comma; we don't split it because we don't know what its
-# parts mean, but observed shape is: <family>_<package>_<triplet> (<build>), e.g.
-#   TeMYG4 _ Main     _ 0.0.0 (78)     or     TeM3 _ SP_XP002p2 _ 0.0.0 (23)
-#   family   package    triplet build           family  package    triplet build
-#
-# After the comma, the version string decomposes into:
-#   platform             : E/Y/X = car model (Model 3 / Y / X). The only field with known meaning.
-#   variant_code         : differentiator WITHIN a platform — hardware/trim/calibration bits packed
-#                          into <digit?><letters?><3-digit series>, e.g. '4HP015', '4003', 'L014',
-#                          'PR003'. We don't fully know what the parts mean individually, but the
-#                          whole string identifies a specific variant within the car model.
-#   software_major/minor : numeric components after the first '.' — conventional release numbers.
-#                          minor is optional (e.g. 'E4S014.27' has no minor).
-#
-# Suspected (not confirmed): for M3/MY, `TeM3_*` outer + no-leading-digit variant_code == HW3, and
-# `TeMYG4_*` outer + leading-'4' variant_code == HW4 (the 'G4' in TeMYG4 likely denotes Gen 4).
-#
-# Example full parse of 'TeMYG4_Main_0.0.0 (78),E4HP015.05.0':
-#   unknown_prefix='TeMYG4_Main_0.0.0 (78)'
-#   platform=E  variant_code=4HP015  software_major=05  software_minor=0
-FW_RE = re.compile(
-  rb'^(?P<unknown_prefix>.+),' +
-  rb'(?P<platform>[EYX])' +
-  rb'(?P<variant_code>\d?[A-Z]*\d{3})' +
-  rb'\.(?P<software_major>\d+)' +
-  rb'(?:\.(?P<software_minor>\d+))?$'
-)
+from opendbc.car.tesla.values import CAR, FSD_14_FW_RULES, NON_FSD_14_SELFDRIVE_FW_RULES, Ecu, FW_RE, match_rules, compile_rules_dict
 
 PLATFORM_TO_CAR = {
   b'E': CAR.TESLA_MODEL_3,
   b'Y': CAR.TESLA_MODEL_Y,
   b'X': CAR.TESLA_MODEL_X,
-}
-
-# Hypothesized FSD 14 profile, in terms of variant_code bookends (given software_major >= 4):
-#   M3: variant_code starts with '4H',  ends with '015'
-#   MY: variant_code starts with '4',   ends with '003'
-# Older series (M3 '014', MY '002') are never FSD 14.
-# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
-FSD_14_FW_RULES = {
-  CAR.TESLA_MODEL_3: [
-    (b'^4H.*015$', 4, 1),
-  ],
-  CAR.TESLA_MODEL_Y: [
-    (b'^4.*003$', 4, 1),
-  ],
-}
-
-# Non FSD 14 HW4 and HW3 cars with recent FW (2026.8.6+) in which Tesla uses
-# "Self-Driving" as name for its ADAS.
-# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
-NON_FSD_14_SELFDRIVE_FW_RULES = {
-  CAR.TESLA_MODEL_3: [
-    (b'^(L|S)?014$', 20, 1),
-  ],
-  CAR.TESLA_MODEL_Y: [
-    (b'^(P|S)?002$', 21, 1),
-  ],
 }
 
 # Non FSD 14 HW4 and HW3 cars with older FW (2026.8.3-) in which Tesla uses
@@ -89,34 +28,33 @@ NON_FSD_14_AUTOPILOT_FW_RULES = {
   ],
 }
 
-def compile_rules_dict(rules_dict):
-  compiled = {}
-  for car_model, rules in rules_dict.items():
-    compiled[car_model] = []
-    for rule in rules:
-      regex_str = rule[0]
-      compiled_rule = (re.compile(regex_str), rule[1], rule[2])
-      compiled[car_model].append(compiled_rule)
-  return compiled
-
-def match_rules(rules, fw) -> bool:
-  decoded_fw = FW_RE.match(fw)
-  assert decoded_fw is not None, f"Unparsable FW: {fw}"
-  any_rule_matches = False
-  for rule in rules:
-    variant_regex, software_major, software_major_geq = rule
-    any_rule_matches |= (
-      variant_regex.match(decoded_fw['variant_code']) is not None
-      and ((software_major_geq and int(decoded_fw['software_major']) >= software_major)
-      or (not software_major_geq and int(decoded_fw['software_major']) <= software_major))
-    )
-  return any_rule_matches
-
-FSD_14_FW_RULES = compile_rules_dict(FSD_14_FW_RULES)
-NON_FSD_14_SELFDRIVE_FW_RULES = compile_rules_dict(NON_FSD_14_SELFDRIVE_FW_RULES)
 NON_FSD_14_AUTOPILOT_FW_RULES = compile_rules_dict(NON_FSD_14_AUTOPILOT_FW_RULES)
 
+# Cars with this EPS FW have FSD 14 and use TeslaFlags.FSD_14
+# For these cars we need to send a different value on DAS_steeringControlType.
+FSD_14_FW = {
+  CAR.TESLA_MODEL_3: [
+    b'TeMYG4_Main_0.0.0 (77),E4HP015.04.5',
+    b'TeMYG4_Main_0.0.0 (78),E4HP015.05.0',
+    b'TeMYG4_Main_0.0.0 (77),E4H015.04.5',
+    b'TeMYG4_Main_0.0.0 (78),E4H015.05.0',
+  ],
+  CAR.TESLA_MODEL_Y: [
+    b'TeMYG4_Legacy3Y_0.0.0 (6),Y4003.04.0',
+    b'TeMYG4_Main_0.0.0 (77),Y4003.05.4',
+    b'TeMYG4_Main_0.0.0 (78),Y4003.06.0',
+  ]
+}
 
+# HW3 cars with FW 2026.8.6+ can trigger a false FSD14 detection.
+NON_FSD_14_SELFDRIVE_FW = {
+  CAR.TESLA_MODEL_3: [
+    b'TeM3_E014p10_0.0.0 (24),E014.20.2',
+  ],
+  CAR.TESLA_MODEL_Y: [
+    b'TeM3_E014p10_0.0.0 (24),YP002.21.2',
+  ]
+}
 class TestTeslaFingerprint(unittest.TestCase):
   def test_fw_platform_code(self):
     # Every EPS FW must parse and its platform letter must match the car it's filed under.
@@ -132,12 +70,27 @@ class TestTeslaFingerprint(unittest.TestCase):
       if car_model not in FSD_14_FW_RULES:
         continue
 
-      for rule in FSD_14_FW_RULES[car_model]:
-        variant_regex, software_major, software_major_geq = rule
-        for fw in ecus.get((Ecu.eps, 0x730, None), []):
-          is_fsd_14 = fw in FSD_14_FW.get(car_model, [])
-          expected = match_rules(FSD_14_FW_RULES[car_model], fw)
-          assert is_fsd_14 == expected, f"{fw}"
+      for fw in ecus.get((Ecu.eps, 0x730, None), []):
+        is_fsd_14 = fw in FSD_14_FW.get(car_model, [])
+        expected = match_rules(FSD_14_FW_RULES[car_model], fw)
+        assert is_fsd_14 == expected, f"{fw}"
+
+  def test_non_fsd_14_selfdrive_fw(self):
+    for car_model, ecus in FW_VERSIONS.items():
+      if car_model not in NON_FSD_14_SELFDRIVE_FW_RULES:
+        continue
+
+      for fw in ecus.get((Ecu.eps, 0x730, None), []):
+        is_non_fsd_14_selfdrive = fw in NON_FSD_14_SELFDRIVE_FW.get(car_model, [])
+        expected = match_rules(NON_FSD_14_SELFDRIVE_FW_RULES[car_model], fw)
+        assert is_non_fsd_14_selfdrive == expected, f"{fw}"
+
+  def test_fingerprints_parsable(self):
+    # check if all fingerprints are parsable
+    for _car_model, ecus in FW_VERSIONS.items():
+      for fw in ecus.get((Ecu.eps, 0x730, None), []):
+        decoded_fw = FW_RE.match(fw)
+        assert decoded_fw is not None, f"Unparsable FW: {fw}"
 
   def test_rules_uniqueness(self):
     # check if rules lead to exactly one match

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -75,6 +75,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
 )
 
 # Cars with this EPS FW have FSD 14 and use TeslaFlags.FSD_14
+# For these cars we need to send a different value on DAS_steeringControlType.
 FSD_14_FW = {
   CAR.TESLA_MODEL_3: [
     b'TeMYG4_Main_0.0.0 (77),E4HP015.04.5',
@@ -89,6 +90,15 @@ FSD_14_FW = {
   ]
 }
 
+# HW3 cars with FW 2026.8.6+ can trigger a false FSD14 detection.
+HW3_FW = {
+  CAR.TESLA_MODEL_3: [
+    b'TeM3_E014p10_0.0.0 (24),E014.20.2',
+  ],
+  CAR.TESLA_MODEL_Y: [
+    b'TeM3_E014p10_0.0.0 (24),YP002.21.2',
+  ]
+}
 
 class CANBUS:
   party = 0
@@ -143,6 +153,7 @@ class TeslaFlags(IntFlag):
   LONG_CONTROL = 1
   FSD_14 = 2
   MISSING_DAS_SETTINGS = 4
+  HW3 = 8
 
 
 DBC = CAR.create_dbc_map()

--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass, field
 from enum import Enum, IntFlag
 from opendbc.car import ACCELERATION_DUE_TO_GRAVITY, Bus, CarSpecs, DbcDict, PlatformConfig, Platforms
@@ -74,31 +75,91 @@ FW_QUERY_CONFIG = FwQueryConfig(
   ]
 )
 
-# Cars with this EPS FW have FSD 14 and use TeslaFlags.FSD_14
-# For these cars we need to send a different value on DAS_steeringControlType.
-FSD_14_FW = {
+# Fields prefixed unknown_* we observe structurally but don't know the meaning of.
+# Only `platform` has evidence-backed semantic meaning (matches car_model in FW_VERSIONS).
+#
+# unknown_prefix is everything before the comma; we don't split it because we don't know what its
+# parts mean, but observed shape is: <family>_<package>_<triplet> (<build>), e.g.
+#   TeMYG4 _ Main     _ 0.0.0 (78)     or     TeM3 _ SP_XP002p2 _ 0.0.0 (23)
+#   family   package    triplet build           family  package    triplet build
+#
+# After the comma, the version string decomposes into:
+#   platform             : E/Y/X = car model (Model 3 / Y / X). The only field with known meaning.
+#   variant_code         : differentiator WITHIN a platform — hardware/trim/calibration bits packed
+#                          into <digit?><letters?><3-digit series>, e.g. '4HP015', '4003', 'L014',
+#                          'PR003'. We don't fully know what the parts mean individually, but the
+#                          whole string identifies a specific variant within the car model.
+#   software_major/minor : numeric components after the first '.' — conventional release numbers.
+#                          minor is optional (e.g. 'E4S014.27' has no minor).
+#
+# Suspected (not confirmed): for M3/MY, `TeM3_*` outer + no-leading-digit variant_code == HW3, and
+# `TeMYG4_*` outer + leading-'4' variant_code == HW4 (the 'G4' in TeMYG4 likely denotes Gen 4).
+#
+# Example full parse of 'TeMYG4_Main_0.0.0 (78),E4HP015.05.0':
+#   unknown_prefix='TeMYG4_Main_0.0.0 (78)'
+#   platform=E  variant_code=4HP015  software_major=05  software_minor=0
+FW_RE = re.compile(
+  rb'^(?P<unknown_prefix>.+),' +
+  rb'(?P<platform>[EYX])' +
+  rb'(?P<variant_code>\d?[A-Z]*\d{3})' +
+  rb'\.(?P<software_major>\d+)' +
+  rb'(?:\.(?P<software_minor>\d+))?$'
+)
+
+# Hypothesized FSD 14 profile, in terms of variant_code bookends (given software_major >= 4):
+#   M3: variant_code starts with '4H',  ends with '015'
+#   MY: variant_code starts with '4',   ends with '003'
+# Older series (M3 '014', MY '002') are never FSD 14.
+# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
+FSD_14_FW_RULES = {
   CAR.TESLA_MODEL_3: [
-    b'TeMYG4_Main_0.0.0 (77),E4HP015.04.5',
-    b'TeMYG4_Main_0.0.0 (78),E4HP015.05.0',
-    b'TeMYG4_Main_0.0.0 (77),E4H015.04.5',
-    b'TeMYG4_Main_0.0.0 (78),E4H015.05.0',
+    (b'^4H.*015$', 4, 1),
   ],
   CAR.TESLA_MODEL_Y: [
-    b'TeMYG4_Legacy3Y_0.0.0 (6),Y4003.04.0',
-    b'TeMYG4_Main_0.0.0 (77),Y4003.05.4',
-    b'TeMYG4_Main_0.0.0 (78),Y4003.06.0',
-  ]
+    (b'^4.*003$', 4, 1),
+  ],
 }
 
-# HW3 cars with FW 2026.8.6+ can trigger a false FSD14 detection.
-HW3_FW = {
+# Non FSD 14 HW4 and HW3 cars with recent FW (2026.8.6+) in which Tesla uses
+# "Self-Driving" as name for its ADAS.
+# Tuple format: (variant_code_regex, software_major, software_major greater or equal)
+NON_FSD_14_SELFDRIVE_FW_RULES = {
   CAR.TESLA_MODEL_3: [
-    b'TeM3_E014p10_0.0.0 (24),E014.20.2',
+    (b'^(L|S)?014$', 20, 1),
   ],
   CAR.TESLA_MODEL_Y: [
-    b'TeM3_E014p10_0.0.0 (24),YP002.21.2',
-  ]
+    (b'^(P|S)?002$', 21, 1),
+  ],
 }
+
+def compile_rules_dict(rules_dict):
+  compiled = {}
+  for car_model, rules in rules_dict.items():
+    compiled[car_model] = []
+    for rule in rules:
+      regex_str = rule[0]
+      compiled_rule = (re.compile(regex_str), rule[1], rule[2])
+      compiled[car_model].append(compiled_rule)
+  return compiled
+
+def match_rules(rules, fw) -> bool:
+  if not rules:
+    return False
+  decoded_fw = FW_RE.match(fw)
+  if not decoded_fw:
+    return False
+  any_rule_matches = False
+  for rule in rules:
+    variant_regex, software_major, software_major_geq = rule
+    any_rule_matches |= (
+      variant_regex.match(decoded_fw['variant_code']) is not None
+      and ((software_major_geq and int(decoded_fw['software_major']) >= software_major)
+      or (not software_major_geq and int(decoded_fw['software_major']) <= software_major))
+    )
+  return any_rule_matches
+
+FSD_14_FW_RULES = compile_rules_dict(FSD_14_FW_RULES)
+NON_FSD_14_SELFDRIVE_FW_RULES = compile_rules_dict(NON_FSD_14_SELFDRIVE_FW_RULES)
 
 class CANBUS:
   party = 0
@@ -147,13 +208,14 @@ class CarControllerParams:
 class TeslaSafetyFlags(IntFlag):
   LONG_CONTROL = 1
   FSD_14 = 2
+  NON_FSD_14_SELFDRIVE = 4
 
 
 class TeslaFlags(IntFlag):
   LONG_CONTROL = 1
   FSD_14 = 2
-  MISSING_DAS_SETTINGS = 4
-  HW3 = 8
+  NON_FSD_14_SELFDRIVE = 4
+  MISSING_DAS_SETTINGS = 8
 
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION
In FW 2026.8.6 Tesla has changed the behavior of stock LKAS. During an intervention AP sends DAS_steeringControlType == 1 which triggers the FSD14 detection heuristic. This causes an invalid LKAS settings fault in Openpilot despite Autosteer being deactivated in the vehicle settings.

Segment which demonstrates the fault in nightly-dev: c0fe59cc1ebbd1b3/000000a0--cdc57134fe/16

Validation
* Dongle ID: c0fe59cc1ebbd1b3
* Route: c0fe59cc1ebbd1b3/000000a4--7aa1bd45e0
* Stock LKAS intervention no longer triggers an openpilot fault: 08:23 into the route
* Vehicle follows openpilot steering commands: 3:45 into the route.
