### PR TITLE
hyundai: reclassify availability-toggle button as main

### DIFF
--- a/opendbc/car/hyundai/carstate.py
+++ b/opendbc/car/hyundai/carstate.py
@@ -21,6 +21,20 @@ BUTTONS_DICT = {Buttons.RES_ACCEL: ButtonType.accelCruise, Buttons.SET_DECEL: Bu
                 Buttons.GAP_DIST: ButtonType.gapAdjustCruise, Buttons.CANCEL: ButtonType.cancel}
 
 
+def maybe_reclassify_main_button(button_events: list[structs.CarState.ButtonEvent], prev_available: bool, available: bool) -> list[structs.CarState.ButtonEvent]:
+    # Some Hyundai platforms expose the main/availability toggle through the same cruise button signal that is
+    # normally used for resume. When the availability bit flips on that button press, treat the event as mainCruise so
+    # higher-level logic does not interpret it as a resume request.
+    if prev_available == available:
+      return button_events
+
+    ret: list[structs.CarState.ButtonEvent] = []
+    for button_event in button_events:
+      button_type = ButtonType.mainCruise if button_event.type == ButtonType.accelCruise else button_event.type
+      ret.append(structs.CarState.ButtonEvent(pressed=button_event.pressed, type=button_type))
+    return ret
+
+
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
@@ -62,6 +76,7 @@ class CarState(CarStateBase):
     self.cluster_speed_counter = CLUSTER_SAMPLE_RATE
 
     self.params = CarControllerParams(CP)
+    self.cruise_available_prev = False
 
   def recent_button_interaction(self) -> bool:
     # On some newer model years, the CANCEL button acts as a pause/resume button based on the PCM state
@@ -192,6 +207,7 @@ class CarState(CarStateBase):
     ret.buttonEvents = [*create_button_events(self.cruise_buttons[-1], prev_cruise_buttons, BUTTONS_DICT),
                         *create_button_events(self.main_buttons[-1], prev_main_buttons, {1: ButtonType.mainCruise}),
                         *create_button_events(self.lda_button, prev_lda_button, {1: ButtonType.lkas})]
+    ret.buttonEvents = maybe_reclassify_main_button(ret.buttonEvents, self.cruise_available_prev, ret.cruiseState.available)
 
     ret.blockPcmEnable = not self.recent_button_interaction()
 
@@ -201,6 +217,7 @@ class CarState(CarStateBase):
     if ret.vEgo > (self.CP.minSteerSpeed + 4.):
       self.low_speed_alert = False
     ret.lowSpeedAlert = self.low_speed_alert
+    self.cruise_available_prev = ret.cruiseState.available
 
     return ret
 
@@ -290,8 +307,10 @@ class CarState(CarStateBase):
     ret.buttonEvents = [*create_button_events(self.cruise_buttons[-1], prev_cruise_buttons, BUTTONS_DICT),
                         *create_button_events(self.main_buttons[-1], prev_main_buttons, {1: ButtonType.mainCruise}),
                         *create_button_events(self.lda_button, prev_lda_button, {1: ButtonType.lkas})]
+    ret.buttonEvents = maybe_reclassify_main_button(ret.buttonEvents, self.cruise_available_prev, ret.cruiseState.available)
 
     ret.blockPcmEnable = not self.recent_button_interaction()
+    self.cruise_available_prev = ret.cruiseState.available
 
     return ret
 

--- a/opendbc/car/hyundai/tests/test_hyundai.py
+++ b/opendbc/car/hyundai/tests/test_hyundai.py
@@ -2,11 +2,13 @@ from hypothesis import settings, given, strategies as st
 
 import unittest
 
+from opendbc.car import structs
 from opendbc.car import gen_empty_fingerprint
 from opendbc.car.structs import CarParams
 from opendbc.car.fw_versions import build_fw_dict
 from opendbc.car.hyundai.interface import CarInterface
 from opendbc.car.hyundai.hyundaicanfd import CanBus
+from opendbc.car.hyundai.carstate import maybe_reclassify_main_button
 from opendbc.car.hyundai.radar_interface import RADAR_START_ADDR
 from opendbc.car.hyundai.values import CAMERA_SCC_CAR, CANFD_CAR, CAN_GEARS, CAR, CHECKSUM, DATE_FW_ECUS, \
                                          HYBRID_CAR, EV_CAR, FW_QUERY_CONFIG, LEGACY_SAFETY_MODE_CAR, CANFD_FUZZY_WHITELIST, \
@@ -246,3 +248,15 @@ class TestHyundaiFingerprint(unittest.TestCase):
         platforms_with_shared_codes.add(platform)
 
     assert platforms_with_shared_codes == excluded_platforms
+
+  def test_main_button_reclassification(self):
+    button_event = structs.CarState.ButtonEvent(pressed=True, type=structs.CarState.ButtonEvent.Type.accelCruise)
+    reclassified = maybe_reclassify_main_button([button_event], prev_available=False, available=True)
+
+    assert len(reclassified) == 1
+    assert reclassified[0].pressed is True
+    assert reclassified[0].type == structs.CarState.ButtonEvent.Type.mainCruise
+
+    unchanged = maybe_reclassify_main_button([button_event], prev_available=True, available=True)
+    assert len(unchanged) == 1
+    assert unchanged[0].type == structs.CarState.ButtonEvent.Type.accelCruise


### PR DESCRIPTION
Reclassify the ambiguous Hyundai cruise button as mainCruise when the cruise availability state flips, so higher-level logic doesn't treat the availability toggle as a resume request.\n\nIncludes a focused regression test for the reclassification helper.