### PR TITLE
VW: explicit per-architecture CarController dispatch

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -44,13 +44,6 @@ class CarController(CarControllerBase):
     if CP.flags & VolkswagenFlags.MEB:
       self.meb_long_state = mebcan.MebLongStateMachine(self.CP, self.CCP)
 
-    if CP.flags & VolkswagenFlags.PQ:
-      self.CCS = pqcan
-    elif CP.flags & VolkswagenFlags.MLB:
-      self.CCS = mlbcan
-    else:
-      self.CCS = mqbcan
-
     self.apply_torque_last = 0
     self.apply_curvature_last = 0.
     self.steering_power_last = 0
@@ -63,142 +56,22 @@ class CarController(CarControllerBase):
   def update(self, CC, CS, now_nanos):
     actuators = CC.actuators
     hud_control = CC.hudControl
-    can_sends = []
 
-    # **** Steering Controls ************************************************ #
-
-    if self.frame % self.CCP.STEER_STEP == 0:
-      apply_torque = 0
-      if self.CP.flags & VolkswagenFlags.MEB:
-        # Logic to avoid HCA refused state:
-        #   * steering power as counter and near zero before OP lane assist deactivation
-        # MEB rack can be used continuously without time limits
-        # maximum real steering angle change ~ 120-130 deg/s
-
-        if CC.latActive:
-          hca_enabled = True
-          # compensate the gap between measured and current curvature
-          apply_curvature = actuators.curvature + (CS.curvature_meas - CC.currentCurvature)
-          apply_curvature = self.CCP.CURVATURE_LIMITS.apply_limits(apply_curvature, self.apply_curvature_last, CS.out.vEgoRaw, CS.curvature_meas,
-                                                                   CC.latActive, self.CCP.STEER_STEP)
-
-          min_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MIN)
-          max_power = min(self.steering_power_last + self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MAX)
-          target_power_driver = int(np.interp(CS.out.steeringTorque, [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
-                                                                     [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
-          target_power = int(np.interp(CS.out.vEgo, [0., 0.5], [self.CCP.STEERING_POWER_MIN, target_power_driver]))
-          steering_power = min(max(target_power, min_power), max_power)
-
-        else:
-          if self.steering_power_last > 0:  # keep HCA alive until steering power has reduced to zero
-            hca_enabled = True
-            apply_curvature = float(np.clip(CS.curvature_meas, -self.CCP.CURVATURE_MAX, self.CCP.CURVATURE_MAX))
-            steering_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, 0)
-          else:
-            hca_enabled = False
-            apply_curvature = 0.  # inactive curvature
-            steering_power = 0
-
-        can_sends.append(mebcan.create_steering_control(self.packer_pt, self.CAN.pt, apply_curvature, hca_enabled, steering_power))
-        self.apply_curvature_last = apply_curvature
-        self.steering_power_last = steering_power
-
-      else:
-        if CC.latActive:
-          new_torque = int(round(actuators.torque * self.CCP.STEER_MAX))
-          apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.CCP)
-
-        apply_torque = self.hca_mitigation.update(apply_torque, self.apply_torque_last)
-        hca_enabled = apply_torque != 0
-        self.apply_torque_last = apply_torque
-        can_sends.append(self.CCS.create_steering_control(self.packer_pt, self.CAN.pt, apply_torque, hca_enabled))
-
-      if self.CP.flags & VolkswagenFlags.STOCK_HCA_PRESENT:
-        # Pacify VW Emergency Assist driver inactivity detection by changing its view of driver steering input torque
-        # to the greatest of actual driver input or 2x openpilot's output (1x openpilot output is not enough to
-        # consistently reset inactivity detection on straight level roads). See commaai/openpilot#23274 for background.
-        ea_simulated_torque = float(np.clip(apply_torque * 2, -self.CCP.STEER_MAX, self.CCP.STEER_MAX))
-        if abs(CS.out.steeringTorque) > abs(ea_simulated_torque):
-          ea_simulated_torque = CS.out.steeringTorque
-        can_sends.append(self.CCS.create_eps_update(self.packer_pt, self.CAN.cam, CS.eps_stock_values, ea_simulated_torque))
-
-    # Emergency Assist intervention
-    if self.CP.flags & VolkswagenFlags.MEB and self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
-      # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
-      # MEB Emergency Assist brake jerks after 30s of continued hands-off time.
-      # We send the stock wheeltouch message to start the stock DM timer when openpilot latches the critical driver monitoring alert
-      if self.frame % self.CCP.KLR_01_STEP == 0:
-        lat_active = CC.latActive and not CC.driverMonitoringEscalation
-        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values))
-        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values))
-
-    # **** Acceleration Controls ******************************************** #
-
-    if self.CP.openpilotLongitudinalControl:
-      if self.frame % self.CCP.ACC_CONTROL_STEP == 0:
-        if self.CP.flags & VolkswagenFlags.MEB:
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
-          accel, acc_status, acc_hold_type, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
-          can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
-                                                           accel, acc_status, acc_hold_type, braking_to_stop,
-                                                           CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
-
-        else:
-          stopping = actuators.longControlState == LongCtrlState.stopping
-          acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
-          starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < 0.25)
-          can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, CS.acc_type, CC.longActive, accel,
-                                                             acc_control, stopping, starting, CS.esp_hold_confirmation))
-
-        self.accel_last = accel
-
-      #if self.aeb_available:
-      #  if self.frame % self.CCP.AEB_CONTROL_STEP == 0:
-      #    can_sends.append(self.CCS.create_aeb_control(self.packer_pt, False, False, 0.0))
-      #  if self.frame % self.CCP.AEB_HUD_STEP == 0:
-      #    can_sends.append(self.CCS.create_aeb_hud(self.packer_pt, False, False))
-
-    # **** HUD Controls ***************************************************** #
-
-    if self.frame % self.CCP.LDW_STEP == 0:
-      hud_alert = 0
-      if hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw):
-        hud_alert = self.CCP.LDW_MESSAGES["laneAssistTakeOver"]
-      can_sends.append(self.CCS.create_lka_hud_control(self.packer_pt, self.CAN.pt, CS.ldw_stock_values, CC.latActive,
-                                                       CS.out.steeringPressed, hud_alert, hud_control))
+    # **** Shared Controls ************************************************** #
 
     if hud_control.leadDistanceBars != self.lead_distance_bars_last:
       self.distance_bar_frame = self.frame
 
-    if self.frame % self.CCP.ACC_HUD_STEP == 0 and self.CP.openpilotLongitudinalControl:
-      if self.CP.flags & VolkswagenFlags.MEB:
-        fcw_alert = hud_control.visualAlert == VisualAlert.fcw
-        show_distance_bars = self.frame - self.distance_bar_frame < 400
-        lead_distance = 0
-        if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:
-          lead_distance = 8
-        can_sends.append(mebcan.create_acc_hud_control(self.packer_pt, self.CAN.pt, self.meb_long_state.acc_status, hud_control.setSpeed * CV.MS_TO_KPH,
-                                                       hud_control.leadVisible, hud_control.leadDistanceBars + 1, show_distance_bars,
-                                                       CS.esp_hold_confirmation, lead_distance, 0, fcw_alert))
+    # **** Architecture Specific Controls *********************************** #
 
-      else:
-        lead_distance = 0
-        if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:  # Don't display lead until we know the scaling factor
-          lead_distance = 512 if CS.upscale_lead_car_signal else 8
-        acc_hud_status = self.CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
-        # FIXME: PQ may need to use the on-the-wire mph/kmh toggle to fix rounding errors
-        # FIXME: Detect clusters with vEgoCluster offsets and apply an identical vCruiseCluster offset
-        set_speed = hud_control.setSpeed * CV.MS_TO_KPH
-        can_sends.append(self.CCS.create_acc_hud_control(self.packer_pt, self.CAN.pt, acc_hud_status, set_speed,
-                                                         lead_distance, hud_control.leadDistanceBars))
-
-    # **** Stock ACC Button Controls **************************************** #
-
-    gra_send_ready = self.CP.pcmCruise and CS.gra_stock_values["COUNTER"] != self.gra_acc_counter_last
-    if gra_send_ready and (CC.cruiseControl.cancel or CC.cruiseControl.resume):
-      can_sends.append(self.CCS.create_acc_buttons_control(self.packer_pt, self.CAN.ext, CS.gra_stock_values,
-                                                           cancel=CC.cruiseControl.cancel, resume=CC.cruiseControl.resume))
+    if self.CP.flags & VolkswagenFlags.PQ:
+      can_sends = self.update_pq(CC, CS)
+    elif self.CP.flags & VolkswagenFlags.MLB:
+      can_sends = self.update_mlb(CC, CS)
+    elif self.CP.flags & VolkswagenFlags.MEB:
+      can_sends = self.update_meb(CC, CS)
+    else:
+      can_sends = self.update_mqb(CC, CS)
 
     new_actuators = actuators.as_builder()
     new_actuators.torque = self.apply_torque_last / self.CCP.STEER_MAX
@@ -210,3 +83,224 @@ class CarController(CarControllerBase):
     self.gra_acc_counter_last = CS.gra_stock_values["COUNTER"]
     self.frame += 1
     return new_actuators, can_sends
+
+  def update_pq(self, CC, CS):
+    can_sends = []
+    can_sends.extend(self.create_torque_steering_msgs(pqcan, CC, CS))
+    can_sends.extend(self.create_torque_acc_msgs(pqcan, CC, CS))
+    can_sends.extend(self.create_lka_hud_msgs(pqcan, CC, CS))
+    can_sends.extend(self.create_torque_acc_hud_msgs(pqcan, CC, CS))
+    can_sends.extend(self.create_acc_button_msgs(pqcan, CC, CS))
+    return can_sends
+
+  def update_mlb(self, CC, CS):
+    can_sends = []
+    can_sends.extend(self.create_torque_steering_msgs(mlbcan, CC, CS))
+    can_sends.extend(self.create_torque_acc_msgs(mlbcan, CC, CS))
+    can_sends.extend(self.create_lka_hud_msgs(mlbcan, CC, CS))
+    can_sends.extend(self.create_torque_acc_hud_msgs(mlbcan, CC, CS))
+    can_sends.extend(self.create_acc_button_msgs(mlbcan, CC, CS))
+    return can_sends
+
+  def update_mqb(self, CC, CS):
+    can_sends = []
+    can_sends.extend(self.create_torque_steering_msgs(mqbcan, CC, CS))
+    can_sends.extend(self.create_mqb_eps_msgs(CS))
+    can_sends.extend(self.create_torque_acc_msgs(mqbcan, CC, CS))
+    can_sends.extend(self.create_lka_hud_msgs(mqbcan, CC, CS))
+    can_sends.extend(self.create_torque_acc_hud_msgs(mqbcan, CC, CS))
+    can_sends.extend(self.create_acc_button_msgs(mqbcan, CC, CS))
+    return can_sends
+
+  def update_meb(self, CC, CS):
+    can_sends = []
+    can_sends.extend(self.create_meb_steering_msgs(CC, CS))
+    can_sends.extend(self.create_meb_wheel_touch_msgs(CC, CS))
+    can_sends.extend(self.create_meb_acc_msgs(CC, CS))
+    can_sends.extend(self.create_lka_hud_msgs(mebcan, CC, CS))
+    can_sends.extend(self.create_meb_acc_hud_msgs(CC, CS))
+    can_sends.extend(self.create_acc_button_msgs(mebcan, CC, CS))
+    return can_sends
+
+  # **** Steering Controls ************************************************** #
+
+  def create_torque_steering_msgs(self, CCS, CC, CS):
+    # PQ/MQB/MLB drive torque based EPS racks
+    can_sends = []
+
+    if self.frame % self.CCP.STEER_STEP == 0:
+      apply_torque = 0
+      if CC.latActive:
+        new_torque = int(round(CC.actuators.torque * self.CCP.STEER_MAX))
+        apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.CCP)
+
+      apply_torque = self.hca_mitigation.update(apply_torque, self.apply_torque_last)
+      hca_enabled = apply_torque != 0
+      self.apply_torque_last = apply_torque
+      can_sends.append(CCS.create_steering_control(self.packer_pt, self.CAN.pt, apply_torque, hca_enabled))
+
+    return can_sends
+
+  def create_meb_steering_msgs(self, CC, CS):
+    # Logic to avoid HCA refused state:
+    #   * steering power as counter and near zero before OP lane assist deactivation
+    # MEB rack can be used continuously without time limits
+    # maximum real steering angle change ~ 120-130 deg/s
+    can_sends = []
+
+    if self.frame % self.CCP.STEER_STEP == 0:
+      if CC.latActive:
+        hca_enabled = True
+        # compensate the gap between measured and current curvature
+        apply_curvature = CC.actuators.curvature + (CS.curvature_meas - CC.currentCurvature)
+        apply_curvature = self.CCP.CURVATURE_LIMITS.apply_limits(apply_curvature, self.apply_curvature_last, CS.out.vEgoRaw, CS.curvature_meas,
+                                                                 CC.latActive, self.CCP.STEER_STEP)
+
+        min_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MIN)
+        max_power = min(self.steering_power_last + self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MAX)
+        target_power_driver = int(np.interp(CS.out.steeringTorque, [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
+                                                                   [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
+        target_power = int(np.interp(CS.out.vEgo, [0., 0.5], [self.CCP.STEERING_POWER_MIN, target_power_driver]))
+        steering_power = min(max(target_power, min_power), max_power)
+
+      else:
+        if self.steering_power_last > 0:  # keep HCA alive until steering power has reduced to zero
+          hca_enabled = True
+          apply_curvature = float(np.clip(CS.curvature_meas, -self.CCP.CURVATURE_MAX, self.CCP.CURVATURE_MAX))
+          steering_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, 0)
+        else:
+          hca_enabled = False
+          apply_curvature = 0.  # inactive curvature
+          steering_power = 0
+
+      can_sends.append(mebcan.create_steering_control(self.packer_pt, self.CAN.pt, apply_curvature, hca_enabled, steering_power))
+      self.apply_curvature_last = apply_curvature
+      self.steering_power_last = steering_power
+
+    return can_sends
+
+  def create_mqb_eps_msgs(self, CS):
+    # Only MQB has a stock HCA to pacify, VolkswagenFlags.STOCK_HCA_PRESENT is never set on the other architectures
+    can_sends = []
+
+    if self.frame % self.CCP.STEER_STEP == 0 and self.CP.flags & VolkswagenFlags.STOCK_HCA_PRESENT:
+      # Pacify VW Emergency Assist driver inactivity detection by changing its view of driver steering input torque
+      # to the greatest of actual driver input or 2x openpilot's output (1x openpilot output is not enough to
+      # consistently reset inactivity detection on straight level roads). See commaai/openpilot#23274 for background.
+      ea_simulated_torque = float(np.clip(self.apply_torque_last * 2, -self.CCP.STEER_MAX, self.CCP.STEER_MAX))
+      if abs(CS.out.steeringTorque) > abs(ea_simulated_torque):
+        ea_simulated_torque = CS.out.steeringTorque
+      can_sends.append(mqbcan.create_eps_update(self.packer_pt, self.CAN.cam, CS.eps_stock_values, ea_simulated_torque))
+
+    return can_sends
+
+  def create_meb_wheel_touch_msgs(self, CC, CS):
+    # Emergency Assist intervention
+    # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
+    # MEB Emergency Assist brake jerks after 30s of continued hands-off time.
+    # We send the stock wheeltouch message to start the stock DM timer when openpilot latches the critical driver monitoring alert
+    can_sends = []
+
+    if self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT and self.frame % self.CCP.KLR_01_STEP == 0:
+      lat_active = CC.latActive and not CC.driverMonitoringEscalation
+      can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values))
+      can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values))
+
+    return can_sends
+
+  # **** Acceleration Controls ********************************************** #
+
+  def create_torque_acc_msgs(self, CCS, CC, CS):
+    can_sends = []
+
+    if self.CP.openpilotLongitudinalControl and self.frame % self.CCP.ACC_CONTROL_STEP == 0:
+      actuators = CC.actuators
+      stopping = actuators.longControlState == LongCtrlState.stopping
+      acc_control = CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
+      accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
+      starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < 0.25)
+      can_sends.extend(CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, CS.acc_type, CC.longActive, accel,
+                                                    acc_control, stopping, starting, CS.esp_hold_confirmation))
+      self.accel_last = accel
+
+    #if self.CP.openpilotLongitudinalControl and self.aeb_available:
+    #  if self.frame % self.CCP.AEB_CONTROL_STEP == 0:
+    #    can_sends.append(CCS.create_aeb_control(self.packer_pt, False, False, 0.0))
+    #  if self.frame % self.CCP.AEB_HUD_STEP == 0:
+    #    can_sends.append(CCS.create_aeb_hud(self.packer_pt, False, False))
+
+    return can_sends
+
+  def create_meb_acc_msgs(self, CC, CS):
+    can_sends = []
+
+    if self.CP.openpilotLongitudinalControl and self.frame % self.CCP.ACC_CONTROL_STEP == 0:
+      accel = float(np.clip(CC.actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
+      accel, acc_status, acc_hold_type, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
+      can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
+                                                       accel, acc_status, acc_hold_type, braking_to_stop,
+                                                       CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
+      self.accel_last = accel
+
+    return can_sends
+
+  # **** HUD Controls ******************************************************* #
+
+  def create_lka_hud_msgs(self, CCS, CC, CS):
+    # All architectures drive an LDW message with the same lane visualization and text alert interface
+    can_sends = []
+
+    if self.frame % self.CCP.LDW_STEP == 0:
+      hud_control = CC.hudControl
+      hud_alert = 0
+      if hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw):
+        hud_alert = self.CCP.LDW_MESSAGES["laneAssistTakeOver"]
+      can_sends.append(CCS.create_lka_hud_control(self.packer_pt, self.CAN.pt, CS.ldw_stock_values, CC.latActive,
+                                                  CS.out.steeringPressed, hud_alert, hud_control))
+
+    return can_sends
+
+  def create_torque_acc_hud_msgs(self, CCS, CC, CS):
+    can_sends = []
+
+    if self.CP.openpilotLongitudinalControl and self.frame % self.CCP.ACC_HUD_STEP == 0:
+      hud_control = CC.hudControl
+      lead_distance = 0
+      if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:  # Don't display lead until we know the scaling factor
+        lead_distance = 512 if CS.upscale_lead_car_signal else 8
+      acc_hud_status = CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
+      # FIXME: PQ may need to use the on-the-wire mph/kmh toggle to fix rounding errors
+      # FIXME: Detect clusters with vEgoCluster offsets and apply an identical vCruiseCluster offset
+      set_speed = hud_control.setSpeed * CV.MS_TO_KPH
+      can_sends.append(CCS.create_acc_hud_control(self.packer_pt, self.CAN.pt, acc_hud_status, set_speed,
+                                                  lead_distance, hud_control.leadDistanceBars))
+
+    return can_sends
+
+  def create_meb_acc_hud_msgs(self, CC, CS):
+    can_sends = []
+
+    if self.CP.openpilotLongitudinalControl and self.frame % self.CCP.ACC_HUD_STEP == 0:
+      hud_control = CC.hudControl
+      fcw_alert = hud_control.visualAlert == VisualAlert.fcw
+      show_distance_bars = self.frame - self.distance_bar_frame < 400
+      lead_distance = 0
+      if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:
+        lead_distance = 8
+      can_sends.append(mebcan.create_acc_hud_control(self.packer_pt, self.CAN.pt, self.meb_long_state.acc_status, hud_control.setSpeed * CV.MS_TO_KPH,
+                                                     hud_control.leadVisible, hud_control.leadDistanceBars + 1, show_distance_bars,
+                                                     CS.esp_hold_confirmation, lead_distance, 0, fcw_alert))
+
+    return can_sends
+
+  # **** Stock ACC Button Controls ****************************************** #
+
+  def create_acc_button_msgs(self, CCS, CC, CS):
+    can_sends = []
+
+    gra_send_ready = self.CP.pcmCruise and CS.gra_stock_values["COUNTER"] != self.gra_acc_counter_last
+    if gra_send_ready and (CC.cruiseControl.cancel or CC.cruiseControl.resume):
+      can_sends.append(CCS.create_acc_buttons_control(self.packer_pt, self.CAN.ext, CS.gra_stock_values,
+                                                      cancel=CC.cruiseControl.cancel, resume=CC.cruiseControl.resume))
+
+    return can_sends

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -16,26 +16,14 @@ def create_steering_control(packer, bus, apply_curvature, lkas_enabled, power=0)
   return packer.make_can_msg("HCA_03", bus, values)
 
 
-def create_eps_update(packer, bus, eps_stock_values, ea_simulated_torque):
-  values = {s: eps_stock_values[s] for s in [
-    "COUNTER",                     # Sync counter value to EPS output
-    "EPS_Lenkungstyp",             # EPS rack type
-    "EPS_Berechneter_LW",          # Absolute raw steering angle
-    "EPS_VZ_BLW",                  # Raw steering angle sign
-    "EPS_HCA_Status",              # EPS HCA control status
-  ]}
-
-  values.update({
-    # Absolute driver torque input and sign, with EA inactivity mitigation
-    "EPS_Lenkmoment": abs(ea_simulated_torque),
-    "EPS_VZ_Lenkmoment": 1 if ea_simulated_torque < 0 else 0,
-  })
-
-  return packer.make_can_msg("LH_EPS_03", bus, values)
+LDW_LERNMODUS_MAX = 3  # LDW_Lernmodus_links/rechts are 2 bit signals, the CAN packer masks instead of clamping
 
 
 def create_lka_hud_control(packer, bus, ldw_stock_values, lat_active, steering_pressed, hud_alert, hud_control, sound_alert=False):
   display_mode = 1 if lat_active else 0  # travel assist style showing yellow lanes when op is active
+
+  def lane_display(lane_depart, lane_visible):
+    return min(3 + display_mode if lane_depart else 1 + lane_visible + display_mode, LDW_LERNMODUS_MAX)
 
   values = {}
   if len(ldw_stock_values):
@@ -51,8 +39,8 @@ def create_lka_hud_control(packer, bus, ldw_stock_values, lat_active, steering_p
     "LDW_Gong": sound_alert,
     "LDW_Status_LED_gelb": 1 if lat_active and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if lat_active and not steering_pressed else 0,
-    "LDW_Lernmodus_links": 3 + display_mode if hud_control.leftLaneDepart else 1 + hud_control.leftLaneVisible + display_mode,
-    "LDW_Lernmodus_rechts": 3 + display_mode if hud_control.rightLaneDepart else 1 + hud_control.rightLaneVisible + display_mode,
+    "LDW_Lernmodus_links": lane_display(hud_control.leftLaneDepart, hud_control.leftLaneVisible),
+    "LDW_Lernmodus_rechts": lane_display(hud_control.rightLaneDepart, hud_control.rightLaneVisible),
     "LDW_Texte": hud_alert,
   })
   return packer.make_can_msg("LDW_02", bus, values)


### PR DESCRIPTION
The CarController selected self.CCS from PQ/MLB/MQB only, so MEB silently fell through to mqbcan for create_lka_hud_control, create_acc_buttons_control and create_eps_update, while calling mebcan directly everywhere else. Follow the carstate.py and Hyundai pattern instead: update() keeps the shared state tracking and dispatches to a named update_pq/update_mlb/update_meb/update_mqb, each of which names its own CAN module. PQ/MQB/MLB share the torque steering, ACC and HUD helpers, MEB has its own curvature steering, ACC and ACC HUD.

MEB behavior changes:
* LDW_02 is now built by mebcan.create_lka_hud_control instead of mqbcan's. LDW_Lernmodus_links/rechts gain the +1 "travel assist yellow lanes" offset while latActive: 1 -> 2 with no lane visible, 2 -> 3 with a lane visible. LDW_Gong, LDW_Texte and the LED signals are unchanged.
* mebcan's un-clamped "3 + display_mode" overflowed the 2 bit LDW_Lernmodus fields on lane depart while latActive. The packer masks rather than clamps, so it would have wrapped to 0. Clamped to 3, matching mqbcan's maximum.
* GRA_ACC_01 now comes from mebcan.create_acc_buttons_control. It packs byte-identically to mqbcan's for the cancel/resume-only call site.
* mebcan.create_eps_update is removed. It was byte-identical to mqbcan's and its only call site is gated on STOCK_HCA_PRESENT, which interface.py only ever sets on MQB.

PQ, MQB and MLB output is bit-identical, verified by replaying a deterministic fuzz sequence through the old and new controllers for every architecture, network location and alpha long combination.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
