### PR TITLE
fix cached carparams in replay

### DIFF
--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -91,7 +91,7 @@ def fingerprint(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_mu
   start_time = time.monotonic()
   if not skip_fw_query:
     if cached_params is not None and cached_params.brand != "mock" and len(cached_params.carFw) > 0 and \
-       cached_params.carVin != VIN_UNKNOWN and not disable_fw_cache:
+       (cached_params.carVin != VIN_UNKNOWN or os.environ.get("REPLAY")) and not disable_fw_cache:
       carlog.warning("Using cached CarParams")
       vin_rx_addr, vin_rx_bus, vin = -1, -1, cached_params.carVin
       car_fw = list(cached_params.carFw)


### PR DESCRIPTION
The fix #3524 disabled cached CarParams in process replay for routes with unknown VIN.

Without the cache, replay attempts live ISO-TP queries against recorded CAN data which causes long runtimes and 2m CI abort.