### PR TITLE
VW MEB: remove unused esp_hold parameter

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -180,7 +180,7 @@ class CarController(CarControllerBase):
           lead_distance = 8
         can_sends.append(mebcan.create_acc_hud_control(self.packer_pt, self.CAN.pt, self.meb_long_state.acc_status, hud_control.setSpeed * CV.MS_TO_KPH,
                                                        hud_control.leadVisible, hud_control.leadDistanceBars + 1, show_distance_bars,
-                                                       CS.esp_hold_confirmation, lead_distance, 0, fcw_alert))
+                                                       lead_distance, 0, fcw_alert))
 
       else:
         lead_distance = 0

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -215,7 +215,7 @@ def get_desired_gap(distance_bars, desired_gap, current_gap_signal):
   return gap
 
 
-def create_acc_hud_control(packer, bus, acc_status, set_speed, lead_visible, distance_bars, show_distance_bars, esp_hold, distance, desired_gap, fcw_alert):
+def create_acc_hud_control(packer, bus, acc_status, set_speed, lead_visible, distance_bars, show_distance_bars, distance, desired_gap, fcw_alert):
   values = {
     "ACC_Status_ACC":                acc_status,
     "ACC_Tempolimit":                0,


### PR DESCRIPTION
The esp_hold parameter of mebcan.create_acc_hud_control was never referenced anywhere in the function body, so the CS.esp_hold_confirmation argument passed by the MEB ACC HUD call site was doing nothing. Drop both.

No CAN output change: the packed ACC_19 payload is byte-identical.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
