### PR TITLE
move conditions for belowEngageSpeed into opendbc

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -202,7 +202,6 @@ struct CarState {
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
-  belowEngageSpeed @61 :Bool;
   blockPcmEnable @60 :Bool;  # whether to allow PCM to enable this frame
 
   # cruise state
@@ -244,6 +243,7 @@ struct CarState {
     available @2 :Bool;
     standstill @4 :Bool;
     nonAdaptive @5 :Bool;
+    belowEngageSpeed @7 :Bool;
 
     speedOffsetDEPRECATED @3 :Float32;
   }

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -202,6 +202,7 @@ struct CarState {
   espActive @51 :Bool;
   vehicleSensorsInvalid @52 :Bool;  # invalid steering angle readings, etc.
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
+  belowEngageSpeed @61 :Bool;
   blockPcmEnable @60 :Bool;  # whether to allow PCM to enable this frame
 
   # cruise state

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -162,7 +162,7 @@ class CarState(CarStateBase):
     # This checks a higher brake threshold at standstill to fix a fault when you engage at a stop
     # with light brake pressure. Likely because PCM and camera have different thresholds in different
     # scenarios (yes, stock ACC faults and so this fixes their bug).
-    ret.belowEngageSpeed = ret.vEgo < self.CP.minEnableSpeed and \
+    ret.cruiseState.belowEngageSpeed = ret.vEgo < self.CP.minEnableSpeed and \
       not (ret.standstill and pt_cp.vl["ECMAcceleratorPos"]["BrakePedalPos"] >= 20 and
            self.CP.networkLocation == NetworkLocation.fwdCamera)
 

--- a/opendbc/car/gm/carstate.py
+++ b/opendbc/car/gm/carstate.py
@@ -157,6 +157,15 @@ class CarState(CarStateBase):
     if ret.vEgo < self.CP.minSteerSpeed:
       ret.lowSpeedAlert = True
 
+    # Enabling at a standstill with brake is allowed
+    # TODO: verify 17 Volt can enable for the first time at a stop and allow for all GMs
+    # This checks a higher brake threshold at standstill to fix a fault when you engage at a stop
+    # with light brake pressure. Likely because PCM and camera have different thresholds in different
+    # scenarios (yes, stock ACC faults and so this fixes their bug).
+    ret.belowEngageSpeed = ret.vEgo < self.CP.minEnableSpeed and \
+      not (ret.standstill and pt_cp.vl["ECMAcceleratorPos"]["BrakePedalPos"] >= 20 and
+           self.CP.networkLocation == NetworkLocation.fwdCamera)
+
     return ret
 
   @staticmethod

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -224,7 +224,7 @@ class CarState(CarStateBase):
       *create_button_events(self.cruise_setting, prev_cruise_setting, SETTINGS_BUTTONS_DICT),
     ]
 
-    ret.belowEngageSpeed = self.CP.pcmCruise and ret.vEgo < self.CP.minEnableSpeed
+    ret.cruiseState.belowEngageSpeed = self.CP.pcmCruise and ret.vEgo < self.CP.minEnableSpeed
 
     return ret
 

--- a/opendbc/car/honda/carstate.py
+++ b/opendbc/car/honda/carstate.py
@@ -224,6 +224,8 @@ class CarState(CarStateBase):
       *create_button_events(self.cruise_setting, prev_cruise_setting, SETTINGS_BUTTONS_DICT),
     ]
 
+    ret.belowEngageSpeed = self.CP.pcmCruise and ret.vEgo < self.CP.minEnableSpeed
+
     return ret
 
   def get_can_parsers(self, CP):

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -201,7 +201,7 @@ class CarState(CarStateBase):
 
     ret.buttonEvents = buttonEvents
 
-    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed
+    ret.cruiseState.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed
 
     return ret
 

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -200,6 +200,9 @@ class CarState(CarStateBase):
         buttonEvents += create_button_events(self.distance_button, prev_distance_button, {1: ButtonType.gapAdjustCruise})
 
     ret.buttonEvents = buttonEvents
+
+    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed
+
     return ret
 
   @staticmethod

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -140,7 +140,7 @@ class CarState(CarStateBase):
     ret.buttonEvents = self.create_button_events(pt_cp, self.CCP.BUTTONS)
 
     ret.lowSpeedAlert = self.update_low_speed_alert(ret.vEgo)
-    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
+    ret.cruiseState.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
 
     self.frame += 1
     return ret
@@ -231,7 +231,7 @@ class CarState(CarStateBase):
     ret.espDisabled = bool(pt_cp.vl["Bremse_1"]["BR1_ESPASR_passive"])
 
     ret.lowSpeedAlert = self.update_low_speed_alert(ret.vEgo)
-    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
+    ret.cruiseState.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
 
     self.frame += 1
     return ret
@@ -372,7 +372,7 @@ class CarState(CarStateBase):
     ret.cruiseState.standstill = self.CP.pcmCruise and self.esp_hold_confirmation
     ret.standstill = ret.vEgoRaw == 0
 
-    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
+    ret.cruiseState.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
 
     self.frame += 1
     return ret

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -140,6 +140,7 @@ class CarState(CarStateBase):
     ret.buttonEvents = self.create_button_events(pt_cp, self.CCP.BUTTONS)
 
     ret.lowSpeedAlert = self.update_low_speed_alert(ret.vEgo)
+    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
 
     self.frame += 1
     return ret
@@ -230,6 +231,7 @@ class CarState(CarStateBase):
     ret.espDisabled = bool(pt_cp.vl["Bremse_1"]["BR1_ESPASR_passive"])
 
     ret.lowSpeedAlert = self.update_low_speed_alert(ret.vEgo)
+    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
 
     self.frame += 1
     return ret
@@ -369,6 +371,8 @@ class CarState(CarStateBase):
 
     ret.cruiseState.standstill = self.CP.pcmCruise and self.esp_hold_confirmation
     ret.standstill = ret.vEgoRaw == 0
+
+    ret.belowEngageSpeed = self.CP.openpilotLongitudinalControl and ret.vEgo < self.CP.minEnableSpeed + 0.5
 
     self.frame += 1
     return ret


### PR DESCRIPTION
Previously `belowEngageSpeed` conditions where calculated by `car_specific.py`.

Added `CruiseState.belowEngageSpeed` and moved conditions into carstate logic.
