### PR TITLE
Hyundai: cover ALT_LIMITS_2 in test_alternate_limits

### DIFF
--- a/opendbc/car/hyundai/tests/test_hyundai.py
+++ b/opendbc/car/hyundai/tests/test_hyundai.py
@@ -63,11 +63,15 @@ class TestHyundaiFingerprint(unittest.TestCase):
       assert CP.radarUnavailable != radar
 
   def test_alternate_limits(self):
-    # Alternate lateral control limits, for high torque cars, verify Panda safety mode flag is set
+    # Alternate lateral control limits: for cars with a non-default steer-torque cap, verify the
+    # car-side flag is propagated to the panda safetyParam so panda enforces the same tier.
+    # Both restrictive tiers must be covered: ALT_LIMITS (270) and ALT_LIMITS_2 (170). If a tier's
+    # flag is not propagated, panda silently falls back to the 384 default (hyundai.h fail-open).
     fingerprint = gen_empty_fingerprint()
     for car_model in CAR:
       CP = CarInterface.get_params(car_model, fingerprint, [], False, False, False)
       assert bool(CP.flags & HyundaiFlags.ALT_LIMITS) == bool(CP.safetyConfigs[-1].safetyParam & HyundaiSafetyFlags.ALT_LIMITS)
+      assert bool(CP.flags & HyundaiFlags.ALT_LIMITS_2) == bool(CP.safetyConfigs[-1].safetyParam & HyundaiSafetyFlags.ALT_LIMITS_2)
 
   def test_can_features(self):
     # Test no EV/HEV in any gear lists (should all use ELECT_GEAR)

--- a/opendbc/car/hyundai/tests/test_hyundai.py
+++ b/opendbc/car/hyundai/tests/test_hyundai.py
@@ -70,11 +70,15 @@ class TestHyundaiFingerprint(unittest.TestCase):
       assert CP.radarUnavailable != radar
 
   def test_alternate_limits(self):
-    # Alternate lateral control limits, for high torque cars, verify Panda safety mode flag is set
+    # Alternate lateral control limits: for cars with a non-default steer-torque cap, verify the
+    # car-side flag is propagated to the panda safetyParam so panda enforces the same tier.
+    # Both restrictive tiers must be covered: ALT_LIMITS (270) and ALT_LIMITS_2 (170). If a tier's
+    # flag is not propagated, panda silently falls back to the 384 default (hyundai.h fail-open).
     fingerprint = gen_empty_fingerprint()
     for car_model in CAR:
       CP = CarInterface.get_params(car_model, fingerprint, [], False, False, False)
       assert bool(CP.flags & HyundaiFlags.ALT_LIMITS) == bool(CP.safetyConfigs[-1].safetyParam & HyundaiSafetyFlags.ALT_LIMITS)
+      assert bool(CP.flags & HyundaiFlags.ALT_LIMITS_2) == bool(CP.safetyConfigs[-1].safetyParam & HyundaiSafetyFlags.ALT_LIMITS_2)
 
   def test_can_features(self):
     for car_model in CAR:


### PR DESCRIPTION
### Summary
`test_alternate_limits` verifies that the car-side `ALT_LIMITS` (270 Nm) flag is propagated to the
panda `safetyParam`, but the sibling `ALT_LIMITS_2` (170 Nm) tier — added for the Kona 2022 in #2072 —
has no equivalent assertion. This adds the missing symmetric check.

### Why it matters
The panda steer-torque tier is selected fail-open: with no flag set, `opendbc/safety/modes/hyundai.h`
falls back to the 384 Nm default. The car cap (`CarControllerParams.STEER_MAX`) and the panda tier are
derived independently, and panda cannot re-derive the per-car limit from the bus. So if the
`ALT_LIMITS_2` flag is set on the car but not propagated into `safetyParam` (`interface.py`), panda
silently enforces 384 for a car that intends 170 — with no RX/TX/`controls_allowed` symptom. That is
the "a simple bug can silently allow more torque than expected" failure mode noted in #1137, and the
dropped-flag regression seen in #2072. The 270 tier is guarded against this today; the 170 tier was not.

### Change
Test-only. One added assertion in `test_alternate_limits`, mirroring the existing `ALT_LIMITS` line for
`ALT_LIMITS_2`.

### Test plan
- `pytest opendbc/car/hyundai/tests/test_hyundai.py -k test_alternate_limits` — passes on master.
- Verified it fails when the `ALT_LIMITS_2 → safetyParam` mapping in `interface.py` is removed: the Kona
  then reports a `safetyParam` missing the bit, so the assertion catches the silent fall-back to 384.

### Scope / non-goals
- No behavior change; no generated code touched — the `car_diff` replay should report 0 changed.
- Guards the flag→`safetyParam` *propagation* only. It intentionally does not assert a per-platform
  expected cap: `STEER_MAX` is also set to non-default values by the CAN-FD and 255 Nm branches ahead of
  the `ALT_LIMITS` branches, so a blanket per-`CAR` "car cap == panda tier" assertion would false-fail on
  those cars.
