### PR TITLE
hyundai: add 2024 Tucson Limited USA camera firmware

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1095,6 +1095,7 @@ FW_VERSIONS = {
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-N9260 14Y',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9100 14A',
       b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.01 99211-N9240 14T',
+      b'\xf1\x00NX4 FR_CMR AT USA LHD 1.00 1.00 99211-CW020 14Z',
     ],
     (Ecu.fwdRadar, 0x7d0, None): [
       b'\xf1\x00NX4__               1.00 1.00 99110-N9100         ',


### PR DESCRIPTION
Adds a previously unseen camera firmware for a US 2024 Hyundai Tucson Limited.

Camera firmware:
99211-CW020 14Z

Radar firmware (99110-N9100) is already present.

Validation

Dongle ID:
d90ba2e1ecdbb770

Route:
d90ba2e1ecdbb770/00000001--01203f97b9
