### PR TITLE
Volkswagen ID.4 EA

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -355,7 +355,7 @@ struct CarControl {
   angularVelocity @14 :List(Float32);
   currentCurvature @17 :Float32;  # From vehicle model
 
-  dmEscalation @18 :Bool; # trigger the car's stock driver monitoring escalation
+  driverMonitoringEscalation @18 :Bool; # trigger the car's stock driver monitoring escalation
 
   cruiseControl @4 :CruiseControl;
   hudControl @5 :HUDControl;

--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -355,6 +355,8 @@ struct CarControl {
   angularVelocity @14 :List(Float32);
   currentCurvature @17 :Float32;  # From vehicle model
 
+  dmEscalation @18 :Bool; # trigger the car's stock driver monitoring escalation
+
   cruiseControl @4 :CruiseControl;
   hudControl @5 :HUDControl;
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -124,7 +124,7 @@ class CarController(CarControllerBase):
     # Emergency Assist intervention
     if self.CP.flags & VolkswagenFlags.MEB and self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
       # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
-      # MEB Emergency Assist break jerks after 30s of continued hands-off time
+      # MEB Emergency Assist brake jerks after 30s of continued hands-off time
       # so we send the stock wheeltouch message starting with the steerRequired alert to reduce reaction time after the latched red alert
       if self.frame % self.CCP.KLR_01_STEP == 0:
         lat_active = CC.latActive and hud_control.visualAlert != VisualAlert.steerRequired

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -127,7 +127,7 @@ class CarController(CarControllerBase):
       # MEB Emergency Assist brake jerks after 30s of continued hands-off time
       # so we send the stock wheeltouch message starting with the steerRequired alert to reduce reaction time after the latched red alert
       if self.frame % self.CCP.KLR_01_STEP == 0:
-        lat_active = CC.latActive and hud_control.visualAlert != VisualAlert.steerRequired
+        lat_active = CC.latActive and not CC.dmEscalation
         can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values))
         can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values))
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -124,9 +124,12 @@ class CarController(CarControllerBase):
     # Emergency Assist intervention
     if self.CP.flags & VolkswagenFlags.MEB and self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
       # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
+      # MEB Emergency Assist break jerks after 30s of continued hands-off time
+      # so we send the stock wheeltouch message starting with the steerRequired alert to reduce reaction time after the latched red alert
       if self.frame % self.CCP.KLR_01_STEP == 0:
-        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, CC.latActive, CS.klr_stock_values))
-        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, CC.latActive, CS.klr_stock_values))
+        lat_active = CC.latActive and hud_control.visualAlert != VisualAlert.steerRequired
+        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values))
+        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values))
 
     # **** Acceleration Controls ******************************************** #
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -124,10 +124,10 @@ class CarController(CarControllerBase):
     # Emergency Assist intervention
     if self.CP.flags & VolkswagenFlags.MEB and self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
       # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
-      # MEB Emergency Assist brake jerks after 30s of continued hands-off time
-      # so we send the stock wheeltouch message starting with the steerRequired alert to reduce reaction time after the latched red alert
+      # MEB Emergency Assist brake jerks after 30s of continued hands-off time.
+      # We send the stock wheeltouch message to start the stock DM timer when openpilot latches the critical driver monitoring alert
       if self.frame % self.CCP.KLR_01_STEP == 0:
-        lat_active = CC.latActive and not CC.dmEscalation
+        lat_active = CC.latActive and not CC.driverMonitoringEscalation
         can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values))
         can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values))
 


### PR DESCRIPTION
Escalate to stock Emergency Assist when openpilot driver monitoring detects distracted driving.
This is done by controlling KLR_01 message and sending the stock steering touch commands when steerRequired alert is active. 
When the driver is attentive again, the internal EA timer resets.