### PR TITLE
VW MEB: fix long control states

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -41,7 +41,8 @@ class CarController(CarControllerBase):
     self.packer_pt = CANPacker(dbc_names[Bus.pt])
     self.aeb_available = not CP.flags & VolkswagenFlags.PQ
 
-    self.meb_long_state_machine = mebcan.MebLongStateMachine(self.CP, self.CCP)
+    if CP.flags & VolkswagenFlags.MEB:
+      self.meb_long_state = mebcan.MebLongStateMachine(self.CP, self.CCP)
 
     if CP.flags & VolkswagenFlags.PQ:
       self.CCS = pqcan
@@ -135,17 +136,16 @@ class CarController(CarControllerBase):
 
     if self.CP.openpilotLongitudinalControl:
       if self.frame % self.CCP.ACC_CONTROL_STEP == 0:
-        stopping = actuators.longControlState == LongCtrlState.stopping
-
         if self.CP.flags & VolkswagenFlags.MEB:
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
-          acc_status, acc_hold_type, accel, braking_to_stop = self.meb_long_state_machine.update(CS, CC, accel)
+          acc_status, acc_hold_type, accel, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
                                                            accel, acc_status, acc_hold_type, braking_to_stop,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
           self.accel_last = accel
 
         else:
+          stopping = actuators.longControlState == LongCtrlState.stopping
           acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
           starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < 0.25)

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -41,6 +41,8 @@ class CarController(CarControllerBase):
     self.packer_pt = CANPacker(dbc_names[Bus.pt])
     self.aeb_available = not CP.flags & VolkswagenFlags.PQ
 
+    self.meb_long_state_machine = mebcan.MebLongStateMachine(self.CP, self.CCP)
+
     if CP.flags & VolkswagenFlags.PQ:
       self.CCS = pqcan
     elif CP.flags & VolkswagenFlags.MLB:

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -154,7 +154,7 @@ class CarController(CarControllerBase):
           # acc_control = mebcan.get_acc_control(CS.out, CC, long_override)
           # acc_hold_type = mebcan.get_acc_hold_type(CS.out, CC, starting, stopping,
           #                                          CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
-          acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS.out, CC, accel)
+          acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
                                                            accel, acc_status, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, long_override, CS.travel_assist_available))

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -54,8 +54,6 @@ class CarController(CarControllerBase):
     self.apply_curvature_last = 0.
     self.steering_power_last = 0
     self.accel_last = 0.
-    self.long_override_counter = 0
-    self.long_disabled_counter = 0
     self.lead_distance_bars_last = None
     self.distance_bar_frame = 0
     self.gra_acc_counter_last = None
@@ -140,19 +138,7 @@ class CarController(CarControllerBase):
         stopping = actuators.longControlState == LongCtrlState.stopping
 
         if self.CP.flags & VolkswagenFlags.MEB:
-          # only send ACC_HMS_RELEASE when in cruise standstill and want to resume
-          # starting = actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))# if CC.enabled else 0)
-          #
-          # long_override = CC.cruiseControl.override or CS.out.gasPressed
-          # self.long_override_counter = min(self.long_override_counter + 1, 5) if long_override else 0
-          # long_override_begin = long_override and self.long_override_counter < 5
-          #
-          # self.long_disabled_counter = min(self.long_disabled_counter + 1, 5) if not CC.enabled else 0
-          # long_disabling = not CC.enabled and self.long_disabled_counter < 5
-          #
-          # acc_hold_type = mebcan.get_acc_hold_type(CS.out, CC, starting, stopping,
-          #                                          CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
+          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
           acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
                                                            accel, acc_status, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -154,7 +154,7 @@ class CarController(CarControllerBase):
           # acc_control = mebcan.get_acc_control(CS.out, CC, long_override)
           # acc_hold_type = mebcan.get_acc_hold_type(CS.out, CC, starting, stopping,
           #                                          CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
-          acc_status, acc_hold_type, accel = self.meb_long_state_machine.step(CS.out, CC, accel)
+          acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS.out, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
                                                            accel, acc_status, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, long_override, CS.travel_assist_available))

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -141,7 +141,7 @@ class CarController(CarControllerBase):
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
           acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
-                                                           accel, acc_status, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,
+                                                           accel, acc_status, acc_hold_type, CS.esp_hold_confirmation,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
           self.accel_last = accel
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -151,7 +151,6 @@ class CarController(CarControllerBase):
           # self.long_disabled_counter = min(self.long_disabled_counter + 1, 5) if not CC.enabled else 0
           # long_disabling = not CC.enabled and self.long_disabled_counter < 5
           #
-          # acc_control = mebcan.get_acc_control(CS.out, CC, long_override)
           # acc_hold_type = mebcan.get_acc_hold_type(CS.out, CC, starting, stopping,
           #                                          CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
           acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS, CC, accel)

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -156,7 +156,7 @@ class CarController(CarControllerBase):
           acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
                                                            accel, acc_status, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,
-                                                           CS.out.vEgoRaw * CV.MS_TO_KPH, long_override, CS.travel_assist_available))
+                                                           CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
           self.accel_last = accel
 
         else:

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -177,8 +177,7 @@ class CarController(CarControllerBase):
         lead_distance = 0
         if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:
           lead_distance = 8
-        acc_hud_status = mebcan.get_acc_hud_status(CS.out, CC, CC.cruiseControl.override or CS.out.gasPressed)
-        can_sends.append(mebcan.create_acc_hud_control(self.packer_pt, self.CAN.pt, acc_hud_status, hud_control.setSpeed * CV.MS_TO_KPH,
+        can_sends.append(mebcan.create_acc_hud_control(self.packer_pt, self.CAN.pt, self.meb_long_state.acc_status, hud_control.setSpeed * CV.MS_TO_KPH,
                                                        hud_control.leadVisible, hud_control.leadDistanceBars + 1, show_distance_bars,
                                                        CS.esp_hold_confirmation, lead_distance, 0, fcw_alert))
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -139,9 +139,9 @@ class CarController(CarControllerBase):
 
         if self.CP.flags & VolkswagenFlags.MEB:
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
-          acc_status, acc_hold_type, accel = self.meb_long_state_machine.update(CS, CC, accel)
+          acc_status, acc_hold_type, accel, braking_to_stop = self.meb_long_state_machine.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
-                                                           accel, acc_status, acc_hold_type, CS.esp_hold_confirmation,
+                                                           accel, acc_status, acc_hold_type, braking_to_stop,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
           self.accel_last = accel
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -141,21 +141,22 @@ class CarController(CarControllerBase):
 
         if self.CP.flags & VolkswagenFlags.MEB:
           # only send ACC_HMS_RELEASE when in cruise standstill and want to resume
-          starting = actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.enabled else 0)
-
-          long_override = CC.cruiseControl.override or CS.out.gasPressed
-          self.long_override_counter = min(self.long_override_counter + 1, 5) if long_override else 0
-          long_override_begin = long_override and self.long_override_counter < 5
-
-          self.long_disabled_counter = min(self.long_disabled_counter + 1, 5) if not CC.enabled else 0
-          long_disabling = not CC.enabled and self.long_disabled_counter < 5
-
-          acc_control = mebcan.get_acc_control(CS.out, CC, long_override)
-          acc_hold_type = mebcan.get_acc_hold_type(CS.out, CC, starting, stopping,
-                                                   CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
+          # starting = actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
+          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))# if CC.enabled else 0)
+          #
+          # long_override = CC.cruiseControl.override or CS.out.gasPressed
+          # self.long_override_counter = min(self.long_override_counter + 1, 5) if long_override else 0
+          # long_override_begin = long_override and self.long_override_counter < 5
+          #
+          # self.long_disabled_counter = min(self.long_disabled_counter + 1, 5) if not CC.enabled else 0
+          # long_disabling = not CC.enabled and self.long_disabled_counter < 5
+          #
+          # acc_control = mebcan.get_acc_control(CS.out, CC, long_override)
+          # acc_hold_type = mebcan.get_acc_hold_type(CS.out, CC, starting, stopping,
+          #                                          CS.esp_hold_confirmation, long_override, long_override_begin, long_disabling)
+          acc_status, acc_hold_type, accel = self.meb_long_state_machine.step(CS.out, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
-                                                           accel, acc_control, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,
+                                                           accel, acc_status, acc_hold_type, stopping, starting, CS.esp_hold_confirmation,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, long_override, CS.travel_assist_available))
           self.accel_last = accel
 

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -138,7 +138,7 @@ class CarController(CarControllerBase):
       if self.frame % self.CCP.ACC_CONTROL_STEP == 0:
         if self.CP.flags & VolkswagenFlags.MEB:
           accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
-          acc_status, acc_hold_type, accel, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
+          accel, acc_status, acc_hold_type, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
           can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
                                                            accel, acc_status, acc_hold_type, braking_to_stop,
                                                            CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -259,10 +259,10 @@ class CarState(CarStateBase):
       ret.gearShifter = self.parse_gear_shifter(self.CCP.shifter_values.get(pt_cp.vl["Gateway_73"]["GE_Fahrstufe"], None))
     else:
       ret.gearShifter = self.parse_gear_shifter(self.CCP.shifter_values.get(pt_cp.vl["Getriebe_11"]["GE_Fahrstufe"], None))
-    drive_mode = ret.gearShifter == GearShifter.drive
+    drive_gear = ret.gearShifter == GearShifter.drive
 
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["QFK_01"]["LatCon_HCA_Status"])
-    ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status, drive_mode)
+    ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status, drive_gear)
 
     ret.carFaultedNonCritical = cam_cp.vl["EA_01"]["EA_Funktionsstatus"] in (3, 4, 5, 6)
 
@@ -297,8 +297,8 @@ class CarState(CarStateBase):
       ret.cruiseState.nonAdaptive = bool(pt_cp.vl["Motor_51"]["TSK_Limiter_ausgewaehlt"])
     accFaulted = (pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7) or
                   ext_cp.vl["ACC_19"]["ACC_Status_ACC"] == 6)  # reversible fault in ACC system
-    ret.accFaulted = self.update_acc_fault(accFaulted, parking_brake=ret.parkingBrake, drive_mode=drive_mode,
-                                            brake_pressed=ret.brakePressed)
+    ret.accFaulted = self.update_acc_fault(accFaulted, parking_brake=ret.parkingBrake, drive_gear=drive_gear,
+                                           brake_pressed=ret.brakePressed)
 
     ret.leftBlinker, ret.rightBlinker = self.update_blinker_from_stalk(240, pt_cp.vl["SMLS_01"]["BH_Blinker_li"],
                                                                             pt_cp.vl["SMLS_01"]["BH_Blinker_re"])
@@ -388,31 +388,31 @@ class CarState(CarStateBase):
       self.low_speed_alert = False
     return self.low_speed_alert
 
-  def parse_mlb_mqb_steering_state(self, ret, pt_cp, drive_mode=True):
+  def parse_mlb_mqb_steering_state(self, ret, pt_cp, drive_gear=True):
     ret.steeringAngleDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradwinkel"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradwinkel"])]
     ret.steeringRateDeg = pt_cp.vl["LWI_01"]["LWI_Lenkradw_Geschw"] * (1, -1)[int(pt_cp.vl["LWI_01"]["LWI_VZ_Lenkradw_Geschw"])]
     ret.steeringTorque = pt_cp.vl["LH_EPS_03"]["EPS_Lenkmoment"] * (1, -1)[int(pt_cp.vl["LH_EPS_03"]["EPS_VZ_Lenkmoment"])]
     ret.steeringPressed = abs(ret.steeringTorque) > self.CCP.STEER_DRIVER_ALLOWANCE
 
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
-    ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status, drive_mode)
+    ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status, drive_gear)
     return
 
-  def update_hca_state(self, hca_status, drive_mode=True):
+  def update_hca_state(self, hca_status, drive_gear=True):
     # Treat FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
     self.eps_init_complete = self.eps_init_complete or (hca_status in ("DISABLED", "READY", "ACTIVE") or self.frame > 600)
-    perm_fault = drive_mode and hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
-    temp_fault = drive_mode and hca_status in ("REJECTED", "PREEMPTED") or not self.eps_init_complete
+    perm_fault = drive_gear and hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
+    temp_fault = drive_gear and hca_status in ("REJECTED", "PREEMPTED") or not self.eps_init_complete
     return temp_fault, perm_fault
 
-  def update_acc_fault(self, acc_fault, parking_brake=False, drive_mode=True, brake_pressed=False, recovery_frames_max=300):
+  def update_acc_fault(self, acc_fault, parking_brake=False, drive_gear=True, brake_pressed=False, recovery_frames_max=300):
     # Ignore FAULT when not in drive mode and parked
     # do not show misleading error during ignition in parked state
     # grant a short time to recover a normal cruise state
     # after hard brake, stock system prevents acc engage for ~3 seconds
     fault = acc_fault
-    if (parking_brake and not drive_mode) or brake_pressed:
+    if (parking_brake and not drive_gear) or brake_pressed:
       fault = False
       self.cruise_recovery_timer = self.frame
     elif self.frame - self.cruise_recovery_timer < recovery_frames_max:

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -99,9 +99,10 @@ class MebLongState(IntEnum):
   DISABLED = 0
   FAULTED = 1
   ENABLED = 2
-  HOLDING = 3
-  OVERRIDE = 4
-  RELEASING = 5
+  ACTIVE = 3
+  STOPPING = 4
+  OVERRIDE = 5
+  RELEASING = 6
 
 
 class MebLongStateMachine:

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -108,45 +108,49 @@ class MebLongStateMachine:
     self.acc_status_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Status_ACC'].items()}
     self.acc_hold_type_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Anforderung_HMS'].items()}
 
-    self.prev_acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+    self.prev_acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
 
-  def acc_status(self, CS, CC):
+  def _get_acc_status(self, CS, CC) -> int:
     # stateless
-    if CS.accFaulted:
-      return self.acc_status_vals['reversibler_Fehler_im_ACC_System']
+    if CS.out.accFaulted:
+      return self.acc_status_vals['REVERSIBLER_FEHLER_IM_ACC_SYSTEM']
     elif CC.enabled:
       return self.acc_status_vals['ACC_OVERRIDE' if CC.cruiseControl.override else 'ACC_AKTIV_regelt']
-    elif CS.cruiseState.available:
+    elif CS.out.cruiseState.available:
       return self.acc_status_vals['ACC_STANDBY']
     else:
-      return self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
+      return self.acc_status_vals['ACC_OFF_HAUPTSCHALTER_AUS']  # disabled
 
-  def update(self, CS, CC, accel):
-    acc_status = self.acc_status(CS, CC)
-
+  def _get_hold_type(self, CS, CC) -> int:
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
     starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
 
-    if CS.accFaulted or not CC.longActive:
-      acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+    if CS.out.accFaulted or not CC.longActive:
+      acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
     elif stopping:
-      acc_hold_type = self.acc_hold_type_vals['halten']  # stopping/stopped
+      acc_hold_type = self.acc_hold_type_vals['HALTEN']  # stopping/stopped
     elif starting:
-      acc_hold_type = self.acc_hold_type_vals['anfahren']  # resume after reaching full stop
+      acc_hold_type = self.acc_hold_type_vals['ANFAHREN']  # resume after reaching full stop
     else:
-      acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+      acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
 
     # enforce legal transitions
     if acc_hold_type == self.acc_hold_type_vals['halten']:
       # allow going into hold at any time, reset ramp counter
       self.ramp_counter = 0
-    elif acc_hold_type == self.acc_hold_type_vals['keine_Anforderung'] and self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
+    elif acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG'] and self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
       # if we request to hold but never hit standstill before wanting to resume, we match stock and send just ramp
-      acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
+      acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter = self.RAMP_FRAMES
     elif self.ramp_counter > 0:
-      acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
+      acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter -= 1
+
+    return acc_hold_type
+
+  def update(self, CS, CC, accel):
+    acc_status = self._get_acc_status(CS, CC)
+    acc_hold_type = self._get_hold_type(CS, CC)
 
     held = CS.esp_hold_confirmation and acc_hold_type == self.acc_hold_type_vals['halten']
     if not CC.enabled or held:
@@ -156,7 +160,6 @@ class MebLongStateMachine:
 
     self.prev_acc_hold_type = acc_hold_type
     self.frame += 1
-
     return acc_status, acc_hold_type, accel
 
 

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -86,7 +86,7 @@ ACC_HUD_DISABLED = 0
 class MebLongStateMachine:
   def __init__(self, CP, CCP):
     self.CCP = CCP
-    self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP
+    self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP  # 100 ms
 
     self.ramp_counter = 0
 

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -121,7 +121,7 @@ class MebLongStateMachine:
     else:
       acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
 
-    # enforce legal transitions.
+    # enforce legal transitions
     if acc_hold_type == self.acc_hold_type_vals['HALTEN']:
       # allow going into hold at any time, reset ramp counter
       self.ramp_counter = 0

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -86,8 +86,6 @@ ACC_HUD_DISABLED = 0
 class MebLongStateMachine:
   def __init__(self, CP, CCP):
     self.CCP = CCP
-    self.frame = 0
-
     self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP
 
     self.ramp_counter = 0
@@ -152,7 +150,6 @@ class MebLongStateMachine:
     braking_to_stop = acc_hold_type == self.acc_hold_type_vals['HALTEN'] and not CS.esp_hold_confirmation
 
     self.prev_acc_hold_type = acc_hold_type
-    self.frame += 1
     return acc_status, acc_hold_type, accel, braking_to_stop
 
 
@@ -162,9 +159,9 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
   # error mitigation when stopping or stopped: (newer gen cars can be very sensitive)
   # - send 0 m stopping distance for cars in kind of parameterized stopping mode (stopping accel -0.2 seen for those cars)
   # -> this mode is seen for different cars with same firmware radars so could be a coded operational mode
-  # - jerk and control limits values set to 0 when fully stopped
+  # - jerk and control limits values set inactive together when fully stopped
   # - set accel to 0 / no stop accel for full stop (seems to be compatible with old (non 0 stop accel) and new gen, because HMS state holds the car anyways)
-  # - stopping command sent as long as actually stopping
+  # - stopping command sent while requesting stop but ESP is not in standstill
   commands = []
 
   # ACC_Anhalteweg: when stopping: MEB: values <> 0 the car can execute a hard brake probably if target is too close, MQBEvo: value 0 results in hard brake

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -117,16 +117,24 @@ class MebLongStateMachine:
     acc_status = self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
     acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
 
+    stopping = CC.actuators.longControlState == LongCtrlState.stopping
+
     if CS.accFaulted:
       self.state = MebLongState.FAULTED
     elif CC.enabled:
-      # TODO: what happens if you engage at stop with foot on brake?
+      # normally active or pre-enabled at a stop with foot on brake
       if CC.longActive:
         acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
       else:
+        # gas overriding
         acc_status = self.acc_status_vals['ACC_OVERRIDE']
     elif CS.cruiseState.available:
       acc_status = self.acc_status_vals['ACC_STANDBY']
+
+    if acc_status == self.acc_status_vals['ACC_AKTIV_regelt']:
+      if stopping:
+        acc_hold_type = self.acc_hold_type_vals['halten']
+        accel = self.CCP.ACCEL_OVERRIDE
 
 
     # if CS.accFaulted:
@@ -137,6 +145,8 @@ class MebLongStateMachine:
     #   if CS.gasPressed:
     #     pass
     #   elif
+
+    return acc_status, acc_hold_type, accel
 
   def update(self, accel):
     acc_status = ACC_CTRL_DISABLED

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -109,10 +109,24 @@ class MebLongStateMachine:
   def __init__(self, CP, CCP):
     self.CCP = CCP
     self.state = MebLongState.DISABLED
+    self.frame = 0
 
     can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
     self.acc_status_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Status_ACC'].items()}
     self.acc_hold_type_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Anforderung_HMS'].items()}
+
+    self.prev_acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+
+  def acc_status(self, CS, CC, override):
+    # stateless: ACC_Status_ACC is a pure function of this frame's inputs, no memory needed
+    if CS.accFaulted:
+      return self.acc_status_vals['reversibler_Fehler_im_ACC_System']  # error state
+    elif CC.enabled:
+      return self.acc_status_vals['ACC_OVERRIDE' if override else 'ACC_AKTIV_regelt']  # overriding / active
+    elif CS.cruiseState.available:
+      return self.acc_status_vals['ACC_STANDBY']  # long control ready
+    else:
+      return self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # long control deactivated
 
   def step(self, CS, CC, accel):
     acc_status = self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
@@ -122,20 +136,33 @@ class MebLongStateMachine:
 
     if CS.accFaulted:
       self.state = MebLongState.FAULTED
-    elif CC.enabled:
-      # normally active or pre-enabled at a stop with foot on brake
-      if CC.longActive:
-        acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
-      else:
-        # gas overriding
-        acc_status = self.acc_status_vals['ACC_OVERRIDE']
-    elif CS.cruiseState.available:
-      acc_status = self.acc_status_vals['ACC_STANDBY']
 
-    if acc_status == self.acc_status_vals['ACC_AKTIV_regelt']:
-      if stopping:
-        acc_hold_type = self.acc_hold_type_vals['halten']
-        accel = self.CCP.ACCEL_OVERRIDE
+    elif not CS.cruiseState.available:
+      self.state = MebLongState.DISABLED
+
+    else:
+      if CC.enabled:
+        # normally active or pre-enabled at a stop with foot on brake
+        if CC.longActive:
+          self.state = MebLongState.STOPPING if stopping else MebLongState.ACTIVE
+          acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
+        else:
+          # gas overriding
+          acc_status = self.acc_status_vals['ACC_OVERRIDE']
+
+      else:
+        pass
+
+
+
+
+
+
+    # # wtf
+    # if acc_status == self.acc_status_vals['ACC_AKTIV_regelt']:
+    #   if stopping:
+    #     acc_hold_type = self.acc_hold_type_vals['halten']
+    #     accel = self.CCP.ACCEL_OVERRIDE
 
 
     # if CS.accFaulted:
@@ -146,6 +173,9 @@ class MebLongStateMachine:
     #   if CS.gasPressed:
     #     pass
     #   elif
+
+    self.prev_acc_hold_type = acc_hold_type
+    self.frame += 1
 
     return acc_status, acc_hold_type, accel
 

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -188,7 +188,7 @@ def get_acc_hold_type(CS, CC, starting, stopping, esp_hold, long_override, long_
 
 
 def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_status, acc_hold_type,
-                             stopping, starting, esp_hold, speed, long_override, travel_assist_available):
+                             stopping, starting, esp_hold, speed, travel_assist_available):
   # active longitudinal control disables one pedal driving (regen mode) while using overriding mechanism
   # error mitigation when stopping or stopped: (newer gen cars can be very sensitive)
   # - send 0 m stopping distance for cars in kind of parameterized stopping mode (stopping accel -0.2 seen for those cars)
@@ -201,25 +201,14 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
   # ACC_Anhalteweg: when stopping: MEB: values <> 0 the car can execute a hard brake probably if target is too close, MQBEvo: value 0 results in hard brake
   terminal_rollout = 0
 
-  full_stop = stopping and esp_hold
   full_stop_no_start = esp_hold and not starting
   actually_stopping = stopping and not esp_hold
-
-  if acc_enabled:
-    if long_override:  # the car expects a non-inactive accel while overriding
-      acceleration = CCP.ACCEL_OVERRIDE  # original ACC still sends active accel in this case (seamless experience)
-    elif full_stop:
-      acceleration = CCP.ACCEL_INACTIVE  # inactive accel, newer gen >2024 error of not neutral value
-    else:
-      acceleration = accel
-  else:
-    acceleration = CCP.ACCEL_INACTIVE  # inactive accel
 
   values = {
     "ACC_Typ":                    acc_type,
     "ACC_Status_ACC":             acc_status,
     "ACC_StartStopp_Info":        acc_enabled,
-    "ACC_Sollbeschleunigung_02":  acceleration,
+    "ACC_Sollbeschleunigung_02":  accel,
     "ACC_zul_Regelabw_unten":     0,
     "ACC_zul_Regelabw_oben":      0,
     "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_status in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -134,7 +134,6 @@ class MebLongStateMachine:
 
   def step(self, CS, CC, accel):
     acc_status = self.acc_status(CS, CC)
-    # acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
 
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
     starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
@@ -160,86 +159,6 @@ class MebLongStateMachine:
       acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
       self.ramp_counter -= 1
 
-    # if acc_hold_type == self.acc_hold_type_vals['keine_Anforderung'] and self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
-    #   # requesting to release brakes, starting from stop or overriding?
-    #   # if we request to hold but never hit standstill before wanting to resume, we match stock and send just ramp
-    #   if starting:
-    #     acc_hold_type = self.acc_hold_type_vals['anfahren']
-    #   else:
-    #     acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
-    #     self.ramp_counter = self.RAMP_FRAMES
-    #
-    # elif acc_hold_type == self.acc_hold_type_vals['Loesen_ueber_Rampe']:
-    #   self.ramp_counter -= 1
-    #   if self.ramp_counter <= 0:
-    #     acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
-
-    # if CS.accFaulted:
-    #   acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
-    #   # self.ramp_counter = 0
-    #   # # self.hold = None
-    #   # # self.state = MebLongState.FAULTED
-    #
-    # # elif self.prev_acc_hold_type == self.acc_hold_type_vals['Loesen_ueber_Rampe']:
-    # #   self.ramp_counter -= 1
-    # #   acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe'] if self.ramp_counter > 0 else self.acc_hold_type_vals['keine_Anforderung']
-    #
-    # elif not CC.longActive:
-    #   acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
-    #   # if self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
-    #   #   self.ramp_counter = self.RAMP_FRAMES
-    #   #   acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
-    #
-    # elif stopping:
-    #   acc_hold_type = self.acc_hold_type_vals['halten']
-    #
-    # else:
-    #   acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
-
-
-
-
-    # elif not CS.cruiseState.available:
-    #   self.state = MebLongState.DISABLED
-    #
-    # else:
-    #   if CC.enabled:
-    #     # normally active or pre-enabled at a stop with foot on brake
-    #     if CC.longActive:
-    #       self.state = MebLongState.STOPPING if stopping else MebLongState.ACTIVE
-    #       acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
-    #     else:
-    #       # gas overriding
-    #       acc_status = self.acc_status_vals['ACC_OVERRIDE']
-    #
-    #   else:
-    #     pass
-
-
-
-
-
-
-    # # wtf
-    # if acc_status == self.acc_status_vals['ACC_AKTIV_regelt']:
-    #   if stopping:
-    #     acc_hold_type = self.acc_hold_type_vals['halten']
-    #     accel = self.CCP.ACCEL_OVERRIDE
-
-
-    # if CS.accFaulted:
-    #   acc_status = ACC_CTRL_ERROR
-    #   acc_hold_type = ACC_HMS_NO_REQUEST
-    # elif not CC.longActive:
-    #   # gas override
-    #   if CS.gasPressed:
-    #     pass
-    #   elif
-
-    # if not CC.enabled:
-    #   accel = self.CCP.ACCEL_INACTIVE
-    # elif override:
-    #   accel = self.CCP.ACCEL_OVERRIDE
 
     self.prev_acc_hold_type = acc_hold_type
     self.frame += 1

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -136,21 +136,20 @@ class MebLongStateMachine:
 
     return acc_hold_type
 
-  def update(self, CS, CC, accel):
+  def update(self, CS, CC, accel) -> tuple[float, int, int, bool]:
     acc_status = self._get_acc_status(CS, CC)
     acc_hold_type = self._get_hold_type(CS, CC)
 
-    held = CS.esp_hold_confirmation and acc_hold_type == self.acc_hold_type_vals['HALTEN']
+    requesting_hold = acc_hold_type == self.acc_hold_type_vals['HALTEN']
+    held = requesting_hold and CS.esp_hold_confirmation
     if not CC.enabled or held:
       accel = self.CCP.ACCEL_INACTIVE
-    else:
-      accel = accel
 
     # hold requested but the car hasn't reached standstill yet
-    braking_to_stop = acc_hold_type == self.acc_hold_type_vals['HALTEN'] and not CS.esp_hold_confirmation
+    braking_to_stop = requesting_hold and not CS.esp_hold_confirmation
 
     self.prev_acc_hold_type = acc_hold_type
-    return acc_status, acc_hold_type, accel, braking_to_stop
+    return accel, acc_status, acc_hold_type, braking_to_stop
 
 
 def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_status, acc_hold_type,

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -122,6 +122,7 @@ class MebLongStateMachine:
       return self.acc_status_vals['ACC_OFF_HAUPTSCHALTER_AUS']  # disabled
 
   def _get_hold_type(self, CS, CC) -> int:
+    # warning: car is reacting to hold mechanic even with long control off
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
     starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
 
@@ -134,12 +135,13 @@ class MebLongStateMachine:
     else:
       acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
 
-    # enforce legal transitions
+    # enforce legal transitions.
     if acc_hold_type == self.acc_hold_type_vals['halten']:
       # allow going into hold at any time, reset ramp counter
       self.ramp_counter = 0
-    elif acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG'] and self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
-      # if we request to hold but never hit standstill before wanting to resume, we match stock and send just ramp
+    elif self.prev_acc_hold_type == self.acc_hold_type_vals['halten'] and acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG']:
+      # HALTEN -> NONE causes car to fault into park. this enforces HALTEN -> RAMP if user overrides, or
+      # if we requested to hold but never hit standstill before wanting to go again, we match stock and send just RAMP.
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter = self.RAMP_FRAMES
     elif self.ramp_counter > 0:
@@ -161,30 +163,6 @@ class MebLongStateMachine:
     self.prev_acc_hold_type = acc_hold_type
     self.frame += 1
     return acc_status, acc_hold_type, accel
-
-
-def get_acc_hold_type(CS, CC, starting, stopping, esp_hold, long_override, long_override_begin, long_disabling):
-  # warning: car is reacting to hold mechanic even with long control off
-  if CS.accFaulted:
-    acc_hold_type = ACC_HMS_NO_REQUEST  # no hold request
-  elif not CC.enabled:
-    if long_disabling:
-      acc_hold_type = ACC_HMS_RAMP_RELEASE  # ramp release of requests right after disabling long control (prevents car error with EPB at low speed)
-    else:
-      acc_hold_type = ACC_HMS_NO_REQUEST  # no hold request
-  elif long_override:
-    if long_override_begin:
-      acc_hold_type = ACC_HMS_RAMP_RELEASE  # ramp release of requests at the beginning of override (prevents car error with EPB at low speed)
-    else:
-      acc_hold_type = ACC_HMS_NO_REQUEST  # overriding / no request
-  elif starting:
-    acc_hold_type = ACC_HMS_RELEASE  # release request and startup
-  elif stopping:
-    acc_hold_type = ACC_HMS_HOLD  # hold while stopping/stopped
-  else:
-    acc_hold_type = ACC_HMS_NO_REQUEST  # no hold request
-
-  return acc_hold_type
 
 
 def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_status, acc_hold_type,

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -163,22 +163,6 @@ class MebLongStateMachine:
     return acc_status, acc_hold_type, accel
 
 
-def get_acc_status(CS, CC, long_override):
-  if CS.accFaulted:
-    acc_status = ACC_CTRL_ERROR  # error state
-  elif CC.enabled:
-    if long_override:
-      acc_status = ACC_CTRL_OVERRIDE  # overriding
-    else:
-      acc_status = ACC_CTRL_ACTIVE  # active long control state
-  elif CS.cruiseState.available:
-    acc_status = ACC_CTRL_ENABLED  # long control ready
-  else:
-    acc_status = ACC_CTRL_DISABLED  # long control deactivated state
-
-  return acc_status
-
-
 def get_acc_hold_type(CS, CC, starting, stopping, esp_hold, long_override, long_override_begin, long_disabling):
   # warning: car is reacting to hold mechanic even with long control off
   if CS.accFaulted:

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -95,20 +95,9 @@ ACC_HUD_ENABLED  = 2
 ACC_HUD_DISABLED = 0
 
 
-class MebLongState(IntEnum):
-  DISABLED = 0
-  FAULTED = 1
-  ENABLED = 2
-  ACTIVE = 3
-  STOPPING = 4
-  OVERRIDE = 5
-  RELEASING = 6
-
-
 class MebLongStateMachine:
   def __init__(self, CP, CCP):
     self.CCP = CCP
-    self.state = MebLongState.DISABLED
     self.frame = 0
 
     self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP
@@ -132,7 +121,7 @@ class MebLongStateMachine:
     else:
       return self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
 
-  def step(self, CS, CC, accel):
+  def update(self, CS, CC, accel):
     acc_status = self.acc_status(CS, CC)
 
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
@@ -159,20 +148,16 @@ class MebLongStateMachine:
       acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
       self.ramp_counter -= 1
 
+    held = CS.esp_hold_confirmation and acc_hold_type == self.acc_hold_type_vals['halten']
+    if not CC.enabled or held:
+      accel = self.CCP.ACCEL_INACTIVE
+    else:
+      accel = accel
 
     self.prev_acc_hold_type = acc_hold_type
     self.frame += 1
 
     return acc_status, acc_hold_type, accel
-
-  def update(self, accel):
-    acc_status = ACC_CTRL_DISABLED
-    acc_hold_type = ACC_HMS_NO_REQUEST
-
-    ...
-
-    return acc_status, acc_hold_type, accel
-
 
 
 def get_acc_status(CS, CC, long_override):

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -110,6 +110,7 @@ class MebLongStateMachine:
 
   def _get_hold_type(self, CS, CC) -> int:
     # warning: car is reacting to hold mechanic even with long control off
+    # NOTE: this allows KEINE_ANFORDERUNG -> ANFAHREN, but we haven't observed a fault due to this yet
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
     starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
 

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -1,4 +1,3 @@
-from enum import IntEnum
 from opendbc.car import Bus, structs
 from opendbc.can import CANDefine
 from opendbc.car.volkswagen.values import DBC
@@ -166,7 +165,7 @@ class MebLongStateMachine:
 
 
 def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_status, acc_hold_type,
-                             stopping, starting, esp_hold, speed, travel_assist_available):
+                             esp_hold, speed, travel_assist_available):
   # active longitudinal control disables one pedal driving (regen mode) while using overriding mechanism
   # error mitigation when stopping or stopped: (newer gen cars can be very sensitive)
   # - send 0 m stopping distance for cars in kind of parameterized stopping mode (stopping accel -0.2 seen for those cars)
@@ -179,8 +178,9 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
   # ACC_Anhalteweg: when stopping: MEB: values <> 0 the car can execute a hard brake probably if target is too close, MQBEvo: value 0 results in hard brake
   terminal_rollout = 0
 
-  full_stop_no_start = esp_hold and not starting
-  actually_stopping = stopping and not esp_hold
+  # derived from the hold request so they can't disagree with it: ANFAHREN is only ever sent when starting,
+  # HALTEN only ever when stopping
+  actually_stopping = acc_hold_type == ACC_HMS_HOLD and not esp_hold
 
   values = {
     "ACC_Typ":                    acc_type,
@@ -189,8 +189,8 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
     "ACC_Sollbeschleunigung_02":  accel,
     "ACC_zul_Regelabw_unten":     0,
     "ACC_zul_Regelabw_oben":      0,
-    "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_status in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
-    "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_status in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
+    "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.INACTIVE_ACCEL else 0,
+    "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.INACTIVE_ACCEL else 0,
     "ACC_Anfahren":               0,  # always zero, stock uses ACC_Anforderung_HMS
     "ACC_Anhalten":               1 if actually_stopping else 0,
     "ACC_Anhalteweg":             terminal_rollout if actually_stopping else 20.46,

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -174,8 +174,8 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
     "ACC_Sollbeschleunigung_02":  accel,
     "ACC_zul_Regelabw_unten":     0,
     "ACC_zul_Regelabw_oben":      0,
-    "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.INACTIVE_ACCEL else 0,
-    "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.INACTIVE_ACCEL else 0,
+    "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.ACCEL_INACTIVE else 0,
+    "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.ACCEL_INACTIVE else 0,
     "ACC_Anfahren":               0,  # always zero, stock uses ACC_Anforderung_HMS
     "ACC_Anhalten":               1 if braking_to_stop else 0,
     "ACC_Anhalteweg":             terminal_rollout if braking_to_stop else 20.46,

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -95,6 +95,7 @@ class MebLongStateMachine:
     self.acc_hold_type_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Anforderung_HMS'].items()}
 
     self.prev_acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
+    self.acc_status = self.acc_status_vals['ACC_OFF_HAUPTSCHALTER_AUS']  # last acc status, read by HUD msg
 
   def _get_acc_status(self, CS, CC) -> int:
     # stateless
@@ -149,6 +150,7 @@ class MebLongStateMachine:
     braking_to_stop = requesting_hold and not CS.esp_hold_confirmation
 
     self.prev_acc_hold_type = acc_hold_type
+    self.acc_status = acc_status
     return accel, acc_status, acc_hold_type, braking_to_stop
 
 
@@ -199,22 +201,6 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
     commands.append(packer.make_can_msg("TA_01", bus, values_ta))
 
   return commands
-
-
-def get_acc_hud_status(CS, CC, long_override):
-  if CS.accFaulted:
-    acc_hud_control = ACC_HUD_ERROR  # error state
-  elif CC.enabled:
-    if long_override:
-      acc_hud_control = ACC_HUD_OVERRIDE  # overriding
-    else:
-      acc_hud_control = ACC_HUD_ACTIVE  # active
-  elif CS.cruiseState.available:
-    acc_hud_control = ACC_HUD_ENABLED  # inactive
-  else:
-    acc_hud_control = ACC_HUD_DISABLED  # deactivated
-
-  return acc_hud_control
 
 
 def get_desired_gap(distance_bars, desired_gap, current_gap_signal):

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -111,47 +111,111 @@ class MebLongStateMachine:
     self.state = MebLongState.DISABLED
     self.frame = 0
 
+    self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP
+
+    self.ramp_counter = 0
+    self.prev_stopping = False
+
     can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
     self.acc_status_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Status_ACC'].items()}
     self.acc_hold_type_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Anforderung_HMS'].items()}
 
     self.prev_acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
 
-  def acc_status(self, CS, CC, override):
-    # stateless: ACC_Status_ACC is a pure function of this frame's inputs, no memory needed
+  def acc_status(self, CS, CC):
+    # stateless
     if CS.accFaulted:
-      return self.acc_status_vals['reversibler_Fehler_im_ACC_System']  # error state
+      return self.acc_status_vals['reversibler_Fehler_im_ACC_System']
     elif CC.enabled:
-      return self.acc_status_vals['ACC_OVERRIDE' if override else 'ACC_AKTIV_regelt']  # overriding / active
+      return self.acc_status_vals['ACC_OVERRIDE' if CC.cruiseControl.override else 'ACC_AKTIV_regelt']
     elif CS.cruiseState.available:
-      return self.acc_status_vals['ACC_STANDBY']  # long control ready
+      return self.acc_status_vals['ACC_STANDBY']
     else:
-      return self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # long control deactivated
+      return self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
 
   def step(self, CS, CC, accel):
-    acc_status = self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
-    acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+    acc_status = self.acc_status(CS, CC)
+    # acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
 
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
+    starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
+    # starting = not stopping and self.prev_stopping
 
-    if CS.accFaulted:
-      self.state = MebLongState.FAULTED
-
-    elif not CS.cruiseState.available:
-      self.state = MebLongState.DISABLED
-
+    if CS.accFaulted or not CC.longActive:
+      acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+    elif stopping:
+      acc_hold_type = self.acc_hold_type_vals['halten']  # stop
+    elif starting:
+      acc_hold_type = self.acc_hold_type_vals['anfahren']  # resume
     else:
-      if CC.enabled:
-        # normally active or pre-enabled at a stop with foot on brake
-        if CC.longActive:
-          self.state = MebLongState.STOPPING if stopping else MebLongState.ACTIVE
-          acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
-        else:
-          # gas overriding
-          acc_status = self.acc_status_vals['ACC_OVERRIDE']
+      acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
 
-      else:
-        pass
+    # enforce legal transitions
+    if acc_hold_type == self.acc_hold_type_vals['halten']:
+      # allow going into hold at any time, reset ramp counter
+      self.ramp_counter = 0
+    elif acc_hold_type == self.acc_hold_type_vals['keine_Anforderung'] and self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
+      # if we request to hold but never hit standstill before wanting to resume, we match stock and send just ramp
+      acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
+      self.ramp_counter = self.RAMP_FRAMES
+    elif self.ramp_counter > 0:
+      acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
+      self.ramp_counter -= 1
+
+    # if acc_hold_type == self.acc_hold_type_vals['keine_Anforderung'] and self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
+    #   # requesting to release brakes, starting from stop or overriding?
+    #   # if we request to hold but never hit standstill before wanting to resume, we match stock and send just ramp
+    #   if starting:
+    #     acc_hold_type = self.acc_hold_type_vals['anfahren']
+    #   else:
+    #     acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
+    #     self.ramp_counter = self.RAMP_FRAMES
+    #
+    # elif acc_hold_type == self.acc_hold_type_vals['Loesen_ueber_Rampe']:
+    #   self.ramp_counter -= 1
+    #   if self.ramp_counter <= 0:
+    #     acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+
+    # if CS.accFaulted:
+    #   acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+    #   # self.ramp_counter = 0
+    #   # # self.hold = None
+    #   # # self.state = MebLongState.FAULTED
+    #
+    # # elif self.prev_acc_hold_type == self.acc_hold_type_vals['Loesen_ueber_Rampe']:
+    # #   self.ramp_counter -= 1
+    # #   acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe'] if self.ramp_counter > 0 else self.acc_hold_type_vals['keine_Anforderung']
+    #
+    # elif not CC.longActive:
+    #   acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+    #   # if self.prev_acc_hold_type == self.acc_hold_type_vals['halten']:
+    #   #   self.ramp_counter = self.RAMP_FRAMES
+    #   #   acc_hold_type = self.acc_hold_type_vals['Loesen_ueber_Rampe']
+    #
+    # elif stopping:
+    #   acc_hold_type = self.acc_hold_type_vals['halten']
+    #
+    # else:
+    #   acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+
+
+
+
+    # elif not CS.cruiseState.available:
+    #   self.state = MebLongState.DISABLED
+    #
+    # else:
+    #   if CC.enabled:
+    #     # normally active or pre-enabled at a stop with foot on brake
+    #     if CC.longActive:
+    #       self.state = MebLongState.STOPPING if stopping else MebLongState.ACTIVE
+    #       acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
+    #     else:
+    #       # gas overriding
+    #       acc_status = self.acc_status_vals['ACC_OVERRIDE']
+    #
+    #   else:
+    #     pass
 
 
 
@@ -174,7 +238,13 @@ class MebLongStateMachine:
     #     pass
     #   elif
 
+    # if not CC.enabled:
+    #   accel = self.CCP.ACCEL_INACTIVE
+    # elif override:
+    #   accel = self.CCP.ACCEL_OVERRIDE
+
     self.prev_acc_hold_type = acc_hold_type
+    self.prev_stopping = stopping
     self.frame += 1
 
     return acc_status, acc_hold_type, accel

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -1,3 +1,11 @@
+from enum import IntEnum
+from opendbc.car import Bus, structs
+from opendbc.can import CANDefine
+from opendbc.car.volkswagen.values import DBC
+
+LongCtrlState = structs.CarControl.Actuators.LongControlState
+
+
 def create_steering_control(packer, bus, apply_curvature, lkas_enabled, power=0):
   values = {
     "Curvature": abs(apply_curvature),  # in rad/m
@@ -87,20 +95,73 @@ ACC_HUD_ENABLED  = 2
 ACC_HUD_DISABLED = 0
 
 
-def get_acc_control(CS, CC, long_override):
+class MebLongState(IntEnum):
+  DISABLED = 0
+  FAULTED = 1
+  ENABLED = 2
+  HOLDING = 3
+  OVERRIDE = 4
+  RELEASING = 5
+
+
+class MebLongStateMachine:
+  def __init__(self, CP, CCP):
+    self.CCP = CCP
+    self.state = MebLongState.DISABLED
+
+    can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
+    self.acc_status_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Status_ACC'].items()}
+    self.acc_hold_type_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Anforderung_HMS'].items()}
+
+  def step(self, CS, CC, accel):
+    acc_status = self.acc_status_vals['ACC_OFF_Hauptschalter_aus']  # disabled
+    acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
+
+    if CS.accFaulted:
+      self.state = MebLongState.FAULTED
+    elif CC.enabled:
+      # TODO: what happens if you engage at stop with foot on brake?
+      if CC.longActive:
+        acc_status = self.acc_status_vals['ACC_AKTIV_regelt']
+      else:
+        acc_status = self.acc_status_vals['ACC_OVERRIDE']
+    elif CS.cruiseState.available:
+      acc_status = self.acc_status_vals['ACC_STANDBY']
+
+
+    # if CS.accFaulted:
+    #   acc_status = ACC_CTRL_ERROR
+    #   acc_hold_type = ACC_HMS_NO_REQUEST
+    # elif not CC.longActive:
+    #   # gas override
+    #   if CS.gasPressed:
+    #     pass
+    #   elif
+
+  def update(self, accel):
+    acc_status = ACC_CTRL_DISABLED
+    acc_hold_type = ACC_HMS_NO_REQUEST
+
+    ...
+
+    return acc_status, acc_hold_type, accel
+
+
+
+def get_acc_status(CS, CC, long_override):
   if CS.accFaulted:
-    acc_control = ACC_CTRL_ERROR  # error state
+    acc_status = ACC_CTRL_ERROR  # error state
   elif CC.enabled:
     if long_override:
-      acc_control = ACC_CTRL_OVERRIDE  # overriding
+      acc_status = ACC_CTRL_OVERRIDE  # overriding
     else:
-      acc_control = ACC_CTRL_ACTIVE  # active long control state
+      acc_status = ACC_CTRL_ACTIVE  # active long control state
   elif CS.cruiseState.available:
-    acc_control = ACC_CTRL_ENABLED  # long control ready
+    acc_status = ACC_CTRL_ENABLED  # long control ready
   else:
-    acc_control = ACC_CTRL_DISABLED  # long control deactivated state
+    acc_status = ACC_CTRL_DISABLED  # long control deactivated state
 
-  return acc_control
+  return acc_status
 
 
 def get_acc_hold_type(CS, CC, starting, stopping, esp_hold, long_override, long_override_begin, long_disabling):
@@ -127,7 +188,7 @@ def get_acc_hold_type(CS, CC, starting, stopping, esp_hold, long_override, long_
   return acc_hold_type
 
 
-def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_control, acc_hold_type,
+def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_status, acc_hold_type,
                              stopping, starting, esp_hold, speed, long_override, travel_assist_available):
   # active longitudinal control disables one pedal driving (regen mode) while using overriding mechanism
   # error mitigation when stopping or stopped: (newer gen cars can be very sensitive)
@@ -157,18 +218,18 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
 
   values = {
     "ACC_Typ":                    acc_type,
-    "ACC_Status_ACC":             acc_control,
+    "ACC_Status_ACC":             acc_status,
     "ACC_StartStopp_Info":        acc_enabled,
     "ACC_Sollbeschleunigung_02":  acceleration,
     "ACC_zul_Regelabw_unten":     0,
     "ACC_zul_Regelabw_oben":      0,
-    "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_control in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
-    "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_control in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
+    "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_status in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
+    "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if acc_status in (ACC_CTRL_ACTIVE, ACC_CTRL_OVERRIDE) and not full_stop_no_start else 0,
     "ACC_Anfahren":               0,  # always zero, stock uses ACC_Anforderung_HMS
     "ACC_Anhalten":               1 if actually_stopping else 0,
     "ACC_Anhalteweg":             terminal_rollout if actually_stopping else 20.46,
     "ACC_Anforderung_HMS":        acc_hold_type,
-    "ACC_AKTIV_regelt":           1 if acc_control == ACC_CTRL_ACTIVE else 0,
+    "ACC_AKTIV_regelt":           1 if acc_status == ACC_CTRL_ACTIVE else 0,
     "Speed":                      speed,
     "SET_ME_0XFE":                0xFE,
     "SET_ME_0X1":                 0x1,
@@ -216,33 +277,33 @@ def get_desired_gap(distance_bars, desired_gap, current_gap_signal):
   return gap
 
 
-def create_acc_hud_control(packer, bus, acc_control, set_speed, lead_visible, distance_bars, show_distance_bars, esp_hold, distance, desired_gap, fcw_alert):
+def create_acc_hud_control(packer, bus, acc_status, set_speed, lead_visible, distance_bars, show_distance_bars, esp_hold, distance, desired_gap, fcw_alert):
   values = {
-    "ACC_Status_ACC":                acc_control,
+    "ACC_Status_ACC":                acc_status,
     "ACC_Tempolimit":                0,
     "ACC_Wunschgeschw_02":           set_speed if set_speed < 250 else 327.36,
     "ACC_Gesetzte_Zeitluecke":       distance_bars, # 5 distance bars available (3 are used by OP)
-    "ACC_Display_Prio":              0 if fcw_alert and acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 1, # probably keeping warning in front
-    "ACC_Optischer_Fahrerhinweis":   1 if fcw_alert and acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # enables optical warning
-    "ACC_Akustischer_Fahrerhinweis": 3 if fcw_alert and acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # enables sound warning
-    "ACC_Texte_Zusatzanz_02":        11 if fcw_alert and acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # type of warning: Break!
+    "ACC_Display_Prio":              0 if fcw_alert and acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 1, # probably keeping warning in front
+    "ACC_Optischer_Fahrerhinweis":   1 if fcw_alert and acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # enables optical warning
+    "ACC_Akustischer_Fahrerhinweis": 3 if fcw_alert and acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # enables sound warning
+    "ACC_Texte_Zusatzanz_02":        11 if fcw_alert and acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # type of warning: Break!
     "ACC_Abstandsindex_02":          569, # seems to be default for MEB but is not static in every case
-    "ACC_EGO_Fahrzeug":              2 if fcw_alert and acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else
-                                     (1 if acc_control == ACC_HUD_ACTIVE else 0), # red car warn symbol for fcw
+    "ACC_EGO_Fahrzeug":              2 if fcw_alert and acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else
+                                     (1 if acc_status == ACC_HUD_ACTIVE else 0), # red car warn symbol for fcw
     "Lead_Type_Detected":            1 if lead_visible else 0, # object should be displayed
     "Lead_Type":                     3 if lead_visible else 0, # displaying a car
     "Lead_Distance":                 distance if lead_visible else 0, # hud distance of object
-    "ACC_Enabled":                   1 if acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0,
-    "ACC_Standby_Override":          1 if acc_control != ACC_HUD_ACTIVE else 0,
-    "Street_Color":                  1 if acc_control in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # light grey (1) or dark (0) street
-    "Lead_Brightness":               3 if acc_control == ACC_HUD_ACTIVE else 0, # object shows in color
+    "ACC_Enabled":                   1 if acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0,
+    "ACC_Standby_Override":          1 if acc_status != ACC_HUD_ACTIVE else 0,
+    "Street_Color":                  1 if acc_status in (ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # light grey (1) or dark (0) street
+    "Lead_Brightness":               3 if acc_status == ACC_HUD_ACTIVE else 0, # object shows in color
     "Zeitluecke_1":                  get_desired_gap(distance_bars, desired_gap, 1), # desired distance to lead object for distance bar 1
     "Zeitluecke_2":                  get_desired_gap(distance_bars, desired_gap, 2), # desired distance to lead object for distance bar 2
     "Zeitluecke_3":                  get_desired_gap(distance_bars, desired_gap, 3), # desired distance to lead object for distance bar 3
     "Zeitluecke_4":                  get_desired_gap(distance_bars, desired_gap, 4), # desired distance to lead object for distance bar 4
     "Zeitluecke_5":                  get_desired_gap(distance_bars, desired_gap, 5), # desired distance to lead object for distance bar 5
-    "Zeitluecke_Farbe":              1 if acc_control in (ACC_HUD_ENABLED, ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # yellow (1) or white (0) time gap
-    "ACC_Anzeige_Zeitluecke":        show_distance_bars if acc_control != ACC_HUD_DISABLED else 0, # show distance bar selection
+    "Zeitluecke_Farbe":              1 if acc_status in (ACC_HUD_ENABLED, ACC_HUD_ACTIVE, ACC_HUD_OVERRIDE) else 0, # yellow (1) or white (0) time gap
+    "ACC_Anzeige_Zeitluecke":        show_distance_bars if acc_status != ACC_HUD_DISABLED else 0, # show distance bar selection
     "SET_ME_0X1":                    0x1,    # unknown
     "SET_ME_0X6A":                   0x6A,   # unknown
     "SET_ME_0XFFFF":                 0xFFFF, # unknown

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -114,7 +114,6 @@ class MebLongStateMachine:
     self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP
 
     self.ramp_counter = 0
-    self.prev_stopping = False
 
     can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
     self.acc_status_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Status_ACC'].items()}
@@ -139,14 +138,13 @@ class MebLongStateMachine:
 
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
     starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
-    # starting = not stopping and self.prev_stopping
 
     if CS.accFaulted or not CC.longActive:
       acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
     elif stopping:
-      acc_hold_type = self.acc_hold_type_vals['halten']  # stop
+      acc_hold_type = self.acc_hold_type_vals['halten']  # stopping/stopped
     elif starting:
-      acc_hold_type = self.acc_hold_type_vals['anfahren']  # resume
+      acc_hold_type = self.acc_hold_type_vals['anfahren']  # resume after reaching full stop
     else:
       acc_hold_type = self.acc_hold_type_vals['keine_Anforderung']  # no request
 
@@ -244,7 +242,6 @@ class MebLongStateMachine:
     #   accel = self.CCP.ACCEL_OVERRIDE
 
     self.prev_acc_hold_type = acc_hold_type
-    self.prev_stopping = stopping
     self.frame += 1
 
     return acc_status, acc_hold_type, accel

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -142,6 +142,7 @@ class MebLongStateMachine:
     acc_status = self._get_acc_status(CS, CC)
     acc_hold_type = self._get_hold_type(CS, CC)
 
+    # transition to inactive accel and jerks as soon as we enter ESP standstill
     requesting_hold = acc_hold_type == self.acc_hold_type_vals['HALTEN']
     held = requesting_hold and CS.esp_hold_confirmation
     if not CC.enabled or held:

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -76,17 +76,6 @@ def create_acc_buttons_control(packer, bus, gra_stock_values, cancel=False, resu
   return packer.make_can_msg("GRA_ACC_01", bus, values)
 
 
-ACC_CTRL_ERROR    = 6
-ACC_CTRL_OVERRIDE = 4
-ACC_CTRL_ACTIVE   = 3
-ACC_CTRL_ENABLED  = 2
-ACC_CTRL_DISABLED = 0
-
-ACC_HMS_RAMP_RELEASE = 5
-ACC_HMS_RELEASE      = 4
-ACC_HMS_HOLD         = 1
-ACC_HMS_NO_REQUEST   = 0
-
 ACC_HUD_ERROR    = 6
 ACC_HUD_OVERRIDE = 4
 ACC_HUD_ACTIVE   = 3
@@ -114,7 +103,7 @@ class MebLongStateMachine:
     if CS.out.accFaulted:
       return self.acc_status_vals['REVERSIBLER_FEHLER_IM_ACC_SYSTEM']
     elif CC.enabled:
-      return self.acc_status_vals['ACC_OVERRIDE' if CC.cruiseControl.override else 'ACC_AKTIV_regelt']
+      return self.acc_status_vals['ACC_OVERRIDE' if CC.cruiseControl.override else 'ACC_AKTIV_REGELT']
     elif CS.out.cruiseState.available:
       return self.acc_status_vals['ACC_STANDBY']
     else:
@@ -135,10 +124,10 @@ class MebLongStateMachine:
       acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
 
     # enforce legal transitions.
-    if acc_hold_type == self.acc_hold_type_vals['halten']:
+    if acc_hold_type == self.acc_hold_type_vals['HALTEN']:
       # allow going into hold at any time, reset ramp counter
       self.ramp_counter = 0
-    elif self.prev_acc_hold_type == self.acc_hold_type_vals['halten'] and acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG']:
+    elif self.prev_acc_hold_type == self.acc_hold_type_vals['HALTEN'] and acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG']:
       # HALTEN -> NONE causes car to fault into park. this enforces HALTEN -> RAMP if user overrides, or
       # if we requested to hold but never hit standstill before wanting to go again, we match stock and send just RAMP.
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
@@ -153,19 +142,22 @@ class MebLongStateMachine:
     acc_status = self._get_acc_status(CS, CC)
     acc_hold_type = self._get_hold_type(CS, CC)
 
-    held = CS.esp_hold_confirmation and acc_hold_type == self.acc_hold_type_vals['halten']
+    held = CS.esp_hold_confirmation and acc_hold_type == self.acc_hold_type_vals['HALTEN']
     if not CC.enabled or held:
       accel = self.CCP.ACCEL_INACTIVE
     else:
       accel = accel
 
+    # hold requested but the car hasn't reached standstill yet
+    braking_to_stop = acc_hold_type == self.acc_hold_type_vals['HALTEN'] and not CS.esp_hold_confirmation
+
     self.prev_acc_hold_type = acc_hold_type
     self.frame += 1
-    return acc_status, acc_hold_type, accel
+    return acc_status, acc_hold_type, accel, braking_to_stop
 
 
 def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc_status, acc_hold_type,
-                             esp_hold, speed, travel_assist_available):
+                             braking_to_stop, speed, travel_assist_available):
   # active longitudinal control disables one pedal driving (regen mode) while using overriding mechanism
   # error mitigation when stopping or stopped: (newer gen cars can be very sensitive)
   # - send 0 m stopping distance for cars in kind of parameterized stopping mode (stopping accel -0.2 seen for those cars)
@@ -178,10 +170,6 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
   # ACC_Anhalteweg: when stopping: MEB: values <> 0 the car can execute a hard brake probably if target is too close, MQBEvo: value 0 results in hard brake
   terminal_rollout = 0
 
-  # derived from the hold request so they can't disagree with it: ANFAHREN is only ever sent when starting,
-  # HALTEN only ever when stopping
-  actually_stopping = acc_hold_type == ACC_HMS_HOLD and not esp_hold
-
   values = {
     "ACC_Typ":                    acc_type,
     "ACC_Status_ACC":             acc_status,
@@ -192,10 +180,10 @@ def create_acc_accel_control(packer, bus, CCP, acc_type, acc_enabled, accel, acc
     "ACC_neg_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.INACTIVE_ACCEL else 0,
     "ACC_pos_Sollbeschl_Grad_02": CCP.JERK_LIMIT if accel != CCP.INACTIVE_ACCEL else 0,
     "ACC_Anfahren":               0,  # always zero, stock uses ACC_Anforderung_HMS
-    "ACC_Anhalten":               1 if actually_stopping else 0,
-    "ACC_Anhalteweg":             terminal_rollout if actually_stopping else 20.46,
+    "ACC_Anhalten":               1 if braking_to_stop else 0,
+    "ACC_Anhalteweg":             terminal_rollout if braking_to_stop else 20.46,
     "ACC_Anforderung_HMS":        acc_hold_type,
-    "ACC_AKTIV_regelt":           1 if acc_status == ACC_CTRL_ACTIVE else 0,
+    "ACC_AKTIV_regelt":           0,  # always zero, stock uses ACC_Status_ACC
     "Speed":                      speed,
     "SET_ME_0XFE":                0xFE,
     "SET_ME_0X1":                 0x1,

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -115,7 +115,6 @@ class CarControllerParams:
 
       # Longitudinal constants
       self.ACCEL_INACTIVE = 3.01  # m/s^2
-      self.ACCEL_OVERRIDE = 0.00  # m/s^2
       self.JERK_LIMIT = 4.0  # m/s^3
 
       self.shifter_values = can_define.dv["Getriebe_11"]["GE_Fahrstufe"]


### PR DESCRIPTION
Logic shouldn't be split across 5 places (many more for pq, mqb, etc)

This fixes the going into park fault