### PR TITLE
Subaru: add 2021 Ascent (Canada) engine and transmission FW

### DIFF
--- a/opendbc/car/subaru/fingerprints.py
+++ b/opendbc/car/subaru/fingerprints.py
@@ -25,10 +25,12 @@ FW_VERSIONS = {
     (Ecu.engine, 0x7e0, None): [
       b'\xbb,\xa0t\x07',
       b'\xd1,\xa0q\x07',
+      b'\xd9,\xa0@\x07',
     ],
     (Ecu.transmission, 0x7e1, None): [
       b'\x00>\xf0\x00\x00',
       b'\x00\xfe\xf7\x00\x00',
+      b'\x01\xfe\xe9\x00\x00',
       b'\x01\xfe\xf7\x00\x00',
       b'\x01\xfe\xf9\x00\x00',
       b'\x01\xfe\xfa\x00\x00',


### PR DESCRIPTION
Fixes #3494.

The 2021 Canadian-market Subaru Ascent stays in dashcam mode ("vehicle not recognized") because its engine and transmission firmware versions are missing from the database. This adds them to `SUBARU_ASCENT`.

From the firmware reported in the issue (route `706bc4e745803fba/00000001--e9ed018c63`):

- engine `0x7e0`: `D92CA04007` → `b'\xd9,\xa0@\x07'` — was missing, added
- transmission `0x7e1`: `01FEE90000` → `b'\x01\xfe\xe9\x00\x00'` — was missing, added
- fwdCamera and eps are already present
- The reported abs `A5210200` looks like the existing `b'\xa5 !\x02\x00'` (`A5 20 21 02 00`) with the `0x20` byte dropped, so abs already matches — happy to confirm from the route if useful.

### Verification
- `match_fw_to_car_exact` on the reported FW set returns nothing on master and uniquely `SUBARU_ASCENT` with this change (checked against all platforms, no false matches).
- `opendbc/car/debug/format_fingerprints.py` produces no further diff.
- New values are unique to `SUBARU_ASCENT` (no duplicate/collision across brands).
- CarDocs already lists "Subaru Ascent 2019-21", so no other changes needed.
