### PR TITLE
VW MEB: sync pre-2024 ACC_18.Speed and Motor_54.Accelerator_Pressure

### DIFF
--- a/opendbc/dbc/generator/volkswagen/vw_meb.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb.dbc
@@ -81,7 +81,7 @@ BO_ 317 QFK_01: 32 XXX
 BO_ 332 Motor_54: 32 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Accelerator_Pressure : 175|8@0+ (0.391,-14.467) [0|100] "Unit_Percent" XXX
+ SG_ Accelerator_Pressure : 175|8@0+ (0.4,-14.8) [0|100] "Unit_Percent" XXX
 
 BO_ 333 ACC_18: 32 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
@@ -107,7 +107,7 @@ BO_ 333 ACC_18: 32 XXX
  SG_ ACC_AKTIV_regelt : 90|1@0+ (1,0) [0|1] "" XXX
  SG_ SET_ME_0X1 : 92|1@0+ (1,0) [0|1] "" XXX
  SG_ SET_ME_0X9 : 232|4@1+ (1,0) [0|15] "" XXX
- SG_ Speed : 236|11@1+ (0.1,0) [0|15] "" XXX
+ SG_ Speed : 236|12@1+ (0.1,0) [0|15] "" XXX
  SG_ Accel_Boost : 248|6@1+ (1,0) [0|3] "" XXX
  SG_ Reversing : 254|1@0+ (1,0) [0|1] "" XXX
 


### PR DESCRIPTION
Both signals already carry these definitions in vw_meb_2024.dbc; only the pre-2024 file lagged behind.

  ACC_18.Speed              236|11 -> 236|12
  Motor_54.Accelerator_Pressure  (0.391,-14.467) -> (0.4,-14.8)

Checked on the ID.4 MK1 route: bit 247, the extra MSB the wider Speed field picks up, is never set over 99k frames, so decoded speed is unchanged (max 101.3 either way). Accelerator_Pressure reads exactly 0.000 at the idle raw value of 37 under both scalings; they differ only in slope, 42.6 vs 43.6 percent at the highest raw value seen.

No decoded-value change on this route, just one definition per signal across both generations.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
