### PR TITLE
VW MEB: move remaining shared messages to common DBC

### DIFF
--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -517,6 +517,36 @@ BO_ 869 NVEM_05: 8 Gateway
  SG_ BEM_HYB_DC_uSollLV : 50|6@1+ (0.1,10.6) [10.6|16] "Unit_Volt" DCDC_800V_PAG,DCDC_HV,LE_MLBevo
  SG_ BEM_HYB_DC_uMinLV : 56|8@1+ (0.1,0) [0|25.3] "Unit_Volt" Vector__XXX
 
+BO_ 870 Blinkmodi_02: 8 Gateway
+ SG_ BM_ZV_auf : 12|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_ZV_zu : 13|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_DWA_ein : 14|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_DWA_Alarm : 15|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Crash : 16|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Panik : 17|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Not_Bremsung : 18|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_GDO : 19|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BM_Warnblinken : 20|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Taxi_Notalarm : 21|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Telematik : 22|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_links : 23|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_rechts : 24|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ Blinken_li_Fzg_Takt : 25|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ Blinken_re_Fzg_Takt : 26|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ Blinken_li_Kombi_Takt : 27|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
+ SG_ Blinken_re_Kombi_Takt : 28|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
+ SG_ BM_NBA_n_codiert_n_aktiv : 29|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BM_NBA_Status : 30|2@1+ (1,0) [0|3] "" Vector__XXX
+ SG_ BM_WBT_Beleuchtung : 32|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_HD_Oeffnung_angelernt : 33|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BM_Autobahn : 34|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ BM_Rollenmodus_Blinken : 35|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ BM_Recas : 36|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Wischblinken : 37|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ BM_Telematik_Abbruchgrund : 38|6@1+ (1,0) [0|63] "" Vector__XXX
+ SG_ BM_PiloPa : 44|1@1+ (1,0) [0|1] "" ZR_High
+ SG_ DWA_Alarmquelle : 59|5@1+ (1,0) [0|31] "" ZR_High
+
 BO_ 888 GNSS_04: 8 Gateway
  SG_ GNSS_Nachrichtenpaket_ID4 : 0|2@1+ (1,0) [0|3] "Unit_Bit" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
  SG_ GNSS_Ortung_Zeit_in_GPSWoche : 2|30@1+ (1,0) [0|604800001] "Unit_MilliSecon" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
@@ -1832,7 +1862,9 @@ BO_ 380196013 MEB_AWV_01: 8 XXX
  SG_ Target : 56|8@1+ (1,0) [0|255] "" XXX
 
 BO_ 380196019 MEB_Camera_07: 16 XXX
+BO_ 380196034 MEB_Radar_Unknown_01: 8 XXX
 BO_ 380196036 MEB_Camera_08: 8 XXX
+BO_ 389241616 MEB_Camera_09: 8 XXX
 BO_ 389241617 MEB_Camera_10: 8 XXX
 BO_ 401604687 MEB_Camera_11: 8 XXX
 BO_ 401604695 MEB_PACC_01: 8 XXX
@@ -1848,6 +1880,7 @@ BO_ 441800114 Charging_Optimization: 8 XXX
  SG_ Temperature_Status_Charge : 15|3@1+ (1,0) [0|7] "" XXX
 
 BO_ 452984911 MEB_Camera_13: 8 XXX
+BO_ 452984919 MEB_Unknown_01: 8 XXX
 
 CM_ BO_ 184 "Motorsteuergerät";
 CM_ BO_ 192 "Motorsteuergerät";

--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -1813,6 +1813,38 @@ BO_ 1716 VIN_01: 8 Gateway_MQB
  SG_ VIN_16 m2 : 48|8@1+ (1,0) [0|255] "" Airbag_MQB
  SG_ VIN_17 m2 : 56|8@1+ (1,0) [0|255] "" Airbag_MQB
 
+BO_ 316495015 VZE_04: 32 XXX
+ SG_ VZE_Anzeigemodus : 0|2@1+ (1,0) [0|3] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ Detected_01 : 8|1@0+ (1,0) [0|1] "" XXX
+ SG_ VZE_Anzeigeunterdrueck_Zeichen_3 : 9|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ VZE_Anzeigeunterdrueck_Zeichen_2 : 10|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ VZE_Verkehrszeichen_1 : 11|8@1+ (5,0) [1|520] "" OTA_FC,ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Verkehrszeichen_2 : 19|8@1+ (5,0) [1|255] "" OTA_FC,ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Verkehrszeichen_3 : 27|8@1+ (5,0) [1|255] "" OTA_FC,ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Warnung_Verkehrszeichen_1 : 35|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Warnung_Verkehrszeichen_2 : 36|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Warnung_Verkehrszeichen_3 : 37|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zusatzschild_1 : 38|4@1+ (1,0) [1|15] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zusatzschild_2 : 42|4@1+ (1,0) [1|15] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zusatzschild_3 : 46|4@1+ (1,0) [1|15] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Anzeigeunterdrueck_Zeichen_1 : 50|1@1+ (1,0) [0|1] "" Vector__XXX
+ SG_ VZE_Zeichen_01_KameraWied : 51|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_02_KameraWied : 52|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_03_KameraWied : 53|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_01_Kamera : 54|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_01_Karte : 55|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_01_Gesetz : 56|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_02_Kamera : 57|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_02_Karte : 58|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_02_Gesetz : 59|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_03_Kamera : 60|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_03_Karte : 61|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Zeichen_03_Gesetz : 62|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Gong : 63|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
+ SG_ VZE_Verkehrszeichen_4 : 75|8@1+ (1,0) [0|31] "" XXX
+ SG_ VZE_Verkehrszeichen_6 : 92|7@1+ (1,0) [0|7] "" XXX
+ SG_ VZE_Baustelle : 110|1@0+ (1,0) [0|1] "" XXX
+
 BO_ 316495049 SAL_01: 8 XXX
  SG_ CRC : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ CNT : 8|4@1+ (1,0) [0|15] "" XXX
@@ -3170,3 +3202,29 @@ VAL_ 1714 UH_Tag 0 "Init";
 VAL_ 1714 Kombi_02_alt 0 "aktuell" 1 "veraltet";
 VAL_ 1714 Uhrzeit_01_alt 0 "aktuell" 1 "veraltet";
 VAL_ 441800114 Temperature_Status_Charge 0 "init" 1 "temp under optimal" 2 "temp optimal" 3 "temp over optimal" 7 "fault";
+VAL_ 316495015 VZE_Anzeigemodus 0 "EU_RDW" 1 "USA" 2 "Canada" 3 "China";
+VAL_ 316495015 VZE_Anzeigeunterdrueck_Zeichen_3 0 "anzeigerelevant" 1 "nicht_anzeigerelevant";
+VAL_ 316495015 VZE_Anzeigeunterdrueck_Zeichen_2 0 "anzeigerelevant" 1 "nicht_anzeigerelevant";
+VAL_ 316495015 VZE_Verkehrszeichen_1 0 "kein_Verkehrszeichen" 520 "Unbegrenzt";
+VAL_ 316495015 VZE_Verkehrszeichen_2 0 "kein_Verkehrszeichen" 520 "Unbegrenzt";
+VAL_ 316495015 VZE_Verkehrszeichen_3 0 "kein_Verkehrszeichen" 520 "Unbegrenzt";
+VAL_ 316495015 VZE_Warnung_Verkehrszeichen_1 0 "keine_Warnung_Initialwert_Fehlerwert" 1 "Warnung";
+VAL_ 316495015 VZE_Warnung_Verkehrszeichen_2 0 "keine_Warnung_Initialwert_Fehlerwert" 1 "Warnung";
+VAL_ 316495015 VZE_Warnung_Verkehrszeichen_3 0 "keine_Warnung_Initialwert_Fehlerwert" 1 "Warnung";
+VAL_ 316495015 VZE_Zusatzschild_1 0 "keine_Zusatzschild_Initialwert_Fehlerwert";
+VAL_ 316495015 VZE_Zusatzschild_2 0 "keine_Zusatzschild_Initialwert_Fehlerwert";
+VAL_ 316495015 VZE_Zusatzschild_3 0 "keine_Zusatzschild_Initialwert_Fehlerwert";
+VAL_ 316495015 VZE_Anzeigeunterdrueck_Zeichen_1 0 "anzeigerelevant" 1 "nicht_anzeigerelevant";
+VAL_ 316495015 VZE_Zeichen_01_KameraWied 0 "inaktiv" 1 "aktiv";
+VAL_ 316495015 VZE_Zeichen_02_KameraWied 0 "inaktiv" 1 "aktiv";
+VAL_ 316495015 VZE_Zeichen_03_KameraWied 0 "inaktiv" 1 "aktiv";
+VAL_ 316495015 VZE_Zeichen_01_Kamera 0 "nicht_erkannt" 1 "erkannt";
+VAL_ 316495015 VZE_Zeichen_01_Karte 0 "inaktiv" 1 "aktiv";
+VAL_ 316495015 VZE_Zeichen_01_Gesetz 0 "nicht_erkannt" 1 "erkannt";
+VAL_ 316495015 VZE_Zeichen_02_Kamera 0 "nicht_erkannt" 1 "erkannt";
+VAL_ 316495015 VZE_Zeichen_02_Karte 0 "inaktiv" 1 "aktiv";
+VAL_ 316495015 VZE_Zeichen_02_Gesetz 0 "nicht_erkannt" 1 "erkannt";
+VAL_ 316495015 VZE_Zeichen_03_Kamera 0 "nicht_erkannt" 1 "erkannt";
+VAL_ 316495015 VZE_Zeichen_03_Karte 0 "inaktiv" 1 "aktiv";
+VAL_ 316495015 VZE_Zeichen_03_Gesetz 0 "nicht_erkannt" 1 "erkannt";
+VAL_ 316495015 VZE_Gong 0 "Gong_deaktiv" 1 "Gong_aktiv";

--- a/opendbc/dbc/generator/volkswagen/vw_meb.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb.dbc
@@ -204,6 +204,4 @@ BO_ 771 HCA_03: 24 XXX
  SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
  SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
 
-BO_ 316495015 MEB_Camera_04: 32 XXX
-
 VAL_ 768 ACC_Events 3 "Starting_Available" 0 "None" 5 "Speed_Limit_Camera" 9 "Street_Type" 4 "Speed_Limit_in_Nav";

--- a/opendbc/dbc/generator/volkswagen/vw_meb.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb.dbc
@@ -204,38 +204,6 @@ BO_ 771 HCA_03: 24 XXX
  SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
  SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
 
-BO_ 870 Blinkmodi_02: 8 Gateway
- SG_ BM_ZV_auf : 12|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_ZV_zu : 13|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_DWA_ein : 14|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_DWA_Alarm : 15|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Crash : 16|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Panik : 17|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Not_Bremsung : 18|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_GDO : 19|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_Warnblinken : 20|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Taxi_Notalarm : 21|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Telematik : 22|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_links : 23|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_rechts : 24|1@1+ (1,0) [0|1] "" ZR_High
- SG_ Blinken_li_Fzg_Takt : 25|1@1+ (1,0) [0|1] "" ZR_High
- SG_ Blinken_re_Fzg_Takt : 26|1@1+ (1,0) [0|1] "" ZR_High
- SG_ Blinken_li_Kombi_Takt : 27|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
- SG_ Blinken_re_Kombi_Takt : 28|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
- SG_ BM_NBA_n_codiert_n_aktiv : 29|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_NBA_Status : 30|2@1+ (1,0) [0|3] "" Vector__XXX
- SG_ BM_WBT_Beleuchtung : 32|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_HD_Oeffnung_angelernt : 33|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_Autobahn : 34|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ BM_Rollenmodus_Blinken : 35|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_Recas : 36|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Wischblinken : 37|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Telematik_Abbruchgrund : 38|6@1+ (1,0) [0|63] "" Vector__XXX
- SG_ BM_PiloPa : 44|1@1+ (1,0) [0|1] "" ZR_High
- SG_ DWA_Alarmquelle : 59|5@1+ (1,0) [0|31] "" ZR_High
-
 BO_ 316495015 MEB_Camera_04: 32 XXX
-
-BO_ 389241616 MEB_Camera_09: 8 XXX
 
 VAL_ 768 ACC_Events 3 "Starting_Available" 0 "None" 5 "Speed_Limit_Camera" 9 "Street_Type" 4 "Speed_Limit_in_Nav";

--- a/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
@@ -104,36 +104,6 @@ BO_ 771 HCA_03: 24 XXX
  SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
  SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
 
-BO_ 870 Blinkmodi_02: 8 Gateway
- SG_ BM_ZV_auf : 12|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_ZV_zu : 13|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_DWA_ein : 14|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_DWA_Alarm : 15|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Crash : 16|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Panik : 17|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Not_Bremsung : 18|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_GDO : 19|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_Warnblinken : 20|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Taxi_Notalarm : 21|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Telematik : 22|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_links : 23|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_rechts : 24|1@1+ (1,0) [0|1] "" ZR_High
- SG_ Blinken_li_Fzg_Takt : 25|1@1+ (1,0) [0|1] "" ZR_High
- SG_ Blinken_re_Fzg_Takt : 26|1@1+ (1,0) [0|1] "" ZR_High
- SG_ Blinken_li_Kombi_Takt : 27|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
- SG_ Blinken_re_Kombi_Takt : 28|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3,ZR_Standard
- SG_ BM_NBA_n_codiert_n_aktiv : 29|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_NBA_Status : 30|2@1+ (1,0) [0|3] "" Vector__XXX
- SG_ BM_WBT_Beleuchtung : 32|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_HD_Oeffnung_angelernt : 33|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_Autobahn : 34|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ BM_Rollenmodus_Blinken : 35|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ BM_Recas : 36|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Wischblinken : 37|1@1+ (1,0) [0|1] "" ZR_High
- SG_ BM_Telematik_Abbruchgrund : 38|6@1+ (1,0) [0|63] "" Vector__XXX
- SG_ BM_PiloPa : 44|1@1+ (1,0) [0|1] "" ZR_High
- SG_ DWA_Alarmquelle : 59|5@1+ (1,0) [0|31] "" ZR_High
-
 BO_ 316495015 VZE_04: 32 XXX
  SG_ VZE_Anzeigemodus : 0|2@1+ (1,0) [0|3] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
  SG_ Detected_01 : 8|1@0+ (1,0) [0|1] "" XXX

--- a/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
@@ -104,66 +104,8 @@ BO_ 771 HCA_03: 24 XXX
  SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
  SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
 
-BO_ 316495015 VZE_04: 32 XXX
- SG_ VZE_Anzeigemodus : 0|2@1+ (1,0) [0|3] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ Detected_01 : 8|1@0+ (1,0) [0|1] "" XXX
- SG_ VZE_Anzeigeunterdrueck_Zeichen_3 : 9|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ VZE_Anzeigeunterdrueck_Zeichen_2 : 10|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ VZE_Verkehrszeichen_1 : 11|8@1+ (5,0) [1|520] "" OTA_FC,ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Verkehrszeichen_2 : 19|8@1+ (5,0) [1|255] "" OTA_FC,ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Verkehrszeichen_3 : 27|8@1+ (5,0) [1|255] "" OTA_FC,ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Warnung_Verkehrszeichen_1 : 35|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Warnung_Verkehrszeichen_2 : 36|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Warnung_Verkehrszeichen_3 : 37|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zusatzschild_1 : 38|4@1+ (1,0) [1|15] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zusatzschild_2 : 42|4@1+ (1,0) [1|15] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zusatzschild_3 : 46|4@1+ (1,0) [1|15] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Anzeigeunterdrueck_Zeichen_1 : 50|1@1+ (1,0) [0|1] "" Vector__XXX
- SG_ VZE_Zeichen_01_KameraWied : 51|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_02_KameraWied : 52|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_03_KameraWied : 53|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_01_Kamera : 54|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_01_Karte : 55|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_01_Gesetz : 56|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_02_Kamera : 57|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_02_Karte : 58|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_02_Gesetz : 59|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_03_Kamera : 60|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_03_Karte : 61|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Zeichen_03_Gesetz : 62|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Gong : 63|1@1+ (1,0) [0|1] "" ZR_High,ZR_LIMU,ZR_MIB_TOP_ab_Gen3
- SG_ VZE_Verkehrszeichen_4 : 75|8@1+ (1,0) [0|31] "" XXX
- SG_ VZE_Verkehrszeichen_6 : 92|7@1+ (1,0) [0|7] "" XXX
- SG_ VZE_Baustelle : 110|1@0+ (1,0) [0|1] "" XXX
-
 VAL_ 768 ACC_Event_Wunschgeschw 1023 "None";
 VAL_ 768 ACC_Events 3 "Starting_Available" 0 "None" 5 "Speed_Limit_Detected" 9 "Crossing" 4 "Speed_Limit_Ahead" 10 "Roundabout" 6 "Curve";
-VAL_ 316495015 VZE_Anzeigemodus 0 "EU_RDW" 1 "USA" 2 "Canada" 3 "China";
-VAL_ 316495015 VZE_Anzeigeunterdrueck_Zeichen_3 0 "anzeigerelevant" 1 "nicht_anzeigerelevant";
-VAL_ 316495015 VZE_Anzeigeunterdrueck_Zeichen_2 0 "anzeigerelevant" 1 "nicht_anzeigerelevant";
-VAL_ 316495015 VZE_Verkehrszeichen_1 0 "kein_Verkehrszeichen" 520 "Unbegrenzt";
-VAL_ 316495015 VZE_Verkehrszeichen_2 0 "kein_Verkehrszeichen" 520 "Unbegrenzt";
-VAL_ 316495015 VZE_Verkehrszeichen_3 0 "kein_Verkehrszeichen" 520 "Unbegrenzt";
-VAL_ 316495015 VZE_Warnung_Verkehrszeichen_1 0 "keine_Warnung_Initialwert_Fehlerwert" 1 "Warnung";
-VAL_ 316495015 VZE_Warnung_Verkehrszeichen_2 0 "keine_Warnung_Initialwert_Fehlerwert" 1 "Warnung";
-VAL_ 316495015 VZE_Warnung_Verkehrszeichen_3 0 "keine_Warnung_Initialwert_Fehlerwert" 1 "Warnung";
-VAL_ 316495015 VZE_Zusatzschild_1 0 "keine_Zusatzschild_Initialwert_Fehlerwert";
-VAL_ 316495015 VZE_Zusatzschild_2 0 "keine_Zusatzschild_Initialwert_Fehlerwert";
-VAL_ 316495015 VZE_Zusatzschild_3 0 "keine_Zusatzschild_Initialwert_Fehlerwert";
-VAL_ 316495015 VZE_Anzeigeunterdrueck_Zeichen_1 0 "anzeigerelevant" 1 "nicht_anzeigerelevant";
-VAL_ 316495015 VZE_Zeichen_01_KameraWied 0 "inaktiv" 1 "aktiv";
-VAL_ 316495015 VZE_Zeichen_02_KameraWied 0 "inaktiv" 1 "aktiv";
-VAL_ 316495015 VZE_Zeichen_03_KameraWied 0 "inaktiv" 1 "aktiv";
-VAL_ 316495015 VZE_Zeichen_01_Kamera 0 "nicht_erkannt" 1 "erkannt";
-VAL_ 316495015 VZE_Zeichen_01_Karte 0 "inaktiv" 1 "aktiv";
-VAL_ 316495015 VZE_Zeichen_01_Gesetz 0 "nicht_erkannt" 1 "erkannt";
-VAL_ 316495015 VZE_Zeichen_02_Kamera 0 "nicht_erkannt" 1 "erkannt";
-VAL_ 316495015 VZE_Zeichen_02_Karte 0 "inaktiv" 1 "aktiv";
-VAL_ 316495015 VZE_Zeichen_02_Gesetz 0 "nicht_erkannt" 1 "erkannt";
-VAL_ 316495015 VZE_Zeichen_03_Kamera 0 "nicht_erkannt" 1 "erkannt";
-VAL_ 316495015 VZE_Zeichen_03_Karte 0 "inaktiv" 1 "aktiv";
-VAL_ 316495015 VZE_Zeichen_03_Gesetz 0 "nicht_erkannt" 1 "erkannt";
-VAL_ 316495015 VZE_Gong 0 "Gong_deaktiv" 1 "Gong_aktiv";
 
 BO_ 258 ESC_50: 48 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX


### PR DESCRIPTION
Blinkmodi_02 was defined identically in both vw_meb.dbc and vw_meb_2024.dbc, and its VAL_ tables already lived in the common file. MEB_Camera_09 was only in vw_meb.dbc but is on the bus for both generations. Two more messages were missing entirely:

  0x366      Blinkmodi_02          (deduplicated from both variants)
  0x17335B10 MEB_Camera_09         (was vw_meb only)
  0x16A954C2 MEB_Radar_Unknown_01  (new)
  0x1B000057 MEB_Unknown_01        (new)

All four confirmed present on both the ID.4 MK1 and MK2 test routes. MEB_Camera_09 is variable length (3/5/8 bytes observed), so it keeps the 8 byte definition to cover the maximum.

Both variants now define the same set of messages.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
