### PR TITLE
Toyota: fix radar distance signal

### DIFF
--- a/opendbc/dbc/toyota_adas.dbc
+++ b/opendbc/dbc/toyota_adas.dbc
@@ -43,7 +43,7 @@ BO_ 291 STATUS_MSG: 7 XXX
 BO_ 528 TRACK_A_0: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -52,7 +52,7 @@ BO_ 528 TRACK_A_0: 8 XXX
 BO_ 529 TRACK_A_1: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -61,7 +61,7 @@ BO_ 529 TRACK_A_1: 8 XXX
 BO_ 530 TRACK_A_2: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -70,7 +70,7 @@ BO_ 530 TRACK_A_2: 8 XXX
 BO_ 531 TRACK_A_3: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -79,7 +79,7 @@ BO_ 531 TRACK_A_3: 8 XXX
 BO_ 532 TRACK_A_4: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -88,7 +88,7 @@ BO_ 532 TRACK_A_4: 8 XXX
 BO_ 533 TRACK_A_5: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -97,7 +97,7 @@ BO_ 533 TRACK_A_5: 8 XXX
 BO_ 534 TRACK_A_6: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -106,7 +106,7 @@ BO_ 534 TRACK_A_6: 8 XXX
 BO_ 535 TRACK_A_7: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -115,7 +115,7 @@ BO_ 535 TRACK_A_7: 8 XXX
 BO_ 536 TRACK_A_8: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -124,7 +124,7 @@ BO_ 536 TRACK_A_8: 8 XXX
 BO_ 537 TRACK_A_9: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -133,7 +133,7 @@ BO_ 537 TRACK_A_9: 8 XXX
 BO_ 538 TRACK_A_10: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -142,7 +142,7 @@ BO_ 538 TRACK_A_10: 8 XXX
 BO_ 539 TRACK_A_11: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -151,7 +151,7 @@ BO_ 539 TRACK_A_11: 8 XXX
 BO_ 540 TRACK_A_12: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -160,7 +160,7 @@ BO_ 540 TRACK_A_12: 8 XXX
 BO_ 541 TRACK_A_13: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -169,7 +169,7 @@ BO_ 541 TRACK_A_13: 8 XXX
 BO_ 542 TRACK_A_14: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -178,7 +178,7 @@ BO_ 542 TRACK_A_14: 8 XXX
 BO_ 543 TRACK_A_15: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX

--- a/opendbc/dbc/toyota_tss2_adas.dbc
+++ b/opendbc/dbc/toyota_tss2_adas.dbc
@@ -43,7 +43,7 @@ BO_ 291 STATUS_MSG: 7 XXX
 BO_ 384 TRACK_A_0: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -52,7 +52,7 @@ BO_ 384 TRACK_A_0: 8 XXX
 BO_ 385 TRACK_A_1: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -61,7 +61,7 @@ BO_ 385 TRACK_A_1: 8 XXX
 BO_ 386 TRACK_A_2: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -70,7 +70,7 @@ BO_ 386 TRACK_A_2: 8 XXX
 BO_ 387 TRACK_A_3: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -79,7 +79,7 @@ BO_ 387 TRACK_A_3: 8 XXX
 BO_ 388 TRACK_A_4: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -88,7 +88,7 @@ BO_ 388 TRACK_A_4: 8 XXX
 BO_ 389 TRACK_A_5: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -97,7 +97,7 @@ BO_ 389 TRACK_A_5: 8 XXX
 BO_ 390 TRACK_A_6: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -106,7 +106,7 @@ BO_ 390 TRACK_A_6: 8 XXX
 BO_ 391 TRACK_A_7: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -115,7 +115,7 @@ BO_ 391 TRACK_A_7: 8 XXX
 BO_ 392 TRACK_A_8: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -124,7 +124,7 @@ BO_ 392 TRACK_A_8: 8 XXX
 BO_ 393 TRACK_A_9: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -133,7 +133,7 @@ BO_ 393 TRACK_A_9: 8 XXX
 BO_ 394 TRACK_A_10: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -142,7 +142,7 @@ BO_ 394 TRACK_A_10: 8 XXX
 BO_ 395 TRACK_A_11: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -151,7 +151,7 @@ BO_ 395 TRACK_A_11: 8 XXX
 BO_ 396 TRACK_A_12: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -160,7 +160,7 @@ BO_ 396 TRACK_A_12: 8 XXX
 BO_ 397 TRACK_A_13: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -169,7 +169,7 @@ BO_ 397 TRACK_A_13: 8 XXX
 BO_ 398 TRACK_A_14: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX
@@ -178,7 +178,7 @@ BO_ 398 TRACK_A_14: 8 XXX
 BO_ 399 TRACK_A_15: 8 XXX
  SG_ COUNTER : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ LAT_DIST : 31|11@0- (0.04,0) [-50|50] "m" XXX
- SG_ LONG_DIST : 15|13@0+ (0.04,0) [0|300] "m" XXX
+ SG_ LONG_DIST : 15|15@0+ (0.01,0) [0|300] "m" XXX
  SG_ NEW_TRACK : 36|1@0+ (1,0) [0|1] "" XXX
  SG_ REL_SPEED : 47|12@0- (0.025,0) [-100|100] "m/s" XXX
  SG_ VALID : 48|1@0+ (1,0) [0|1] "" XXX


### PR DESCRIPTION
No functional difference, but includes two bits that add a tiny amount of precision

before

<img width="843" height="1004" alt="image" src="https://github.com/user-attachments/assets/f880af6e-b8c5-4d7c-9051-20ff00b93295" />

after

<img width="832" height="958" alt="image" src="https://github.com/user-attachments/assets/1054040e-ac39-43d2-8a8a-34705f0d132b" />
