### PR TITLE
rivian: note message counters are 0-14, not full 4-bit

### DIFF
--- a/opendbc/car/rivian/riviancan.py
+++ b/opendbc/car/rivian/riviancan.py
@@ -21,7 +21,7 @@ def create_lka_steering(packer, frame, acm_lka_hba_cmd, apply_torque, enabled, a
   )}
 
   values |= {
-    "ACM_lkaHbaCmd_Counter": frame % 15,
+    "ACM_lkaHbaCmd_Counter": frame % 15,  # 0-14 counter (15 states), so % 15 is correct despite the 4-bit field
     "ACM_lkaStrToqReq": apply_torque,
     "ACM_lkaActToi": active,
 
@@ -64,7 +64,7 @@ def create_wheel_touch(packer, sccm_wheel_touch, enabled):
 
 def create_longitudinal(packer, frame, accel, enabled):
   values = {
-    "ACM_longitudinalRequest_Counter": frame % 15,
+    "ACM_longitudinalRequest_Counter": frame % 15,  # 0-14 counter (15 states), so % 15 is correct despite the 4-bit field
     "ACM_AccelerationRequest": accel,
     "ACM_PrndRequest": 0,
     "ACM_longInterfaceEnable": 1 if enabled else 0,


### PR DESCRIPTION
The ACM message counters (`ACM_lkaHbaCmd_Counter`, `ACM_longitudinalRequest_Counter`) are 0-14 counters (15 states), so `frame % 15` is correct even though the DBC field is 4 bits wide. Adding a comment so it isn't mistaken for a bug and "fixed" to `% 16` in the future.

Context: #3533. Thanks to @lukasloetkolben for confirming the 0-14 range.
