### PR TITLE
Docs: Fix unclear Mazda requirements

### DIFF
--- a/opendbc/car/docs_definitions.py
+++ b/opendbc/car/docs_definitions.py
@@ -241,6 +241,8 @@ class CarDocs:
 
   # all the parts needed for the supported car
   car_parts: CarParts = field(default_factory=CarParts)
+  # Mazda requires comma power
+  requires_comma_power: bool = False
 
   merged: bool = True
   support_type: SupportType = SupportType.UPSTREAM

--- a/opendbc/car/mazda/values.py
+++ b/opendbc/car/mazda/values.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass, field
-from enum import IntFlag
+from enum import Enum, IntFlag
 
 from opendbc.car import Bus, CarSpecs, DbcDict, PlatformConfig, Platforms
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.structs import CarParams
-from opendbc.car.docs_definitions import CarHarness, CarDocs, CarParts
+from opendbc.car.docs_definitions import CarFootnote, CarHarness, CarDocs, CarParts, Column
 from opendbc.car.fw_query_definitions import FwQueryConfig, Request, StdQueries
 
 Ecu = CarParams.Ecu
@@ -29,6 +29,14 @@ class CarControllerParams:
 class MazdaCarDocs(CarDocs):
   package: str = "All"
   car_parts: CarParts = field(default_factory=CarParts.common([CarHarness.mazda]))
+  footnotes: list[Enum] = field(default_factory=lambda: [Footnote.COMMA_POWER_REQUIRED])
+  requires_comma_power: bool = True
+
+
+class Footnote(Enum):
+  COMMA_POWER_REQUIRED = CarFootnote(
+    "Mazda vehicles <b>require</b> comma power installation.",
+    Column.MAKE, setup_note=True)
 
 
 @dataclass(frozen=True, kw_only=True)


### PR DESCRIPTION
Currently on website and in CARS.md there are no mentions of Mazda requiring comma power.

Proposed changes:
- add a flag when comma power is required for website repo to consume
- add setup note and CARS.md footnote for Mazda

Related PR: https://github.com/commaai/website/pull/322

## Context
<img width="1286" height="526" alt="comments-mazda" src="https://github.com/user-attachments/assets/400db299-15ca-43b5-8c36-ec2cca1aa785" />
<img width="2206" height="1172" alt="CleanShot 2026-07-11 at 13 38 14@2x" src="https://github.com/user-attachments/assets/9930571d-7228-4537-a86e-9d6914bbf423" />

<br>

## Links:
 Reddit: https://www.reddit.com/r/Comma_ai/comments/1ubdfc4/bad_comma_power_adapter_i_thought_it_was_optional/
 Discord-1: https://discord.com/channels/469524606043160576/524592892627517450/1496944296509702264
 Discord-2: https://discord.com/channels/469524606043160576/524592892627517450/1525540512969396305
 Wiki: https://github.com/commaai/openpilot/wiki/Mazda#setup-notes
