### PR TITLE
safety: add option to ignore frequency check for RX checks

### DIFF
--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -181,6 +181,7 @@ typedef struct {
   const bool ignore_counter;         // counter check is not performed when set to true
   const uint8_t max_counter;         // maximum value of the counter. 0 means that the counter check is skipped
   const bool ignore_quality_flag;    // true if quality flag check is skipped
+  const bool ignore_frequency_check; // true if minimum frequency enforcement is skipped
 } CanMsgCheck;
 
 typedef struct {

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -333,7 +333,7 @@ void safety_tick(const safety_config *cfg) {
       }
 
       // enforce minimum frequency for safety-relevant messages
-      bool frequency_invalid = frequency < 10U;
+      bool frequency_invalid = !cfg->rx_checks[i].msg[cfg->rx_checks[i].status.index].ignore_frequency_check && (frequency < 10U);
       if (lagging || frequency_invalid || !is_msg_valid(cfg->rx_checks, i)) {
         rx_checks_invalid = true;
         controls_allowed = false;


### PR DESCRIPTION
Add optional `ignore_frequency_check` flag to `CanMsgCheck` for RX messages that are physically broadcasted below the 10Hz minimum enforced in #3359.