### PR TITLE
VW MEB: unify HCA_03, VMM_02 and ACC_18 into the common DBC

### DIFF
--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -285,6 +285,19 @@ BO_ 299 GRA_ACC_01: 8 Gateway
  SG_ GRA_reserveByte8 : 56|8@1+ (1,0) [0|255] "" Vector__XXX
 
 BO_ 312 IPA_01: 32 XXX
+BO_ 313 VMM_02: 32 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ FCW_Reaction_1 : 12|1@0+ (1,0) [0|1] "" XXX
+ SG_ Brake_Pressed_1 : 16|1@0+ (1,0) [0|1] "" XXX
+ SG_ Brake_Pressed_2 : 27|1@0+ (1,0) [0|1] "" XXX
+ SG_ AEB_Active : 31|1@0+ (1,0) [0|1] "" XXX
+ SG_ ESP_Hold : 35|1@0+ (1,0) [0|1] "" XXX
+ SG_ Brake_Pressed_3 : 48|1@0+ (1,0) [0|1] "" XXX
+ SG_ FCW_Reaction_2 : 56|1@1+ (1,0) [0|1] "" XXX
+ SG_ Brake_Pressure : 76|11@1+ (1,0) [0|100] "" XXX
+ SG_ FCW_Reaction_3 : 88|5@1+ (1,0) [0|31] "" XXX
+
 BO_ 319 PreCrash_02: 8 Gateway
  SG_ PreCrash_02_CRC : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ PreCrash_02_BZ : 8|4@1+ (1,0) [0|15] "" Vector__XXX
@@ -308,6 +321,35 @@ BO_ 319 PreCrash_02: 8 Gateway
  SG_ PreCrash_Fo_KSV_verfahren : 51|4@1+ (1,0) [0|15] "" Vector__XXX
  SG_ SC_PreCrash_Warnung : 56|4@1+ (1,0) [0|15] "" NightVision
  SG_ SC_PreCrash_Texte : 60|4@1+ (1,0) [0|15] "" Vector__XXX
+
+BO_ 333 ACC_18: 32 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ ACC_limitierte_Anfahrdyn : 12|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_nachtr_Stopp_Anf : 13|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_DynErhoehung : 14|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_Freilaufstrategie_TSK : 15|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_zul_Regelabw_unten : 16|6@1+ (0.024,0) [0|1.512] "Unit_MeterPerSeconSquar" XXX
+ SG_ ACC_StartStopp_Info : 22|2@1+ (1,0) [0|3] "" XXX
+ SG_ ACC_Sollbeschleunigung_02 : 24|11@1+ (0.005,-7.22) [-7.22|3.005] "Unit_MeterPerSeconSquar" XXX
+ SG_ ACC_zul_Regelabw_oben : 35|5@1+ (0.0625,0) [0|1.9375] "Unit_MeterPerSeconSquar" XXX
+ SG_ ACC_neg_Sollbeschl_Grad_02 : 40|8@1+ (0.05,0) [0|12.75] "Unit_MeterPerCubicSecon" XXX
+ SG_ ACC_pos_Sollbeschl_Grad_02 : 48|8@1+ (0.05,0) [0|12.75] "Unit_MeterPerCubicSecon" XXX
+ SG_ ACC_Anfahren : 56|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_Anhalten : 57|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_Typ : 58|2@1+ (1,0) [0|3] "" XXX
+ SG_ ACC_Status_ACC : 60|3@1+ (1,0) [0|7] "" XXX
+ SG_ ACC_Minimale_Bremsung : 63|1@1+ (1,0) [0|1] "" XXX
+ SG_ ACC_Anhalteweg : 64|11@1+ (0.01,0) [0|2046] "" XXX
+ SG_ ACC_Anforderung_HMS : 77|3@1+ (1,0) [0|7] "" XXX
+ SG_ SET_ME_0XFE : 80|8@1+ (1,0) [0|255] "" XXX
+ SG_ ACC_AKTIV_regelt : 90|1@0+ (1,0) [0|1] "" XXX
+ SG_ SET_ME_0X1 : 92|1@0+ (1,0) [0|1] "" XXX
+ SG_ SET_ME_0x2FE : 98|10@1+ (1,0) [0|63] "" XXX
+ SG_ SET_ME_0X9 : 232|4@1+ (1,0) [0|15] "" XXX
+ SG_ Speed : 236|12@1+ (0.1,0) [0|15] "" XXX
+ SG_ Accel_Boost : 248|6@1+ (1,0) [0|3] "" XXX
+ SG_ Reversing : 254|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 339 MSG_HYB_30: 8 Gateway
  SG_ MSG_HYB_30_CRC : 0|8@1+ (1,0) [0|255] "" Ladegeraet_Konzern
@@ -431,6 +473,15 @@ BO_ 706 Motor_41: 8 Gateway
  SG_ WIV_Enable_Oeldr_Motor : 51|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ MO_OelMessung_Dauer : 52|4@1+ (15,15) [15|225] "Unit_Secon" Vector__XXX
  SG_ TSK_vMax_FahrerInfo : 56|8@1+ (1,15) [16|270] "" Vector__XXX
+
+BO_ 771 HCA_03: 24 XXX
+ SG_ RequestStatus : 12|4@1+ (1,0) [0|15] "" XXX
+ SG_ Power : 16|8@1+ (0.4,0) [0.0|100.0] "Unit_Percent" XXX
+ SG_ Curvature : 24|15@1+ (6.7e-06,0) [0|0.219] "Unit_rad/m" XXX
+ SG_ Curvature_VZ : 39|1@1+ (1,0) [0|1] "" XXX
+ SG_ Unknown_01 : 53|1@0+ (1,0) [0|1] "" XXX
+ SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
+ SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
 
 BO_ 792 MEB_Camera_03: 8 XXX
 BO_ 795 ESP_24: 8 Gateway
@@ -1937,6 +1988,7 @@ CM_ BO_ 219 "AEB_Object_Status and AEB_Object_Status_B values 4 and 5/6 coincide
 CM_ SG_ 219 AEB_Target_Decel "Scale is estimated. Lowest request seen was -6.99";
 CM_ SG_ 219 AEB_TTC_Countdown "Can count down to zero before AEB activates, but may not always precede an AEB or mean it will happen";
 CM_ SG_ 219 VRU_Detected "Commonly high when a pedestrian is seen";
+CM_ SG_ 333 SET_ME_0x2FE "Only set by stock ACC on 2024+; reads 0 on pre-2024 and is not packed by mebcan";
 CM_ BO_ 317 "Lenkungssteuergerät";
 CM_ BO_ 517 "Steuergerät für Motorstart";
 CM_ BO_ 522 "Steuergerät für Fahrzeugbewegung";

--- a/opendbc/dbc/generator/volkswagen/vw_meb.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb.dbc
@@ -45,17 +45,6 @@ BO_ 267 Motor_51: 32 XXX
  SG_ TSK_Status : 88|3@1+ (1,0) [0|7] "" XXX
  SG_ TSK_Limiter_ausgewaehlt : 95|1@1+ (1,0) [0|3] "" XXX
 
-BO_ 313 VMM_02: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Brake_Pressed_1 : 16|1@0+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressed_2 : 27|1@0+ (1,0) [0|1] "" XXX
- SG_ AEB_Active : 31|1@0+ (1,0) [0|1] "" XXX
- SG_ ESP_Hold : 35|1@0+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressed_3 : 48|1@0+ (1,0) [0|1] "" XXX
- SG_ FCW_Active : 56|1@1+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressure : 76|11@1+ (1,0) [0|100] "" XXX
-
 BO_ 317 QFK_01: 32 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
@@ -70,34 +59,6 @@ BO_ 332 Motor_54: 32 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
  SG_ Accelerator_Pressure : 175|8@0+ (0.4,-14.8) [0|100] "Unit_Percent" XXX
-
-BO_ 333 ACC_18: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ ACC_limitierte_Anfahrdyn : 12|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_nachtr_Stopp_Anf : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_DynErhoehung : 14|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Freilaufstrategie_TSK : 15|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_zul_Regelabw_unten : 16|6@1+ (0.024,0) [0|1.512] "Unit_MeterPerSeconSquar" XXX
- SG_ ACC_StartStopp_Info : 22|2@1+ (1,0) [0|3] "" XXX
- SG_ ACC_Sollbeschleunigung_02 : 24|11@1+ (0.005,-7.22) [-7.22|3.005] "Unit_MeterPerSeconSquar" XXX
- SG_ ACC_zul_Regelabw_oben : 35|5@1+ (0.0625,0) [0|1.9375] "Unit_MeterPerSeconSquar" XXX
- SG_ ACC_neg_Sollbeschl_Grad_02 : 40|8@1+ (0.05,0) [0|12.75] "Unit_MeterPerCubicSecon" XXX
- SG_ ACC_pos_Sollbeschl_Grad_02 : 48|8@1+ (0.05,0) [0|12.75] "Unit_MeterPerCubicSecon" XXX
- SG_ ACC_Anfahren : 56|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Anhalten : 57|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Typ : 58|2@1+ (1,0) [0|3] "" XXX
- SG_ ACC_Status_ACC : 60|3@1+ (1,0) [0|7] "" XXX
- SG_ ACC_Minimale_Bremsung : 63|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Anhalteweg : 64|11@1+ (0.01,0) [0|2046] "" XXX
- SG_ ACC_Anforderung_HMS : 77|3@1+ (1,0) [0|7] "" XXX
- SG_ SET_ME_0XFE : 80|8@1+ (1,0) [0|255] "" XXX
- SG_ ACC_AKTIV_regelt : 90|1@0+ (1,0) [0|1] "" XXX
- SG_ SET_ME_0X1 : 92|1@0+ (1,0) [0|1] "" XXX
- SG_ SET_ME_0X9 : 232|4@1+ (1,0) [0|15] "" XXX
- SG_ Speed : 236|12@1+ (0.1,0) [0|15] "" XXX
- SG_ Accel_Boost : 248|6@1+ (1,0) [0|3] "" XXX
- SG_ Reversing : 254|1@0+ (1,0) [0|1] "" XXX
 
 BO_ 496 EA_02: 8 Gateway
  SG_ EA_02_CRC : 0|8@1+ (1,0) [0|255] "" Vector__XXX
@@ -182,14 +143,5 @@ BO_ 768 ACC_19: 48 XXX
  SG_ Zeitluecke_3 : 354|9@1+ (0.171,0) [0|100] "Unit_Meter" XXX
  SG_ Zeitluecke_4 : 364|9@1+ (0.171,0) [0|100] "Unit_Meter" XXX
  SG_ Zeitluecke_5 : 374|9@1+ (0.171,0) [0|100] "Unit_Meter" XXX
-
-BO_ 771 HCA_03: 24 XXX
- SG_ RequestStatus : 12|4@1+ (1,0) [0|15] "" XXX
- SG_ Power : 16|8@1+ (0.4,0) [0.0|100.0] "percent" XXX
- SG_ Curvature : 24|15@1+ (6.7e-06,0) [0|0.219] "Unit_rad/m" XXX
- SG_ Curvature_VZ : 39|1@1+ (1,0) [0|1] "" XXX
- SG_ Unknown_01 : 53|1@0+ (1,0) [0|1] "" XXX
- SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
- SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
 
 VAL_ 768 ACC_Events 3 "Starting_Available" 0 "None" 5 "Speed_Limit_Camera" 9 "Street_Type" 4 "Speed_Limit_in_Nav";

--- a/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
@@ -96,14 +96,6 @@ BO_ 768 ACC_19: 48 XXX
  SG_ Zeitluecke_4 : 364|9@1+ (0.171,0) [0|100] "Unit_Meter" XXX
  SG_ Zeitluecke_5 : 374|9@1+ (0.171,0) [0|100] "Unit_Meter" XXX
 
-BO_ 771 HCA_03: 24 XXX
- SG_ RequestStatus : 12|4@1+ (1,0) [0|15] "" XXX
- SG_ Power : 16|8@1+ (0.4,0) [0.0|100.0] "Unit_Percent" XXX
- SG_ Curvature : 24|15@1+ (6.7e-06,0) [0|0.219] "Unit_rad/m" XXX
- SG_ Curvature_VZ : 39|1@1+ (1,0) [0|1] "" XXX
- SG_ Vibration : 56|1@0+ (1,0) [0|1] "" XXX
- SG_ HighSendRate : 66|1@1+ (1,0) [0|1] "" XXX
-
 VAL_ 768 ACC_Event_Wunschgeschw 1023 "None";
 VAL_ 768 ACC_Events 3 "Starting_Available" 0 "None" 5 "Speed_Limit_Detected" 9 "Crossing" 4 "Speed_Limit_Ahead" 10 "Roundabout" 6 "Curve";
 
@@ -145,19 +137,6 @@ BO_ 317 QFK_01: 32 XXX
  SG_ Curvature_VZ : 55|1@0+ (1,0) [0|1] "" XXX
  SG_ Steering_Angle : 76|17@1+ (0.00906,0) [0|32767] "" XXX
 
-BO_ 313 VMM_02: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ FCW_Reaction_1 : 12|1@0+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressed_1 : 16|1@0+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressed_2 : 27|1@0+ (1,0) [0|1] "" XXX
- SG_ AEB_Active : 31|1@0+ (1,0) [0|1] "" XXX
- SG_ ESP_Hold : 35|1@0+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressed_3 : 48|1@0+ (1,0) [0|1] "" XXX
- SG_ FCW_Reaction_2 : 56|1@1+ (1,0) [0|1] "" XXX
- SG_ Brake_Pressure : 76|11@1+ (1,0) [0|100] "" XXX
- SG_ FCW_Reaction_3 : 88|5@1+ (1,0) [0|31] "" XXX
-
 BO_ 619 TA_01: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
@@ -169,33 +148,4 @@ BO_ 619 TA_01: 8 XXX
  SG_ Travel_Assist_Available : 23|1@1+ (1,0) [0|1] "" XXX
  SG_ Speed_Mode_Status : 32|3@1+ (1,0) [0|7] "" XXX
  SG_ Lane_Unsure : 37|2@1+ (1,0) [0|3] "" XXX
-
-BO_ 333 ACC_18: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ ACC_limitierte_Anfahrdyn : 12|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_nachtr_Stopp_Anf : 13|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_DynErhoehung : 14|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Freilaufstrategie_TSK : 15|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_zul_Regelabw_unten : 16|6@1+ (0.024,0) [0|1.512] "Unit_MeterPerSeconSquar" XXX
- SG_ ACC_StartStopp_Info : 22|2@1+ (1,0) [0|3] "" XXX
- SG_ ACC_Sollbeschleunigung_02 : 24|11@1+ (0.005,-7.22) [-7.22|3.005] "Unit_MeterPerSeconSquar" XXX
- SG_ ACC_zul_Regelabw_oben : 35|5@1+ (0.0625,0) [0|1.9375] "Unit_MeterPerSeconSquar" XXX
- SG_ ACC_neg_Sollbeschl_Grad_02 : 40|8@1+ (0.05,0) [0|12.75] "Unit_MeterPerCubicSecon" XXX
- SG_ ACC_pos_Sollbeschl_Grad_02 : 48|8@1+ (0.05,0) [0|12.75] "Unit_MeterPerCubicSecon" XXX
- SG_ ACC_Anfahren : 56|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Anhalten : 57|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Typ : 58|2@1+ (1,0) [0|3] "" XXX
- SG_ ACC_Status_ACC : 60|3@1+ (1,0) [0|7] "" XXX
- SG_ ACC_Minimale_Bremsung : 63|1@1+ (1,0) [0|1] "" XXX
- SG_ ACC_Anhalteweg : 64|11@1+ (0.01,0) [0|2046] "" XXX
- SG_ ACC_Anforderung_HMS : 77|3@1+ (1,0) [0|7] "" XXX
- SG_ SET_ME_0XFE : 80|8@1+ (1,0) [0|255] "" XXX
- SG_ ACC_AKTIV_regelt : 90|1@0+ (1,0) [0|1] "" XXX
- SG_ SET_ME_0X1 : 92|1@0+ (1,0) [0|1] "" XXX
- SG_ SET_ME_0x2FE : 98|10@1+ (1,0) [0|63] "" XXX
- SG_ SET_ME_0X9 : 232|4@1+ (1,0) [0|15] "" XXX
- SG_ Speed : 236|12@1+ (0.1,0) [0|15] "" XXX
- SG_ Accel_Boost : 248|6@1+ (1,0) [0|3] "" XXX
- SG_ Reversing : 254|1@0+ (1,0) [0|1] "" XXX
 


### PR DESCRIPTION
HCA_03 and VMM_02 are defined identically in both reference DBCs, so take those definitions verbatim, unknown signals included:

  HCA_03  vw_meb gains the Unit_Percent unit string on Power,
          vw_meb_2024 gains Unknown_01 (53|1)
  VMM_02  vw_meb gains FCW_Reaction_1 and FCW_Reaction_3, and its
          FCW_Active is renamed FCW_Reaction_2 (identical bits) to
          match 2024. Nothing referenced it - the FCW_Active read in
          carstate is AWV_03's, a different message.

ACC_18 differs between the two reference DBCs by SET_ME_0x2FE alone, exactly as opendbc did, so unify on the superset and document it. The signal reads 0 across 99572 frames of the ID.4 MK1 route and mebcan never packs it, so carrying it for both generations is inert.

Nine messages remain variant specific.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
