### PR TITLE
Nissan Altima: add missing engine query for newer models and expand model years

### DIFF
--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -72,7 +72,7 @@ class CAR(Platforms):
     NissanCarSpecs(mass=1610, wheelbase=2.705)
   )
   NISSAN_ALTIMA = NissanPlatformConfig(
-    [NissanCarDocs("Nissan Altima 2019-20, 2024", car_parts=CarParts.common([CarHarness.nissan_b]))],
+    [NissanCarDocs("Nissan Altima 2019-20, 2023-24", car_parts=CarParts.common([CarHarness.nissan_b]))],
     NissanCarSpecs(mass=1492, wheelbase=2.824)
   )
 

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -121,5 +121,12 @@ FW_QUERY_CONFIG = FwQueryConfig(
       bus=bus,
       logging=logging,
     ),
+    # Some newer Altima respond at normal rx offset
+    Request(
+      [StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
+      [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
+      bus=bus,
+      logging=logging,
+    ),
   ]],
 )

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -121,7 +121,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       bus=bus,
       logging=logging,
     ),
-    # Some newer Altima respond at normal rx offset
+    # Some newer Altima engines respond at normal rx offset
     Request(
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -72,7 +72,7 @@ class CAR(Platforms):
     NissanCarSpecs(mass=1610, wheelbase=2.705)
   )
   NISSAN_ALTIMA = NissanPlatformConfig(
-    [NissanCarDocs("Nissan Altima 2019-20, 2023-24", car_parts=CarParts.common([CarHarness.nissan_b]))],
+    [NissanCarDocs("Nissan Altima 2019-24", car_parts=CarParts.common([CarHarness.nissan_b]))],
     NissanCarSpecs(mass=1492, wheelbase=2.824)
   )
 

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -262,7 +262,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 7.4
+    total_ref_time = 7.6
     brand_ref_times = {
       'gm': 1.0,
       'body': 0.1,
@@ -271,7 +271,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
       'honda': 0.45,
       'hyundai': 0.65,
       'mazda': 0.1,
-      'nissan': 0.8,
+      'nissan': 1.0,
       'subaru': 0.65,
       'tesla': 0.1,
       'toyota': 0.7,


### PR DESCRIPTION
This guy wasn't actually fingerprinting after https://github.com/commaai/opendbc/pull/2831

```
                         {'address': 2016,
                          'brand': 'mazda',
                          'bus': 0,
                          'ecu': 'engine',
                          'fwVersion': b'237106GU3B',
                          'logging': False,
                          'obdMultiplexing': True,
                          'request': [b'"\xf1\x88'],
                          'responseAddress': 2024,
                          'subAddress': 0},
```

Last year, two 2024 Altima dongles: ba40d0a9dda06597 (PR above, non-US), 39ebcbb0284c6f8b (only fwdCamera responds on bus 0, won't fingerprint as-is, US). I'm hoping we can rent the latter to see what's going on.

---

Last year, two 2023 Altima dongles: 1414bd4bad5acc8f, 6806e3afd093b01e.

First one (1414bd4bad5acc8f) is similar to second dongle above (39ebcbb0284c6f8b), only fwdCamera responds on bus 0. Checking logs, no response on bus 0 from engine at all, but it does use 0xF188 and 0x8 rx offset on bus 1. This PR should get engine, but maybe we should drop it as a required ECU. EPS also only responds on OBD bus 1 and rx offset 0x20 :/, but we haven't tried bus 1 non-OBD. Once we rent one, we can fix this up since there's so few users to contact to help debug.

For 6806e3afd093b01e, same thing as first dongle.

Going to mark as supported in the year list since it technically does work on forks, we just need to fix fingerprinting.

---

Don't see any 2022 dongles.

---

Last year, two 2021 Altima dongles: a03baa34319c25ca, 0aca7e19925e62e0.

Same thing as 2023.