### PR TITLE
rivian: use full range on 4-bit message counters

### DIFF
--- a/opendbc/car/rivian/riviancan.py
+++ b/opendbc/car/rivian/riviancan.py
@@ -21,7 +21,7 @@ def create_lka_steering(packer, frame, acm_lka_hba_cmd, apply_torque, enabled, a
   )}
 
   values |= {
-    "ACM_lkaHbaCmd_Counter": frame % 15,
+    "ACM_lkaHbaCmd_Counter": frame % 16,
     "ACM_lkaStrToqReq": apply_torque,
     "ACM_lkaActToi": active,
 
@@ -64,7 +64,7 @@ def create_wheel_touch(packer, sccm_wheel_touch, enabled):
 
 def create_longitudinal(packer, frame, accel, enabled):
   values = {
-    "ACM_longitudinalRequest_Counter": frame % 15,
+    "ACM_longitudinalRequest_Counter": frame % 16,
     "ACM_AccelerationRequest": accel,
     "ACM_PrndRequest": 0,
     "ACM_longInterfaceEnable": 1 if enabled else 0,


### PR DESCRIPTION
`ACM_lkaHbaCmd_Counter` and `ACM_longitudinalRequest_Counter` are 4-bit fields (DBC range `[0|15]`), but they're packed with `frame % 15`, which skips value 15 and makes the counter step +2 (mod 16) at every wrap instead of +1. Use `frame % 16` so the counter uses its full range, matching every other brand's 4-bit rolling counters. The checksum is computed after the counter is set, so the messages stay self-consistent.

Validation
* Dongle ID: N/A (no Rivian on hand; fix is a 2-value counter-range correction, DBC-confirmed 4-bit)
* Route: N/A
