### PR TITLE
set VW MEB steer limit timer to default

### DIFF
--- a/opendbc/car/volkswagen/interface.py
+++ b/opendbc/car/volkswagen/interface.py
@@ -99,7 +99,6 @@ class CarInterface(CarInterfaceBase):
       CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
     elif ret.flags & VolkswagenFlags.MEB:
       ret.steerActuatorDelay = 0.3
-      ret.steerLimitTimer = 0.1
     else:
       ret.steerActuatorDelay = 0.1
       ret.lateralTuning.pid.kpBP = [0.]


### PR DESCRIPTION
We initially set the steer limit timer conservatively, this sets the timer to default value to make it less agressive.