### PR TITLE
Nissan Altima: fix fingerprinting without comma power

### DIFF
--- a/opendbc/car/nissan/fingerprints.py
+++ b/opendbc/car/nissan/fingerprints.py
@@ -16,6 +16,7 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [
       b'237106GU3B',
       b'237109HE2B',
+      b'237106GV3A',
     ],
     (Ecu.gateway, 0x18dad0f1, None): [
       b'284U29HE0A',

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -93,34 +93,39 @@ NISSAN_VERSION_RESPONSE_KWP = b'\x61\x83'
 
 NISSAN_RX_OFFSET = 0x20
 
+# TODO: once we gather enough Altima data on PT bus (1), we can remove OBD queries to speed up fingerprinting
 FW_QUERY_CONFIG = FwQueryConfig(
-  requests=[request for bus, logging in ((0, False), (1, True)) for request in [
+  requests=[request for bus, obd_multiplexing in ((0, False), (1, False), (1, True)) for request in [
     Request(
       [NISSAN_DIAGNOSTIC_REQUEST_KWP, NISSAN_VERSION_REQUEST_KWP],
       [NISSAN_DIAGNOSTIC_RESPONSE_KWP, NISSAN_VERSION_RESPONSE_KWP],
       bus=bus,
-      logging=logging,
+      logging=obd_multiplexing,
+      obd_multiplexing=obd_multiplexing,
     ),
     Request(
       [NISSAN_DIAGNOSTIC_REQUEST_KWP, NISSAN_VERSION_REQUEST_KWP],
       [NISSAN_DIAGNOSTIC_RESPONSE_KWP, NISSAN_VERSION_RESPONSE_KWP],
       rx_offset=NISSAN_RX_OFFSET,
       bus=bus,
-      logging=logging,
+      logging=obd_multiplexing,
+      obd_multiplexing=obd_multiplexing,
     ),
     # Rogue's engine solely responds to this
     Request(
       [NISSAN_DIAGNOSTIC_REQUEST_KWP_2, NISSAN_VERSION_REQUEST_KWP],
       [NISSAN_DIAGNOSTIC_RESPONSE_KWP_2, NISSAN_VERSION_RESPONSE_KWP],
       bus=bus,
-      logging=logging,
+      logging=obd_multiplexing,
+      obd_multiplexing=obd_multiplexing,
     ),
     Request(
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
       rx_offset=NISSAN_RX_OFFSET,
       bus=bus,
-      logging=logging,
+      logging=obd_multiplexing,
+      obd_multiplexing=obd_multiplexing,
     ),
     # Some newer Altima engines respond at normal rx offset
     Request(
@@ -128,6 +133,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
       bus=bus,
       logging=logging,
+      obd_multiplexing=obd_multiplexing,
     ),
   ]],
+  extra_ecus=[(Ecu.engine, 0x7e0, None)],
 )

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -136,5 +136,4 @@ FW_QUERY_CONFIG = FwQueryConfig(
       obd_multiplexing=obd_multiplexing,
     ),
   ]],
-  extra_ecus=[(Ecu.engine, 0x7e0, None)],
 )

--- a/opendbc/car/nissan/values.py
+++ b/opendbc/car/nissan/values.py
@@ -132,7 +132,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_REQUEST],
       [StdQueries.MANUFACTURER_SOFTWARE_VERSION_RESPONSE],
       bus=bus,
-      logging=logging,
+      logging=obd_multiplexing,
       obd_multiplexing=obd_multiplexing,
     ),
   ]],

--- a/opendbc/car/tests/test_fw_fingerprint.py
+++ b/opendbc/car/tests/test_fw_fingerprint.py
@@ -232,7 +232,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
     return self.total_time / self.N
 
   def _assert_timing(self, avg_time, ref_time):
-    assert avg_time < ref_time + self.TOL
+    assert avg_time < ref_time + self.TOL, avg_time
     assert avg_time > ref_time - self.TOL, "Performance seems to have improved, update test refs."
 
   def test_startup_timing(self):
@@ -262,7 +262,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
         print(f'get_vin {name} case, query time={self.total_time / self.N} seconds')
 
   def test_fw_query_timing(self):
-    total_ref_time = 7.6
+    total_ref_time = 8.2
     brand_ref_times = {
       'gm': 1.0,
       'body': 0.1,
@@ -271,7 +271,7 @@ class TestFwFingerprintTiming(unittest.TestCase):
       'honda': 0.45,
       'hyundai': 0.65,
       'mazda': 0.1,
-      'nissan': 1.0,
+      'nissan': 1.6,
       'subaru': 0.65,
       'tesla': 0.1,
       'toyota': 0.7,


### PR DESCRIPTION
I wasn't aware this car has pt on bus 1, so we need to query there for most ECUs

Bus 0 seems like a private bus with camera, but we also see the STEER_TORQUE_SENSOR message on it

```
comma@comma-77cd7a54:/data/openpilot/panda/examples$ ./query_fw_versions.py --bus 1 --no-obd --nonstandard --rxoffset 0x20

*** Results for address 0x707 ***


0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'284N86CA1D'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'B418'
0xF18C ECU_SERIAL_NUMBER: b'2842315400215CO2B418'
0xF190 VIN: b'123456789ABCDEFGH'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'\x00\x00\x00\x00\x00'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'_9'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'?\x04'


*** Results for address 0x740 ***


0xF180 BOOT_SOFTWARE_IDENTIFICATION: b'\x01BL-R3.5-210903'
0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x00\x0b'
0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'476609HF0B'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'B408'
0xF18C ECU_SERIAL_NUMBER: b'8640100001608230602 '
0xF190 VIN: b'00000000000000000'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'0265956924'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'1267983913'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'23'


*** Results for address 0x743 ***


0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'3311'
0xF18C ECU_SERIAL_NUMBER: b'                    '
0xF190 VIN: b'00000000000000000'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'  10346301'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'200303'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'200303'


*** Results for address 0x744 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'N01-0000\x00\x00'
0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'0000000000'
0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'275339HF8B'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'B517'
0xF18C ECU_SERIAL_NUMBER: b'PEP4J03264277WL9HJ4B'
0xF190 VIN: b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'0000000000'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'000000'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'023A54'


*** Results for address 0x745 ***


0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'284B29HF1A'
0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'284B39HF1D'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'CONTINENTAL AUTOMOTIVE'
0xF18C ECU_SERIAL_NUMBER: b'\x001Bq\x12\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF190 VIN: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'284B56CA0A'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'4310'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'2406'


*** Results for address 0x747 ***


0xF186 ACTIVE_DIAGNOSTIC_SESSION: b'\x03'
0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'0000000000'
0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'283C35MM9D'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'BOSCH'
0xF18C ECU_SERIAL_NUMBER: b'00000001ZY2NNG0     '
0xF190 VIN: b'1N4BL4EW4PN412929'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'259159HG0C'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'I_PRJ_RN_AIVI_22.11V06'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'5256_220803'


*** Results for address 0x74E ***


0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'D617'
0xF18C ECU_SERIAL_NUMBER: b'FFF21148642315000226'
0xF190 VIN: b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'285386CA3C'
0xF192 SYSTEM_SUPPLIER_ECU_HARDWARE_NUMBER: b'211490'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'L139'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'30'


*** Results for address 0x752 ***


0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'988209HF5A'
0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'285A49HF7A'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'1D22  '
0xF18C ECU_SERIAL_NUMBER: b'AEE5A2360680AD      '
0xF190 VIN: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'645048500C'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'FNIL42P_____2F05S03B01R07PHHX2M3'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'S2_206OH.P37                    '


*** Results for address 0x758 ***


0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'284B24BAA0'
0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'407116CA0A'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'CONTINENTAL AUTOMOTIVE'
0xF18C ECU_SERIAL_NUMBER: b'\x001Bq\x12\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF190 VIN: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'284B56CA0A'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'4310'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'2406'


*** Results for address 0x75D ***


0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'284E79HF2A'
0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'284E79HF2A'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'A604'
0xF18C ECU_SERIAL_NUMBER: b'00000002023020500239'
0xF190 VIN: b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'284E79HF2A'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'B205'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'00001719'


*** Results for address 0x782 ***


0xF180 BOOT_SOFTWARE_IDENTIFICATION: b'\x0101.00.00.FFF'
0xF182 APPLICATION_DATA_IDENTIFICATION: b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
0xF187 VEHICLE_MANUFACTURER_SPARE_PART_NUMBER: b'0000000000'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'A851'
0xF18C ECU_SERIAL_NUMBER: b'280T\x01235\x00\x00\x00\x00\x10\x12(     '
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'280616CA0B'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'01.00.00.FF'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'00.FF.FF.FF.FF.FF.FF.FF.FF.FF'
```

```
comma@comma-77cd7a54:/data/openpilot/panda/examples$ ./query_fw_versions.py --bus 0 --no-obd --nonstandard --rxoffset 0x20

*** Results for address 0x707 ***


0xF188 VEHICLE_MANUFACTURER_ECU_SOFTWARE_NUMBER: b'284N86CA1D'
0xF18A SYSTEM_SUPPLIER_IDENTIFIER: b'B418'
0xF18C ECU_SERIAL_NUMBER: b'2842315400215CO2B418'
0xF190 VIN: b'123456789ABCDEFGH'
0xF191 VEHICLE_MANUFACTURER_ECU_HARDWARE_NUMBER: b'\x00\x00\x00\x00\x00'
0xF194 SYSTEM_SUPPLIER_ECU_SOFTWARE_NUMBER: b'_9'
0xF195 SYSTEM_SUPPLIER_ECU_SOFTWARE_VERSION_NUMBER: b'?\x04'
```