### PR TITLE
VW MEB: fix driver override only reducing steering power in one direction

### DIFF
--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -84,8 +84,8 @@ class CarController(CarControllerBase):
 
           min_power = max(self.steering_power_last - self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MIN)
           max_power = min(self.steering_power_last + self.CCP.STEERING_POWER_STEP, self.CCP.STEERING_POWER_MAX)
-          target_power_driver = int(np.interp(CS.out.steeringTorque, [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
-                                                                     [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
+          target_power_driver = int(np.interp(abs(CS.out.steeringTorque), [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
+                                                                          [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
           target_power = int(np.interp(CS.out.vEgo, [0., 0.5], [self.CCP.STEERING_POWER_MIN, target_power_driver]))
           steering_power = min(max(target_power, min_power), max_power)
 


### PR DESCRIPTION
`opendbc/car/volkswagen/carcontroller.py:87` feeds signed driver torque into `np.interp`:

```python
target_power_driver = int(np.interp(CS.out.steeringTorque,
                                    [self.CCP.STEER_DRIVER_ALLOWANCE, self.CCP.STEER_DRIVER_MAX],
                                    [self.CCP.STEERING_POWER_MAX, self.CCP.STEERING_POWER_MIN]))
```

`steeringTorque` is signed — `carstate.py:252` reconstructs it from `EPS_Lenkmoment` and the
separate `EPS_VZ_Lenkmoment` sign bit, and takes `abs()` on the next line for `steeringPressed`.
`np.interp` clamps anything below the first x-point to the first y-point, so every negative
torque returns `STEERING_POWER_MAX`. Override only reduces HCA power for one sign of driver
input; the other direction holds full power no matter how hard the driver pulls.

This is independent of which physical direction is negative on any given rack — there's no
polarity under which clamping negatives to max power is correct. Introduced in #3366.

Nothing downstream compensates: `steeringPressed` is a bool and carries no direction, and the
legacy MQB path uses `apply_driver_steer_torque_limits()` (`opendbc/car/lateral.py:76-77`),
which derives both `driver_max_torque` and `driver_min_torque` from `±STEER_DRIVER_ALLOWANCE`.

## Measurements

I don't have an ID.4 — I hit this on a Golf MK8 running a fork that widens this branch to
`MEB | MQB_EVO`. The fork changes neither the torque decode nor this power calculation, so the
numbers below show what the clamp does on a real rack. Values are decoded from the transmitted
`HCA_03` `Power` field in rlogs, paired with `carState.steeringTorque`; 31 minutes of driving.
Torque sign was calibrated against GPS bearing and yaw rate rather than assumed.

HCA power vs driver torque magnitude, `latActive`, `vEgo > 1 m/s`:

| driver torque | negative side | positive side | interp implies |
|---|---|---|---|
| 0.6 – 1.5 N·m | 49.7 % | 43.9 % | 41 % |
| 1.5 – 2.5 N·m | **50.0 %** | 24.3 % | 23 % |
| > 2.5 N·m     | **50.0 %** | 10.8 % | 4 % |

```
negative torque  n=4130   power  mean=49.8%  max=50.0%
positive torque  n=5737   power  mean=33.5%  max=50.0%
```

The positive side tracks the intended curve. The negative side is flat at max.

Turning into an intersection, torque well past `STEER_DRIVER_MAX`, power pinned for the whole
turn-in:

```
steerAngle   driverTq   HCA power
  -0.5 deg      -80       50.0%
  -2.8 deg     -155       50.0%
 -12.0 deg     -280       50.0%
 -33.0 deg     -344       50.0%
-124.0 deg     -237       50.0%
```

Same driver, same session, opposite direction — power drops as designed:

```
 +27.2 deg     +222       17.2%
+114.3 deg     +234       15.2%
```

Across the session there were 19 episodes where the commanded curvature opposed driver torque
for >0.5 s on the negative side; all ran at exactly 50.0 % power. The 22 positive-side episodes
averaged 29.4 %. Peak torque needed to override: 4.25 N·m negative vs 3.19 N·m positive.

Validation
* Dongle ID: 7ed4b3a4312b08b6
* Route: 7ed4b3a4312b08b6|00000012--e0f69a9b4d

The intersection turn above is at ~21:06:37 in that route; the opposite-direction comparison is
at ~21:19:04.
