### PR TITLE
car: remove redundant CarSpecs assignments

### DIFF
--- a/opendbc/car/chrysler/interface.py
+++ b/opendbc/car/chrysler/interface.py
@@ -66,7 +66,6 @@ class CarInterface(CarInterfaceBase):
     # Ram
     elif candidate == CAR.RAM_1500_5TH_GEN:
       ret.steerActuatorDelay = 0.2
-      ret.wheelbase = 3.88
       # Older EPS FW allow steer to zero
       if any(fw.ecu == 'eps' and b"68" < fw.fwVersion[:4] <= b"6831" for fw in car_fw):
         ret.minSteerSpeed = 0.

--- a/opendbc/car/mock/interface.py
+++ b/opendbc/car/mock/interface.py
@@ -13,9 +13,5 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, alpha_long, is_release, docs) -> structs.CarParams:
     ret.brand = "mock"
-    ret.mass = 1700.
-    ret.wheelbase = 2.70
-    ret.centerToFront = ret.wheelbase * 0.5
-    ret.steerRatio = 13.
     ret.dashcamOnly = True
     return ret


### PR DESCRIPTION
`ret.wheelbase` is already set from the platform CarSpecs (`ret.wheelbase = platform.config.specs.wheelbase` in interfaces.py, and RAM_1500_5TH_GEN's CarSpecs is `wheelbase=3.88`), so this line re-sets the identical value. Remove the redundant assignment.

Validation
* Dongle ID: N/A (no behavior change)
* Route: N/A
