### PR TITLE
safety: speed mismatch invalidates rx checks

### DIFF
--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -271,6 +271,8 @@ extern bool vehicle_moving;
 extern bool acc_main_on; // referred to as "ACC off" in ISO 15622:2018
 extern int cruise_button_prev;
 extern bool safety_rx_checks_invalid;
+extern bool speed_mismatch;            // two speed sources disagree beyond threshold
+extern bool rx_msgs_invalid;           // safety rx messages lagging/invalid (computed at 1Hz)
 
 // for safety modes with torque steering control
 extern int desired_torque_last;       // last desired steer torque

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -59,6 +59,9 @@ bool vehicle_moving = false;
 bool acc_main_on = false;  // referred to as "ACC off" in ISO 15622:2018
 int cruise_button_prev = 0;
 bool safety_rx_checks_invalid = false;
+bool speed_mismatch = false;  // set in speed_mismatch_check
+bool rx_msgs_invalid = false;  // lagging/invalid safety rx messages, set in safety_tick
+// safety_rx_checks_invalid = rx_msgs_invalid || speed_mismatch, recomputed wherever either changes
 
 // for safety modes with torque steering control
 int desired_torque_last = 0;       // last desired steer torque
@@ -341,7 +344,8 @@ void safety_tick(const safety_config *cfg) {
     }
   }
 
-  safety_rx_checks_invalid = rx_checks_invalid;
+  rx_msgs_invalid = rx_checks_invalid;
+  safety_rx_checks_invalid = rx_msgs_invalid || speed_mismatch;
 }
 
 static void relay_malfunction_set(void) {
@@ -465,6 +469,8 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   controls_allowed = false;
   relay_malfunction_reset();
   safety_rx_checks_invalid = false;
+  speed_mismatch = false;
+  rx_msgs_invalid = false;
 
   current_safety_config.rx_checks = NULL;
   current_safety_config.rx_checks_len = 0;
@@ -547,6 +553,8 @@ void speed_mismatch_check(const float speed_2) {
   // For safety modes that use speed to adjust torque or angle limits
   const float MAX_SPEED_DELTA = 2.0;  // m/s
   bool is_invalid_speed = SAFETY_ABS(speed_2 - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > MAX_SPEED_DELTA;
+  speed_mismatch = is_invalid_speed;
+  safety_rx_checks_invalid = rx_msgs_invalid || speed_mismatch;
   if (is_invalid_speed) {
     controls_allowed = false;
   }

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -1243,6 +1243,9 @@ class CarSafetyTest(SafetyTest):
         within_delta = abs(speed - speed_2) <= MAX_SPEED_DELTA
         self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
+        # a speed mismatch should also invalidate the safety rx checks, not just disable controls
+        self.assertEqual(self.safety.get_safety_rx_checks_invalid(), not within_delta)
+
   def test_safety_tick(self):
     self.safety.set_timer(int(2e6))
     self.safety.set_controls_allowed(True)

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -63,6 +63,7 @@ int set_safety_hooks(uint16_t mode, uint16_t param);
 
 void set_controls_allowed(bool c);
 bool get_controls_allowed(void);
+bool get_safety_rx_checks_invalid(void);
 bool get_longitudinal_allowed(void);
 void set_alternative_experience(int mode);
 int get_alternative_experience(void);

--- a/opendbc/safety/tests/libsafety/safety.c
+++ b/opendbc/safety/tests/libsafety/safety.c
@@ -54,6 +54,10 @@ bool get_controls_allowed(void){
   return controls_allowed;
 }
 
+bool get_safety_rx_checks_invalid(void){
+  return safety_rx_checks_invalid;
+}
+
 bool get_ignition_can(void){
   return ignition_can;
 }

--- a/opendbc/safety/tests/test_tesla.py
+++ b/opendbc/safety/tests/test_tesla.py
@@ -199,6 +199,9 @@ class TestTeslaSafetyBase(common.CarSafetyTest, common.AngleSteeringSafetyTest, 
         within_delta = abs(speed - speed_2) <= MAX_SPEED_DELTA
         self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
+        # a speed mismatch should also invalidate the safety rx checks, not just disable controls
+        self.assertEqual(self.safety.get_safety_rx_checks_invalid(), not within_delta)
+
     # Test ESP_B quality flag
     for quality_flag in (True, False):
       self.safety.set_controls_allowed(True)


### PR DESCRIPTION
## What

A speed mismatch between two speed sources (`speed_mismatch_check`) previously only set `controls_allowed = false`. This implements the behavior requested in #2234: a mismatch now also marks the safety rx checks invalid (`safety_rx_checks_invalid`), so it's treated like other rx faults and the mismatched data itself is flagged as suspect rather than producing only a silent disengage.

## How

- Track the mismatch in a persisted `speed_mismatch` flag, and the existing lagging/invalid-message result in a persisted `rx_msgs_invalid` flag.
- Compute `safety_rx_checks_invalid = rx_msgs_invalid || speed_mismatch`, recomputed in both `safety_tick()` (1 Hz) and `speed_mismatch_check()` (per message). Combining the two sources explicitly means a valid speed message can't clear (mask) a real lagging/invalid-message fault between ticks.
- Reset the new flags on safety mode init.

## Testing

- Added `get_safety_rx_checks_invalid()` and extended the existing `test_rx_hook_speed_mismatch` (common + Tesla override) to assert the flag tracks the mismatch across the full speed sweep, for every mode with a second speed source (Tesla, Rivian, Ford).
- `python -m unittest discover -s opendbc/safety/tests` passes (3196 tests); 100% safety line coverage maintained.

The issue also notes Tesla compares a signed speed with an unsigned speed; I left that out to keep this PR focused on the rx-invalid behavior and can address it as a follow-up.
