### PR TITLE
match MEB ACC signal to MEB GEN2

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -289,8 +289,8 @@ class CarState(CarStateBase):
     ret.cruiseState.enabled = pt_cp.vl["Motor_51"]["TSK_Status"] in (3, 4, 5)
     ret.cruiseState.standstill = self.CP.pcmCruise and self.esp_hold_confirmation
     if self.CP.pcmCruise:
-      ret.cruiseState.nonAdaptive = bool(ext_cp.vl["MEB_ACC_01"]["ACC_Limiter_Mode"])
-      ret.cruiseState.speed = ext_cp.vl["MEB_ACC_01"]["ACC_Wunschgeschw_02"] * CV.KPH_TO_MS
+      ret.cruiseState.nonAdaptive = bool(ext_cp.vl["ACC_19"]["ACC_Limiter_Mode"])
+      ret.cruiseState.speed = ext_cp.vl["ACC_19"]["ACC_Wunschgeschw_02"] * CV.KPH_TO_MS
       if ret.cruiseState.speed > 90:  # 255 kph in m/s == no current setpoint
         ret.cruiseState.speed = 0
     else:

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -256,7 +256,7 @@ def create_acc_hud_control(packer, bus, acc_control, set_speed, lead_visible, di
     "SET_ME_0X7FFF":                 0x7FFF, # unknown
   }
 
-  return packer.make_can_msg("MEB_ACC_01", bus, values)
+  return packer.make_can_msg("ACC_19", bus, values)
 
 
 def create_capacitive_wheel_touch(packer, bus, lat_active, klr_stock_values):

--- a/opendbc/dbc/vw_meb.dbc
+++ b/opendbc/dbc/vw_meb.dbc
@@ -601,7 +601,7 @@ BO_ 706 Motor_41: 8 Gateway
  SG_ MO_OelMessung_Dauer : 52|4@1+ (15,15) [15|225] "Unit_Secon" Vector__XXX
  SG_ TSK_vMax_FahrerInfo : 56|8@1+ (1,15) [16|270] "" Vector__XXX
 
-BO_ 768 MEB_ACC_01: 48 XXX
+BO_ 768 ACC_19: 48 XXX
  SG_ ACC_Tempolimit : 64|5@1+ (1,0) [0|31] "" OTA_FC
  SG_ ACC_Wunschgeschw_Farbe : 69|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ ACC_Warnung_Verkehrszeichen_1 : 70|1@1+ (1,0) [0|1] "" Vector__XXX

--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -7,7 +7,7 @@
 #define MSG_ACC_18           0x14DU   // TX by OP, ACC control instructions to the drivetrain coordinator
 #define MSG_ESP_21           0xFDU    // RX, redundant vehicle speed source
 #define MSG_HCA_03           0x303U
-#define MSG_MEB_ACC_01       0x300U   // TX by OP, ACC HUD data to the instrument cluster
+#define MSG_ACC_19           0x300U   // TX by OP, ACC HUD data to the instrument cluster
 #define MSG_QFK_01           0x13DU
 #define MSG_Motor_51         0x10BU   // RX for TSK state and accel pedal
 #define MSG_KLR_01           0x25DU   // TX, for capacitive steering wheel
@@ -60,7 +60,7 @@ static safety_config volkswagen_meb_init(uint16_t param) {
     {MSG_LDW_02, 0, 8, .check_relay = true},
     {MSG_KLR_01, 0, 8, .check_relay = false},
     {MSG_KLR_01, 2, 8, .check_relay = true},
-    {MSG_MEB_ACC_01, 0, 48, .check_relay = true},
+    {MSG_ACC_19, 0, 48, .check_relay = true},
     {MSG_ACC_18, 0, 32, .check_relay = true},
     {MSG_TA_01, 0, 8, .check_relay = true},
   };

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -20,7 +20,7 @@ MSG_QFK_01     = 0x13D
 MSG_ACC_18     = 0x14D
 MSG_KLR_01     = 0x25D
 MSG_TA_01      = 0x26B
-MSG_MEB_ACC_01 = 0x300
+MSG_ACC_19     = 0x300
 MSG_HCA_03     = 0x303
 MSG_LDW_02     = 0x397
 MSG_MOTOR_14   = 0x3BE
@@ -257,11 +257,11 @@ class TestVolkswagenMebStockSafety(TestVolkswagenMebSafetyBase):
 
 
 class TestVolkswagenMebLongSafety(TestVolkswagenMebSafetyBase):
-  TX_MSGS = [[MSG_HCA_03, 0], [MSG_LDW_02, 0], [MSG_MEB_ACC_01, 0], [MSG_ACC_18, 0],
+  TX_MSGS = [[MSG_HCA_03, 0], [MSG_LDW_02, 0], [MSG_ACC_19, 0], [MSG_ACC_18, 0],
              [MSG_TA_01, 0], [MSG_KLR_01, 0], [MSG_KLR_01, 2]]
   FWD_BLACKLISTED_ADDRS = {0: [MSG_KLR_01],
-                           2: [MSG_HCA_03, MSG_LDW_02, MSG_MEB_ACC_01, MSG_ACC_18, MSG_TA_01]}
-  RELAY_MALFUNCTION_ADDRS = {0: (MSG_HCA_03, MSG_LDW_02, MSG_MEB_ACC_01, MSG_ACC_18, MSG_TA_01),
+                           2: [MSG_HCA_03, MSG_LDW_02, MSG_ACC_19, MSG_ACC_18, MSG_TA_01]}
+  RELAY_MALFUNCTION_ADDRS = {0: (MSG_HCA_03, MSG_LDW_02, MSG_ACC_19, MSG_ACC_18, MSG_TA_01),
                              2: (MSG_KLR_01,)}
 
   ALLOW_OVERRIDE = True


### PR DESCRIPTION
Rename ACC signal to match more accurate MEB GEN2 0x300 message.