### PR TITLE
cppcheck: replace bool 0 assignment with false

### DIFF
--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -345,7 +345,7 @@ static bool toyota_tx_hook(const CANPacket_t *msg) {
     // this address is sub-addressed. only allow tester present to radar (0xF)
     bool invalid_uds_msg = (GET_BYTES(msg, 0, 4) != 0x003E020FU) || (GET_BYTES(msg, 4, 4) != 0x0U);
     if (invalid_uds_msg) {
-      tx = 0;
+      tx = false;
     }
   }
 


### PR DESCRIPTION
This PR is related to the cleanup requested in commaai/panda#2105, 
where the original ask is to replace bool assignments that use 
integer  `0/1` with `false/true`.

After updating panda to use cppcheck `2.21.0` and re-running the 
MISRA/static-analysis path locally, the remaining cppcheck rule 10.3 
finding from opendbc is in Toyota safety:

- `tx = 0;`

Since `tx` is a bool, this change replaces that assignment with:

- `tx = false;`

## Validation:

What cppcheck report through panda before the opendbc fix:
```sh
 Devanshs-MacBook-Pro    \panda  ➜ (  new_zero_one)   30ms   1:26 AM   
 ⚡devanshvarshney ❯❯ SKIP_BUILD=1 SKIP_TABLES_DIFF=1 tests/misra/test_misra.sh 2>&1 | rg "misra-c2012-10.3"

/Users/devanshvarshney/panda/.venv/lib/python3.12/site-packages/opendbc/safety/modes/toyota.h:334:10: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-10.3]
/Users/devanshvarshney/panda/board/drivers/can_common.h:41:12: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-10.3]
/Users/devanshvarshney/panda/board/drivers/can_common.h:51:9: style: misra violation (use --rule-texts=<file> to get proper output) [misra-c2012-10.3]
```

After the fix:
```sh
 Devanshs-MacBook-Pro    \panda  ➜ (  new_zero_one)   60ms   1:48 AM   
 ⚡devanshvarshney ❯❯ SKIP_BUILD=1 SKIP_TABLES_DIFF=1 tests/misra/test_misra.sh 2>&1 | rg "misra-c2012-10.3"

# no output
```

Where this was found:

- https://github.com/commaai/panda/issues/2105
- https://github.com/commaai/panda/issues/2105#issuecomment-4150089160

Related:

- https://github.com/cppcheck-opensource/cppcheck/pull/8340
- https://github.com/cppcheck-opensource/cppcheck/pull/8388
- https://github.com/cppcheck-opensource/cppcheck/releases/tag/2.21.0 
