### PR TITLE
Honda - Bump Civic sedan (ICE) compatibility to 2026

### DIFF
--- a/docs/CARS.md
+++ b/docs/CARS.md
@@ -98,7 +98,7 @@
 |Honda|City (Brazil only) 2023|All|[Upstream](#upstream)|
 |Honda|Civic 2016-18|Honda Sensing|[Upstream](#upstream)|
 |Honda|Civic 2019-21|All|[Upstream](#upstream)|
-|Honda|Civic 2022-24|All|[Upstream](#upstream)|
+|Honda|Civic 2022-26|All|[Upstream](#upstream)|
 |Honda|Civic Hatchback 2017-18|Honda Sensing|[Upstream](#upstream)|
 |Honda|Civic Hatchback 2019-21|All|[Upstream](#upstream)|
 |Honda|Civic Hatchback 2022-24|All|[Upstream](#upstream)|

--- a/opendbc/car/honda/values.py
+++ b/opendbc/car/honda/values.py
@@ -197,7 +197,7 @@ class CAR(Platforms):
   )
   HONDA_CIVIC_2022 = HondaBoschPlatformConfig(
     [
-      HondaCarDocs("Honda Civic 2022-24", "All", video="https://youtu.be/ytiOT5lcp6Q"),
+      HondaCarDocs("Honda Civic 2022-26", "All", video="https://youtu.be/ytiOT5lcp6Q"),
       HondaCarDocs("Honda Civic Hybrid 2025-26", "All"),
       HondaCarDocs("Honda Civic Hatchback 2022-24", "All", video="https://youtu.be/ytiOT5lcp6Q"),
       HondaCarDocs("Honda Civic Hatchback Hybrid (Europe only) 2023", "All"),


### PR DESCRIPTION
Test route: d1c5b2602b6d0c43/00000003--36c2da0265

Test route was 2026 model, no fingerprint changes.