### PR TITLE
toyota: remove unused NO_DSU_CAR

### DIFF
--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -589,8 +589,6 @@ EPS_SCALE = defaultdict(lambda: 73,
 # Toyota/Lexus Safety Sense 2.0 and 2.5
 TSS2_CAR = CAR.with_flags(ToyotaFlags.TSS2)
 
-NO_DSU_CAR = CAR.with_flags(ToyotaFlags.NO_DSU)
-
 # the DSU uses the AEB message for longitudinal on these cars
 UNSUPPORTED_DSU_CAR = CAR.with_flags(ToyotaFlags.UNSUPPORTED_DSU)
 


### PR DESCRIPTION
`NO_DSU_CAR` is defined but referenced nowhere in the repo (its sibling `_CAR` sets are all used). The `NO_DSU` flag itself is still used elsewhere, so only the dead derived set is removed.

Validation
* Dongle ID: N/A (removes an unused constant, no behavior change)
* Route: N/A
