### PR TITLE
perf: reduce pytest collection time 7x for car/tests/ (1.63s → 0.22s)

### DIFF
--- a/opendbc/car/__init__.py
+++ b/opendbc/car/__init__.py
@@ -1,5 +1,4 @@
 # functions common among cars
-import numpy as np
 from dataclasses import dataclass, field
 from enum import IntFlag, ReprEnum, StrEnum, EnumType, auto
 from dataclasses import replace
@@ -93,7 +92,7 @@ class Bus(StrEnum):
 
 
 def rate_limit(new_value, last_value, dw_step, up_step):
-  return float(np.clip(new_value, last_value + dw_step, last_value + up_step))
+  return float(min(max(new_value, last_value + dw_step), last_value + up_step))
 
 
 def make_tester_present_msg(addr, bus, subaddr=None, suppress_response=False):

--- a/opendbc/car/body/carcontroller.py
+++ b/opendbc/car/body/carcontroller.py
@@ -1,4 +1,4 @@
-import numpy as np
+import math
 
 from opendbc.can import CANPacker
 from opendbc.car import Bus, DT_CTRL
@@ -9,7 +9,7 @@ from opendbc.car.interfaces import CarControllerBase
 
 MAX_TORQUE = 500
 MAX_TORQUE_RATE = 50
-MAX_ANGLE_ERROR = np.radians(7)
+MAX_ANGLE_ERROR = math.radians(7)
 MAX_POS_INTEGRATOR = 0.2   # meters
 MAX_TURN_INTEGRATOR = 0.1  # meters
 
@@ -61,14 +61,14 @@ class CarController(CarControllerBase):
       torque_l = torque - torque_diff
 
       # Torque rate limits
-      self.torque_r_filtered = np.clip(self.deadband_filter(torque_r, 10),
-                                       self.torque_r_filtered - MAX_TORQUE_RATE,
-                                       self.torque_r_filtered + MAX_TORQUE_RATE)
-      self.torque_l_filtered = np.clip(self.deadband_filter(torque_l, 10),
-                                       self.torque_l_filtered - MAX_TORQUE_RATE,
-                                       self.torque_l_filtered + MAX_TORQUE_RATE)
-      torque_r = int(np.clip(self.torque_r_filtered, -MAX_TORQUE, MAX_TORQUE))
-      torque_l = int(np.clip(self.torque_l_filtered, -MAX_TORQUE, MAX_TORQUE))
+      self.torque_r_filtered = max(self.torque_r_filtered - MAX_TORQUE_RATE,
+                                   min(self.torque_r_filtered + MAX_TORQUE_RATE,
+                                       self.deadband_filter(torque_r, 10)))
+      self.torque_l_filtered = max(self.torque_l_filtered - MAX_TORQUE_RATE,
+                                   min(self.torque_l_filtered + MAX_TORQUE_RATE,
+                                       self.deadband_filter(torque_l, 10)))
+      torque_r = int(max(-MAX_TORQUE, min(MAX_TORQUE, self.torque_r_filtered)))
+      torque_l = int(max(-MAX_TORQUE, min(MAX_TORQUE, self.torque_l_filtered)))
 
     can_sends = []
     can_sends.append(bodycan.create_control(self.packer, torque_l, torque_r))

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -14,14 +14,65 @@ from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
 FRAME_FINGERPRINT = 100  # 1s
 
 
-def load_interfaces(brand_names):
-  ret = {}
-  for brand_name in brand_names:
+class _LazyInterfacesDict:
+  """Dict-like mapping of car model name → CarInterface, loaded per-brand on first access."""
+
+  def __init__(self, brand_names: dict[str, list[str]]) -> None:
+    self._brand_names = brand_names
+    self._cache: dict = {}
+    self._model_to_brand: dict[str, str] = {
+      model: brand for brand, models in brand_names.items() for model in models
+    }
+
+  def _ensure_brand(self, brand_name: str) -> None:
+    if brand_name not in self._brand_names:
+      raise KeyError(brand_name)
+    if any(m in self._cache for m in self._brand_names[brand_name]):
+      return
     path = f'opendbc.car.{brand_name}'
     CarInterface = __import__(path + '.interface', fromlist=['CarInterface']).CarInterface
-    for model_name in brand_names[brand_name]:
-      ret[model_name] = CarInterface
-  return ret
+    for model in self._brand_names[brand_name]:
+      self._cache[model] = CarInterface
+
+  def _ensure_all(self) -> None:
+    for brand_name in self._brand_names:
+      self._ensure_brand(brand_name)
+
+  def __getitem__(self, key: str):
+    if key not in self._model_to_brand:
+      raise KeyError(key)
+    self._ensure_brand(self._model_to_brand[key])
+    return self._cache[key]
+
+  def __contains__(self, key) -> bool:
+    return key in self._model_to_brand
+
+  def __iter__(self):
+    return iter(self._model_to_brand)
+
+  def __len__(self) -> int:
+    return len(self._model_to_brand)
+
+  def keys(self):
+    return self._model_to_brand.keys()
+
+  def values(self):
+    self._ensure_all()
+    return self._cache.values()
+
+  def items(self):
+    self._ensure_all()
+    return self._cache.items()
+
+  def get(self, key, default=None):
+    try:
+      return self[key]
+    except KeyError:
+      return default
+
+
+def load_interfaces(brand_names: dict[str, list[str]]) -> _LazyInterfacesDict:
+  return _LazyInterfacesDict(brand_names)
 
 
 def _get_interface_names() -> dict[str, list[str]]:
@@ -36,7 +87,23 @@ def _get_interface_names() -> dict[str, list[str]]:
 
 # imports from directory opendbc/car/<name>/
 interface_names = _get_interface_names()
-interfaces = load_interfaces(interface_names)
+_interfaces: _LazyInterfacesDict | None = None
+
+
+def _get_interfaces() -> _LazyInterfacesDict:
+  global _interfaces
+  if _interfaces is None:
+    _interfaces = load_interfaces(interface_names)
+  return _interfaces
+
+
+def __getattr__(name: str):
+  # Lazy-load `interfaces` to defer heavy brand imports (secoc, Crypto) until
+  # actually needed at runtime. This keeps pytest collection fast.
+  global _interfaces
+  if name == "interfaces":
+    return _get_interfaces()
+  raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def can_fingerprint(can_recv: CanRecvCallable) -> tuple[str | None, dict[int, dict]]:
@@ -156,18 +223,18 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
     carlog.error({"event": "car doesn't match any fingerprints", "fingerprints": repr(fingerprints)})
     candidate = "MOCK"
 
-  CarInterface = interfaces[candidate]
+  CarInterface = _get_interfaces()[candidate]
   CP: CarParams = CarInterface.get_params(candidate, fingerprints, car_fw, alpha_long_allowed, is_release, docs=False)
   CP.carVin = vin
   CP.carFw = car_fw
   CP.fingerprintSource = source
   CP.fuzzyFingerprint = not exact_match
 
-  return interfaces[CP.carFingerprint](CP)
+  return _get_interfaces()[CP.carFingerprint](CP)
 
 
 def get_demo_car_params():
   platform = MOCK.MOCK
-  CarInterface = interfaces[platform]
+  CarInterface = _get_interfaces()[platform]
   CP = CarInterface.get_non_essential_params(platform)
   return CP

--- a/opendbc/car/common/conversions.py
+++ b/opendbc/car/common/conversions.py
@@ -1,4 +1,4 @@
-import numpy as np
+import math
 
 
 class Conversions:
@@ -13,7 +13,7 @@ class Conversions:
   KNOTS_TO_MS = 1. / MS_TO_KNOTS
 
   # Angle
-  DEG_TO_RAD = np.pi / 180.
+  DEG_TO_RAD = math.pi / 180.
   RAD_TO_DEG = 1. / DEG_TO_RAD
 
   # Mass

--- a/opendbc/car/common/pid.py
+++ b/opendbc/car/common/pid.py
@@ -1,5 +1,15 @@
-import numpy as np
+import bisect
 from numbers import Number
+
+
+def _interp(x: float, xp: list, fp: list) -> float:
+  if x <= xp[0]:
+    return float(fp[0])
+  if x >= xp[-1]:
+    return float(fp[-1])
+  i = bisect.bisect_right(xp, x) - 1
+  t = (x - xp[i]) / (xp[i + 1] - xp[i])
+  return float(fp[i] + t * (fp[i + 1] - fp[i]))
 
 
 class PIDController:
@@ -26,15 +36,15 @@ class PIDController:
 
   @property
   def k_p(self):
-    return np.interp(self.speed, self._k_p[0], self._k_p[1])
+    return _interp(self.speed, self._k_p[0], self._k_p[1])
 
   @property
   def k_i(self):
-    return np.interp(self.speed, self._k_i[0], self._k_i[1])
+    return _interp(self.speed, self._k_i[0], self._k_i[1])
 
   @property
   def k_d(self):
-    return np.interp(self.speed, self._k_d[0], self._k_d[1])
+    return _interp(self.speed, self._k_d[0], self._k_d[1])
 
   @property
   def error_integral(self):
@@ -55,17 +65,17 @@ class PIDController:
     self.d = error_rate * self.k_d
 
     if override:
-      self.i -= self.i_unwind_rate * float(np.sign(self.i))
+      self.i -= self.i_unwind_rate * (1.0 if self.i > 0 else (-1.0 if self.i < 0 else 0.0))
     else:
       if not freeze_integrator:
         self.i = self.i + error * self.k_i * self.i_rate
 
         # Clip i to prevent exceeding control limits
         control_no_i = self.p + self.d + self.f
-        control_no_i = np.clip(control_no_i, self.neg_limit, self.pos_limit)
-        self.i = np.clip(self.i, self.neg_limit - control_no_i, self.pos_limit - control_no_i)
+        control_no_i = max(self.neg_limit, min(self.pos_limit, control_no_i))
+        self.i = max(self.neg_limit - control_no_i, min(self.pos_limit - control_no_i, self.i))
 
     control = self.p + self.i + self.d + self.f
 
-    self.control = np.clip(control, self.neg_limit, self.pos_limit)
+    self.control = max(self.neg_limit, min(self.pos_limit, control))
     return self.control

--- a/opendbc/car/common/simple_kalman.py
+++ b/opendbc/car/common/simple_kalman.py
@@ -1,7 +1,5 @@
-import numpy as np
-
-
 def get_kalman_gain(dt, A, C, Q, R, iterations=100):
+  import numpy as np
   P = np.zeros_like(Q)
   for _ in range(iterations):
     P = A.dot(P).dot(A.T) + dt * Q

--- a/opendbc/car/docs.py
+++ b/opendbc/car/docs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import re
 import os
-import jinja2
 import argparse
 import unicodedata
 from typing import get_args
@@ -88,6 +87,7 @@ def group_by_make(all_car_docs: list[CarDocs]) -> dict[str, list[CarDocs]]:
 # CAUTION: This function is imported by shop.comma.ai and comma.ai/vehicles, test changes carefully
 def generate_cars_md(all_car_docs: list[CarDocs], template_fn: str, **kwargs) -> str:
   with open(template_fn) as f:
+    import jinja2
     template = jinja2.Template(f.read(), trim_blocks=True, lstrip_blocks=True)
 
   footnotes = [fn.value.text for fn in get_all_footnotes()]

--- a/opendbc/car/fw_versions.py
+++ b/opendbc/car/fw_versions.py
@@ -2,8 +2,6 @@ from collections import defaultdict
 from collections.abc import Callable, Iterator
 from typing import Protocol, TypeVar
 
-from tqdm import tqdm
-
 from opendbc.car import uds
 from opendbc.car.can_definitions import CanRecvCallable, CanSendCallable
 from opendbc.car.carlog import carlog
@@ -284,7 +282,8 @@ def get_fw_versions(can_recv: CanRecvCallable, can_send: CanSendCallable, set_ob
   # Get versions and build capnp list to put into CarParams
   car_fw = []
   requests = [(brand, config, r) for brand, config, r in REQUESTS if is_brand(brand, query_brand)]
-  for addr_group in tqdm(addrs, disable=not progress):  # split by subaddr, if any
+  from tqdm import tqdm
+  for addr_group in tqdm(addrs, disable=not progress):
     for addr_chunk in chunks(addr_group):
       for brand, config, r in requests:
         # Toggle OBD multiplexing for each request

--- a/opendbc/car/hyundai/hyundaicanfd.py
+++ b/opendbc/car/hyundai/hyundaicanfd.py
@@ -1,4 +1,3 @@
-import numpy as np
 from opendbc.car import CanBusBase
 from opendbc.car.crc import CRC16_XMODEM
 from opendbc.car.hyundai.values import HyundaiFlags
@@ -131,7 +130,7 @@ def create_acc_control(packer, CAN, enabled, accel_last, accel, stopping, gas_ov
     a_val, a_raw = 0, 0
   else:
     a_raw = accel
-    a_val = np.clip(accel, accel_last - jn, accel_last + jn)
+    a_val = max(accel_last - jn, min(accel_last + jn, accel))
 
   values = {
     "ACCMode": 0 if not enabled else (2 if gas_override else 1),

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import os
-import numpy as np
 import time
 import tomllib
 from abc import abstractmethod, ABC
 from enum import StrEnum
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 from functools import cache
 
@@ -14,8 +15,9 @@ from opendbc.car.can_definitions import CanData, CanRecvCallable, CanSendCallabl
 from opendbc.car.common.basedir import BASEDIR
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.common.simple_kalman import KF1D, get_kalman_gain
-from opendbc.car.values import PLATFORMS
-from opendbc.can import CANParser
+
+if TYPE_CHECKING:
+  from opendbc.can import CANParser
 
 GearShifter = structs.CarState.GearShifter
 ButtonType = structs.CarState.ButtonEvent.Type
@@ -92,9 +94,9 @@ class RadarInterfaceBase(ABC):
 
 
 class CarInterfaceBase(ABC):
-  CarState: type['CarStateBase']
-  CarController: type['CarControllerBase']
-  RadarInterface: type['RadarInterfaceBase'] = RadarInterfaceBase
+  CarState: type[CarStateBase]
+  CarController: type[CarControllerBase]
+  RadarInterface: type[RadarInterfaceBase] = RadarInterfaceBase
 
   DRIVABLE_GEARS: tuple[structs.CarState.GearShifter, ...] = ()
 
@@ -131,6 +133,7 @@ class CarInterfaceBase(ABC):
                  alpha_long: bool, is_release: bool, docs: bool) -> structs.CarParams:
     ret = CarInterfaceBase.get_std_params(candidate)
 
+    from opendbc.car.values import PLATFORMS
     platform = PLATFORMS[candidate]
     ret.mass = platform.config.specs.mass
     ret.wheelbase = platform.config.specs.wheelbase
@@ -286,6 +289,7 @@ class CarStateBase(ABC):
     A = [[1.0, DT_CTRL], [0.0, 1.0]]
     C = [[1.0, 0.0]]
     x0=[[0.0], [0.0]]
+    import numpy as np
     K = get_kalman_gain(DT_CTRL, np.array(A), np.array(C), np.array(Q), R)
     self.v_ego_kf = KF1D(x0=x0, A=A, C=C[0], K=K)
 
@@ -315,6 +319,7 @@ class CarStateBase(ABC):
   def update_steering_pressed(self, steering_pressed, steering_pressed_min_count):
     """Applies filtering on steering pressed for noisy driver torque signals."""
     self.steering_pressed_cnt += 1 if steering_pressed else -1
+    import numpy as np
     self.steering_pressed_cnt = int(np.clip(self.steering_pressed_cnt, 0, steering_pressed_min_count * 2 + 1))
     return self.steering_pressed_cnt > steering_pressed_min_count
 
@@ -379,15 +384,21 @@ INTERFACE_ATTR_FILE = {
 # interface-specific helpers
 
 
-def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: bool = False) -> dict[str | StrEnum, Any]:
-  # read all the folders in opendbc/car and return a dict where:
-  # - keys are all the car models or brand names
-  # - values are attr values from all car folders
+@cache
+def _get_interface_attr_cached(attr: str, combine_brands: bool, ignore_none: bool) -> tuple:
+  # Iterate over known BRANDS instead of filesystem walking to avoid
+  # os.walk overhead and failed __import__ attempts on non-brand dirs.
+  from opendbc.car.values import BRANDS
   result = {}
-  for car_folder in sorted([x[0] for x in os.walk(BASEDIR)]):
+  seen_brands: set[str] = set()
+  for brand in BRANDS:
+    brand_name = brand.__module__.split('.')[-2]
+    if brand_name in seen_brands:
+      continue
+    seen_brands.add(brand_name)
+    module_name = f'opendbc.car.{brand_name}.{INTERFACE_ATTR_FILE.get(attr, "values")}'
     try:
-      brand_name = car_folder.split('/')[-1]
-      brand_values = __import__(f'opendbc.car.{brand_name}.{INTERFACE_ATTR_FILE.get(attr, "values")}', fromlist=[attr])
+      brand_values = __import__(module_name, fromlist=[attr])
       if hasattr(brand_values, attr) or not ignore_none:
         attr_data = getattr(brand_values, attr, None)
       else:
@@ -402,4 +413,8 @@ def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: boo
     except (ImportError, OSError):
       pass
 
-  return result
+  return tuple(result.items())
+
+
+def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: bool = False) -> dict[str | StrEnum, Any]:
+  return dict(_get_interface_attr_cached(attr, combine_brands, ignore_none))

--- a/opendbc/car/lateral.py
+++ b/opendbc/car/lateral.py
@@ -50,17 +50,17 @@ def apply_driver_steer_torque_limits(apply_torque: int, apply_torque_last: int, 
   driver_min_torque = -steer_max + (-LIMITS.STEER_DRIVER_ALLOWANCE + driver_torque * LIMITS.STEER_DRIVER_FACTOR) * LIMITS.STEER_DRIVER_MULTIPLIER
   max_steer_allowed = max(min(steer_max, driver_max_torque), 0)
   min_steer_allowed = min(max(-steer_max, driver_min_torque), 0)
-  apply_torque = _clip(apply_torque, min_steer_allowed, max_steer_allowed)
+  torque: float = _clip(apply_torque, min_steer_allowed, max_steer_allowed)
 
   # slow rate if steer torque increases in magnitude
   if apply_torque_last > 0:
-    apply_torque = _clip(apply_torque, max(apply_torque_last - LIMITS.STEER_DELTA_DOWN, -LIMITS.STEER_DELTA_UP),
-                         apply_torque_last + LIMITS.STEER_DELTA_UP)
+    torque = _clip(torque, max(apply_torque_last - LIMITS.STEER_DELTA_DOWN, -LIMITS.STEER_DELTA_UP),
+                   apply_torque_last + LIMITS.STEER_DELTA_UP)
   else:
-    apply_torque = _clip(apply_torque, apply_torque_last - LIMITS.STEER_DELTA_UP,
-                         min(apply_torque_last + LIMITS.STEER_DELTA_DOWN, LIMITS.STEER_DELTA_UP))
+    torque = _clip(torque, apply_torque_last - LIMITS.STEER_DELTA_UP,
+                   min(apply_torque_last + LIMITS.STEER_DELTA_DOWN, LIMITS.STEER_DELTA_UP))
 
-  return int(round(float(apply_torque)))
+  return int(round(torque))
 
 
 def apply_dist_to_meas_limits(val, val_last, val_meas,

--- a/opendbc/car/lateral.py
+++ b/opendbc/car/lateral.py
@@ -1,5 +1,4 @@
 import math
-import numpy as np
 from dataclasses import dataclass
 from opendbc.car import structs, rate_limit, DT_CTRL
 from opendbc.car.vehicle_model import VehicleModel
@@ -9,6 +8,23 @@ FRICTION_THRESHOLD = 0.2
 # ISO 11270
 ISO_LATERAL_ACCEL = 3.0  # m/s^2
 ISO_LATERAL_JERK = 5.0  # m/s^3
+
+
+def _clip(x: float, lo: float, hi: float) -> float:
+  return max(lo, min(hi, x))
+
+
+def _interp(x: float, xp: list[float], fp: list[float]) -> float:
+  """Scalar linear interpolation equivalent to numpy.interp for a scalar x."""
+  if x <= xp[0]:
+    return fp[0]
+  if x >= xp[-1]:
+    return fp[-1]
+  for i in range(len(xp) - 1):
+    if xp[i] <= x <= xp[i + 1]:
+      t = (x - xp[i]) / (xp[i + 1] - xp[i])
+      return fp[i] + t * (fp[i + 1] - fp[i])
+  return fp[-1]
 
 
 @dataclass
@@ -34,15 +50,15 @@ def apply_driver_steer_torque_limits(apply_torque: int, apply_torque_last: int, 
   driver_min_torque = -steer_max + (-LIMITS.STEER_DRIVER_ALLOWANCE + driver_torque * LIMITS.STEER_DRIVER_FACTOR) * LIMITS.STEER_DRIVER_MULTIPLIER
   max_steer_allowed = max(min(steer_max, driver_max_torque), 0)
   min_steer_allowed = min(max(-steer_max, driver_min_torque), 0)
-  apply_torque = np.clip(apply_torque, min_steer_allowed, max_steer_allowed)
+  apply_torque = _clip(apply_torque, min_steer_allowed, max_steer_allowed)
 
   # slow rate if steer torque increases in magnitude
   if apply_torque_last > 0:
-    apply_torque = np.clip(apply_torque, max(apply_torque_last - LIMITS.STEER_DELTA_DOWN, -LIMITS.STEER_DELTA_UP),
-                           apply_torque_last + LIMITS.STEER_DELTA_UP)
+    apply_torque = _clip(apply_torque, max(apply_torque_last - LIMITS.STEER_DELTA_DOWN, -LIMITS.STEER_DELTA_UP),
+                         apply_torque_last + LIMITS.STEER_DELTA_UP)
   else:
-    apply_torque = np.clip(apply_torque, apply_torque_last - LIMITS.STEER_DELTA_UP,
-                           min(apply_torque_last + LIMITS.STEER_DELTA_DOWN, LIMITS.STEER_DELTA_UP))
+    apply_torque = _clip(apply_torque, apply_torque_last - LIMITS.STEER_DELTA_UP,
+                         min(apply_torque_last + LIMITS.STEER_DELTA_DOWN, LIMITS.STEER_DELTA_UP))
 
   return int(round(float(apply_torque)))
 
@@ -54,17 +70,17 @@ def apply_dist_to_meas_limits(val, val_last, val_meas,
   max_lim = min(max(val_meas + STEER_ERROR_MAX, STEER_ERROR_MAX), STEER_MAX)
   min_lim = max(min(val_meas - STEER_ERROR_MAX, -STEER_ERROR_MAX), -STEER_MAX)
 
-  val = np.clip(val, min_lim, max_lim)
+  val = _clip(val, min_lim, max_lim)
 
   # slow rate if val increases in magnitude
   if val_last > 0:
-    val = np.clip(val,
-                  max(val_last - STEER_DELTA_DOWN, -STEER_DELTA_UP),
-                  val_last + STEER_DELTA_UP)
+    val = _clip(val,
+                max(val_last - STEER_DELTA_DOWN, -STEER_DELTA_UP),
+                val_last + STEER_DELTA_UP)
   else:
-    val = np.clip(val,
-                  val_last - STEER_DELTA_UP,
-                  min(val_last + STEER_DELTA_DOWN, STEER_DELTA_UP))
+    val = _clip(val,
+                val_last - STEER_DELTA_UP,
+                min(val_last + STEER_DELTA_DOWN, STEER_DELTA_UP))
 
   return float(val)
 
@@ -81,14 +97,14 @@ def apply_std_steer_angle_limits(apply_angle: float, apply_angle_last: float, v_
   steer_up = apply_angle_last * apply_angle >= 0. and abs(apply_angle) > abs(apply_angle_last)
   rate_limits = limits.ANGLE_RATE_LIMIT_UP if steer_up else limits.ANGLE_RATE_LIMIT_DOWN
 
-  angle_rate_lim = np.interp(v_ego, rate_limits[0], rate_limits[1])
-  new_apply_angle = np.clip(apply_angle, apply_angle_last - angle_rate_lim, apply_angle_last + angle_rate_lim)
+  angle_rate_lim = _interp(v_ego, rate_limits[0], rate_limits[1])
+  new_apply_angle = _clip(apply_angle, apply_angle_last - angle_rate_lim, apply_angle_last + angle_rate_lim)
 
   # angle is current steering wheel angle when inactive on all angle cars
   if not lat_active:
     new_apply_angle = steering_angle
 
-  return float(np.clip(new_apply_angle, -limits.STEER_ANGLE_MAX, limits.STEER_ANGLE_MAX))
+  return float(_clip(new_apply_angle, -limits.STEER_ANGLE_MAX, limits.STEER_ANGLE_MAX))
 
 
 def get_max_angle_delta_vm(v_ego_raw: float, VM: VehicleModel, limits):
@@ -118,14 +134,14 @@ def apply_steer_angle_limits_vm(apply_angle: float, apply_angle_last: float, v_e
 
   # *** max lateral accel limit ***
   max_angle = get_max_angle_vm(v_ego_raw, VM, limits)
-  new_apply_angle = np.clip(new_apply_angle, -max_angle, max_angle)
+  new_apply_angle = _clip(new_apply_angle, -max_angle, max_angle)
 
   # angle is current angle when inactive
   if not lat_active:
     new_apply_angle = steering_angle
 
   # prevent fault
-  return float(np.clip(new_apply_angle, -limits.ANGLE_LIMITS.STEER_ANGLE_MAX, limits.ANGLE_LIMITS.STEER_ANGLE_MAX))
+  return float(_clip(new_apply_angle, -limits.ANGLE_LIMITS.STEER_ANGLE_MAX, limits.ANGLE_LIMITS.STEER_ANGLE_MAX))
 
 
 def common_fault_avoidance(fault_condition: bool, request: bool, above_limit_frames: int,
@@ -161,7 +177,7 @@ def apply_center_deadzone(error, deadzone):
 def get_friction(lateral_accel_error: float, lateral_accel_deadzone: float, friction_threshold: float,
                  torque_params: structs.CarParams.LateralTorqueTuning) -> float:
   # TODO torque params' friction should be in lataxel space, not torque space
-  friction_interp = np.interp(
+  friction_interp = _interp(
     apply_center_deadzone(lateral_accel_error, lateral_accel_deadzone),
     [-friction_threshold, friction_threshold],
     [-torque_params.friction * torque_params.latAccelFactor, torque_params.friction * torque_params.latAccelFactor]

--- a/opendbc/car/secoc.py
+++ b/opendbc/car/secoc.py
@@ -1,10 +1,9 @@
 import struct
 
-from Crypto.Hash import CMAC
-from Crypto.Cipher import AES
-
 
 def add_mac(key, trip_cnt, reset_cnt, msg_cnt, msg):
+  from Crypto.Hash import CMAC
+  from Crypto.Cipher import AES
   # TODO: clean up conversion to and from hex
 
   addr, payload, bus = msg
@@ -35,6 +34,8 @@ def add_mac(key, trip_cnt, reset_cnt, msg_cnt, msg):
 
 
 def build_sync_mac(key, trip_cnt, reset_cnt, id_=0xf):
+  from Crypto.Hash import CMAC
+  from Crypto.Cipher import AES
   id_ = struct.pack('>H', id_) # 16
   trip_cnt = struct.pack('>H', trip_cnt) # 16
   reset_cnt = struct.pack('>I', reset_cnt << 12)[:-1] # 20 + 4 padding

--- a/opendbc/car/vehicle_model.py
+++ b/opendbc/car/vehicle_model.py
@@ -12,9 +12,12 @@ x_dot = A*x + B*u
 
 A depends on longitudinal speed, u [m/s], and vehicle parameters CP
 """
+from __future__ import annotations
 
-import numpy as np
-from numpy.linalg import solve
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+  import numpy as np
 
 from opendbc.car.structs import CarParams
 from opendbc.car import ACCELERATION_DUE_TO_GRAVITY
@@ -161,6 +164,7 @@ def kin_ss_sol(sa: float, u: float, VM: VehicleModel) -> np.ndarray:
   Returns:
     2x1 matrix with steady state solution
   """
+  import numpy as np
   K = np.zeros((2, 1))
   K[0, 0] = VM.aR / VM.sR / VM.l * u
   K[1, 0] = 1. / VM.sR / VM.l * u
@@ -187,6 +191,7 @@ def create_dyn_state_matrices(u: float, VM: VehicleModel) -> tuple[np.ndarray, n
     sR: Steering ratio [-]
     chi: Steer ratio rear [-]
   """
+  import numpy as np
   A = np.zeros((2, 2))
   B = np.zeros((2, 2))
   A[0, 0] = - (VM.cF + VM.cR) / (VM.m * u)
@@ -217,6 +222,8 @@ def dyn_ss_sol(sa: float, u: float, roll: float, VM: VehicleModel) -> np.ndarray
   Returns:
     2x1 matrix with steady state solution
   """
+  import numpy as np
+  from numpy.linalg import solve
   A, B = create_dyn_state_matrices(u, VM)
   inp = np.array([[sa], [roll]])
   return -solve(A, B) @ inp


### PR DESCRIPTION
## Summary

Fixes #1184 — reduces `pytest --collect-only opendbc/car/tests/` from **1.63s → 0.22s** (7.4× improvement) by deferring expensive module-level imports.

## Root cause

Several modules imported at collection time pulled in heavyweight libraries at module level:
- **numpy** (~50ms) via `lateral.py`, `vehicle_model.py`, `simple_kalman.py`, `pid.py`, `body/carcontroller.py`, `hyundai/hyundaicanfd.py`, `car/__init__.py`, `conversions.py`
- **Crypto/pycparser** (~25ms) via `secoc.py`
- **jinja2** via `docs.py`
- **tqdm** via `fw_versions.py`
- All brand **interface.py** modules (loaded eagerly via `load_interfaces()` during `test_car_interfaces.py` collection)

## Changes

| File | Change |
|------|--------|
| `car_helpers.py` | `load_interfaces()` now returns a `_LazyInterfacesDict` that imports each brand's `interface.py` on first key access; internal `_get_interfaces()` helper replaces direct `interfaces[]` calls |
| `lateral.py` | Remove module-level numpy; add `_clip()` and `_interp()` pure-Python helpers |
| `vehicle_model.py` | Defer numpy imports to function bodies; `TYPE_CHECKING` guard for `np.ndarray` annotations |
| `common/pid.py` | Remove numpy; add `_interp()` with `bisect`; replace `np.clip`/`np.sign` with `min/max` and inline expression |
| `common/simple_kalman.py` | Move `import numpy` inside `get_kalman_gain()` |
| `body/carcontroller.py` | Replace `numpy` with `math`; `np.radians` → `math.radians`, `np.clip` → `max/min` |
| `hyundai/hyundaicanfd.py` | Remove numpy; replace `np.clip` with `max/min` |
| `car/__init__.py` | Remove numpy; replace `np.clip` in `rate_limit` with `min/max` |
| `common/conversions.py` | Replace `numpy` with `math`; `np.pi` → `math.pi` |
| `secoc.py` | Defer `Crypto` imports to inside `add_mac`/`build_sync_mac` |
| `docs.py` | Defer `jinja2` import to inside `generate_cars_md()` |
| `fw_versions.py` | Defer `tqdm` import to inside `get_fw_versions()` |
| `interfaces.py` | `from __future__ import annotations`; defer numpy to methods; cache `get_interface_attr` via `@cache` |

## Measurements

```
# Before
763 tests collected in 1.63s

# After  
763 tests collected in 0.22s
```

All 711 tests pass (322 skipped), 5092 subtests pass.

## Hard floor

The 0.1s target is not achievable without modifying test files:
- `hypothesis` (imported at module level in `test_car_interfaces.py`): ~80ms  
- `capnp`/`cereal` (via `opendbc.car.structs`, needed for `ButtonType`): ~33ms
- `fingerprints.py` brand values (imported directly by `test_can_fingerprint.py`): ~50ms

These libraries load before any test runs and cannot be deferred from within the library code.