### PR TITLE
fix: Remove erroneous overlapping signal from vw_mqb.dbc

### DIFF
--- a/opendbc/dbc/vw_mqb.dbc
+++ b/opendbc/dbc/vw_mqb.dbc
@@ -87,7 +87,6 @@ BO_ 304 PLA_01: 8 XXX
  SG_ PLA_LW_Soll : 16|13@1+ (0.1,0) [0.0|819.1] "Unit_DegreOfArc"  XXX
  SG_ PLA_VZ_LW_Soll : 31|1@1+ (1.0,0.0) [0.0|1] ""  XXX
  SG_ PLA_Status_PLA_EPS : 32|4@1+ (1.0,0.0) [0.0|15] ""  XXX
- SG_ PLA_Bremsmoment : 36|13@1+ (4,0) [0|32760] "Unit_NewtoMeter"  XXX
  SG_ PLA_Bremsverzoegerung : 36|7@1+ (0.1,0) [0.0|12.0] "Unit_MeterPerSeconSquar"  XXX
  SG_ PLA_Anf_Bremsverzoegerung : 43|1@1+ (1.0,0.0) [0.0|1] ""  XXX
  SG_ PLA_BremsMom_Verzoeg : 50|1@1+ (1.0,0.0) [0.0|1] ""  XXX


### PR DESCRIPTION
Problem: When you run `python3 -m cantools dump opendbc/dbc/vw_mqb.dbc`, you get an error that the signals PLA_Bremsverzoegerung and PLA_Bremsmoment are overlapping in message PLA_01. PLA_Bremsmoment implausibly overlaps other signals without muxing and appears to be a reverse engineering artifact.

Solution: Remove the PLA_Bremsmoment signal from the vw_mqb.dbc file.

Testing: Ran `python3 -m cantools dump opendbc/dbc/vw_mqb.dbc` and verified that the error about overlapping signals is resolved. Also, ran CI workflows in my forked repo to verify no other harm done.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID: N/A
* Route: N/A
