### PR TITLE
[codex] Enable CAN parser length checks

### DIFF
--- a/opendbc/can/parser.py
+++ b/opendbc/can/parser.py
@@ -233,6 +233,9 @@ class CANParser:
         state = self.message_states.get(address)
         if state is None or len(dat) > 64:
           continue
+        if len(dat) != state.size:
+          state.rate_limited_log(t, f"got message with unexpected length: expected {state.size}, got {len(dat)}")
+          continue
         if state.parse(t, dat):
           updated_addrs.add(address)
 

--- a/opendbc/can/tests/test_packer_parser.py
+++ b/opendbc/can/tests/test_packer_parser.py
@@ -79,6 +79,26 @@ class TestCanParserPacker(unittest.TestCase):
     ret = parser.update([])
     assert len(ret) == 0
 
+  def test_parser_message_length(self):
+    msgs = [("Brake_Status", 0)]
+    parser = CANParser(TEST_DBC, msgs, 0)
+    packer = CANPacker(TEST_DBC)
+
+    msg = packer.make_can_msg("Brake_Status", 0, {"Signal1": 1})
+    parser.update([0, [msg]])
+    assert parser.vl["Brake_Status"]["Signal1"] == 1
+
+    expected_length = len(msg[1])
+    short_msg = (msg[0], msg[1][:-1], msg[2])
+    long_msg = (msg[0], msg[1] + b"\x00", msg[2])
+
+    for bad_msg in (short_msg, long_msg):
+      ret = parser.update([0, [bad_msg]])
+      assert ret == set()
+      assert parser.vl["Brake_Status"]["Signal1"] == 1
+      assert parser.vl_all["Brake_Status"]["Signal1"] == []
+      assert len(bad_msg[1]) != expected_length
+
   def test_parser_counter_can_valid(self):
     """
     Tests number of allowed bad counters + ensures CAN stays invalid


### PR DESCRIPTION
## Summary
Reject frames for tracked CAN messages when the payload length does not match the DBC message size. Previously the parser only rejected payloads over 64 bytes, so a short or padded frame could still update signal values.

The regression test covers both truncated and padded frames and checks that `vl`, `vl_all`, and the returned updated address set stay unchanged.

## Validation
- `python -m unittest opendbc.can.tests.test_packer_parser`
- `python -m unittest opendbc.can.tests.test_dbc_parser opendbc.can.tests.test_dbc_exceptions`
- `ruff check opendbc/can/parser.py opendbc/can/tests/test_packer_parser.py`
- `./test.sh`