### PR TITLE
VW: add MEB to the CarController architecture dispatch

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -41,13 +41,13 @@ class CarController(CarControllerBase):
     self.packer_pt = CANPacker(dbc_names[Bus.pt])
     self.aeb_available = not CP.flags & VolkswagenFlags.PQ
 
-    if CP.flags & VolkswagenFlags.MEB:
-      self.meb_long_state = mebcan.MebLongStateMachine(self.CP, self.CCP)
-
     if CP.flags & VolkswagenFlags.PQ:
       self.CCS = pqcan
     elif CP.flags & VolkswagenFlags.MLB:
       self.CCS = mlbcan
+    elif CP.flags & VolkswagenFlags.MEB:
+      self.CCS = mebcan
+      self.meb_long_state = mebcan.MebLongStateMachine(self.CP, self.CCP)
     else:
       self.CCS = mqbcan
 
@@ -61,97 +61,19 @@ class CarController(CarControllerBase):
     self.hca_mitigation = HCAMitigation(self.CCP)
 
   def update(self, CC, CS, now_nanos):
-    actuators = CC.actuators
     hud_control = CC.hudControl
     can_sends = []
 
-    # **** Steering Controls ************************************************ #
-
     if self.frame % self.CCP.STEER_STEP == 0:
-      apply_torque = 0
-      if self.CP.flags & VolkswagenFlags.MEB:
-        # Logic to avoid HCA refused state:
-        #   * steering power as counter and near zero before OP lane assist deactivation
-        # MEB rack can be used continuously without time limits
-        # maximum real steering angle change ~ 120-130 deg/s
+      can_sends.extend(self.create_steering_msgs(CC, CS))
 
-        if CC.latActive:
-          hca_enabled = True
-          # compensate the gap between measured and current curvature
-          apply_curvature = actuators.curvature + (CS.curvature_meas - CC.currentCurvature)
-          apply_curvature = self.CCP.CURVATURE_LIMITS.apply_limits(apply_curvature, self.apply_curvature_last, CS.out.vEgoRaw, CS.curvature_meas,
-                                                                   CC.latActive, self.CCP.STEER_STEP)
-
-          min_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MIN)
-          max_power = min(self.steering_power_last + self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MAX)
-          target_power_driver = int(np.interp(CS.out.steeringTorque, [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
-                                                                     [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
-          target_power = int(np.interp(CS.out.vEgo, [0., 0.5], [self.CCP.STEERING_POWER_MIN, target_power_driver]))
-          steering_power = min(max(target_power, min_power), max_power)
-
-        else:
-          if self.steering_power_last > 0:  # keep HCA alive until steering power has reduced to zero
-            hca_enabled = True
-            apply_curvature = float(np.clip(CS.curvature_meas, -self.CCP.CURVATURE_MAX, self.CCP.CURVATURE_MAX))
-            steering_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, 0)
-          else:
-            hca_enabled = False
-            apply_curvature = 0.  # inactive curvature
-            steering_power = 0
-
-        can_sends.append(mebcan.create_steering_control(self.packer_pt, self.CAN.pt, apply_curvature, hca_enabled, steering_power))
-        self.apply_curvature_last = apply_curvature
-        self.steering_power_last = steering_power
-
-      else:
-        if CC.latActive:
-          new_torque = int(round(actuators.torque * self.CCP.STEER_MAX))
-          apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.CCP)
-
-        apply_torque = self.hca_mitigation.update(apply_torque, self.apply_torque_last)
-        hca_enabled = apply_torque != 0
-        self.apply_torque_last = apply_torque
-        can_sends.append(self.CCS.create_steering_control(self.packer_pt, self.CAN.pt, apply_torque, hca_enabled))
-
-      if self.CP.flags & VolkswagenFlags.STOCK_HCA_PRESENT:
-        # Pacify VW Emergency Assist driver inactivity detection by changing its view of driver steering input torque
-        # to the greatest of actual driver input or 2x openpilot's output (1x openpilot output is not enough to
-        # consistently reset inactivity detection on straight level roads). See commaai/openpilot#23274 for background.
-        ea_simulated_torque = float(np.clip(apply_torque * 2, -self.CCP.STEER_MAX, self.CCP.STEER_MAX))
-        if abs(CS.out.steeringTorque) > abs(ea_simulated_torque):
-          ea_simulated_torque = CS.out.steeringTorque
-        can_sends.append(self.CCS.create_eps_update(self.packer_pt, self.CAN.cam, CS.eps_stock_values, ea_simulated_torque))
-
-    # Emergency Assist intervention
-    if self.CP.flags & VolkswagenFlags.MEB and self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT:
-      # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
-      # MEB Emergency Assist brake jerks after 30s of continued hands-off time.
-      # We send the stock wheeltouch message to start the stock DM timer when openpilot latches the critical driver monitoring alert
-      if self.frame % self.CCP.KLR_01_STEP == 0:
-        lat_active = CC.latActive and not CC.driverMonitoringEscalation
-        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values))
-        can_sends.append(mebcan.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values))
-
-    # **** Acceleration Controls ******************************************** #
+    # Emergency Assist intervention, MEB only
+    if self.CP.flags & VolkswagenFlags.STOCK_KLR_PRESENT and self.frame % self.CCP.KLR_01_STEP == 0:
+      can_sends.extend(self.create_wheel_touch_msgs(CC, CS))
 
     if self.CP.openpilotLongitudinalControl:
       if self.frame % self.CCP.ACC_CONTROL_STEP == 0:
-        if self.CP.flags & VolkswagenFlags.MEB:
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
-          accel, acc_status, acc_hold_type, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
-          can_sends.extend(mebcan.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
-                                                           accel, acc_status, acc_hold_type, braking_to_stop,
-                                                           CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
-
-        else:
-          stopping = actuators.longControlState == LongCtrlState.stopping
-          acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
-          accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
-          starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < 0.25)
-          can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, CS.acc_type, CC.longActive, accel,
-                                                             acc_control, stopping, starting, CS.esp_hold_confirmation))
-
-        self.accel_last = accel
+        can_sends.extend(self.create_acc_msgs(CC, CS))
 
       #if self.aeb_available:
       #  if self.frame % self.CCP.AEB_CONTROL_STEP == 0:
@@ -159,48 +81,18 @@ class CarController(CarControllerBase):
       #  if self.frame % self.CCP.AEB_HUD_STEP == 0:
       #    can_sends.append(self.CCS.create_aeb_hud(self.packer_pt, False, False))
 
-    # **** HUD Controls ***************************************************** #
-
     if self.frame % self.CCP.LDW_STEP == 0:
-      hud_alert = 0
-      if hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw):
-        hud_alert = self.CCP.LDW_MESSAGES["laneAssistTakeOver"]
-      can_sends.append(self.CCS.create_lka_hud_control(self.packer_pt, self.CAN.pt, CS.ldw_stock_values, CC.latActive,
-                                                       CS.out.steeringPressed, hud_alert, hud_control))
+      can_sends.extend(self.create_lka_hud_msgs(CC, CS))
 
     if hud_control.leadDistanceBars != self.lead_distance_bars_last:
       self.distance_bar_frame = self.frame
 
-    if self.frame % self.CCP.ACC_HUD_STEP == 0 and self.CP.openpilotLongitudinalControl:
-      if self.CP.flags & VolkswagenFlags.MEB:
-        fcw_alert = hud_control.visualAlert == VisualAlert.fcw
-        show_distance_bars = self.frame - self.distance_bar_frame < 400
-        lead_distance = 0
-        if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:
-          lead_distance = 8
-        can_sends.append(mebcan.create_acc_hud_control(self.packer_pt, self.CAN.pt, self.meb_long_state.acc_status, hud_control.setSpeed * CV.MS_TO_KPH,
-                                                       hud_control.leadVisible, hud_control.leadDistanceBars, show_distance_bars,
-                                                       lead_distance, fcw_alert))
+    if self.CP.openpilotLongitudinalControl and self.frame % self.CCP.ACC_HUD_STEP == 0:
+      can_sends.extend(self.create_acc_hud_msgs(CC, CS))
 
-      else:
-        lead_distance = 0
-        if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:  # Don't display lead until we know the scaling factor
-          lead_distance = 512 if CS.upscale_lead_car_signal else 8
-        acc_hud_status = self.CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
-        # FIXME: PQ may need to use the on-the-wire mph/kmh toggle to fix rounding errors
-        # FIXME: Detect clusters with vEgoCluster offsets and apply an identical vCruiseCluster offset
-        set_speed = hud_control.setSpeed * CV.MS_TO_KPH
-        can_sends.append(self.CCS.create_acc_hud_control(self.packer_pt, self.CAN.pt, acc_hud_status, set_speed,
-                                                         lead_distance, hud_control.leadDistanceBars))
+    can_sends.extend(self.create_acc_button_msgs(CC, CS))
 
-    # **** Stock ACC Button Controls **************************************** #
-
-    gra_send_ready = self.CP.pcmCruise and CS.gra_stock_values["COUNTER"] != self.gra_acc_counter_last
-    if gra_send_ready and (CC.cruiseControl.cancel or CC.cruiseControl.resume):
-      can_sends.append(self.CCS.create_acc_buttons_control(self.packer_pt, self.CAN.ext, CS.gra_stock_values,
-                                                           cancel=CC.cruiseControl.cancel, resume=CC.cruiseControl.resume))
-
-    new_actuators = actuators.as_builder()
+    new_actuators = CC.actuators.as_builder()
     new_actuators.torque = self.apply_torque_last / self.CCP.STEER_MAX
     new_actuators.torqueOutputCan = self.apply_torque_last
     new_actuators.curvature = self.apply_curvature_last
@@ -210,3 +102,138 @@ class CarController(CarControllerBase):
     self.gra_acc_counter_last = CS.gra_stock_values["COUNTER"]
     self.frame += 1
     return new_actuators, can_sends
+
+  # **** Steering Controls ************************************************** #
+
+  def create_steering_msgs(self, CC, CS):
+    can_sends = []
+
+    if self.CP.flags & VolkswagenFlags.MEB:
+      # Logic to avoid HCA refused state:
+      #   * steering power as counter and near zero before OP lane assist deactivation
+      # MEB rack can be used continuously without time limits
+      # maximum real steering angle change ~ 120-130 deg/s
+
+      if CC.latActive:
+        hca_enabled = True
+        # compensate the gap between measured and current curvature
+        apply_curvature = CC.actuators.curvature + (CS.curvature_meas - CC.currentCurvature)
+        apply_curvature = self.CCP.CURVATURE_LIMITS.apply_limits(apply_curvature, self.apply_curvature_last, CS.out.vEgoRaw, CS.curvature_meas,
+                                                                 CC.latActive, self.CCP.STEER_STEP)
+
+        min_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MIN)
+        max_power = min(self.steering_power_last + self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MAX)
+        target_power_driver = int(np.interp(CS.out.steeringTorque, [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
+                                                                   [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
+        target_power = int(np.interp(CS.out.vEgo, [0., 0.5], [self.CCP.STEERING_POWER_MIN, target_power_driver]))
+        steering_power = min(max(target_power, min_power), max_power)
+
+      else:
+        if self.steering_power_last > 0:  # keep HCA alive until steering power has reduced to zero
+          hca_enabled = True
+          apply_curvature = float(np.clip(CS.curvature_meas, -self.CCP.CURVATURE_MAX, self.CCP.CURVATURE_MAX))
+          steering_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, 0)
+        else:
+          hca_enabled = False
+          apply_curvature = 0.  # inactive curvature
+          steering_power = 0
+
+      can_sends.append(self.CCS.create_steering_control(self.packer_pt, self.CAN.pt, apply_curvature, hca_enabled, steering_power))
+      self.apply_curvature_last = apply_curvature
+      self.steering_power_last = steering_power
+
+    else:
+      apply_torque = 0
+      if CC.latActive:
+        new_torque = int(round(CC.actuators.torque * self.CCP.STEER_MAX))
+        apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.CCP)
+
+      apply_torque = self.hca_mitigation.update(apply_torque, self.apply_torque_last)
+      hca_enabled = apply_torque != 0
+      self.apply_torque_last = apply_torque
+      can_sends.append(self.CCS.create_steering_control(self.packer_pt, self.CAN.pt, apply_torque, hca_enabled))
+
+      # Only MQB has a stock Emergency Assist to pacify, STOCK_HCA_PRESENT is never set on the other architectures
+      if self.CP.flags & VolkswagenFlags.STOCK_HCA_PRESENT:
+        # Pacify VW Emergency Assist driver inactivity detection by changing its view of driver steering input torque
+        # to the greatest of actual driver input or 2x openpilot's output (1x openpilot output is not enough to
+        # consistently reset inactivity detection on straight level roads). See commaai/openpilot#23274 for background.
+        ea_simulated_torque = float(np.clip(apply_torque * 2, -self.CCP.STEER_MAX, self.CCP.STEER_MAX))
+        if abs(CS.out.steeringTorque) > abs(ea_simulated_torque):
+          ea_simulated_torque = CS.out.steeringTorque
+        can_sends.append(self.CCS.create_eps_update(self.packer_pt, self.CAN.cam, CS.eps_stock_values, ea_simulated_torque))
+
+    return can_sends
+
+  def create_wheel_touch_msgs(self, CC, CS):
+    # send capacitive steering wheel hands-on message to keep ACC resume active and control Emergency Assist
+    # MEB Emergency Assist brake jerks after 30s of continued hands-off time.
+    # We send the stock wheeltouch message to start the stock DM timer when openpilot latches the critical driver monitoring alert
+    lat_active = CC.latActive and not CC.driverMonitoringEscalation
+    return [self.CCS.create_capacitive_wheel_touch(self.packer_pt, self.CAN.cam, lat_active, CS.klr_stock_values),
+            self.CCS.create_capacitive_wheel_touch(self.packer_pt, self.CAN.pt, lat_active, CS.klr_stock_values)]
+
+  # **** Acceleration Controls ********************************************** #
+
+  def create_acc_msgs(self, CC, CS):
+    can_sends = []
+    actuators = CC.actuators
+
+    if self.CP.flags & VolkswagenFlags.MEB:
+      accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX))
+      accel, acc_status, acc_hold_type, braking_to_stop = self.meb_long_state.update(CS, CC, accel)
+      can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, self.CCP, CS.acc_type, CC.enabled,
+                                                         accel, acc_status, acc_hold_type, braking_to_stop,
+                                                         CS.out.vEgoRaw * CV.MS_TO_KPH, CS.travel_assist_available))
+
+    else:
+      stopping = actuators.longControlState == LongCtrlState.stopping
+      acc_control = self.CCS.acc_control_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
+      accel = float(np.clip(actuators.accel, self.CCP.ACCEL_MIN, self.CCP.ACCEL_MAX) if CC.longActive else 0)
+      starting = actuators.longControlState == LongCtrlState.pid and (CS.esp_hold_confirmation or CS.out.vEgo < 0.25)
+      can_sends.extend(self.CCS.create_acc_accel_control(self.packer_pt, self.CAN.pt, CS.acc_type, CC.longActive, accel,
+                                                         acc_control, stopping, starting, CS.esp_hold_confirmation))
+
+    self.accel_last = accel
+    return can_sends
+
+  # **** HUD Controls ******************************************************* #
+
+  def create_lka_hud_msgs(self, CC, CS):
+    hud_control = CC.hudControl
+    hud_alert = 0
+    if hud_control.visualAlert in (VisualAlert.steerRequired, VisualAlert.ldw):
+      hud_alert = self.CCP.LDW_MESSAGES["laneAssistTakeOver"]
+    return [self.CCS.create_lka_hud_control(self.packer_pt, self.CAN.pt, CS.ldw_stock_values, CC.latActive,
+                                            CS.out.steeringPressed, hud_alert, hud_control)]
+
+  def create_acc_hud_msgs(self, CC, CS):
+    hud_control = CC.hudControl
+    lead_distance = 0
+
+    if self.CP.flags & VolkswagenFlags.MEB:
+      if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:
+        lead_distance = 8
+      fcw_alert = hud_control.visualAlert == VisualAlert.fcw
+      show_distance_bars = self.frame - self.distance_bar_frame < 400
+      return [self.CCS.create_acc_hud_control(self.packer_pt, self.CAN.pt, self.meb_long_state.acc_status, hud_control.setSpeed * CV.MS_TO_KPH,
+                                              hud_control.leadVisible, hud_control.leadDistanceBars, show_distance_bars,
+                                              lead_distance, fcw_alert)]
+
+    if hud_control.leadVisible and self.frame * DT_CTRL > 1.0:  # Don't display lead until we know the scaling factor
+      lead_distance = 512 if CS.upscale_lead_car_signal else 8
+    acc_hud_status = self.CCS.acc_hud_status_value(CS.out.cruiseState.available, CS.out.accFaulted, CC.longActive)
+    # FIXME: PQ may need to use the on-the-wire mph/kmh toggle to fix rounding errors
+    # FIXME: Detect clusters with vEgoCluster offsets and apply an identical vCruiseCluster offset
+    set_speed = hud_control.setSpeed * CV.MS_TO_KPH
+    return [self.CCS.create_acc_hud_control(self.packer_pt, self.CAN.pt, acc_hud_status, set_speed,
+                                            lead_distance, hud_control.leadDistanceBars)]
+
+  # **** Stock ACC Button Controls ****************************************** #
+
+  def create_acc_button_msgs(self, CC, CS):
+    gra_send_ready = self.CP.pcmCruise and CS.gra_stock_values["COUNTER"] != self.gra_acc_counter_last
+    if gra_send_ready and (CC.cruiseControl.cancel or CC.cruiseControl.resume):
+      return [self.CCS.create_acc_buttons_control(self.packer_pt, self.CAN.ext, CS.gra_stock_values,
+                                                  cancel=CC.cruiseControl.cancel, resume=CC.cruiseControl.resume)]
+    return []

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -35,8 +35,6 @@ def create_eps_update(packer, bus, eps_stock_values, ea_simulated_torque):
 
 
 def create_lka_hud_control(packer, bus, ldw_stock_values, lat_active, steering_pressed, hud_alert, hud_control, sound_alert=False):
-  display_mode = 1 if lat_active else 0  # travel assist style showing yellow lanes when op is active
-
   values = {}
   if len(ldw_stock_values):
     values = {s: ldw_stock_values[s] for s in [
@@ -51,8 +49,8 @@ def create_lka_hud_control(packer, bus, ldw_stock_values, lat_active, steering_p
     "LDW_Gong": sound_alert,
     "LDW_Status_LED_gelb": 1 if lat_active and steering_pressed else 0,
     "LDW_Status_LED_gruen": 1 if lat_active and not steering_pressed else 0,
-    "LDW_Lernmodus_links": 3 + display_mode if hud_control.leftLaneDepart else 1 + hud_control.leftLaneVisible + display_mode,
-    "LDW_Lernmodus_rechts": 3 + display_mode if hud_control.rightLaneDepart else 1 + hud_control.rightLaneVisible + display_mode,
+    "LDW_Lernmodus_links": 3 if hud_control.leftLaneDepart else 1 + hud_control.leftLaneVisible,
+    "LDW_Lernmodus_rechts": 3 if hud_control.rightLaneDepart else 1 + hud_control.rightLaneVisible,
     "LDW_Texte": hud_alert,
   })
   return packer.make_can_msg("LDW_02", bus, values)


### PR DESCRIPTION
self.CCS had no MEB branch, so MEB silently fell through to mqbcan while also calling mebcan directly for steering/accel/wheel touch. LDW_02 and GRA_ACC_01 were built by mqbcan, leaving mebcan's own versions dead.

Add MEB to the dispatch and route every message through self.CCS. The per-message rate checks are shared, so update() keeps them in one place and hands off to a function per concern that branches only where the architectures truly differ (steering, ACC, ACC HUD).

Drop mebcan's LDW display_mode offset: LDW_Lernmodus_links/rechts are 2 bit signals fully spoken for by 0-3, so 3 + display_mode overflowed to 0 on lane depart, and the non-depart branch rendered a merely visible lane as the departure value. Now matches mqbcan/pqcan.

Verified no change on the wire: 4493 messages over 400 frames x PQ/MQB/MLB/MEB x stock/longitudinal are bit-identical to master.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
