### PR TITLE
VW MEB: fix lead distance and velocity signals

### DIFF
--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -334,22 +334,22 @@ BO_ 591 MEB_Distance_01: 64 XXX
  SG_ Right_Lane_02_ObjectID : 46|6@1+ (1,0) [0|63] "Unit_ObjectID" XXX
  SG_ Unknown_02 : 52|2@1+ (1,0) [0|3] "" XXX
  SG_ Unknown_03 : 54|10@1+ (1,0) [0|3] "" XXX
- SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_01_Lat_Distance : 76|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
  SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_01_Lat_Distance : 108|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
  SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_01_Lat_Distance : 140|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
  SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_02_Lat_Distance : 172|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
  SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_02_Lat_Distance : 204|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
  SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
- SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.07,-6) [0|300] "Unit_Meter" XXX
+ SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_02_Lat_Distance : 236|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
  SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Unknown_04 : 256|8@1+ (1,-128) [0|31] "" XXX

--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -336,22 +336,22 @@ BO_ 591 MEB_Distance_01: 64 XXX
  SG_ Unknown_03 : 54|10@1+ (1,0) [0|3] "" XXX
  SG_ Same_Lane_01_Long_Distance : 64|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_01_Lat_Distance : 76|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Same_Lane_01_Rel_Velo : 86|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Left_Lane_01_Long_Distance : 96|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_01_Lat_Distance : 108|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Left_Lane_01_Rel_Velo : 118|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Right_Lane_01_Long_Distance : 128|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_01_Lat_Distance : 140|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_01_Rel_Velo : 150|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Same_Lane_02_Long_Distance : 160|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Same_Lane_02_Lat_Distance : 172|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Same_Lane_02_Rel_Velo : 182|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Left_Lane_02_Long_Distance : 192|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Left_Lane_02_Lat_Distance : 204|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Left_Lane_02_Rel_Velo : 214|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Right_Lane_02_Long_Distance : 224|12@1+ (0.0625,-3.75) [0|300] "Unit_Meter" XXX
  SG_ Right_Lane_02_Lat_Distance : 236|10@1+ (0.065,-33.28) [-50|50] "Unit_Meter" XXX
- SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.28,-143.36) [-150|150] "Unit_MeterPerSecond" XXX
+ SG_ Right_Lane_02_Rel_Velo : 246|10@1+ (0.25,-128) [-150|150] "Unit_MeterPerSecond" XXX
  SG_ Unknown_04 : 256|8@1+ (1,-128) [0|31] "" XXX
  SG_ Unknown_05 : 264|6@1+ (1,-15) [0|31] "" XXX
  SG_ Unknown_06 : 270|6@1+ (1,0) [0|127] "" XXX


### PR DESCRIPTION
Using a tape measure and integrating vego to a stopped car, came to these values

```
radar reported: actually
-1.10m: 4in
-1.03m: 2ft 5in
-0.05m: 5ft 5 in
1.00m: 7ft 11 in
1.98m: 11ft
3.03m: 13 ft 11 in
4.01m: 16 ft 10 in
4.99m: 19ft 11 in
5.97m: 22ft 11in
6.46m: 24ft 7in
```

before:
<img width="1100" height="450" alt="image" src="https://github.com/user-attachments/assets/957477e6-0003-4d97-a3bc-b1445233effc" />

after:
<img width="1100" height="450" alt="image" src="https://github.com/user-attachments/assets/6824ea8b-574d-4e71-92b3-49ae2bbdd554" />

(before fixing scale)
<img width="640" height="480" alt="radar_vs_real" src="https://github.com/user-attachments/assets/a193eb29-794b-4bf2-86a0-bc915359b231" />