### PR TITLE
Add MADS (Modular Assistive Driving System) safety for Hyundai/Kia

### DIFF
--- a/opendbc/safety/__init__.py
+++ b/opendbc/safety/__init__.py
@@ -8,3 +8,7 @@ class ALTERNATIVE_EXPERIENCE:
   DISABLE_STOCK_AEB = 2
   RAISE_LONGITUDINAL_LIMITS_TO_ISO_MAX = 8
   ALLOW_AEB = 16
+  # MADS (Modular Assistive Driving System) - must match opendbc/safety/sunnypilot/mads_declarations.h
+  ENABLE_MADS = 1024
+  MADS_DISENGAGE_LATERAL_ON_BRAKE = 2048
+  MADS_PAUSE_LATERAL_ON_BRAKE = 4096

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -1,4 +1,5 @@
 #include "opendbc/safety/declarations.h"
+#include "opendbc/safety/sunnypilot/mads.h"  // MADS: adds controls_allowed_lateral
 
 // ISO 11270
 static const float ISO_LATERAL_ACCEL = 3.0;  // m/s^2
@@ -61,7 +62,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
   bool violation = false;
   uint32_t ts = microsecond_timer_get();
 
-  if (controls_allowed) {
+  if (controls_allowed || controls_allowed_lateral) {
     // Some safety models support variable torque limit based on vehicle speed
     int max_torque = limits.max_torque;
     if (limits.dynamic_max_torque) {
@@ -96,7 +97,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
   }
 
   // no torque if controls is not allowed
-  if (!controls_allowed && (desired_torque != 0)) {
+  if (!(controls_allowed || controls_allowed_lateral) && (desired_torque != 0)) {
     violation = true;
   }
 
@@ -138,7 +139,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
   }
 
   // reset to 0 if either controls is not allowed or there's a violation
-  if (violation || !controls_allowed) {
+  if (violation || !(controls_allowed || controls_allowed_lateral)) {
     valid_steer_req_count = 0;
     invalid_steer_req_count = 0;
     desired_torque_last = 0;
@@ -176,7 +177,7 @@ static bool rt_angle_rate_limit_check(AngleSteeringLimits limits) {
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits) {
   bool violation = false;
 
-  if (controls_allowed && steer_control_enabled) {
+  if ((controls_allowed || controls_allowed_lateral) && steer_control_enabled) {
     // convert floating point angle rate limits to integers in the scale of the desired angle on CAN,
     // add 1 to not false trigger the violation. also fudge the speed by 1 m/s so rate limits are
     // always slightly above openpilot's in case we read an updated speed in between angle commands
@@ -262,12 +263,12 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
   }
 
   // No angle control allowed when controls are not allowed
-  if (!controls_allowed) {
+  if (!(controls_allowed || controls_allowed_lateral)) {
     violation |= steer_control_enabled;
   }
 
   // reset to current angle if either controls is not allowed or there's a violation
-  if (violation || !controls_allowed) {
+  if (violation || !(controls_allowed || controls_allowed_lateral)) {
     if (limits.inactive_angle_is_zero) {
       desired_angle_last = 0;
     } else {
@@ -304,7 +305,7 @@ bool steer_angle_cmd_checks_vm(int desired_angle, bool steer_control_enabled, co
 
   bool violation = false;
 
-  if (controls_allowed && steer_control_enabled) {
+  if ((controls_allowed || controls_allowed_lateral) && steer_control_enabled) {
     // *** ISO lateral jerk limit ***
     // calculate maximum angle rate per second
     const float max_curvature_rate_sec = MAX_LATERAL_JERK / (fudged_speed * fudged_speed);
@@ -340,12 +341,12 @@ bool steer_angle_cmd_checks_vm(int desired_angle, bool steer_control_enabled, co
   }
 
   // No angle control allowed when controls are not allowed
-  if (!controls_allowed) {
+  if (!(controls_allowed || controls_allowed_lateral)) {
     violation |= steer_control_enabled;
   }
 
   // reset to current angle if either controls is not allowed or there's a violation
-  if (violation || !controls_allowed) {
+  if (violation || !(controls_allowed || controls_allowed_lateral)) {
     desired_angle_last = SAFETY_CLAMP(angle_meas.values[0], -limits.max_angle, limits.max_angle);
   }
 

--- a/opendbc/safety/modes/hyundai.h
+++ b/opendbc/safety/modes/hyundai.h
@@ -137,11 +137,25 @@ static void hyundai_rx_hook(const CANPacket_t *msg) {
     }
   }
 
+  // MADS: ACC MAIN (LFA/cruise main) state from SCC11, used to engage lateral on main-cruise
+  if (msg->addr == 0x420U) {
+    if (((msg->bus == 0U) && !hyundai_camera_scc) || ((msg->bus == 2U) && hyundai_camera_scc)) {
+      if (!hyundai_longitudinal) {
+        acc_main_on = GET_BIT(msg, 0U);
+      }
+    }
+  }
+
   if (msg->bus == 0U) {
     if (msg->addr == 0x251U) {
       int torque_driver_new = (GET_BYTES(msg, 0, 2) & 0x7ffU) - 1024U;
       // update array of samples
       update_sample(&torque_driver, torque_driver_new);
+    }
+
+    // MADS: LKAS/LFA button (0x391 bit 4) toggles lateral independently of ACC
+    if (msg->addr == 0x391U) {
+      mads_button_press = GET_BIT(msg, 4U) ? MADS_BUTTON_PRESSED : MADS_BUTTON_NOT_PRESSED;
     }
 
     // ACC steering wheel buttons

--- a/opendbc/safety/modes/hyundai_canfd.h
+++ b/opendbc/safety/modes/hyundai_canfd.h
@@ -88,9 +88,11 @@ static void hyundai_canfd_rx_hook(const CANPacket_t *msg) {
       if (msg->addr == 0x1cfU) {
         cruise_button = msg->data[2] & 0x7U;
         main_button = GET_BIT(msg, 19U);
+        mads_button_press = GET_BIT(msg, 23U) ? MADS_BUTTON_PRESSED : MADS_BUTTON_NOT_PRESSED;  // MADS: LFA button
       } else {
         cruise_button = (msg->data[4] >> 4) & 0x7U;
         main_button = GET_BIT(msg, 34U);
+        mads_button_press = GET_BIT(msg, 39U) ? MADS_BUTTON_PRESSED : MADS_BUTTON_NOT_PRESSED;  // MADS: LFA button (alt)
       }
       hyundai_common_cruise_buttons_check(cruise_button, main_button);
     }
@@ -131,6 +133,7 @@ static void hyundai_canfd_rx_hook(const CANPacket_t *msg) {
       int cruise_status = ((msg->data[8] >> 4) & 0x7U);
       bool cruise_engaged = (cruise_status == 1) || (cruise_status == 2);
       hyundai_common_cruise_state_check(cruise_engaged);
+      acc_main_on = GET_BIT(msg, 66U);  // MADS: ACC MAIN state for main-cruise lateral engagement
     }
   }
 }

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -325,6 +325,7 @@ void safety_tick(const safety_config *cfg) {
       cfg->rx_checks[i].status.lagging = lagging;
       if (lagging) {
         controls_allowed = false;
+        mads_exit_controls(MADS_DISENGAGE_REASON_LAG);  // MADS: also drop lateral on lag
       }
 
       // enforce minimum frequency for safety-relevant messages
@@ -373,6 +374,9 @@ static void stock_ecu_check(bool stock_ecu_detected) {
   if ((safety_mode_cnt > RELAY_TRNS_TIMEOUT) && stock_ecu_detected) {
     relay_malfunction_set();
   }
+
+  // MADS: update the independent lateral-controls-allowed state machine each rx cycle
+  mads_state_update(vehicle_moving, acc_main_on, controls_allowed, brake_pressed || regen_braking, steering_disengage);
 }
 
 static void relay_malfunction_reset(void) {

--- a/opendbc/safety/sunnypilot/mads.h
+++ b/opendbc/safety/sunnypilot/mads.h
@@ -1,0 +1,192 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+#include "opendbc/safety/sunnypilot/mads_declarations.h"
+
+// ===============================
+// Global Variables
+// ===============================
+
+ButtonState mads_button_press = MADS_BUTTON_UNAVAILABLE;
+MADSState m_mads_state;
+
+bool controls_allowed_lateral = false;
+
+// state for mads controls_allowed_lateral timeout logic
+bool heartbeat_engaged_mads = false;  // MADS enabled, passed in heartbeat USB command
+uint32_t heartbeat_engaged_mads_mismatches = 0U;  // count of mismatches between heartbeat_engaged_mads and controls_allowed_lateral
+
+// ===============================
+// State Update Helpers
+// ===============================
+
+inline EdgeTransition m_get_edge_transition(const bool current, const bool last) {
+  EdgeTransition state;
+
+  if (current && !last) {
+    state = MADS_EDGE_RISING;
+  } else if (!current && last) {
+    state = MADS_EDGE_FALLING;
+  } else {
+    state = MADS_EDGE_NO_CHANGE;
+  }
+
+  return state;
+}
+
+inline void m_mads_state_init(void) {
+  m_mads_state.is_vehicle_moving = NULL;
+  m_mads_state.acc_main.current = NULL;
+  m_mads_state.mads_button.current = MADS_BUTTON_UNAVAILABLE;
+
+  m_mads_state.system_enabled = false;
+  m_mads_state.disengage_lateral_on_brake = false;
+  m_mads_state.pause_lateral_on_brake = false;
+
+  m_mads_state.acc_main.previous = false;
+  m_mads_state.acc_main.transition = MADS_EDGE_NO_CHANGE;
+
+  m_mads_state.mads_button.last = MADS_BUTTON_UNAVAILABLE;
+  m_mads_state.mads_button.transition = MADS_EDGE_NO_CHANGE;
+
+
+  m_mads_state.current_disengage.active_reason = MADS_DISENGAGE_REASON_NONE;
+  m_mads_state.current_disengage.pending_reasons = MADS_DISENGAGE_REASON_NONE;
+
+  m_mads_state.controls_requested_lateral = false;
+  controls_allowed_lateral = false;
+}
+
+inline void m_update_button_state(ButtonStateTracking *button_state) {
+  if (button_state->current != MADS_BUTTON_UNAVAILABLE) {
+    button_state->transition = m_get_edge_transition(button_state->current == MADS_BUTTON_PRESSED, button_state->last == MADS_BUTTON_PRESSED);
+    button_state->last = button_state->current;
+  }
+}
+
+inline void m_update_binary_state(BinaryStateTracking *state) {
+  state->transition = m_get_edge_transition(state->current, state->previous);
+  state->previous = state->current;
+}
+
+/**
+ * @brief Updates the MADS control state based on current system conditions
+ *
+ * @return void
+ */
+inline void m_update_control_state(void) {
+  bool allowed = true;
+
+  // Initial control requests from button or ACC transitions
+  if ((m_mads_state.acc_main.transition == MADS_EDGE_RISING) ||
+      (m_mads_state.mads_button.transition == MADS_EDGE_RISING) ||
+      (m_mads_state.op_controls_allowed.transition == MADS_EDGE_RISING)) {
+    m_mads_state.controls_requested_lateral = true;
+  }
+
+  // Primary control blockers - these prevent any further control processing
+  if (m_mads_state.acc_main.transition == MADS_EDGE_FALLING) {
+    mads_exit_controls(MADS_DISENGAGE_REASON_ACC_MAIN_OFF);
+    allowed = false;  // No matter what, no further control processing on this cycle
+  }
+
+  if (m_mads_state.mads_steering_disengage.transition == MADS_EDGE_RISING) {
+    mads_exit_controls(MADS_DISENGAGE_REASON_STEERING_DISENGAGE);
+    allowed = false;  // No matter what, no further control processing on this cycle
+  }
+
+  if (m_mads_state.disengage_lateral_on_brake && (m_mads_state.braking.transition == MADS_EDGE_RISING)) {
+    mads_exit_controls(MADS_DISENGAGE_REASON_BRAKE);
+    allowed = false;
+  }
+
+  // Secondary control conditions - only checked if primary conditions don't block further control processing
+  if (allowed && m_mads_state.pause_lateral_on_brake) {
+    // Brake rising edge immediately blocks controls
+    // Brake release might request controls if brake was the ONLY reason for disengagement
+    if (m_mads_state.braking.transition == MADS_EDGE_RISING) {
+      mads_exit_controls(MADS_DISENGAGE_REASON_BRAKE);
+      allowed = false;
+    } else if ((m_mads_state.braking.transition == MADS_EDGE_FALLING) &&
+               (m_mads_state.current_disengage.active_reason == MADS_DISENGAGE_REASON_BRAKE) &&
+               (m_mads_state.current_disengage.pending_reasons == MADS_DISENGAGE_REASON_BRAKE)) {
+      m_mads_state.controls_requested_lateral = true;
+    } else if (m_mads_state.braking.current) {
+      allowed = false;
+    } else {
+    }
+  }
+
+  // Process control request if conditions allow. Gate the write on system_enabled so that
+  // stock safety builds (MADS disabled) never flip the global on.
+  if (allowed && m_mads_state.system_enabled && m_mads_state.controls_requested_lateral && !controls_allowed_lateral) {
+    m_mads_state.controls_requested_lateral = false;
+    controls_allowed_lateral = true;
+    m_mads_state.current_disengage.active_reason = MADS_DISENGAGE_REASON_NONE;
+    m_mads_state.current_disengage.pending_reasons = MADS_DISENGAGE_REASON_NONE;
+  }
+}
+
+inline void mads_heartbeat_engaged_check(void) {
+  if (controls_allowed_lateral && !heartbeat_engaged_mads) {
+    heartbeat_engaged_mads_mismatches += 1U;
+    if (heartbeat_engaged_mads_mismatches >= 3U) {
+      mads_exit_controls(MADS_DISENGAGE_REASON_HEARTBEAT_ENGAGED_MISMATCH);
+    }
+  } else {
+    heartbeat_engaged_mads_mismatches = 0U;
+  }
+}
+
+// ===============================
+// Function Implementations
+// ===============================
+
+inline void mads_set_alternative_experience(const int *mode) {
+  const bool mads_enabled = (*mode & ALT_EXP_ENABLE_MADS) != 0;
+  const bool disengage_lateral_on_brake = (*mode & ALT_EXP_MADS_DISENGAGE_LATERAL_ON_BRAKE) != 0;
+  const bool pause_lateral_on_brake = (*mode & ALT_EXP_MADS_PAUSE_LATERAL_ON_BRAKE) != 0;
+
+  mads_set_system_state(mads_enabled, disengage_lateral_on_brake, pause_lateral_on_brake);
+}
+
+extern inline void mads_set_system_state(const bool enabled, const bool disengage_lateral_on_brake, const bool pause_lateral_on_brake) {
+  m_mads_state_init();
+  m_mads_state.system_enabled = enabled;
+  m_mads_state.disengage_lateral_on_brake = disengage_lateral_on_brake;
+  m_mads_state.pause_lateral_on_brake = pause_lateral_on_brake;
+}
+
+inline void mads_exit_controls(const DisengageReason reason) {
+  // Always track this as a pending reason
+  m_mads_state.current_disengage.pending_reasons |= reason;
+
+  if (controls_allowed_lateral) {
+    m_mads_state.current_disengage.active_reason = reason;
+    m_mads_state.controls_requested_lateral = false;
+    controls_allowed_lateral = false;
+  }
+}
+
+inline void mads_state_update(const bool op_vehicle_moving, const bool op_acc_main, const bool op_allowed, const bool is_braking, const bool _steering_disengage) {
+  m_mads_state.is_vehicle_moving = op_vehicle_moving;
+  m_mads_state.acc_main.current = op_acc_main;
+  m_mads_state.op_controls_allowed.current = op_allowed;
+  m_mads_state.mads_button.current = mads_button_press;
+  m_mads_state.braking.current = is_braking;
+  m_mads_state.mads_steering_disengage.current = _steering_disengage;
+
+  m_update_binary_state(&m_mads_state.acc_main);
+  m_update_binary_state(&m_mads_state.op_controls_allowed);
+  m_update_binary_state(&m_mads_state.braking);
+  m_update_binary_state(&m_mads_state.mads_steering_disengage);
+  m_update_button_state(&m_mads_state.mads_button);
+
+  m_update_control_state();
+}

--- a/opendbc/safety/sunnypilot/mads_declarations.h
+++ b/opendbc/safety/sunnypilot/mads_declarations.h
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+ *
+ * This file is part of sunnypilot and is licensed under the MIT License.
+ * See the LICENSE.md file in the root directory for more details.
+ */
+
+#pragma once
+
+// ===============================
+// Type Definitions and Enums
+// ===============================
+
+typedef enum __attribute__((packed)) {
+  MADS_BUTTON_UNAVAILABLE = -1,  ///< Button state cannot be determined
+  MADS_BUTTON_NOT_PRESSED = 0,   ///< Button is not pressed
+  MADS_BUTTON_PRESSED = 1        ///< Button is pressed
+} ButtonState;
+
+typedef enum __attribute__((packed)) {
+  MADS_EDGE_NO_CHANGE = 0,  ///< No state change detected
+  MADS_EDGE_RISING = 1,     ///< State changed from false to true
+  MADS_EDGE_FALLING = 2     ///< State changed from true to false
+} EdgeTransition;
+
+typedef enum __attribute__((packed)) {
+  MADS_DISENGAGE_REASON_NONE = 0,                         ///< No disengagement
+  MADS_DISENGAGE_REASON_BRAKE = 1,                        ///< Brake pedal pressed
+  MADS_DISENGAGE_REASON_LAG = 2,                          ///< System lag detected
+  MADS_DISENGAGE_REASON_BUTTON = 4,                       ///< User button press
+  MADS_DISENGAGE_REASON_ACC_MAIN_OFF = 8,                 ///< ACC system turned off
+  MADS_DISENGAGE_REASON_NON_PCM_ACC_MAIN_DESYNC = 16,     ///< ACC sync error
+  MADS_DISENGAGE_REASON_HEARTBEAT_ENGAGED_MISMATCH = 32,  ///< Heartbeat mismatch
+  MADS_DISENGAGE_REASON_STEERING_DISENGAGE = 64,          ///< Steering disengage
+} DisengageReason;
+
+// ===============================
+// Constants and Defines
+// ===============================
+
+#define ALT_EXP_ENABLE_MADS 1024
+#define ALT_EXP_MADS_DISENGAGE_LATERAL_ON_BRAKE 2048
+#define ALT_EXP_MADS_PAUSE_LATERAL_ON_BRAKE 4096
+
+#define MISMATCH_DEFAULT_THRESHOLD 25
+
+// ===============================
+// Data Structures
+// ===============================
+
+typedef struct {
+  DisengageReason active_reason;    // The reason that actually disengaged controls
+  DisengageReason pending_reasons;  // All conditions that would've prevented engagement while controls were disengaged
+} DisengageState;
+
+typedef struct {
+  ButtonState current;
+  ButtonState last;
+  EdgeTransition transition;
+} ButtonStateTracking;
+
+typedef struct {
+  EdgeTransition transition;
+  bool current : 1;
+  bool previous : 1;
+} BinaryStateTracking;
+
+typedef struct {
+  bool is_vehicle_moving : 1;
+
+  ButtonStateTracking mads_button;
+  BinaryStateTracking acc_main;
+  BinaryStateTracking op_controls_allowed;
+  BinaryStateTracking braking;
+  BinaryStateTracking mads_steering_disengage;
+
+  DisengageState current_disengage;
+
+  bool system_enabled : 1;
+  bool disengage_lateral_on_brake : 1;
+  bool pause_lateral_on_brake : 1;
+  bool controls_requested_lateral : 1;
+} MADSState;
+
+// ===============================
+// Global Variables
+// ===============================
+
+extern ButtonState mads_button_press;
+extern MADSState m_mads_state;
+
+extern bool controls_allowed_lateral;
+
+// state for mads controls_allowed_lateral timeout logic
+extern bool heartbeat_engaged_mads;
+extern uint32_t heartbeat_engaged_mads_mismatches;
+
+// ===============================
+// External Function Declarations (kept as needed)
+// ===============================
+
+extern void mads_set_system_state(bool enabled, bool disengage_lateral_on_brake, bool pause_lateral_on_brake);
+extern void mads_set_alternative_experience(const int *mode);
+extern void mads_state_update(bool op_vehicle_moving, bool op_acc_main, bool op_allowed, bool is_braking, bool steering_disengage);
+extern void mads_exit_controls(DisengageReason reason);
+extern void mads_heartbeat_engaged_check(void);
+
+// ===============================
+// Inline Function Implementations, must be included in the header file to comply with MISRA-C:2012 Rule 8.10
+// These are really only used internally.
+// ===============================
+extern EdgeTransition m_get_edge_transition(bool current, bool last);
+extern void m_mads_state_init(void);
+extern void m_update_button_state(ButtonStateTracking *button_state);
+extern void m_update_binary_state(BinaryStateTracking *state);
+extern void m_update_control_state(void);


### PR DESCRIPTION
Port of sunnypilot MADS: controls_allowed_lateral lets steering engage independently of longitudinal. Hyundai CAN + CAN-FD button/acc_main.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
