### PR TITLE
VW MEB: log camera faults immediately

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -294,10 +294,12 @@ class CarState(CarStateBase):
         ret.cruiseState.speed = 0
     else:
       ret.cruiseState.nonAdaptive = bool(pt_cp.vl["Motor_51"]["TSK_Limiter_ausgewaehlt"])
-    accFaulted = (pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7) or
-                  ext_cp.vl["ACC_19"]["ACC_Status_ACC"] == 6)  # reversible fault in ACC system
-    ret.accFaulted = self.update_acc_fault(accFaulted, parking_brake=ret.parkingBrake, in_drive=in_drive,
-                                           brake_pressed=ret.brakePressed)
+
+    tsk_faulted = pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7)
+    tsk_faulted = self.update_acc_fault(tsk_faulted, parking_brake=ret.parkingBrake, in_drive=in_drive,
+                                        brake_pressed=ret.brakePressed)
+    # TODO: check permanent camera fault, it happens too often right now
+    ret.accFaulted = tsk_faulted or ext_cp.vl["ACC_19"]["ACC_Status_ACC"] == 6  # reversible fault in ACC system
 
     ret.leftBlinker, ret.rightBlinker = self.update_blinker_from_stalk(240, pt_cp.vl["SMLS_01"]["BH_Blinker_li"],
                                                                             pt_cp.vl["SMLS_01"]["BH_Blinker_re"])


### PR DESCRIPTION
Small part of https://github.com/commaai/opendbc/pull/3597

catches a855ef160c36392e/00000008--b05b4204aa which also has an LKAS fault, so fine