### PR TITLE
interfaces: drop unused bool from torque callback types

### DIFF
--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -41,8 +41,8 @@ GEAR_SHIFTER_MAP: dict[str, structs.CarState.GearShifter] = {
   'B': GearShifter.brake, 'BRAKE': GearShifter.brake,
 }
 
-TorqueFromLateralAccelCallbackType = Callable[[float, structs.CarParams.LateralTorqueTuning, bool], float]
-LateralAccelFromTorqueCallbackType = Callable[[float, structs.CarParams.LateralTorqueTuning, bool], float]
+TorqueFromLateralAccelCallbackType = Callable[[float, structs.CarParams.LateralTorqueTuning], float]
+LateralAccelFromTorqueCallbackType = Callable[[float, structs.CarParams.LateralTorqueTuning], float]
 
 
 @cache


### PR DESCRIPTION
The torque callback type aliases declare a third `bool` parameter that none of the implementations take (all are `(float, LateralTorqueTuning) -> float`). Drop the stale `bool` so the annotations match the callbacks.

Validation
* Dongle ID: N/A (no behavior change)
* Route: N/A
