### PR TITLE
VW MEB: fix another park fault on hills

### DIFF
--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -132,6 +132,11 @@ class MebLongStateMachine:
       # if we requested to hold but never hit standstill before wanting to go again, we match stock and send just RAMP.
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter = self.RAMP_FRAMES
+    elif self.prev_acc_hold_type == self.acc_hold_type_vals['ANFAHREN'] and acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG']:
+      # Stock behavior is to transition to LOESEN_UEBER_RAMPE after resuming from a stop
+      # TODO: determine if this is a time constant or speed threshold (5 kph?)
+      acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
+      self.ramp_counter = self.RAMP_FRAMES
     elif self.ramp_counter > 0:
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter -= 1

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -89,6 +89,7 @@ class MebLongStateMachine:
     self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP  # 100 ms
 
     self.ramp_counter = 0
+    self.launching = False
 
     can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
     self.acc_status_vals = {v: k for k, v in can_define.dv['ACC_18']['ACC_Status_ACC'].items()}
@@ -124,22 +125,31 @@ class MebLongStateMachine:
       acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
 
     # enforce legal transitions
+    # TODO: stock also ramps on a brake disengage (NONE -> RAMP), starting on brakePressed and ending once TSK_Status leaves 5, we send no request
     if acc_hold_type == self.acc_hold_type_vals['HALTEN']:
-      # allow going into hold at any time, reset ramp counter
+      # allow going into hold at any time, reset ramp counter. stock also aborts the drive-off ramp back to HALTEN
       self.ramp_counter = 0
+      self.launching = False
     elif self.prev_acc_hold_type == self.acc_hold_type_vals['HALTEN'] and acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG']:
       # HALTEN -> NONE causes car to fault into park. this enforces HALTEN -> RAMP if user overrides, or
       # if we requested to hold but never hit standstill before wanting to go again, we match stock and send just RAMP.
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter = self.RAMP_FRAMES
     elif self.prev_acc_hold_type == self.acc_hold_type_vals['ANFAHREN'] and acc_hold_type == self.acc_hold_type_vals['KEINE_ANFORDERUNG']:
-      # Stock behavior is to transition to LOESEN_UEBER_RAMPE after resuming from a stop
-      # TODO: determine if this is a time constant or speed threshold (5 kph?)
+      # stock transitions to LOESEN_UEBER_RAMPE after resuming from a stop and holds it until the car is actually
+      # rolling. dropping to no request while still at a standstill hands standstill management back to the EPB,
+      # which clamps and faults into park on a grade.
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
       self.ramp_counter = self.RAMP_FRAMES
-    elif self.ramp_counter > 0:
+      self.launching = True
+    elif self.ramp_counter > 0 or self.launching:
       acc_hold_type = self.acc_hold_type_vals['LOESEN_UEBER_RAMPE']
-      self.ramp_counter -= 1
+      self.ramp_counter = max(self.ramp_counter - 1, 0)
+
+    # stock ends the drive-off ramp on speed, not time: 5.02 kph mean over 6 launches, sd 0.20. bail if we lose
+    # long control so we can never hold the request indefinitely
+    if self.launching and (not CC.longActive or CS.out.vEgo > self.CCP.LAUNCH_RAMP_SPEED):
+      self.launching = False
 
     return acc_hold_type
 

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -116,6 +116,7 @@ class CarControllerParams:
       # Longitudinal constants
       self.ACCEL_INACTIVE = 3.01  # m/s^2
       self.JERK_LIMIT = 4.0  # m/s^3
+      self.LAUNCH_RAMP_SPEED = 5 * CV.KPH_TO_MS  # stock drops the drive-off ramp request at 5 kph
 
       self.shifter_values = can_define.dv["Getriebe_11"]["GE_Fahrstufe"]
       self.hca_status_values = can_define.dv["QFK_01"]["LatCon_HCA_Status"]


### PR DESCRIPTION
anfahren looks like it mostly matches ESC_50->Standstill, and not time duration, so good we already do that.

https://connect.comma.ai/f73c01590368ee5b/00000039--99d1e7be6c

<img width="2470" height="598" alt="anfahren_dist" src="https://github.com/user-attachments/assets/f5856149-ab17-48a0-9d66-737be0cc74b0" />

---

however we're missing going to ramp release after resuming, which may be faulting some cars on steep hills. stock on our ID4 does this on every resume:

you can see after 4 (resume) it go to 5 (ramp) until speed reaches ~5 kph every single time. it's also able to go back to halten if it needs to

<img width="593" height="1159" alt="image" src="https://github.com/user-attachments/assets/16f3eb24-542c-404f-814e-d1c8c7d3013c" />
