### PR TITLE
Rivian: correct SCCM_WheelTouch

### DIFF
--- a/opendbc/car/rivian/riviancan.py
+++ b/opendbc/car/rivian/riviancan.py
@@ -47,8 +47,9 @@ def create_wheel_touch(packer, sccm_wheel_touch, enabled):
   values = {s: sccm_wheel_touch[s] for s in (
     "SCCM_WheelTouch_Counter",
     "SCCM_WheelTouch_HandsOn",
+    "SCCM_WheelTouch_Calibration",
     "SCCM_WheelTouch_CapacitiveValue",
-    "SETME_X52",
+    "SCCM_WheelTouch_ResistiveValue",
   )}
 
   # When only using ACC without lateral, the ACM warns the driver to hold the steering wheel on engagement

--- a/opendbc/dbc/rivian_primary_actuator.dbc
+++ b/opendbc/dbc/rivian_primary_actuator.dbc
@@ -342,8 +342,9 @@ BO_ 801 SCCM_WheelTouch: 7 SCCM
  SG_ SCCM_WheelTouch_Checksum : 7|8@0+ (1,0) [0|255] "" XXX
  SG_ SCCM_WheelTouch_Counter : 11|4@0+ (1,0) [0|15] "" XXX
  SG_ SCCM_WheelTouch_HandsOn : 21|1@0+ (1,0) [0|1] "" XXX
- SG_ SETME_X52 : 31|8@0+ (1,0) [0|255] "" XXX
- SG_ SCCM_WheelTouch_CapacitiveValue : 32|12@1+ (1,0) [0|4095] "" XXX
+ SG_ SCCM_WheelTouch_Calibration : 31|8@0+ (1,0) [0|255] "" XXX
+ SG_ SCCM_WheelTouch_CapacitiveValue : 32|8@1+ (1,0) [0|255] "" XXX
+ SG_ SCCM_WheelTouch_ResistiveValue : 40|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 811 ESP_EpbStatus: 8 ESP
  SG_ ESP_EpbStatus_Checksum : 7|8@0+ (1,0) [0|255] "" ACM,VDM

--- a/opendbc/safety/tests/test_rivian.py
+++ b/opendbc/safety/tests/test_rivian.py
@@ -85,7 +85,7 @@ class TestRivianSafetyBase(common.CarSafetyTest, common.DriverTorqueSteeringSafe
       values = {
         "SCCM_WheelTouch_HandsOn": 1 if controls_allowed else 0,
         "SCCM_WheelTouch_CapacitiveValue": 100 if controls_allowed else 0,
-        "SETME_X52": 100,
+        "SCCM_WheelTouch_Calibration": 100,
       }
       self.assertTrue(self._tx(self.packer.make_can_msg_safety("SCCM_WheelTouch", 2, values)))
 


### PR DESCRIPTION
`SCCM_WheelTouch_HandsOn` becomes true once `SCCM_WheelTouch_CapacitiveValue` rises above `SCCM_WheelTouch_Calibration`.

I split the 12-bit CapacitiveValue into two 8-bit signals: `SCCM_WheelTouch_CapacitiveValue` and a new `SCCM_WheelTouch_ResistiveValue`.
ResistiveValue seems to reflects the resistive component of the touch. it changes depending on whether you are wearing gloves or have wet hands.