### PR TITLE
Honda - Add more 2026 models to extra_cars.py

### DIFF
--- a/opendbc/car/extra_cars.py
+++ b/opendbc/car/extra_cars.py
@@ -52,7 +52,8 @@ class CAR(Platforms):
       CommunityCarDocs("Honda Accord Hybrid 2017"),
       CommunityCarDocs("Honda Clarity 2018-21"),
       CommunityCarDocs("Honda Pilot 2026"),
-      GMSecurityCarDocs("Honda Prologue 2024-25"),
+      GMSecurityCarDocs("Honda Prologue 2024-26"),
+      CommunityCarDocs("Honda Ridgeline 2026"),
     ],
   )
 


### PR DESCRIPTION
2026 Ridgeline - https://github.com/commaai/opendbc/pull/3502
2026 Prologue - Still GM Global B - see GM reference in Sensing in [manufacturer specs](https://hondanews.com/en-US/honda-automobiles/releases/release-e5d30c25af38c0c6604e43e79c015883-2026-honda-prologue-specifications-features).