### PR TITLE
Hyundai: add Genesis G80 T1210 camera firmware

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -542,6 +542,7 @@ FW_VERSIONS = {
     ],
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00RG3 MFC  AT USA LHD 1.00 1.01 99211-T1200 230607',
+      b'\xf1\x00RG3 MFC  AT USA LHD 1.00 1.01 99211-T1210 230607',
     ],
   },
   CAR.GENESIS_G90: {


### PR DESCRIPTION
## Summary

Add the forward-camera firmware used by the US-market 2024 Genesis G80
2.5T Sport Prestige with HDA II to the existing
`GENESIS_G80_2ND_GEN_FL` platform.

The existing 2024 G80 Advanced entry uses part number `99211-T1200`.
The Sport Prestige reports the otherwise matching `99211-T1210` firmware.
Without this entry, firmware fingerprinting falls back to dashcam mode.

## Validation

- Exact production firmware match: `GENESIS_G80_2ND_GEN_FL`
- `fingerprintSource=fw`
- `fuzzyFingerprint=False`
- `dashcamOnly=False`
- Focused firmware-version-list test passed on the comma's supported Python environment
- Automatic detection and lateral control verified on the vehicle

Supporting route:
https://connect.comma.ai/ffe7d2315938753c/00000291--7cddafe624

Vehicle report and screenshots:
https://community.sunnypilot.ai/t/2024-genesis-g80-2-5t-sport-prestige-hda-ii-car-unrecognized/6420

Local Windows test execution was not available because the installed Python is
3.13, while opendbc currently requires Python 3.11-3.12. `git diff --check`
passes.
