### PR TITLE
VW MEB: unify QFK_01 and Motor_54 into the common DBC

### DIFF
--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -298,6 +298,17 @@ BO_ 313 VMM_02: 32 XXX
  SG_ Brake_Pressure : 76|11@1+ (1,0) [0|100] "" XXX
  SG_ FCW_Reaction_3 : 88|5@1+ (1,0) [0|31] "" XXX
 
+BO_ 317 QFK_01: 32 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ HCA_No_Override : 14|1@0+ (1,0) [0|1] "" XXX
+ SG_ LatCon_HCA_Accept : 17|2@1+ (1,0) [0|3] "" XXX
+ SG_ LatCon_HCA_Status : 20|3@1+ (1,0) [0|15] "" XXX
+ SG_ Steering_Angle_VZ : 36|1@0+ (1,0) [0|1] "" XXX
+ SG_ Curvature : 40|15@1+ (6.7e-06,0) [0|65535] "" XXX
+ SG_ Curvature_VZ : 55|1@0+ (1,0) [0|1] "" XXX
+ SG_ Steering_Angle : 76|17@1+ (0.00906,0) [0|32767] "" XXX
+
 BO_ 319 PreCrash_02: 8 Gateway
  SG_ PreCrash_02_CRC : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ PreCrash_02_BZ : 8|4@1+ (1,0) [0|15] "" Vector__XXX
@@ -321,6 +332,12 @@ BO_ 319 PreCrash_02: 8 Gateway
  SG_ PreCrash_Fo_KSV_verfahren : 51|4@1+ (1,0) [0|15] "" Vector__XXX
  SG_ SC_PreCrash_Warnung : 56|4@1+ (1,0) [0|15] "" NightVision
  SG_ SC_PreCrash_Texte : 60|4@1+ (1,0) [0|15] "" Vector__XXX
+
+BO_ 332 Motor_54: 32 XXX
+ SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
+ SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
+ SG_ Engine_On : 77|1@1+ (1,0) [0|1] "" XXX
+ SG_ Accelerator_Pressure : 175|8@0+ (0.4,-14.8) [0|100] "Unit_Percent" XXX
 
 BO_ 333 ACC_18: 32 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX

--- a/opendbc/dbc/generator/volkswagen/vw_meb.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb.dbc
@@ -45,21 +45,6 @@ BO_ 267 Motor_51: 32 XXX
  SG_ TSK_Status : 88|3@1+ (1,0) [0|7] "" XXX
  SG_ TSK_Limiter_ausgewaehlt : 95|1@1+ (1,0) [0|3] "" XXX
 
-BO_ 317 QFK_01: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ LatCon_HCA_Accept : 17|2@1+ (1,0) [0|3] "" XXX
- SG_ LatCon_HCA_Status : 20|3@1+ (1,0) [0|15] "" XXX
- SG_ Steering_Angle_VZ : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ Curvature : 40|15@1+ (6.7e-06,0) [0|65535] "" XXX
- SG_ Curvature_VZ : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ Steering_Angle : 76|17@1+ (0.00906,0) [0|32767] "" XXX
-
-BO_ 332 Motor_54: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Accelerator_Pressure : 175|8@0+ (0.4,-14.8) [0|100] "Unit_Percent" XXX
-
 BO_ 496 EA_02: 8 Gateway
  SG_ EA_02_CRC : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ EA_02_BZ : 8|4@1+ (1,0) [0|15] "" Vector__XXX

--- a/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
@@ -17,12 +17,6 @@ BO_ 190 MEB_HVEM_01: 48 XXX
  SG_ Inactive : 300|1@0+ (1,0) [0|1] "" XXX
  SG_ Inactive_02 : 303|1@0+ (1,0) [0|1] "" XXX
 
-BO_ 332 Motor_54: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ Engine_On : 77|1@1+ (1,0) [0|1] "" XXX
- SG_ Accelerator_Pressure : 175|8@0+ (0.4,-14.8) [0|100] "Unit_Percent" XXX
-
 BO_ 496 EA_02: 8 Gateway
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" Vector__XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" Vector__XXX
@@ -125,17 +119,6 @@ BO_ 267 Motor_51: 48 XXX
  SG_ Accel_Low_Pressed_Support : 21|1@1+ (1,0) [0|7] "" XXX
  SG_ TSK_Status : 88|3@1+ (1,0) [0|7] "" XXX
  SG_ TSK_Limiter_ausgewaehlt : 95|1@1+ (1,0) [0|3] "" XXX
-
-BO_ 317 QFK_01: 32 XXX
- SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
- SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX
- SG_ HCA_No_Override : 14|1@0+ (1,0) [0|1] "" XXX
- SG_ LatCon_HCA_Accept : 17|2@1+ (1,0) [0|3] "" XXX
- SG_ LatCon_HCA_Status : 20|3@1+ (1,0) [0|15] "" XXX
- SG_ Steering_Angle_VZ : 36|1@0+ (1,0) [0|1] "" XXX
- SG_ Curvature : 40|15@1+ (6.7e-06,0) [0|65535] "" XXX
- SG_ Curvature_VZ : 55|1@0+ (1,0) [0|1] "" XXX
- SG_ Steering_Angle : 76|17@1+ (0.00906,0) [0|32767] "" XXX
 
 BO_ 619 TA_01: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX


### PR DESCRIPTION
Each differed from 2024 by a single signal. Both are present and behave the same way on both generations, so add them to pre-2024 and move the messages to the common file.

  QFK_01.HCA_No_Override  14|1@0   MK1 873/199158 frames set,
                                   MK2 183/44658 (bus 0)
  Motor_54.Engine_On      77|1@1   constant 1 once the car is on:
                                   MK1 20078 set / 1 clear,
                                   MK2 4511 set / 5 clear

QFK_01's CM_ and LatCon_HCA_Status VAL_ were already in the common file, so they now sit with their message.

Seven messages remain variant specific.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
