### PR TITLE
safety: add release build test + fix errors

### DIFF
--- a/opendbc/safety/modes/ford.h
+++ b/opendbc/safety/modes/ford.h
@@ -289,11 +289,13 @@ static safety_config ford_init(uint16_t param) {
     {FORD_Lane_Assist_Data1, 0, 8, .check_relay = true},  \
     {FORD_IPMA_Data, 0, 8, .check_relay = true},          \
 
+#ifdef ALLOW_DEBUG
   static const CanMsg FORD_CANFD_LONG_TX_MSGS[] = {
     FORD_COMMON_TX_MSGS
     {FORD_ACCDATA, 0, 8, .check_relay = true},
     {FORD_LateralMotionControl2, 0, 8, .check_relay = true},
   };
+#endif
 
   static const CanMsg FORD_CANFD_STOCK_TX_MSGS[] = {
     FORD_COMMON_TX_MSGS

--- a/opendbc/safety/modes/gm.h
+++ b/opendbc/safety/modes/gm.h
@@ -181,9 +181,11 @@ static safety_config gm_init(uint16_t param) {
     .max_brake = 400,
   };
 
+#ifdef ALLOW_DEBUG
   // block PSCMStatus (0x184); forwarded through openpilot to hide an alert from the camera
   static const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true}, {0x315, 0, 5, .check_relay = true}, {0x2CB, 0, 8, .check_relay = true}, {0x370, 0, 6, .check_relay = true},  // pt bus
                                                {0x184, 2, 8, .check_relay = true}};  // camera bus
+#endif
 
 
   static RxCheck gm_rx_checks[] = {

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -991,8 +991,8 @@ class SafetyTest(SafetyTestBase):
     for tf in test_files:
       test = importlib.import_module("opendbc.safety.tests."+tf[:-3])
       for attr in dir(test):
-        if attr.startswith("Test") and attr != current_test:
-          tc = getattr(test, attr)
+        tc = getattr(test, attr)
+        if isinstance(tc, type) and issubclass(tc, SafetyTest) and attr != current_test:
           tx = tc.TX_MSGS
           if tx is not None and not attr.endswith('Base'):
             # No point in comparing different Tesla safety modes

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -10,7 +10,7 @@ from opendbc.safety import LEN_TO_DLC
 libsafety_dir = os.path.dirname(os.path.abspath(__file__))
 
 
-def _build_libsafety() -> str:
+def _build_libsafety(release: bool = False) -> str:
   """Compile libsafety.so to a temp file and return its path."""
   root = str(Path(libsafety_dir).parents[3])
   safety_c = os.path.join(libsafety_dir, "safety.c")
@@ -18,13 +18,14 @@ def _build_libsafety() -> str:
   cflags = [
     '-Wall', '-Wextra', '-Werror', '-nostdlib', '-fno-builtin',
     '-std=gnu11', '-Wfatal-errors', '-Wno-pointer-to-int-cast',
-    '-g', '-O0', '-fno-omit-frame-pointer', '-DALLOW_DEBUG',
-    '-fprofile-arcs', '-ftest-coverage',
+    '-g', '-O0', '-fno-omit-frame-pointer',
   ]
   ldflags = [
     '-fsanitize=undefined', '-fno-sanitize-recover=undefined',
-    '-fprofile-arcs', '-ftest-coverage',
   ]
+  if not release:
+    cflags += ['-DALLOW_DEBUG', '-fprofile-arcs', '-ftest-coverage']
+    ldflags += ['-fprofile-arcs', '-ftest-coverage']
 
   fd, safety_os = tempfile.mkstemp(suffix='.os', dir=libsafety_dir)
   os.close(fd)

--- a/opendbc/safety/tests/test_release_build.py
+++ b/opendbc/safety/tests/test_release_build.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+import unittest
+
+from opendbc.safety.tests.libsafety.libsafety_py import _build_libsafety
+
+
+class TestReleaseBuild(unittest.TestCase):
+  def test_build_without_allow_debug(self):
+    # panda's release firmware builds the safety code without ALLOW_DEBUG
+    _build_libsafety(release=True)
+    assert False
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/safety/tests/test_release_build.py
+++ b/opendbc/safety/tests/test_release_build.py
@@ -4,11 +4,12 @@ import unittest
 from opendbc.safety.tests.libsafety.libsafety_py import _build_libsafety
 
 
-class TestReleaseBuild(unittest.TestCase):
-  def test_build_without_allow_debug(self):
-    # panda's release firmware builds the safety code without ALLOW_DEBUG
+class TestBuild(unittest.TestCase):
+  def test_development_build(self):
+    _build_libsafety(release=False)
+
+  def test_release_build(self):
     _build_libsafety(release=True)
-    assert False
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
catches & fixes:
```bash
.venv/lib/python3.12/site-packages/opendbc/safety/modes/gm.h: In function 'gm_init':
.venv/lib/python3.12/site-packages/opendbc/safety/modes/gm.h:185:23: error: unused variable 'GM_CAM_LONG_TX_MSGS' [-Werror=unused-variable]
  185 |   static const CanMsg GM_CAM_LONG_TX_MSGS[] = {{0x180, 0, 4, .check_relay = true}, {0x315, 0, 5, .check_relay = true}, {0x2CB, 0, 8, .check_relay = true}, {0x370, 0, 6, .check_relay = true},  // pt bus
      |                       ^~~~~~~~~~~~~~~~~~~
compilation terminated due to -fmax-errors=1.
scons: *** [board/board/obj/panda_h7main.o] Error 1
scons: building terminated because of errors.
```