### PR TITLE
Hyundai: correct Kia EV6 steer ratio

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -542,7 +542,8 @@ class CAR(Platforms):
       HyundaiCarDocs("Kia EV6 (without HDA II) 2022-24", "Highway Driving Assist", car_parts=CarParts.common([CarHarness.hyundai_l])),
       HyundaiCarDocs("Kia EV6 (with HDA II) 2022-24", "Highway Driving Assist II", car_parts=CarParts.common([CarHarness.hyundai_p]))
     ],
-    CarSpecs(mass=2055, wheelbase=2.9, steerRatio=16, tireStiffnessFactor=0.65),
+    # steerRatio from Kia's documentation (14.25); matches the E-GMP platform twin Ioniq 5 (14.26)
+    CarSpecs(mass=2055, wheelbase=2.9, steerRatio=14.25, tireStiffnessFactor=0.65),
     flags=HyundaiFlags.EV,
   )
   KIA_CARNIVAL_4TH_GEN = HyundaiCanFDPlatformConfig(


### PR DESCRIPTION
Fixes #3500.

The Kia EV6 `steerRatio` is currently `16`, which is an outlier on the E-GMP platform:

| Car (E-GMP) | steerRatio |
| --- | --- |
| Hyundai Ioniq 5 (EV6's platform twin) | 14.26 |
| **Kia EV6** | **16 → 14.25** |

The EV6 and Ioniq 5 are the same E-GMP platform (both EV, `tireStiffnessFactor=0.65`, ~2.9 m wheelbase, similar mass), so they should have a near-identical steer ratio. Kia documents the EV6 at **14.25** (12.56 for the GT trim), which also matches the Ioniq 5's existing `14.26`. The current `16` looks like a placeholder.

Set to Kia's documented 14.25. `opendbc/car/hyundai/tests/test_hyundai.py` passes.
