### PR TITLE
safety: remove inactive is zero in curvature

### DIFF
--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -140,7 +140,6 @@ typedef struct {
   const int max_curvature_error;         // rad/m * curvature_to_can, max deviation from measured curvature (0 disables)
   const float curvature_error_min_speed; // min speed for the curvature error check [m/s]
   const int max_steer_power;             // max steer power if EPS supports it (0 disables)
-  const bool inactive_curvature_is_zero; // true resets desired to 0 on violation, false resets to measured curvature
 } CurvatureSteeringLimits;
 
 // parameters for lateral accel/jerk angle limiting using a simple vehicle model

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -296,9 +296,8 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
     violation |= !controls_allowed && steer_control_enabled;
   }
 
-  // reset to zero or measured curvature depending on EPS expectation
-  if (violation || !controls_allowed) {
-    curvature_state.desired_last = limits.inactive_curvature_is_zero ? 0 : curvature_state.meas.values[0];
+  if (violation) {
+    curvature_state.desired_last = 0;
   }
 
   return violation;

--- a/opendbc/safety/modes/ford.h
+++ b/opendbc/safety/modes/ford.h
@@ -93,7 +93,6 @@ static const CurvatureSteeringLimits FORD_STEERING_LIMITS = {
   .max_curvature_error = 100,         // 0.002 rad/m * curvature_to_can
   .curvature_error_min_speed = 10.0,  // m/s
   .max_steer_power = 0,               // disabled, Ford has no steed power signal
-  .inactive_curvature_is_zero = true, // Ford EPS expects curvature=0 when inactive
 };
 
 static void ford_rx_hook(const CANPacket_t *msg) {

--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -246,7 +246,6 @@ static bool volkswagen_meb_tx_hook(const CANPacket_t *msg) {
       .max_curvature_error = 0,          // disabled, MEB doesn't track rack
       .curvature_error_min_speed = 0.0,  // disabled
       .max_steer_power = 125,
-      .inactive_curvature_is_zero = false, // MEB winds down with measured curvature
     };
 
     int desired_curvature_raw = GET_BYTES(msg, 3, 2) & 0x7FFFU;

--- a/opendbc/safety/tests/mutation.py
+++ b/opendbc/safety/tests/mutation.py
@@ -621,7 +621,7 @@ def main():
       ("opendbc/safety/lateral.h", 188, "boundary"),
       ("opendbc/safety/lateral.h", 212, "boundary"),
       ("opendbc/safety/lateral.h", 213, "boundary"),
-      ("opendbc/safety/lateral.h", 363, "arithmetic"),
+      ("opendbc/safety/lateral.h", 362, "arithmetic"),
     }
     survivors = [r for r in survivors if (str(r.site.origin_file.relative_to(ROOT)), r.site.origin_line, r.site.mutator) not in known_survivors]
 

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -206,7 +206,7 @@ class TestVolkswagenMebSafetyBase(common.CarSafetyTest, common.CurvatureSteering
         self.assertEqual(self.safety.get_controls_allowed(), within_delta)
 
   def test_curvature_violation(self):
-    # if violation occurs, MEB resets desired_curvature_last to measured curvature
+    # if violation occurs, desired_curvature_last is reset to 0
     meas = self.MAX_CURVATURE_TEST / 4
     self.safety.set_controls_allowed(True)
     self._reset_curvature_measurement(meas)
@@ -215,8 +215,8 @@ class TestVolkswagenMebSafetyBase(common.CarSafetyTest, common.CurvatureSteering
     # cause a violation by sending a command far from prev=0
     self.assertFalse(self._tx(self._curvature_cmd_msg(self.MAX_CURVATURE_TEST, steer_req=True, power=50)))
 
-    # prev should track curvature_meas
-    self.assertEqual(self.safety.get_curvature_meas_min(), self.safety.get_desired_curvature_last())
+    # prev should be reset to 0
+    self.assertEqual(0, self.safety.get_desired_curvature_last())
 
   def test_curvature_cmd_when_not_steering(self):
     # Tests that only a zero curvature is allowed while the steer


### PR DESCRIPTION
This flag existed because the MEB carcontroller snapped the curvature command to raw measured curvature on disengage and on engage while winding down power to prevent EPS fault.
Not required anymore after fixing carcontroller behavior.

Route that blocked HCA_03:
ba3e5241ca8129d2/00000005--0ff3605397