### PR TITLE
define public safety API

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ When a [panda](https://comma.ai/shop/panda) powers up with [opendbc safety firmw
 
 Safety modes optionally support `controls_allowed`, which allows or blocks a subset of messages based on a customizable state in the board.
 
+Consumers must use the public interface in [`opendbc/safety/api.h`](opendbc/safety/api.h). Other headers in that directory are implementation details; internal headers reject direct inclusion at compile time.
+
 ## Code Rigor
 
 The opendbc safety firmware is written for its use in conjunction with [openpilot](https://github.com/commaai/openpilot) and [panda](https://github.com/commaai/panda). The safety firmware, through its safety model, provides and enforces the

--- a/opendbc/safety/api.h
+++ b/opendbc/safety/api.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "opendbc/safety/can.h"
+
+// This header is the supported interface for consumers of opendbc safety.
+// Everything not declared here is internal and may change without notice.
+
+// from cereal.car.CarParams.SafetyModel
+#define SAFETY_SILENT 0U
+#define SAFETY_HONDA_NIDEC 1U
+#define SAFETY_TOYOTA 2U
+#define SAFETY_ELM327 3U
+#define SAFETY_GM 4U
+#define SAFETY_HONDA_BOSCH_GIRAFFE 5U
+#define SAFETY_FORD 6U
+#define SAFETY_HYUNDAI 8U
+#define SAFETY_CHRYSLER 9U
+#define SAFETY_TESLA 10U
+#define SAFETY_SUBARU 11U
+#define SAFETY_MAZDA 13U
+#define SAFETY_NISSAN 14U
+#define SAFETY_VOLKSWAGEN_MQB 15U
+#define SAFETY_ALLOUTPUT 17U
+#define SAFETY_GM_ASCM 18U
+#define SAFETY_NOOUTPUT 19U
+#define SAFETY_HONDA_BOSCH 20U
+#define SAFETY_VOLKSWAGEN_PQ 21U
+#define SAFETY_SUBARU_PREGLOBAL 22U
+#define SAFETY_HYUNDAI_LEGACY 23U
+#define SAFETY_HYUNDAI_COMMUNITY 24U
+#define SAFETY_VOLKSWAGEN_MLB 25U
+#define SAFETY_FAW 26U
+#define SAFETY_BODY 27U
+#define SAFETY_HYUNDAI_CANFD 28U
+#define SAFETY_CHRYSLER_CUSW 30U
+#define SAFETY_PSA 31U
+#define SAFETY_RIVIAN 33U
+#define SAFETY_VOLKSWAGEN_MEB 34U
+
+typedef struct {
+  bool controls_allowed;
+  bool relay_malfunction;
+  bool heartbeat_engaged;
+  bool rx_checks_invalid;
+  uint16_t mode;
+  uint16_t param;
+  int alternative_experience;
+} safety_state;
+
+// Configure and run the safety hooks.
+int set_safety_hooks(uint16_t mode, uint16_t param);
+bool safety_rx_hook(const CANPacket_t *msg);
+bool safety_tx_hook(CANPacket_t *msg);
+int safety_fwd_hook(int bus_num, int addr);
+void safety_tick(void);
+
+// Read and update state shared with the safety host.
+safety_state safety_get_state(void);
+void safety_disengage(void);
+void safety_set_alternative_experience(int mode);
+void safety_set_heartbeat_engaged(bool engaged);

--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -1,39 +1,13 @@
 #pragma once
 
+#ifndef OPENDBC_SAFETY_INTERNAL
+  #error "This is an internal opendbc safety header; include opendbc/safety/api.h instead"
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 
-// from cereal.car.CarParams.SafetyModel
-#define SAFETY_SILENT 0U
-#define SAFETY_HONDA_NIDEC 1U
-#define SAFETY_TOYOTA 2U
-#define SAFETY_ELM327 3U
-#define SAFETY_GM 4U
-#define SAFETY_HONDA_BOSCH_GIRAFFE 5U
-#define SAFETY_FORD 6U
-#define SAFETY_HYUNDAI 8U
-#define SAFETY_CHRYSLER 9U
-#define SAFETY_TESLA 10U
-#define SAFETY_SUBARU 11U
-#define SAFETY_MAZDA 13U
-#define SAFETY_NISSAN 14U
-#define SAFETY_VOLKSWAGEN_MQB 15U
-#define SAFETY_ALLOUTPUT 17U
-#define SAFETY_GM_ASCM 18U
-#define SAFETY_NOOUTPUT 19U
-#define SAFETY_HONDA_BOSCH 20U
-#define SAFETY_VOLKSWAGEN_PQ 21U
-#define SAFETY_SUBARU_PREGLOBAL 22U
-#define SAFETY_HYUNDAI_LEGACY 23U
-#define SAFETY_HYUNDAI_COMMUNITY 24U
-#define SAFETY_VOLKSWAGEN_MLB 25U
-#define SAFETY_FAW 26U
-#define SAFETY_BODY 27U
-#define SAFETY_HYUNDAI_CANFD 28U
-#define SAFETY_CHRYSLER_CUSW 30U
-#define SAFETY_PSA 31U
-#define SAFETY_RIVIAN 33U
-#define SAFETY_VOLKSWAGEN_MEB 34U
+#include "opendbc/safety/api.h"
 
 #define GET_BIT(msg, b) ((bool)!!(((msg)->data[((b) / 8U)] >> ((b) % 8U)) & 0x1U))
 #define GET_FLAG(value, mask) (((value) & (mask)) == (mask))
@@ -230,8 +204,6 @@ typedef struct {
   get_quality_flag_valid_t get_quality_flag_valid;
 } safety_hooks;
 
-bool safety_rx_hook(const CANPacket_t *msg);
-bool safety_tx_hook(CANPacket_t *msg);
 int to_signed(int d, int bits);
 void update_sample(struct sample_t *sample, int sample_new);
 bool get_longitudinal_allowed(void);
@@ -251,11 +223,9 @@ bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limit
 void pcm_cruise_check(bool cruise_engaged);
 void speed_mismatch_check(const float speed_2);
 
-void safety_tick(const safety_config *safety_config);
-
 // This can be set by the safety hooks
-extern bool controls_allowed;
-extern bool relay_malfunction;
+extern bool safety_controls_allowed_internal;
+extern bool safety_relay_malfunction_internal;
 extern bool gas_pressed;
 extern bool gas_pressed_prev;
 extern bool brake_pressed;
@@ -270,7 +240,7 @@ extern struct sample_t vehicle_speed_2;
 extern bool vehicle_moving;
 extern bool acc_main_on; // referred to as "ACC off" in ISO 15622:2018
 extern int cruise_button_prev;
-extern bool safety_rx_checks_invalid;
+extern bool safety_rx_checks_invalid_internal;
 
 // for safety modes with torque steering control
 extern int desired_torque_last;       // last desired steer torque
@@ -282,9 +252,8 @@ extern struct sample_t torque_driver;     // last 6 driver torques measured
 extern uint32_t ts_torque_check_last;
 extern uint32_t ts_steer_req_mismatch_last;  // last timestamp steer req was mismatched with torque
 
-// state for controls_allowed timeout logic
-extern bool heartbeat_engaged;             // openpilot enabled, passed in heartbeat USB command
-extern uint32_t heartbeat_engaged_mismatches;  // count of mismatches between heartbeat_engaged and controls_allowed
+// state for safety_controls_allowed_internal timeout logic
+extern bool safety_heartbeat_engaged_internal;             // openpilot enabled, passed in heartbeat USB command
 
 // for safety modes with angle steering control
 extern uint32_t rt_angle_msgs;
@@ -321,22 +290,19 @@ extern CurvatureSteeringState curvature_state;
 // This flag allows AEB to be commanded from openpilot.
 #define ALT_EXP_ALLOW_AEB 16
 
-extern int alternative_experience;
+extern int safety_alternative_experience_internal;
 
 // time since safety mode has been changed
-extern uint32_t safety_mode_cnt;
+extern uint32_t safety_mode_cnt_internal;
 
 typedef struct {
   uint16_t id;
   const safety_hooks *hooks;
 } safety_hook_config;
 
-extern uint16_t current_safety_mode;
-extern uint16_t current_safety_param;
-extern safety_config current_safety_config;
-
-int safety_fwd_hook(int bus_num, int addr);
-int set_safety_hooks(uint16_t mode, uint16_t param);
+extern uint16_t safety_mode_internal;
+extern uint16_t safety_param_internal;
+extern safety_config safety_config_internal;
 
 extern const safety_hooks body_hooks;
 extern const safety_hooks chrysler_hooks;

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -61,7 +61,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
   bool violation = false;
   uint32_t ts = microsecond_timer_get();
 
-  if (controls_allowed) {
+  if (safety_controls_allowed_internal) {
     // Some safety models support variable torque limit based on vehicle speed
     int max_torque = limits.max_torque;
     if (limits.dynamic_max_torque) {
@@ -96,7 +96,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
   }
 
   // no torque if controls is not allowed
-  if (!controls_allowed && (desired_torque != 0)) {
+  if (!safety_controls_allowed_internal && (desired_torque != 0)) {
     violation = true;
   }
 
@@ -138,7 +138,7 @@ bool steer_torque_cmd_checks(int desired_torque, int steer_req, const TorqueStee
   }
 
   // reset to 0 if either controls is not allowed or there's a violation
-  if (violation || !controls_allowed) {
+  if (violation || !safety_controls_allowed_internal) {
     valid_steer_req_count = 0;
     invalid_steer_req_count = 0;
     desired_torque_last = 0;
@@ -198,7 +198,7 @@ static bool rt_curvature_rate_limit_check(CurvatureSteeringLimits limits) {
 bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const AngleSteeringLimits limits) {
   bool violation = false;
 
-  if (controls_allowed && steer_control_enabled) {
+  if (safety_controls_allowed_internal && steer_control_enabled) {
     // convert floating point angle rate limits to integers in the scale of the desired angle on CAN,
     // add 1 to not false trigger the violation. also fudge the speed by 1 m/s so rate limits are
     // always slightly above openpilot's in case we read an updated speed in between angle commands
@@ -225,12 +225,12 @@ bool steer_angle_cmd_checks(int desired_angle, bool steer_control_enabled, const
   }
 
   // No angle control allowed when controls are not allowed
-  if (!controls_allowed) {
+  if (!safety_controls_allowed_internal) {
     violation |= steer_control_enabled;
   }
 
   // reset to current angle if either controls is not allowed or there's a violation
-  if (violation || !controls_allowed) {
+  if (violation || !safety_controls_allowed_internal) {
     desired_angle_last = SAFETY_CLAMP(angle_meas.values[0], -limits.max_angle, limits.max_angle);
   }
 
@@ -249,7 +249,7 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
 
   speed_mismatch_check((float)vehicle_speed_2.values[0] / VEHICLE_SPEED_FACTOR);
 
-  if (controls_allowed && steer_control_enabled) {
+  if (safety_controls_allowed_internal && steer_control_enabled) {
     // *** absolute curvature cap ***
     violation |= safety_max_limit_check(desired_curvature, limits.max_curvature, -limits.max_curvature);
 
@@ -289,15 +289,15 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
   if (limits.max_steer_power != 0) {
     violation |= safety_max_limit_check(steer_power, limits.max_steer_power, 0);
     violation |= (steer_power != 0) && !steer_control_enabled;
-    violation |= !controls_allowed && (steer_power != 0) && (steer_power >= curvature_state.steer_power_last);
+    violation |= !safety_controls_allowed_internal && (steer_power != 0) && (steer_power >= curvature_state.steer_power_last);
     curvature_state.steer_power_last = steer_power;
   } else {
     // No curvature control allowed when controls are not allowed
-    violation |= !controls_allowed && steer_control_enabled;
+    violation |= !safety_controls_allowed_internal && steer_control_enabled;
   }
 
   // reset to zero or measured curvature depending on EPS expectation
-  if (violation || !controls_allowed) {
+  if (violation || !safety_controls_allowed_internal) {
     curvature_state.desired_last = limits.inactive_curvature_is_zero ? 0 : curvature_state.meas.values[0];
   }
 
@@ -330,7 +330,7 @@ bool steer_angle_cmd_checks_vm(int desired_angle, bool steer_control_enabled, co
 
   bool violation = false;
 
-  if (controls_allowed && steer_control_enabled) {
+  if (safety_controls_allowed_internal && steer_control_enabled) {
     // *** ISO lateral jerk limit ***
     // calculate maximum angle rate per second
     const float max_curvature_rate_sec = MAX_LATERAL_JERK / (fudged_speed * fudged_speed);
@@ -366,12 +366,12 @@ bool steer_angle_cmd_checks_vm(int desired_angle, bool steer_control_enabled, co
   }
 
   // No angle control allowed when controls are not allowed
-  if (!controls_allowed) {
+  if (!safety_controls_allowed_internal) {
     violation |= steer_control_enabled;
   }
 
   // reset to current angle if either controls is not allowed or there's a violation
-  if (violation || !controls_allowed) {
+  if (violation || !safety_controls_allowed_internal) {
     desired_angle_last = SAFETY_CLAMP(angle_meas.values[0], -limits.max_angle, limits.max_angle);
   }
 

--- a/opendbc/safety/longitudinal.h
+++ b/opendbc/safety/longitudinal.h
@@ -1,7 +1,7 @@
 #include "opendbc/safety/declarations.h"
 
 bool get_longitudinal_allowed(void) {
-  return controls_allowed && !gas_pressed_prev;
+  return safety_controls_allowed_internal && !gas_pressed_prev;
 }
 
 // Safety checks for longitudinal actuation

--- a/opendbc/safety/modes/body.h
+++ b/opendbc/safety/modes/body.h
@@ -4,20 +4,20 @@
 
 static void body_rx_hook(const CANPacket_t *msg) {
   if (msg->addr == 0x201U) {
-    controls_allowed = true;
+    safety_controls_allowed_internal = true;
   }
 }
 
 static bool body_tx_hook(const CANPacket_t *msg) {
   bool tx = true;
 
-  if (!controls_allowed && (msg->addr != 0x1U)) {
+  if (!safety_controls_allowed_internal && (msg->addr != 0x1U)) {
     tx = false;
   }
 
   // Allow going into CAN flashing mode even if controls are not allowed
   bool flash_msg = (msg->addr == 0x250U) && (GET_LEN(msg) == 8U);
-  if (!controls_allowed && (GET_BYTES(msg, 0, 4) == 0xdeadfaceU) && (GET_BYTES(msg, 4, 4) == 0x0ab00b1eU) && flash_msg) {
+  if (!safety_controls_allowed_internal && (GET_BYTES(msg, 0, 4) == 0xdeadfaceU) && (GET_BYTES(msg, 4, 4) == 0x0ab00b1eU) && flash_msg) {
     tx = true;
   }
 

--- a/opendbc/safety/modes/chrysler.h
+++ b/opendbc/safety/modes/chrysler.h
@@ -133,7 +133,7 @@ static bool chrysler_tx_hook(const CANPacket_t *msg) {
   if (msg->addr == CHRYSLER_ADDR(CRUISE_BUTTONS)) {
     const bool is_cancel = msg->data[0] == 1U;
     const bool is_resume = msg->data[0] == 0x10U;
-    const bool allowed = is_cancel || (is_resume && controls_allowed);
+    const bool allowed = is_cancel || (is_resume && safety_controls_allowed_internal);
     if (!allowed) {
       tx = false;
     }

--- a/opendbc/safety/modes/chrysler_cusw.h
+++ b/opendbc/safety/modes/chrysler_cusw.h
@@ -83,7 +83,7 @@ static bool chrysler_cusw_tx_hook(const CANPacket_t *msg) {
     // Signal: CRUISE_BUTTONS.ACC_Resume
     const bool is_cancel = GET_BIT(msg, 0U);
     const bool is_resume = GET_BIT(msg, 4U);
-    const bool allowed = is_cancel || (is_resume && controls_allowed);
+    const bool allowed = is_cancel || (is_resume && safety_controls_allowed_internal);
     if (!allowed) {
       tx = false;
     }

--- a/opendbc/safety/modes/defaults.h
+++ b/opendbc/safety/modes/defaults.h
@@ -34,7 +34,7 @@ const safety_hooks nooutput_hooks = {
 static safety_config alloutput_init(uint16_t param) {
   // Enables passthrough mode where relay is open and bus 0 gets forwarded to bus 2 and vice versa
   const uint16_t ALLOUTPUT_PARAM_PASSTHROUGH = 1;
-  controls_allowed = true;
+  safety_controls_allowed_internal = true;
   bool alloutput_passthrough = GET_FLAG(param, ALLOUTPUT_PARAM_PASSTHROUGH);
   return (safety_config){NULL, 0, NULL, 0, !alloutput_passthrough}; // NOLINT(readability/braces)
 }

--- a/opendbc/safety/modes/ford.h
+++ b/opendbc/safety/modes/ford.h
@@ -202,7 +202,7 @@ static bool ford_tx_hook(const CANPacket_t *msg) {
     // if cancel button is pressed when cruise isn't engaged.
     bool violation = false;
     violation |= ((msg->data[1] >> 0) & 1U) && !cruise_engaged_prev;   // Signal: CcAslButtnCnclPress (cancel)
-    violation |= ((msg->data[3] >> 1) & 1U) && !controls_allowed;     // Signal: CcAsllButtnResPress (resume)
+    violation |= ((msg->data[3] >> 1) & 1U) && !safety_controls_allowed_internal;     // Signal: CcAsllButtnResPress (resume)
 
     if (violation) {
       tx = false;

--- a/opendbc/safety/modes/gm.h
+++ b/opendbc/safety/modes/gm.h
@@ -55,12 +55,12 @@ static void gm_rx_hook(const CANPacket_t *msg) {
       bool set = (button != GM_BTN_SET) && (cruise_button_prev == GM_BTN_SET);
       bool res = (button == GM_BTN_RESUME) && (cruise_button_prev != GM_BTN_RESUME);
       if (set || res) {
-        controls_allowed = true;
+        safety_controls_allowed_internal = true;
       }
 
       // exit controls on cancel press
       if (button == GM_BTN_CANCEL) {
-        controls_allowed = false;
+        safety_controls_allowed_internal = false;
       }
 
       cruise_button_prev = button;
@@ -134,7 +134,7 @@ static bool gm_tx_hook(const CANPacket_t *msg) {
 
     bool violation = false;
     // Allow apply bit in pre-enabled and overriding states
-    violation |= !controls_allowed && apply;
+    violation |= !safety_controls_allowed_internal && apply;
     violation |= longitudinal_gas_checks(gas_regen, *gm_long_limits);
 
     if (violation) {

--- a/opendbc/safety/modes/honda.h
+++ b/opendbc/safety/modes/honda.h
@@ -81,7 +81,7 @@ static void honda_rx_hook(const CANPacket_t *msg) {
   if ((msg->addr == 0x326U) || (msg->addr == 0x1A6U)) {
     acc_main_on = GET_BIT(msg, ((msg->addr == 0x326U) ? 28U : 47U));
     if (!acc_main_on) {
-      controls_allowed = false;
+      safety_controls_allowed_internal = false;
     }
   }
 
@@ -90,13 +90,13 @@ static void honda_rx_hook(const CANPacket_t *msg) {
     const bool cruise_engaged = GET_BIT(msg, 38U);
     // engage on rising edge
     if (cruise_engaged && !cruise_engaged_prev) {
-      controls_allowed = true;
+      safety_controls_allowed_internal = true;
     }
 
     // Since some Nidec cars can brake down to 0 after the PCM disengages,
     // we don't disengage when the PCM does.
     if (!cruise_engaged && (honda_hw != HONDA_NIDEC)) {
-      controls_allowed = false;
+      safety_controls_allowed_internal = false;
     }
     cruise_engaged_prev = cruise_engaged;
   }
@@ -110,12 +110,12 @@ static void honda_rx_hook(const CANPacket_t *msg) {
     bool set = (button != HONDA_BTN_SET) && (cruise_button_prev == HONDA_BTN_SET);
     bool res = (button != HONDA_BTN_RESUME) && (cruise_button_prev == HONDA_BTN_RESUME);
     if (acc_main_on && !pcm_cruise && (set || res)) {
-      controls_allowed = true;
+      safety_controls_allowed_internal = true;
     }
 
     // exit controls once main or cancel are pressed
     if ((button == HONDA_BTN_MAIN) || (button == HONDA_BTN_CANCEL)) {
-      controls_allowed = false;
+      safety_controls_allowed_internal = false;
     }
     cruise_button_prev = button;
   }
@@ -144,7 +144,7 @@ static void honda_rx_hook(const CANPacket_t *msg) {
   }
 
   // disable stock Honda AEB in alternative experience
-  if (!(alternative_experience & ALT_EXP_DISABLE_STOCK_AEB)) {
+  if (!(safety_alternative_experience_internal & ALT_EXP_DISABLE_STOCK_AEB)) {
     if ((msg->bus == 2U) && (msg->addr == 0x1FAU)) {
       bool honda_stock_aeb = GET_BIT(msg, 29U);
       int honda_stock_brake = (msg->data[0] << 2) | (msg->data[1] >> 6);
@@ -238,7 +238,7 @@ static bool honda_tx_hook(const CANPacket_t *msg) {
 
   // STEER: safety check
   if ((msg->addr == 0xE4U) || (msg->addr == 0x194U)) {
-    if (!controls_allowed) {
+    if (!safety_controls_allowed_internal) {
       bool steer_applied = msg->data[0] | msg->data[1];
       if (steer_applied) {
         tx = false;
@@ -256,7 +256,7 @@ static bool honda_tx_hook(const CANPacket_t *msg) {
   // FORCE CANCEL: safety check only relevant when spamming the cancel button in Bosch HW
   // ensuring that only the cancel button press is sent (VAL 2) when controls are off.
   // This avoids unintended engagements while still allowing resume spam
-  if ((msg->addr == 0x296U) && !controls_allowed && (msg->bus == bus_buttons)) {
+  if ((msg->addr == 0x296U) && !safety_controls_allowed_internal && (msg->bus == bus_buttons)) {
     if (((msg->data[0] >> 5) & 0x7U) != 2U) {
       tx = false;
     }

--- a/opendbc/safety/modes/hyundai.h
+++ b/opendbc/safety/modes/hyundai.h
@@ -238,7 +238,7 @@ static bool hyundai_tx_hook(const CANPacket_t *msg) {
   if ((msg->addr == 0x4F1U) && !hyundai_longitudinal) {
     int button = msg->data[0] & 0x7U;
 
-    bool allowed_resume = (button == 1) && controls_allowed;
+    bool allowed_resume = (button == 1) && safety_controls_allowed_internal;
     bool allowed_cancel = (button == 4) && cruise_engaged_prev;
     if (!(allowed_resume || allowed_cancel)) {
       tx = false;

--- a/opendbc/safety/modes/hyundai_canfd.h
+++ b/opendbc/safety/modes/hyundai_canfd.h
@@ -172,7 +172,7 @@ static bool hyundai_canfd_tx_hook(const CANPacket_t *msg) {
     bool is_cancel = (button == HYUNDAI_BTN_CANCEL);
     bool is_resume = (button == HYUNDAI_BTN_RESUME);
 
-    bool allowed = (is_cancel && cruise_engaged_prev) || (is_resume && controls_allowed);
+    bool allowed = (is_cancel && cruise_engaged_prev) || (is_resume && safety_controls_allowed_internal);
     if (!allowed) {
       tx = false;
     }

--- a/opendbc/safety/modes/hyundai_common.h
+++ b/opendbc/safety/modes/hyundai_common.h
@@ -78,11 +78,11 @@ void hyundai_common_cruise_state_check(const bool cruise_engaged) {
   // enter controls on rising edge of ACC and recent user button press, exit controls when ACC off
   if (!hyundai_longitudinal) {
     if (cruise_engaged && !cruise_engaged_prev && (hyundai_last_button_interaction < HYUNDAI_PREV_BUTTON_SAMPLES)) {
-      controls_allowed = true;
+      safety_controls_allowed_internal = true;
     }
 
     if (!cruise_engaged) {
-      controls_allowed = false;
+      safety_controls_allowed_internal = false;
     }
     cruise_engaged_prev = cruise_engaged;
   }
@@ -100,12 +100,12 @@ void hyundai_common_cruise_buttons_check(const int cruise_button, const bool mai
     bool set = (cruise_button != HYUNDAI_BTN_SET) && (cruise_button_prev == HYUNDAI_BTN_SET);
     bool res = (cruise_button != HYUNDAI_BTN_RESUME) && (cruise_button_prev == HYUNDAI_BTN_RESUME);
     if (set || res) {
-      controls_allowed = true;
+      safety_controls_allowed_internal = true;
     }
 
     // exit controls on cancel press
     if (cruise_button == HYUNDAI_BTN_CANCEL) {
-      controls_allowed = false;
+      safety_controls_allowed_internal = false;
     }
 
     cruise_button_prev = cruise_button;

--- a/opendbc/safety/modes/mazda.h
+++ b/opendbc/safety/modes/mazda.h
@@ -74,7 +74,7 @@ static bool mazda_tx_hook(const CANPacket_t *msg) {
       // allow resume spamming while controls allowed, but
       // only allow cancel while controls not allowed
       bool cancel_cmd = (msg->data[0] == 0x1U);
-      if (!controls_allowed && !cancel_cmd) {
+      if (!safety_controls_allowed_internal && !cancel_cmd) {
         tx = false;
       }
     }

--- a/opendbc/safety/modes/tesla.h
+++ b/opendbc/safety/modes/tesla.h
@@ -194,7 +194,7 @@ static void tesla_rx_hook(const CANPacket_t *msg) {
       bool tesla_stock_lkas_now = steering_control_type == tesla_get_steer_ctrl_type(2);  // "LANE_KEEP_ASSIST"
 
       // Only consider rising edges while controls are not allowed
-      if (tesla_stock_lkas_now && !tesla_stock_lkas_prev && !controls_allowed) {
+      if (tesla_stock_lkas_now && !tesla_stock_lkas_prev && !safety_controls_allowed_internal) {
         tesla_stock_lkas = true;
       }
       if (!tesla_stock_lkas_now) {

--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -184,7 +184,7 @@ static void volkswagen_meb_rx_hook(const CANPacket_t *msg) {
       }
 
       if (!acc_main_on) {
-        controls_allowed = false;
+        safety_controls_allowed_internal = false;
       }
 
       int accel_pedal_value = ((msg->data[1] >> 4) & 0x0FU) | ((msg->data[2] & 0x1FU) << 4);
@@ -199,7 +199,7 @@ static void volkswagen_meb_rx_hook(const CANPacket_t *msg) {
         bool set_button = GET_BIT(msg, 16U);
         bool resume_button = GET_BIT(msg, 19U);
         if ((volkswagen_set_button_prev && !set_button) || (volkswagen_resume_button_prev && !resume_button)) {
-          controls_allowed = acc_main_on;
+          safety_controls_allowed_internal = acc_main_on;
         }
         volkswagen_set_button_prev = set_button;
         volkswagen_resume_button_prev = resume_button;
@@ -207,7 +207,7 @@ static void volkswagen_meb_rx_hook(const CANPacket_t *msg) {
 
       // Always exit controls on rising edge of Cancel
       if (GET_BIT(msg, 13U)) {
-        controls_allowed = false;
+        safety_controls_allowed_internal = false;
       }
     }
 
@@ -232,7 +232,7 @@ static bool volkswagen_meb_tx_hook(const CANPacket_t *msg) {
     // Signal: ACC_18.ACC_Sollbeschleunigung_02 (acceleration in m/s2, scale 0.005, offset -7.22)
     int desired_accel = ((((msg->data[4] & 0x7U) << 8) | msg->data[3]) * 5U) - 7220U;
     // allow ACCEL_OVERRIDE (0) while controls are allowed even when the driver is on the gas
-    bool accel_override = controls_allowed && (desired_accel == 0);
+    bool accel_override = safety_controls_allowed_internal && (desired_accel == 0);
     if (!accel_override && longitudinal_accel_checks(desired_accel, VOLKSWAGEN_MEB_LONG_LIMITS)) {
       tx = false;
     }
@@ -264,7 +264,7 @@ static bool volkswagen_meb_tx_hook(const CANPacket_t *msg) {
     }
   }
 
-  if ((msg->addr == MSG_GRA_ACC_01) && !controls_allowed) {
+  if ((msg->addr == MSG_GRA_ACC_01) && !safety_controls_allowed_internal) {
     // only allow cancel button: bit 13
     if (!GET_BIT(msg, 13U)) {
       tx = false;

--- a/opendbc/safety/modes/volkswagen_mlb.h
+++ b/opendbc/safety/modes/volkswagen_mlb.h
@@ -47,7 +47,7 @@ static void volkswagen_mlb_rx_hook(const CANPacket_t *msg) {
       // Always exit controls on rising edge of Cancel
       // Signal: LS_01.LS_Abbrechen
       if (GET_BIT(msg, 13U)) {
-        controls_allowed = false;
+        safety_controls_allowed_internal = false;
       }
     }
 
@@ -106,7 +106,7 @@ static bool volkswagen_mlb_tx_hook(const CANPacket_t *msg) {
 
   // FORCE CANCEL: ensuring that only the cancel button press is sent when controls are off.
   // This avoids unintended engagements while still allowing resume spam
-  if ((msg->addr == MSG_LS_01) && !controls_allowed) {
+  if ((msg->addr == MSG_LS_01) && !safety_controls_allowed_internal) {
     // disallow resume and set: bits 16 and 19
     if (GET_BIT(msg, 16U) || GET_BIT(msg, 19U)) {
       tx = false;

--- a/opendbc/safety/modes/volkswagen_mqb.h
+++ b/opendbc/safety/modes/volkswagen_mqb.h
@@ -68,7 +68,7 @@ static void volkswagen_mqb_rx_hook(const CANPacket_t *msg) {
       }
 
       if (!acc_main_on) {
-        controls_allowed = false;
+        safety_controls_allowed_internal = false;
       }
     }
 
@@ -80,7 +80,7 @@ static void volkswagen_mqb_rx_hook(const CANPacket_t *msg) {
         bool set_button = GET_BIT(msg, 16U);
         bool resume_button = GET_BIT(msg, 19U);
         if ((volkswagen_set_button_prev && !set_button) || (volkswagen_resume_button_prev && !resume_button)) {
-          controls_allowed = acc_main_on;
+          safety_controls_allowed_internal = acc_main_on;
         }
         volkswagen_set_button_prev = set_button;
         volkswagen_resume_button_prev = resume_button;
@@ -88,7 +88,7 @@ static void volkswagen_mqb_rx_hook(const CANPacket_t *msg) {
       // Always exit controls on rising edge of Cancel
       // Signal: GRA_ACC_01.GRA_Abbrechen
       if (GET_BIT(msg, 13U)) {
-        controls_allowed = false;
+        safety_controls_allowed_internal = false;
       }
     }
 
@@ -169,7 +169,7 @@ static bool volkswagen_mqb_tx_hook(const CANPacket_t *msg) {
 
   // FORCE CANCEL: ensuring that only the cancel button press is sent when controls are off.
   // This avoids unintended engagements while still allowing resume spam
-  if ((msg->addr == MSG_GRA_ACC_01) && !controls_allowed) {
+  if ((msg->addr == MSG_GRA_ACC_01) && !safety_controls_allowed_internal) {
     // disallow resume and set: bits 16 and 19
     if ((msg->data[2] & 0x9U) != 0U) {
       tx = false;

--- a/opendbc/safety/modes/volkswagen_pq.h
+++ b/opendbc/safety/modes/volkswagen_pq.h
@@ -101,7 +101,7 @@ static void volkswagen_pq_rx_hook(const CANPacket_t *msg) {
         // Signal: Motor_5.MO5_GRA_Hauptsch
         acc_main_on = GET_BIT(msg, 50U);
         if (!acc_main_on) {
-          controls_allowed = false;
+          safety_controls_allowed_internal = false;
         }
       }
 
@@ -112,14 +112,14 @@ static void volkswagen_pq_rx_hook(const CANPacket_t *msg) {
         bool set_button = GET_BIT(msg, 16U);
         bool resume_button = GET_BIT(msg, 17U);
         if ((volkswagen_set_button_prev && !set_button) || (volkswagen_resume_button_prev && !resume_button)) {
-          controls_allowed = acc_main_on;
+          safety_controls_allowed_internal = acc_main_on;
         }
         volkswagen_set_button_prev = set_button;
         volkswagen_resume_button_prev = resume_button;
         // Exit controls on rising edge of Cancel, override Set/Resume if present simultaneously
         // Signal: GRA_ACC_01.GRA_Abbrechen
         if (GET_BIT(msg, 9U)) {
-          controls_allowed = false;
+          safety_controls_allowed_internal = false;
         }
       }
     } else {
@@ -198,7 +198,7 @@ static bool volkswagen_pq_tx_hook(const CANPacket_t *msg) {
 
   // FORCE CANCEL: ensuring that only the cancel button press is sent when controls are off.
   // This avoids unintended engagements while still allowing resume spam
-  if ((msg->addr == MSG_GRA_NEU) && !controls_allowed) {
+  if ((msg->addr == MSG_GRA_NEU) && !safety_controls_allowed_internal) {
     // Signal: GRA_Neu.GRA_Neu_Setzen
     // Signal: GRA_Neu.GRA_Neu_Recall
     if (GET_BIT(msg, 16U) || GET_BIT(msg, 17U)) {

--- a/opendbc/safety/safety.h
+++ b/opendbc/safety/safety.h
@@ -1,5 +1,10 @@
 #pragma once
 
+// Header-only implementation entry point. Consumers should use the interface
+// declared in api.h and define OPENDBC_SAFETY_API_ONLY before including this.
+#define OPENDBC_SAFETY_INTERNAL
+
+#include "opendbc/safety/api.h"
 #include "opendbc/safety/helpers.h"
 #include "opendbc/safety/lateral.h"
 #include "opendbc/safety/longitudinal.h"
@@ -42,8 +47,8 @@ uint32_t GET_BYTES(const CANPacket_t *msg, int start, int len) {
 const int MAX_WRONG_COUNTERS = 5;
 
 // This can be set by the safety hooks
-bool controls_allowed = false;
-bool relay_malfunction = false;
+bool safety_controls_allowed_internal = false;
+bool safety_relay_malfunction_internal = false;
 bool gas_pressed = false;
 bool gas_pressed_prev = false;
 bool brake_pressed = false;
@@ -58,7 +63,7 @@ struct sample_t vehicle_speed_2;
 bool vehicle_moving = false;
 bool acc_main_on = false;  // referred to as "ACC off" in ISO 15622:2018
 int cruise_button_prev = 0;
-bool safety_rx_checks_invalid = false;
+bool safety_rx_checks_invalid_internal = false;
 
 // for safety modes with torque steering control
 int desired_torque_last = 0;       // last desired steer torque
@@ -70,9 +75,8 @@ struct sample_t torque_driver;     // last 6 driver torques measured
 uint32_t ts_torque_check_last = 0;
 uint32_t ts_steer_req_mismatch_last = 0;  // last timestamp steer req was mismatched with torque
 
-// state for controls_allowed timeout logic
-bool heartbeat_engaged = false;             // openpilot enabled, passed in heartbeat USB command
-uint32_t heartbeat_engaged_mismatches = 0;  // count of mismatches between heartbeat_engaged and controls_allowed
+// state for safety_controls_allowed_internal timeout logic
+bool safety_heartbeat_engaged_internal = false;             // openpilot enabled, passed in heartbeat USB command
 
 // for safety modes with angle steering control
 uint32_t rt_angle_msgs = 0;
@@ -84,15 +88,15 @@ struct sample_t angle_meas;         // last 6 steer angles
 CurvatureSteeringState curvature_state;
 
 
-int alternative_experience = 0;
+int safety_alternative_experience_internal = 0;
 
 // time since safety mode has been changed
-uint32_t safety_mode_cnt = 0U;
+uint32_t safety_mode_cnt_internal = 0U;
 
-uint16_t current_safety_mode = SAFETY_SILENT;
-uint16_t current_safety_param = 0;
+uint16_t safety_mode_internal = SAFETY_SILENT;
+uint16_t safety_param_internal = 0;
 static const safety_hooks *current_hooks = &nooutput_hooks;
-safety_config current_safety_config;
+safety_config safety_config_internal;
 
 static void generic_rx_checks(void);
 static void stock_ecu_check(bool stock_ecu_detected);
@@ -102,7 +106,7 @@ static bool is_msg_valid(RxCheck addr_list[], int index) {
   if (index != -1) {
     if (!addr_list[index].status.valid_checksum || !addr_list[index].status.valid_quality_flag || (addr_list[index].status.wrong_counters >= MAX_WRONG_COUNTERS)) {
       valid = false;
-      controls_allowed = false;
+      safety_controls_allowed_internal = false;
     }
   }
   return valid;
@@ -190,10 +194,8 @@ static bool rx_msg_safety_check(const CANPacket_t *msg,
 }
 
 bool safety_rx_hook(const CANPacket_t *msg) {
-  bool controls_allowed_prev = controls_allowed;
-
-  bool valid = rx_msg_safety_check(msg, &current_safety_config, current_hooks);
-  bool whitelisted = get_addr_check_index(msg, current_safety_config.rx_checks, current_safety_config.rx_checks_len) != -1;
+  bool valid = rx_msg_safety_check(msg, &safety_config_internal, current_hooks);
+  bool whitelisted = get_addr_check_index(msg, safety_config_internal.rx_checks, safety_config_internal.rx_checks_len) != -1;
   if (valid && whitelisted) {
     current_hooks->rx(msg);
   }
@@ -205,16 +207,11 @@ bool safety_rx_hook(const CANPacket_t *msg) {
   // check all applicable tx msgs for liveness on sending bus.
   // used to detect a relay malfunction or control messages from disabled ECUs like the radar
   const int addr = msg->addr;
-  for (int i = 0; i < current_safety_config.tx_msgs_len; i++) {
-    const CanMsg *m = &current_safety_config.tx_msgs[i];
+  for (int i = 0; i < safety_config_internal.tx_msgs_len; i++) {
+    const CanMsg *m = &safety_config_internal.tx_msgs[i];
     if (m->check_relay) {
       stock_ecu_check((m->addr == addr) && (m->bus == msg->bus));
     }
-  }
-
-  // reset mismatches on rising edge of controls_allowed to avoid rare race condition
-  if (controls_allowed && !controls_allowed_prev) {
-    heartbeat_engaged_mismatches = 0;
   }
 
   return valid;
@@ -235,8 +232,8 @@ static bool tx_msg_safety_check(const CANPacket_t *msg, const CanMsg msg_list[],
 }
 
 bool safety_tx_hook(CANPacket_t *msg) {
-  bool whitelisted = tx_msg_safety_check(msg, current_safety_config.tx_msgs, current_safety_config.tx_msgs_len);
-  if ((current_safety_mode == SAFETY_ALLOUTPUT) || (current_safety_mode == SAFETY_ELM327)) {
+  bool whitelisted = tx_msg_safety_check(msg, safety_config_internal.tx_msgs, safety_config_internal.tx_msgs_len);
+  if ((safety_mode_internal == SAFETY_ALLOUTPUT) || (safety_mode_internal == SAFETY_ELM327)) {
     whitelisted = true;
   }
 
@@ -245,7 +242,7 @@ bool safety_tx_hook(CANPacket_t *msg) {
     safety_allowed = current_hooks->tx(msg);
   }
 
-  return !relay_malfunction && whitelisted && safety_allowed;
+  return !safety_relay_malfunction_internal && whitelisted && safety_allowed;
 }
 
 static int get_fwd_bus(int bus_num) {
@@ -261,14 +258,14 @@ static int get_fwd_bus(int bus_num) {
 }
 
 int safety_fwd_hook(int bus_num, int addr) {
-  bool blocked = relay_malfunction || current_safety_config.disable_forwarding;
+  bool blocked = safety_relay_malfunction_internal || safety_config_internal.disable_forwarding;
 
   // Block messages that are being checked for relay malfunctions. Safety modes can opt out of this
   // in the case of selective AEB forwarding
   const int destination_bus = get_fwd_bus(bus_num);
   if (!blocked) {
-    for (int i = 0; i < current_safety_config.tx_msgs_len; i++) {
-      const CanMsg *m = &current_safety_config.tx_msgs[i];
+    for (int i = 0; i < safety_config_internal.tx_msgs_len; i++) {
+      const CanMsg *m = &safety_config_internal.tx_msgs[i];
       if (m->check_relay && !m->disable_static_blocking && (m->addr == addr) && (m->bus == (unsigned int)destination_bus)) {
         blocked = true;
         break;
@@ -314,38 +311,63 @@ void gen_crc_lookup_table_16(uint16_t poly, uint16_t crc_lut[]) {
 }
 
 // 1Hz safety function called by main. Now just a check for lagging safety messages
-void safety_tick(const safety_config *cfg) {
+void safety_tick(void) {
   const uint8_t MAX_MISSED_MSGS = 10U;
   bool rx_checks_invalid = false;
   uint32_t ts = microsecond_timer_get();
-  if (cfg != NULL) {
-    for (int i=0; i < cfg->rx_checks_len; i++) {
-      uint32_t elapsed_time = safety_get_ts_elapsed(ts, cfg->rx_checks[i].status.last_timestamp);
-      // lag threshold is max of: 1s and MAX_MISSED_MSGS * expected timestep.
-      // Quite conservative to not risk false triggers.
-      // 2s of lag is worse case, since the function is called at 1Hz
-      uint32_t frequency = cfg->rx_checks[i].msg[cfg->rx_checks[i].status.index].frequency;
-      uint32_t timestep = 1e6 / frequency;
-      bool lagging = elapsed_time > SAFETY_MAX(timestep * MAX_MISSED_MSGS, 1e6);
-      cfg->rx_checks[i].status.lagging = lagging;
-      if (lagging) {
-        controls_allowed = false;
-      }
+  const safety_config *cfg = &safety_config_internal;
+  for (int i=0; i < cfg->rx_checks_len; i++) {
+    uint32_t elapsed_time = safety_get_ts_elapsed(ts, cfg->rx_checks[i].status.last_timestamp);
+    // lag threshold is max of: 1s and MAX_MISSED_MSGS * expected timestep.
+    // Quite conservative to not risk false triggers.
+    // 2s of lag is worse case, since the function is called at 1Hz
+    uint32_t frequency = cfg->rx_checks[i].msg[cfg->rx_checks[i].status.index].frequency;
+    uint32_t timestep = 1e6 / frequency;
+    bool lagging = elapsed_time > SAFETY_MAX(timestep * MAX_MISSED_MSGS, 1e6);
+    cfg->rx_checks[i].status.lagging = lagging;
+    if (lagging) {
+      safety_controls_allowed_internal = false;
+    }
 
-      // enforce minimum frequency for safety-relevant messages
-      bool frequency_invalid = frequency < 10U;
-      if (lagging || frequency_invalid || !is_msg_valid(cfg->rx_checks, i)) {
-        rx_checks_invalid = true;
-        controls_allowed = false;
-      }
+    // enforce minimum frequency for safety-relevant messages
+    bool frequency_invalid = frequency < 10U;
+    if (lagging || frequency_invalid || !is_msg_valid(cfg->rx_checks, i)) {
+      rx_checks_invalid = true;
+      safety_controls_allowed_internal = false;
     }
   }
 
-  safety_rx_checks_invalid = rx_checks_invalid;
+  safety_rx_checks_invalid_internal = rx_checks_invalid;
+  safety_mode_cnt_internal += 1U;
+}
+
+safety_state safety_get_state(void) {
+  const safety_state state = {
+    .controls_allowed = safety_controls_allowed_internal,
+    .relay_malfunction = safety_relay_malfunction_internal,
+    .heartbeat_engaged = safety_heartbeat_engaged_internal,
+    .rx_checks_invalid = safety_rx_checks_invalid_internal,
+    .mode = safety_mode_internal,
+    .param = safety_param_internal,
+    .alternative_experience = safety_alternative_experience_internal,
+  };
+  return state;
+}
+
+void safety_disengage(void) {
+  safety_controls_allowed_internal = false;
+}
+
+void safety_set_alternative_experience(int mode) {
+  safety_alternative_experience_internal = mode;
+}
+
+void safety_set_heartbeat_engaged(bool engaged) {
+  safety_heartbeat_engaged_internal = engaged;
 }
 
 static void relay_malfunction_set(void) {
-  relay_malfunction = true;
+  safety_relay_malfunction_internal = true;
 }
 
 static void generic_rx_checks(void) {
@@ -353,19 +375,19 @@ static void generic_rx_checks(void) {
 
   // exit controls on rising edge of brake press
   if (brake_pressed && (!brake_pressed_prev || vehicle_moving)) {
-    controls_allowed = false;
+    safety_controls_allowed_internal = false;
   }
   brake_pressed_prev = brake_pressed;
 
   // exit controls on rising edge of regen paddle
   if (regen_braking && (!regen_braking_prev || vehicle_moving)) {
-    controls_allowed = false;
+    safety_controls_allowed_internal = false;
   }
   regen_braking_prev = regen_braking;
 
   // exit controls on rising edge of steering override/disengage
   if (steering_disengage && !steering_disengage_prev) {
-    controls_allowed = false;
+    safety_controls_allowed_internal = false;
   }
   steering_disengage_prev = steering_disengage;
 }
@@ -375,13 +397,13 @@ static void stock_ecu_check(bool stock_ecu_detected) {
   const uint32_t RELAY_TRNS_TIMEOUT = 1U;
 
   // check if stock ECU is on bus broken by car harness
-  if ((safety_mode_cnt > RELAY_TRNS_TIMEOUT) && stock_ecu_detected) {
+  if ((safety_mode_cnt_internal > RELAY_TRNS_TIMEOUT) && stock_ecu_detected) {
     relay_malfunction_set();
   }
 }
 
 static void relay_malfunction_reset(void) {
-  relay_malfunction = false;
+  safety_relay_malfunction_internal = false;
 }
 
 // resets values and min/max for sample_t struct
@@ -425,8 +447,8 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   };
 
   // reset state set by safety mode
-  safety_mode_cnt = 0U;
-  relay_malfunction = false;
+  safety_mode_cnt_internal = 0U;
+  safety_relay_malfunction_internal = false;
   gas_pressed = false;
   gas_pressed_prev = false;
   brake_pressed = false;
@@ -462,36 +484,36 @@ int set_safety_hooks(uint16_t mode, uint16_t param) {
   reset_sample(&angle_meas);
   reset_sample(&curvature_state.meas);
 
-  controls_allowed = false;
+  safety_controls_allowed_internal = false;
   relay_malfunction_reset();
-  safety_rx_checks_invalid = false;
+  safety_rx_checks_invalid_internal = false;
 
-  current_safety_config.rx_checks = NULL;
-  current_safety_config.rx_checks_len = 0;
-  current_safety_config.tx_msgs = NULL;
-  current_safety_config.tx_msgs_len = 0;
-  current_safety_config.disable_forwarding = false;
+  safety_config_internal.rx_checks = NULL;
+  safety_config_internal.rx_checks_len = 0;
+  safety_config_internal.tx_msgs = NULL;
+  safety_config_internal.tx_msgs_len = 0;
+  safety_config_internal.disable_forwarding = false;
 
   int set_status = -1;  // not set
   int hook_config_count = sizeof(safety_hook_registry) / sizeof(safety_hook_config);
   for (int i = 0; i < hook_config_count; i++) {
     if (safety_hook_registry[i].id == mode) {
       current_hooks = safety_hook_registry[i].hooks;
-      current_safety_mode = mode;
-      current_safety_param = param;
+      safety_mode_internal = mode;
+      safety_param_internal = param;
       set_status = 0;  // set
     }
   }
   if ((set_status == 0) && (current_hooks->init != NULL)) {
     safety_config cfg = current_hooks->init(param);
-    current_safety_config.rx_checks = cfg.rx_checks;
-    current_safety_config.rx_checks_len = cfg.rx_checks_len;
-    current_safety_config.tx_msgs = cfg.tx_msgs;
-    current_safety_config.tx_msgs_len = cfg.tx_msgs_len;
-    current_safety_config.disable_forwarding = cfg.disable_forwarding;
+    safety_config_internal.rx_checks = cfg.rx_checks;
+    safety_config_internal.rx_checks_len = cfg.rx_checks_len;
+    safety_config_internal.tx_msgs = cfg.tx_msgs;
+    safety_config_internal.tx_msgs_len = cfg.tx_msgs_len;
+    safety_config_internal.disable_forwarding = cfg.disable_forwarding;
     // reset all dynamic fields in addr struct
-    for (int j = 0; j < current_safety_config.rx_checks_len; j++) {
-      current_safety_config.rx_checks[j].status = (RxStatus){0};
+    for (int j = 0; j < safety_config_internal.rx_checks_len; j++) {
+      safety_config_internal.rx_checks[j].status = (RxStatus){0};
     }
   }
   return set_status;
@@ -534,10 +556,10 @@ int ROUND(float val) {
 void pcm_cruise_check(bool cruise_engaged) {
   // Enter controls on rising edge of stock ACC, exit controls if stock ACC disengages
   if (!cruise_engaged) {
-    controls_allowed = false;
+    safety_controls_allowed_internal = false;
   }
   if (cruise_engaged && !cruise_engaged_prev) {
-    controls_allowed = true;
+    safety_controls_allowed_internal = true;
   }
   cruise_engaged_prev = cruise_engaged;
 }
@@ -548,6 +570,11 @@ void speed_mismatch_check(const float speed_2) {
   const float MAX_SPEED_DELTA = 2.0;  // m/s
   bool is_invalid_speed = SAFETY_ABS(speed_2 - ((float)vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR)) > MAX_SPEED_DELTA;
   if (is_invalid_speed) {
-    controls_allowed = false;
+    safety_controls_allowed_internal = false;
   }
 }
+
+#ifdef OPENDBC_SAFETY_API_ONLY
+  #pragma GCC poison safety_controls_allowed_internal safety_relay_malfunction_internal safety_heartbeat_engaged_internal safety_rx_checks_invalid_internal
+  #pragma GCC poison safety_mode_internal safety_param_internal safety_config_internal safety_alternative_experience_internal safety_mode_cnt_internal
+#endif

--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -91,6 +91,24 @@ class SafetyTestBase(unittest.TestCase):
   def _tx(self, msg):
     return self.safety.safety_tx_hook(msg)
 
+  def test_public_api(self):
+    state = self.safety.safety_get_state()
+    self.assertEqual(state.mode, self.safety.get_current_safety_mode())
+    self.assertEqual(state.param, self.safety.get_current_safety_param())
+
+    self.safety.set_controls_allowed(True)
+    self.safety.safety_disengage()
+    self.assertFalse(self.safety.safety_get_state().controls_allowed)
+
+    self.safety.safety_set_heartbeat_engaged(True)
+    self.assertTrue(self.safety.safety_get_state().heartbeat_engaged)
+    self.safety.safety_set_heartbeat_engaged(False)
+
+    alternative_experience = state.alternative_experience
+    self.safety.safety_set_alternative_experience(alternative_experience + 1)
+    self.assertEqual(self.safety.safety_get_state().alternative_experience, alternative_experience + 1)
+    self.safety.safety_set_alternative_experience(alternative_experience)
+
   @staticmethod
   def _boundary_values(boundaries, min_val, max_val, step=1, width=5, sparse_count=100):
     """Generate test values dense around boundaries and sparse across the full range."""

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -56,10 +56,24 @@ class CANPacket:
   pass
 
 ffi.cdef("""
+typedef struct {
+  bool controls_allowed;
+  bool relay_malfunction;
+  bool heartbeat_engaged;
+  bool rx_checks_invalid;
+  uint16_t mode;
+  uint16_t param;
+  int alternative_experience;
+} safety_state;
+
 bool safety_rx_hook(CANPacket_t *msg);
 bool safety_tx_hook(CANPacket_t *msg);
 int safety_fwd_hook(int bus_num, int addr);
 int set_safety_hooks(uint16_t mode, uint16_t param);
+void safety_disengage(void);
+safety_state safety_get_state(void);
+void safety_set_alternative_experience(int mode);
+void safety_set_heartbeat_engaged(bool engaged);
 
 void set_controls_allowed(bool c);
 bool get_controls_allowed(void);

--- a/opendbc/safety/tests/libsafety/safety.c
+++ b/opendbc/safety/tests/libsafety/safety.c
@@ -14,17 +14,17 @@ uint32_t microsecond_timer_get(void) {
 #include "opendbc/safety/ignition.h"
 
 void safety_tick_current_safety_config() {
-  safety_tick(&current_safety_config);
+  safety_tick();
 }
 
 bool safety_config_valid() {
-  if (current_safety_config.rx_checks_len <= 0) {
+  if (safety_config_internal.rx_checks_len <= 0) {
     printf("missing RX checks\n");
     return false;
   }
 
-  for (int i = 0; i < current_safety_config.rx_checks_len; i++) {
-    const RxCheck addr = current_safety_config.rx_checks[i];
+  for (int i = 0; i < safety_config_internal.rx_checks_len; i++) {
+    const RxCheck addr = safety_config_internal.rx_checks[i];
     bool valid = addr.status.msg_seen && !addr.status.lagging && addr.status.valid_checksum && (addr.status.wrong_counters < MAX_WRONG_COUNTERS) && addr.status.valid_quality_flag;
     if (!valid) {
       // printf("i %d seen %d lagging %d valid checksum %d wrong counters %d valid quality flag %d\n", i, addr.status.msg_seen, addr.status.lagging, addr.status.valid_checksum, addr.status.wrong_counters, addr.status.valid_quality_flag);
@@ -35,15 +35,15 @@ bool safety_config_valid() {
 }
 
 void set_controls_allowed(bool c){
-  controls_allowed = c;
+  safety_controls_allowed_internal = c;
 }
 
 void set_alternative_experience(int mode){
-  alternative_experience = mode;
+  safety_alternative_experience_internal = mode;
 }
 
 void set_relay_malfunction(bool c){
-  relay_malfunction = c;
+  safety_relay_malfunction_internal = c;
 }
 
 void set_ignition_can(bool c){
@@ -51,7 +51,7 @@ void set_ignition_can(bool c){
 }
 
 bool get_controls_allowed(void){
-  return controls_allowed;
+  return safety_controls_allowed_internal;
 }
 
 bool get_ignition_can(void){
@@ -59,11 +59,11 @@ bool get_ignition_can(void){
 }
 
 int get_alternative_experience(void){
-  return alternative_experience;
+  return safety_alternative_experience_internal;
 }
 
 bool get_relay_malfunction(void){
-  return relay_malfunction;
+  return safety_relay_malfunction_internal;
 }
 
 bool get_gas_pressed_prev(void){
@@ -111,11 +111,11 @@ float get_vehicle_speed_max(void){
 }
 
 int get_current_safety_mode(void){
-  return current_safety_mode;
+  return safety_mode_internal;
 }
 
 int get_current_safety_param(void){
-  return current_safety_param;
+  return safety_param_internal;
 }
 
 void set_timer(uint32_t t){
@@ -222,8 +222,8 @@ bool get_honda_fwd_brake(void){
 }
 
 void init_tests(void){
-  safety_mode_cnt = 2U;  // avoid ignoring relay_malfunction logic
-  alternative_experience = 0;
+  safety_mode_cnt_internal = 2U;  // avoid ignoring safety_relay_malfunction_internal logic
+  safety_alternative_experience_internal = 0;
   set_timer(0);
   ts_steer_req_mismatch_last = 0;
   valid_steer_req_count = 0;

--- a/opendbc/safety/tests/misra/main.c
+++ b/opendbc/safety/tests/misra/main.c
@@ -5,10 +5,14 @@
 extern uint32_t microsecond_timer_get(void);
 
 // Ignore misra-c2012-8.7 as these functions are only called from libsafety
-SAFETY_UNUSED(heartbeat_engaged);
+SAFETY_UNUSED(safety_heartbeat_engaged_internal);
 
 SAFETY_UNUSED(safety_rx_hook);
 SAFETY_UNUSED(safety_tx_hook);
 SAFETY_UNUSED(safety_fwd_hook);
 SAFETY_UNUSED(safety_tick);
+SAFETY_UNUSED(safety_get_state);
+SAFETY_UNUSED(safety_disengage);
+SAFETY_UNUSED(safety_set_alternative_experience);
+SAFETY_UNUSED(safety_set_heartbeat_engaged);
 SAFETY_UNUSED(set_safety_hooks);

--- a/opendbc/safety/tests/test_api.py
+++ b/opendbc/safety/tests/test_api.py
@@ -1,0 +1,26 @@
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[3]
+
+
+def compile_header(header: str) -> subprocess.CompletedProcess:
+  return subprocess.run(
+    ["cc", "-Werror", "-std=gnu11", "-fsyntax-only", "-x", "c", "-I", str(ROOT), "-"],
+    input=f'#include "{header}"',
+    text=True,
+    capture_output=True,
+    check=False,
+  )
+
+
+def test_public_api_header():
+  result = compile_header("opendbc/safety/api.h")
+  assert result.returncode == 0, result.stderr
+
+
+def test_internal_header_is_rejected():
+  result = compile_header("opendbc/safety/declarations.h")
+  assert result.returncode != 0
+  assert "internal opendbc safety header" in result.stderr


### PR DESCRIPTION
Defines the supported safety interface in `opendbc/safety/api.h` and makes internal-header access a compile-time error.