### PR TITLE
add laneChange to AudibleAlert

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -433,6 +433,8 @@ struct CarControl {
       prompt @6;
       promptRepeat @7;
       promptDistracted @8;
+
+      laneChange @9;
     }
   }
 


### PR DESCRIPTION
Adds laneChange to the AudibleAlert enum so openpilot can play a sound when the user confirms a lane change.