### PR TITLE
car_helpers: compare VIN with != instead of is not

### DIFF
--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -91,7 +91,7 @@ def fingerprint(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_mu
   start_time = time.monotonic()
   if not skip_fw_query:
     if cached_params is not None and cached_params.brand != "mock" and len(cached_params.carFw) > 0 and \
-       cached_params.carVin is not VIN_UNKNOWN and not disable_fw_cache:
+       cached_params.carVin != VIN_UNKNOWN and not disable_fw_cache:
       carlog.warning("Using cached CarParams")
       vin_rx_addr, vin_rx_bus, vin = -1, -1, cached_params.carVin
       car_fw = list(cached_params.carFw)


### PR DESCRIPTION
`VIN_UNKNOWN` is a string (`"0" * 17`), so `carVin is not VIN_UNKNOWN` checks object identity rather than value. A `carVin` read back from a cached `CarParams` is a different object, so the guard is effectively always true and an unknown cached VIN gets treated as valid. Use `!=` to compare by value as intended.

Validation
* Dongle ID: N/A (one-line correctness fix; no behavior change for a valid cached VIN)
* Route: N/A
