### PR TITLE
safety: add --fail-under-branch=100 to coverage check

### DIFF
--- a/opendbc/safety/tests/test.sh
+++ b/opendbc/safety/tests/test.sh
@@ -29,7 +29,7 @@ if [ "$1" == "--report" ]; then
 fi
 
 # test coverage
-GCOV="gcovr -r $DIR/../ --gcov-executable \"$GCOV_EXEC\" -d --fail-under-line=100 -e ^libsafety"
+GCOV="gcovr -r $DIR/../ --gcov-executable \"$GCOV_EXEC\" -d --fail-under-line=100 --fail-under-branch=100 -e ^libsafety"
 if ! GCOV_OUTPUT="$(eval $GCOV)"; then
   echo -e "FAILED:\n$GCOV_OUTPUT"
   exit 1


### PR DESCRIPTION
## Summary

Adds `--fail-under-branch=100` to the `gcovr` invocation in `test.sh`, enforcing 100% branch coverage on all production safety files (closes #2557).

## How it works

All production safety headers (`safety.h`, `lateral.h`, `longitudinal.h`, all `modes/*.h`, etc.) already have 100% branch coverage with the existing test suite.

The test harness wrapper `tests/libsafety/safety.c` (which exposes C helpers to Python via cffi) does not achieve 100% coverage — some helper getter/setter functions and error branches are not exercised. This file is already excluded from the line-coverage check via `-e ^libsafety`, and the same exclusion applies to the new branch-coverage check.

## Changes

```diff
-GCOV="gcovr -r $DIR/../ --gcov-executable "$GCOV_EXEC" -d --fail-under-line=100 -e ^libsafety"
+GCOV="gcovr -r $DIR/../ --gcov-executable "$GCOV_EXEC" -d --fail-under-line=100 --fail-under-branch=100 -e ^libsafety"
```

## Verification

Running all 2759 safety tests (1312 skipped) with gcovr confirms every production safety file achieves 100% branch coverage. The only file below 100% branch coverage is `tests/libsafety/safety.c`, which is the cffi test harness excluded by the existing `-e ^libsafety` filter.