### PR TITLE
Chrysler: reliable fuzzy fingerprinting (#1092)

### DIFF
--- a/opendbc/car/chrysler/tests/test_chrysler.py
+++ b/opendbc/car/chrysler/tests/test_chrysler.py
@@ -1,4 +1,4 @@
-import pytest
+import unittest
 
 from opendbc.car.chrysler.fingerprints import FW_VERSIONS
 from opendbc.car.chrysler.values import CAR, PLATFORM_CODE_ECUS, get_platform_codes, match_fw_to_car_fuzzy
@@ -9,7 +9,7 @@ Ecu = CarParams.Ecu
 CarFw = CarParams.CarFw
 
 
-class TestGetPlatformCodes:
+class TestGetPlatformCodes(unittest.TestCase):
   def test_extracts_part_number(self):
     # Standard Chrysler FW format: 8 digit part number + 2 char revision
     codes = get_platform_codes([b'68227902AF'])
@@ -37,37 +37,37 @@ class TestGetPlatformCodes:
     assert codes == set()
 
 
-class TestPlatformCodeEcus:
-  @pytest.mark.parametrize("car_model, ecus", FW_VERSIONS.items())
-  def test_platform_code_ecus_available(self, car_model, ecus):
+class TestPlatformCodeEcus(unittest.TestCase):
+  def test_platform_code_ecus_available(self):
     """Each platform must have at least 2 ECUs with platform codes for reliable matching."""
-    platform_ecus = [ecu for ecu in ecus if ecu[0] in PLATFORM_CODE_ECUS]
-    assert len(platform_ecus) >= 2, f"{car_model}: needs at least 2 platform ECUs for fuzzy fingerprinting"
+    for car_model, ecus in FW_VERSIONS.items():
+      platform_ecus = [ecu for ecu in ecus if ecu[0] in PLATFORM_CODE_ECUS]
+      assert len(platform_ecus) >= 2, f"{car_model}: needs at least 2 platform ECUs for fuzzy fingerprinting"
 
 
-class TestMatchFwToCarFuzzy:
+class TestMatchFwToCarFuzzy(unittest.TestCase):
   def _mutate_revision(self, fw: bytes) -> bytes:
     """Simulate an unseen firmware revision (last 4 chars are the variable part)."""
     clean_fw = fw.rstrip(b'\x00').strip()
     return clean_fw[:-4] + b'ZZZZ'
 
-  @pytest.mark.parametrize("car_model, ecus", FW_VERSIONS.items())
-  def test_matches_with_mutated_revision(self, car_model, ecus):
+  def test_matches_with_mutated_revision(self):
     """Fuzzy matching should work when only the revision suffix changes."""
-    fw = []
-    for (ecu_name, addr, sub_addr), versions in ecus.items():
-      if ecu_name not in PLATFORM_CODE_ECUS:
-        continue
+    for car_model, ecus in FW_VERSIONS.items():
+      fw = []
+      for (ecu_name, addr, sub_addr), versions in ecus.items():
+        if ecu_name not in PLATFORM_CODE_ECUS:
+          continue
 
-      mutated_fw = self._mutate_revision(versions[0])
-      fw.append(CarFw(ecu=ecu_name, fwVersion=mutated_fw, brand='chrysler',
-                      address=addr, subAddress=0 if sub_addr is None else sub_addr))
+        mutated_fw = self._mutate_revision(versions[0])
+        fw.append(CarFw(ecu=ecu_name, fwVersion=mutated_fw, brand='chrysler',
+                        address=addr, subAddress=0 if sub_addr is None else sub_addr))
 
-    CP = CarParams(carFw=fw)
-    live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
-    matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, FW_VERSIONS)
+      CP = CarParams(carFw=fw)
+      live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
+      matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, FW_VERSIONS)
 
-    assert car_model in matches, f"{car_model} should match with mutated revision"
+      assert car_model in matches, f"{car_model} should match with mutated revision"
 
   def test_no_match_with_wrong_part_number(self):
     """Should not match when part numbers are completely different."""
@@ -96,7 +96,7 @@ class TestMatchFwToCarFuzzy:
   # `novel=True` ECUs are held out of the offline DB below to simulate the revision being
   # truly unseen; `novel=False` ECUs reflect that real cars don't update every ECU at once,
   # so those are left as known exact-match firmware. See PR description for methodology.
-  @pytest.mark.parametrize("car_model, live_versions", [
+  REAL_WORLD_UNSEEN_FW_CASES = [
     (CAR.CHRYSLER_PACIFICA_2020, {
       (Ecu.combinationMeter, 1858, None): (b'68405327AC', False),
       (Ecu.abs, 1863, None): (b'68397394AA', False),
@@ -120,26 +120,32 @@ class TestMatchFwToCarFuzzy:
       (Ecu.fwdRadar, 1875, None): (b'04672788AA', False),
       (Ecu.eps, 1882, None): (b'68501186AA', True),
     }),
-  ])
-  def test_matches_real_world_unseen_firmware(self, car_model, live_versions):
+  ]
+
+  def test_matches_real_world_unseen_firmware(self):
     # Hold out only the genuinely novel ECU revisions, so this tests fuzzy generalization
     # on the ECUs that actually updated, combined with exact matches on the ones that didn't -
     # mirroring how a real car's firmware profile evolves piecemeal, not all at once.
-    offline_fw_versions = {platform: dict(ecus) for platform, ecus in FW_VERSIONS.items()}
-    for (ecu, addr, sub), (version, novel) in live_versions.items():
-      if not novel:
-        continue
-      key = (ecu, addr, sub)
-      versions = [v for v in offline_fw_versions[car_model][key] if v != version]
-      assert versions, f"held-out test fixture invalid: {key} would have no other known versions"
-      offline_fw_versions[car_model][key] = versions
+    for car_model, live_versions in self.REAL_WORLD_UNSEEN_FW_CASES:
+      offline_fw_versions = {platform: dict(ecus) for platform, ecus in FW_VERSIONS.items()}
+      for (ecu, addr, sub), (version, novel) in live_versions.items():
+        if not novel:
+          continue
+        key = (ecu, addr, sub)
+        versions = [v for v in offline_fw_versions[car_model][key] if v != version]
+        assert versions, f"held-out test fixture invalid: {key} would have no other known versions"
+        offline_fw_versions[car_model][key] = versions
 
-    fw = [CarFw(ecu=ecu, fwVersion=version, brand='chrysler', address=addr, subAddress=0 if sub is None else sub)
-          for (ecu, addr, sub), (version, novel) in live_versions.items()]
+      fw = [CarFw(ecu=ecu, fwVersion=version, brand='chrysler', address=addr, subAddress=0 if sub is None else sub)
+            for (ecu, addr, sub), (version, novel) in live_versions.items()]
 
-    CP = CarParams(carFw=fw)
-    live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
-    matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, offline_fw_versions)
+      CP = CarParams(carFw=fw)
+      live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
+      matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, offline_fw_versions)
 
-    assert matches == {car_model}, \
-      f"expected unique match to {car_model} on unseen firmware, got {matches}"
+      assert matches == {car_model}, \
+        f"expected unique match to {car_model} on unseen firmware, got {matches}"
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/car/chrysler/tests/test_chrysler.py
+++ b/opendbc/car/chrysler/tests/test_chrysler.py
@@ -1,0 +1,145 @@
+import pytest
+
+from opendbc.car.chrysler.fingerprints import FW_VERSIONS
+from opendbc.car.chrysler.values import CAR, PLATFORM_CODE_ECUS, get_platform_codes, match_fw_to_car_fuzzy
+from opendbc.car.fw_versions import build_fw_dict
+from opendbc.car.structs import CarParams
+
+Ecu = CarParams.Ecu
+CarFw = CarParams.CarFw
+
+
+class TestGetPlatformCodes:
+  def test_extracts_part_number(self):
+    # Standard Chrysler FW format: 8 digit part number + 2 char revision
+    codes = get_platform_codes([b'68227902AF'])
+    assert codes == {b'682279'}
+
+  def test_handles_multiple_versions(self):
+    codes = get_platform_codes([b'68227902AF', b'68227902AG', b'68227905AH'])
+    assert codes == {b'682279'}
+
+  def test_strips_null_bytes(self):
+    codes = get_platform_codes([b'68227902AF\x00\x00'])
+    assert codes == {b'682279'}
+
+  def test_strips_whitespace(self):
+    codes = get_platform_codes([b'68267018AO '])
+    assert codes == {b'682670'}
+
+  def test_ignores_short_firmware(self):
+    # FW too short to have a platform code once the revision is dropped
+    codes = get_platform_codes([b'AB'])
+    assert codes == set()
+
+  def test_empty_input(self):
+    codes = get_platform_codes([])
+    assert codes == set()
+
+
+class TestPlatformCodeEcus:
+  @pytest.mark.parametrize("car_model, ecus", FW_VERSIONS.items())
+  def test_platform_code_ecus_available(self, car_model, ecus):
+    """Each platform must have at least 2 ECUs with platform codes for reliable matching."""
+    platform_ecus = [ecu for ecu in ecus if ecu[0] in PLATFORM_CODE_ECUS]
+    assert len(platform_ecus) >= 2, f"{car_model}: needs at least 2 platform ECUs for fuzzy fingerprinting"
+
+
+class TestMatchFwToCarFuzzy:
+  def _mutate_revision(self, fw: bytes) -> bytes:
+    """Simulate an unseen firmware revision (last 4 chars are the variable part)."""
+    clean_fw = fw.rstrip(b'\x00').strip()
+    return clean_fw[:-4] + b'ZZZZ'
+
+  @pytest.mark.parametrize("car_model, ecus", FW_VERSIONS.items())
+  def test_matches_with_mutated_revision(self, car_model, ecus):
+    """Fuzzy matching should work when only the revision suffix changes."""
+    fw = []
+    for (ecu_name, addr, sub_addr), versions in ecus.items():
+      if ecu_name not in PLATFORM_CODE_ECUS:
+        continue
+
+      mutated_fw = self._mutate_revision(versions[0])
+      fw.append(CarFw(ecu=ecu_name, fwVersion=mutated_fw, brand='chrysler',
+                      address=addr, subAddress=0 if sub_addr is None else sub_addr))
+
+    CP = CarParams(carFw=fw)
+    live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
+    matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, FW_VERSIONS)
+
+    assert car_model in matches, f"{car_model} should match with mutated revision"
+
+  def test_no_match_with_wrong_part_number(self):
+    """Should not match when part numbers are completely different."""
+    fw = [
+      CarFw(ecu=Ecu.combinationMeter, fwVersion=b'99999999AA', brand='chrysler', address=0x742, subAddress=0),
+      CarFw(ecu=Ecu.abs, fwVersion=b'99999998AA', brand='chrysler', address=0x747, subAddress=0),
+      CarFw(ecu=Ecu.fwdRadar, fwVersion=b'99999997AA', brand='chrysler', address=0x753, subAddress=0),
+      CarFw(ecu=Ecu.eps, fwVersion=b'99999996AA', brand='chrysler', address=0x75a, subAddress=0),
+    ]
+
+    CP = CarParams(carFw=fw)
+    live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
+    matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, FW_VERSIONS)
+
+    assert len(matches) == 0, "Should not match any platform with fake part numbers"
+
+  def test_empty_live_fw(self):
+    """Should return no matches when no live firmware is provided."""
+    matches = match_fw_to_car_fuzzy({}, '', FW_VERSIONS)
+    assert len(matches) == 0
+
+  # Real-world regression cases: actual firmware strings comma's fingerprint-collection bot
+  # observed in the field that were NOT yet in the offline database at the time. These were
+  # mined from opendbc's git history (Aug 2024 snapshot vs current master) to validate the
+  # matcher against genuine, organically-seen updates rather than synthetic mutations alone.
+  # `novel=True` ECUs are held out of the offline DB below to simulate the revision being
+  # truly unseen; `novel=False` ECUs reflect that real cars don't update every ECU at once,
+  # so those are left as known exact-match firmware. See PR description for methodology.
+  @pytest.mark.parametrize("car_model, live_versions", [
+    (CAR.CHRYSLER_PACIFICA_2020, {
+      (Ecu.combinationMeter, 1858, None): (b'68405327AC', False),
+      (Ecu.abs, 1863, None): (b'68397394AA', False),
+      (Ecu.fwdRadar, 1875, None): (b'68540436AB', True),
+      (Ecu.eps, 1882, None): (b'68416742AA', False),
+    }),
+    (CAR.CHRYSLER_PACIFICA_2019_HYBRID, {
+      (Ecu.combinationMeter, 1858, None): (b'68594991AB', True),
+      (Ecu.fwdRadar, 1875, None): (b'04672758AB', False),
+      (Ecu.eps, 1882, None): (b'68594341AC', True),
+    }),
+    (CAR.JEEP_GRAND_CHEROKEE, {
+      (Ecu.combinationMeter, 1858, None): (b'68302214AC', True),
+      (Ecu.abs, 1863, None): (b'68252642AG', False),
+      (Ecu.fwdRadar, 1875, None): (b'04672627AB', False),
+      (Ecu.eps, 1882, None): (b'68321650AC', True),
+    }),
+    (CAR.JEEP_GRAND_CHEROKEE_2019, {
+      (Ecu.combinationMeter, 1858, None): (b'68402736AB', True),
+      (Ecu.abs, 1863, None): (b'68408639AC', False),
+      (Ecu.fwdRadar, 1875, None): (b'04672788AA', False),
+      (Ecu.eps, 1882, None): (b'68501186AA', True),
+    }),
+  ])
+  def test_matches_real_world_unseen_firmware(self, car_model, live_versions):
+    # Hold out only the genuinely novel ECU revisions, so this tests fuzzy generalization
+    # on the ECUs that actually updated, combined with exact matches on the ones that didn't -
+    # mirroring how a real car's firmware profile evolves piecemeal, not all at once.
+    offline_fw_versions = {platform: dict(ecus) for platform, ecus in FW_VERSIONS.items()}
+    for (ecu, addr, sub), (version, novel) in live_versions.items():
+      if not novel:
+        continue
+      key = (ecu, addr, sub)
+      versions = [v for v in offline_fw_versions[car_model][key] if v != version]
+      assert versions, f"held-out test fixture invalid: {key} would have no other known versions"
+      offline_fw_versions[car_model][key] = versions
+
+    fw = [CarFw(ecu=ecu, fwVersion=version, brand='chrysler', address=addr, subAddress=0 if sub is None else sub)
+          for (ecu, addr, sub), (version, novel) in live_versions.items()]
+
+    CP = CarParams(carFw=fw)
+    live_fw = build_fw_dict(CP.carFw, filter_brand='chrysler')
+    matches = match_fw_to_car_fuzzy(live_fw, CP.carVin, offline_fw_versions)
+
+    assert matches == {car_model}, \
+      f"expected unique match to {car_model} on unseen firmware, got {matches}"

--- a/opendbc/car/chrysler/values.py
+++ b/opendbc/car/chrysler/values.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from opendbc.car import Bus, CarSpecs, DbcDict, PlatformConfig, Platforms, uds
 from opendbc.car.structs import CarParams
 from opendbc.car.docs_definitions import CarHarness, CarDocs, CarParts
-from opendbc.car.fw_query_definitions import FwQueryConfig, Request, p16
+from opendbc.car.fw_query_definitions import FwQueryConfig, LiveFwVersions, OfflineFwVersions, Request, p16
 
 Ecu = CarParams.Ecu
 
@@ -141,6 +141,67 @@ CHRYSLER_SOFTWARE_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTI
 
 CHRYSLER_RX_OFFSET = -0x280
 
+
+# Chrysler FW responses encode a part number followed by a variable-length revision
+# suffix, e.g. 68227902AF. The trailing characters are bumped on every software update
+# (recalls, calibration tweaks, model-year refreshes), while the leading digits identify
+# the physical part/platform. Empirically (validated against ~2 years of real firmware
+# seen in the wild via opendbc's fingerprint-collection bot, see PR description) Chrysler
+# revises more than just the last 2 characters on actual updates, so we drop the last 4.
+PLATFORM_CODE_TRIM = 4
+
+# ECUs that consistently report platform part numbers, observed across all known platforms
+PLATFORM_CODE_ECUS = (Ecu.combinationMeter, Ecu.abs, Ecu.fwdRadar, Ecu.eps)
+
+
+def get_platform_codes(fw_versions: list[bytes] | set[bytes]) -> set[bytes]:
+  """Extract platform codes (part numbers with the revision suffix dropped) from firmware versions."""
+  codes: set[bytes] = set()
+  for fw in fw_versions:
+    clean_fw = fw.rstrip(b'\x00').strip()
+    if len(clean_fw) <= PLATFORM_CODE_TRIM:
+      continue
+    codes.add(clean_fw[:-PLATFORM_CODE_TRIM])
+  return codes
+
+
+def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str,
+                           offline_fw_versions: OfflineFwVersions) -> set[str]:
+  """
+  Match live firmware versions to car platforms using fuzzy fingerprinting.
+
+  Requires agreement across all PLATFORM_CODE_ECUS simultaneously (not just any one),
+  since any single ECU's code can collide between platforms - corroboration across
+  multiple independent ECUs is what keeps false positives at zero in validation.
+  """
+  candidates: set[str] = set()
+
+  for candidate, fws in offline_fw_versions.items():
+    valid_found_ecus: set[tuple[int, int | None]] = set()
+    valid_expected_ecus = {ecu[1:] for ecu in fws if ecu[0] in PLATFORM_CODE_ECUS}
+
+    for ecu, expected_versions in fws.items():
+      if ecu[0] not in PLATFORM_CODE_ECUS:
+        continue
+
+      addr = ecu[1:]
+      expected_codes = get_platform_codes(expected_versions)
+      found_codes = get_platform_codes(live_fw_versions.get(addr, set()))
+
+      if not expected_codes or not found_codes:
+        break
+
+      if not any(code in expected_codes for code in found_codes):
+        break
+
+      valid_found_ecus.add(addr)
+
+    if valid_expected_ecus and valid_expected_ecus.issubset(valid_found_ecus):
+      candidates.add(candidate)
+
+  return candidates
+
+
 FW_QUERY_CONFIG = FwQueryConfig(
   requests=[
     Request(
@@ -166,6 +227,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[
     (Ecu.abs, 0x7e4, None),  # alt address for abs on hybrids, NOTE: not on all hybrid platforms
   ],
+  match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION

Adds fuzzy FW matching for Chrysler/Jeep/Ram/Dodge so new firmware revisions get identified without needing exact DB entries.

Addresses #1092. Builds on the analysis in #3018.

Three prior attempts (#2928, #3018, #3329) all assumed the last 2 chars of the 10-char firmware string are the revision suffix. Strip those, match on the remaining 8. That assumption is wrong. Validated against ~22 months of real firmware from opendbc's fingerprint bot (Aug 2024 snapshot vs current master), the 2-char strip correctly identifies only 1/5 (20%) of genuinely unseen real-world revisions. Chrysler part numbers themselves change across updates for the same ECU/platform, not just the tail.

Swept strip lengths 2-6 against the same dataset, requiring agreement across all PLATFORM_CODE_ECUS (combinationMeter, abs, fwdRadar, eps) simultaneously to keep collision risk low:

strip=2: 1/5 correct (20%), 0 wrong, 4 no-match
strip=3: 2/5 correct (40%), 0 wrong, 3 no-match
strip=4: 4/5 correct (80%), 0 wrong, 1 no-match <- chosen
strip=5: 3/5 correct (60%), 0 wrong, 1 ambiguous
strip=6: 3/5 correct (60%), 0 wrong, 1 ambiguous

strip=4 gets the best real-world recall with zero dangerous misidentifications at any setting. Failures degrade safely to no match and fall back to exact-match behavior rather than matching the wrong platform.

Sample size is n=5, capped by opendbc's available git history since the repo split from openpilot in Aug 2024. Worth expanding with more historical data before merge if possible, flagging this upfront.

Tests include 4 held-out regression cases built from real bot-collected firmware, not synthetic single-revision mutations. Each holds out only the genuinely novel ECU readings from the offline DB, mirroring how real cars update firmware piecemeal rather than all ECUs at once.

Validation
Dongle ID:
Route: