### PR TITLE
CI: fix op.sh path in test_models job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
         repository: 'commaai/openpilot'
         ref: 'master'
         submodules: true
-    - run: ./openpilot/tools/op.sh setup
+    - run: ./tools/op.sh setup
     - run: rm -rf opendbc_repo/
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
### Goal
The `test models` job has been failing on every PR since #3495 (commit 58b89559):

```
Run ./openpilot/tools/op.sh setup
./openpilot/tools/op.sh: No such file or directory
##[error]Process completed with exit code 127.
```

### Root cause
openpilot recently moved its source into an `openpilot/` subdirectory, but `tools/` stayed at the repo root (`tools/op.sh`). Commit 58b89559 correctly prefixed `common/`, `cereal/`, `selfdrive/`, and the test paths with `openpilot/`, but it also prefixed the `op.sh` step — and `op.sh` is still at the root, so `./openpilot/tools/op.sh` doesn't exist.

### Fix
Drop the `openpilot/` prefix from the `op.sh` step only (one line). The other prefixed paths are correct for the new layout and are left unchanged.

Note: I can't run the Namespace runner locally. On an earlier revision of this PR the job got past `op.sh` and then failed at `scons ... cereal` because `cereal` is now under `openpilot/` — which confirmed the rest of the prefixes are correct and only the `op.sh` path was wrong.
