### PR TITLE
VW MQB: release standstill hold on gas override

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -159,7 +159,7 @@ class CarController(CarControllerBase):
 
         else:
           acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.enabled, CC.longActive)
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
+          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else self.CCP.ACCEL_INACTIVE)
           driver_gas_override = CC.enabled and CS.out.gasPressed
           start_control_required = CS.esp_hold_confirmation or CS.out.vEgo < self.CP.vEgoStopping
           starting = (actuators.longControlState == LongCtrlState.pid or driver_gas_override) and start_control_required

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -158,10 +158,13 @@ class CarController(CarControllerBase):
           self.accel_last = accel
 
         else:
-          acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
+          acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.enabled, CC.longActive)
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
-          starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < self.CP.vEgoStopping)
-          can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, CS.acc_type, CC.longActive, accel,
+          driver_gas_override = CC.enabled and CS.out.gasPressed
+          start_control_required = CS.esp_hold_confirmation or CS.out.vEgo < self.CP.vEgoStopping
+          starting = (actuators.longControlState == LongCtrlState.pid or driver_gas_override) and start_control_required
+          stopping = stopping and not starting
+          can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, CS.acc_type, CC.enabled, accel,
                                                              acc_control, stopping, starting, CS.esp_hold_confirmation))
 
       #if self.aeb_available:
@@ -199,7 +202,7 @@ class CarController(CarControllerBase):
         lead_distance = 0
         if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:  # Don't display lead until we know the scaling factor
           lead_distance = 512 if CS.upscale_lead_car_signal else 8
-        acc_hud_status = self.CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
+        acc_hud_status = self.CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.enabled, CC.longActive)
         # FIXME: PQ may need to use the on-the-wire mph/kmh toggle to fix rounding errors
         # FIXME: Detect clusters with vEgoCluster offsets and apply an identical vCruiseCluster offset
         set_speed = hud_control.setSpeed * CV.MS_TO_KPH

--- a/opendbc/car/volkswagen/mlbcan.py
+++ b/opendbc/car/volkswagen/mlbcan.py
@@ -35,11 +35,11 @@ def create_acc_buttons_control(packer, bus, gra_stock_values, cancel=False, resu
   return packer.make_can_msg("LS_01", bus, values)
 
 
-def acc_control_value(main_switch_on, acc_faulted, long_active):
+def acc_control_value(main_switch_on, acc_faulted, enabled, long_active):
   return 0
 
 
-def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
+def acc_hud_status_value(main_switch_on, acc_faulted, enabled, long_active):
   return 0
 
 

--- a/opendbc/car/volkswagen/mqbcan.py
+++ b/opendbc/car/volkswagen/mqbcan.py
@@ -70,11 +70,13 @@ def create_acc_buttons_control(packer, bus, gra_stock_values, cancel=False, resu
   return packer.make_can_msg("GRA_ACC_01", bus, values)
 
 
-def acc_control_value(main_switch_on, acc_faulted, long_active):
+def acc_control_value(main_switch_on, acc_faulted, enabled, long_active):
   if acc_faulted:
     acc_control = 6
   elif long_active:
     acc_control = 3
+  elif enabled:
+    acc_control = 4
   elif main_switch_on:
     acc_control = 2
   else:
@@ -83,9 +85,8 @@ def acc_control_value(main_switch_on, acc_faulted, long_active):
   return acc_control
 
 
-def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
-  # TODO: happens to resemble the ACC control value for now, but extend this for init/gas override later
-  return acc_control_value(main_switch_on, acc_faulted, long_active)
+def acc_hud_status_value(main_switch_on, acc_faulted, enabled, long_active):
+  return acc_control_value(main_switch_on, acc_faulted, enabled, long_active)
 
 
 def create_acc_accel_control(packer, bus, acc_type, acc_enabled, accel, acc_control, stopping, starting, esp_hold):

--- a/opendbc/car/volkswagen/pqcan.py
+++ b/opendbc/car/volkswagen/pqcan.py
@@ -49,7 +49,7 @@ def create_acc_buttons_control(packer, bus, gra_stock_values, cancel=False, resu
   return packer.make_can_msg("GRA_Neu", bus, values)
 
 
-def acc_control_value(main_switch_on, acc_faulted, long_active):
+def acc_control_value(main_switch_on, acc_faulted, enabled, long_active):
   if long_active:
     acc_control = 1
   elif main_switch_on:
@@ -60,11 +60,13 @@ def acc_control_value(main_switch_on, acc_faulted, long_active):
   return acc_control
 
 
-def acc_hud_status_value(main_switch_on, acc_faulted, long_active):
+def acc_hud_status_value(main_switch_on, acc_faulted, enabled, long_active):
   if acc_faulted:
     hud_status = 6
   elif long_active:
     hud_status = 3
+  elif enabled:
+    hud_status = 4
   elif main_switch_on:
     hud_status = 2
   else:

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -67,6 +67,7 @@ class CarControllerParams:
 
   ACCEL_MAX = 2.0                          # 2.0 m/s^2 max acceleration
   ACCEL_MIN = -3.5                         # 3.5 m/s^2 max deceleration
+  ACCEL_INACTIVE = 3.01
 
   def __init__(self, CP):
     can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])


### PR DESCRIPTION
Continuation of @jyoung8607’s [mqb-accel-override](https://github.com/jyoung8607/openpilot/compare/fe6aff01311ca3c5a4a549b0eb5d081fa1740f86..mqb-accel-override)

Fixes https://github.com/commaai/opendbc/issues/1159

Keep ACC in the driver-override state and request standstill hold release when accelerating from a stop while engaged. Send VW’s inactive acceleration value while openpilot longitudinal control is overridden.

Although happens way less often than in 2023/2024, it still happens to brake for ~1s when overriding from a standstill.

Validation
* Dongle ID: ca83aca15dc27f35
* Route: ca83aca15dc27f35/000000a2--caa169b80e/22

EDIT: this might not be needed anymore if https://github.com/commaai/opendbc/pull/3135 and https://github.com/commaai/opendbc/pull/3165 get merged.