### PR TITLE
safety: add ignition branch coverage tests

### DIFF
--- a/opendbc/safety/tests/test_gm.py
+++ b/opendbc/safety/tests/test_gm.py
@@ -250,6 +250,14 @@ class TestGmIgnition(unittest.TestCase):
     self.safety.ignition_can_hook(self._msg(0))
     self.assertFalse(self.safety.get_ignition_can())
 
+  def test_ignition_wrong_bus_ignored(self):
+    self.safety.ignition_can_hook(common.make_msg(1, 0x1F1, dat=b"\x02" + b"\x00" * 7))
+    self.assertFalse(self.safety.get_ignition_can())
+
+  def test_ignition_wrong_len_ignored(self):
+    self.safety.ignition_can_hook(common.make_msg(0, 0x1F1, dat=b"\x02" + b"\x00" * 6))
+    self.assertFalse(self.safety.get_ignition_can())
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/opendbc/safety/tests/test_mazda.py
+++ b/opendbc/safety/tests/test_mazda.py
@@ -102,6 +102,10 @@ class TestMazdaIgnition(unittest.TestCase):
     self.safety.ignition_can_hook(self._msg(0x20))
     self.assertFalse(self.safety.get_ignition_can())
 
+  def test_ignition_wrong_len_ignored(self):
+    self.safety.ignition_can_hook(make_msg(0, 0x9E, dat=b"\xC0" + b"\x00" * 6))
+    self.assertFalse(self.safety.get_ignition_can())
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/opendbc/safety/tests/test_rivian.py
+++ b/opendbc/safety/tests/test_rivian.py
@@ -172,6 +172,13 @@ class TestRivianIgnition(unittest.TestCase):
     self.safety.ignition_can_hook(self._msg(3, 0))
     self.assertFalse(self.safety.get_ignition_can())
 
+  def test_ignition_wrong_len_ignored(self):
+    self.safety.ignition_can_hook(self._msg(0, 1))
+    msg = self._msg(1, 1)
+    msg[0].data_len_code = 7
+    self.safety.ignition_can_hook(msg)
+    self.assertFalse(self.safety.get_ignition_can())
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -486,6 +486,13 @@ class TestTeslaIgnition(unittest.TestCase):
     self.safety.ignition_can_hook(self._msg(3, 2))
     self.assertFalse(self.safety.get_ignition_can())
 
+  def test_ignition_wrong_len_ignored(self):
+    self.safety.ignition_can_hook(self._msg(0, 3))
+    msg = self._msg(1, 3)
+    msg[0].data_len_code = 7
+    self.safety.ignition_can_hook(msg)
+    self.assertFalse(self.safety.get_ignition_can())
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -35,6 +35,13 @@ class TestVolkswagenMebIgnition(unittest.TestCase):
     self.safety.ignition_can_hook(self._msg(3, 0))
     self.assertFalse(self.safety.get_ignition_can())
 
+  def test_ignition_wrong_len_ignored(self):
+    self.safety.ignition_can_hook(self._msg(0, 1))
+    msg = self._msg(1, 1)
+    msg[0].data_len_code = 3
+    self.safety.ignition_can_hook(msg)
+    self.assertFalse(self.safety.get_ignition_can())
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Part of #2557.

Adds focused branch coverage tests for ignition CAN handling. This covers malformed ignition message paths without changing production safety logic.

Covered cases:
- GM ignition messages ignored on wrong bus / wrong DLC
- Rivian ignition messages ignored with wrong DLC
- Tesla ignition messages ignored with wrong DLC
- Mazda ignition messages ignored with wrong DLC
- Volkswagen MEB ignition messages ignored with wrong DLC

These tests exercise ignored-path branches in `ignition.h` for malformed or non-primary-bus ignition messages.

Validation:
- `./test.sh`
- No production code modified
- No safety behavior changes