### PR TITLE
HKG: document 2023 Kia Sportage Plug-in Hybrid

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -496,6 +496,7 @@ class CAR(Platforms):
     [
       HyundaiCarDocs("Kia Sportage 2023-24", car_parts=CarParts.common([CarHarness.hyundai_n])),
       HyundaiCarDocs("Kia Sportage Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_n])),
+      HyundaiCarDocs("Kia Sportage Plug-in Hybrid 2023", car_parts=CarParts.common([CarHarness.hyundai_n])),
     ],
     # weight from SX and above trims, average of FWD and AWD version, steering ratio according to Kia News https://www.kiamedia.com/us/en/models/sportage/2023/specifications
     CarSpecs(mass=1725, wheelbase=2.756, steerRatio=13.6),


### PR DESCRIPTION
Document the 2023 Kia Sportage Plug-in Hybrid as supported under the existing `KIA_SPORTAGE_5TH_GEN` platform.

Current stock openpilot already identifies this vehicle exactly as `KIA_SPORTAGE_5TH_GEN` from its firmware and applies the correct CAN-FD, hybrid, camera-SCC, and alternate-button configuration. This PR therefore adds only the missing consumer-facing support entry; it does not change fingerprinting, tuning, controller behavior, or safety limits.

## Validation

* Dongle ID: `428412ad82894ba3`
* Route: `428412ad82894ba3/00000005--9ce9a58d79`
* Public route: https://connect.comma.ai/428412ad82894ba3/00000005--9ce9a58d79
* Vehicle: 2023 Kia Sportage Plug-in Hybrid X-Line Prestige
* Harness: Hyundai N
* Device: comma 3X
* Software: stock openpilot [v0.11.1](https://github.com/commaai/openpilot/releases/tag/v0.11.1), `release-tizi`, commit https://github.com/commaai/openpilot/commit/70e157462304e5ce7d03ffbec6cb7f45bf347bb7


<details>
<summary>Expand for route and fingerprinting details</summary>

The fully uploaded route contains approximately 11.4 minutes of engaged lateral control, including highway driving up to approximately 68 mph and demanding curves. It produced no CAN, steering, vehicle-sensor, or panda faults and no lateral-controller saturation. Physical achieved/requested lateral acceleration had a regression slope of 1.021 overall and 1.013 above 50 mph.

The exact PHEV powertrain is visible in this vehicle's logged HVAC firmware through the markers `NQ5PH` and `NQ5PHEV`. That ECU is currently logging-only and is not needed for this documentation-only change because the existing shared Sportage configuration performs correctly.

</details>

