### PR TITLE
VW MEB: unify side assist DBC definitions

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -311,16 +311,11 @@ class CarState(CarStateBase):
                                                                             pt_cp.vl["SMLS_01"]["BH_Blinker_re"])
 
     if self.CP.enableBsm:
-      if self.CP.flags & VolkswagenFlags.MEB_GEN2:
-        ret.leftBlindspot = (bool(pt_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Info_Driver"]) or
-                             bool(pt_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Warn_Driver"]))
-        ret.rightBlindspot = (bool(pt_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Info_Passenger"]) or
-                              bool(pt_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Warn_Passenger"]))
-      else:
-        ret.leftBlindspot = (bool(ext_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Info_Left"]) or
-                             bool(ext_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Warn_Left"]))
-        ret.rightBlindspot = (bool(ext_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Info_Right"]) or
-                              bool(ext_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Warn_Right"]))
+      bsm_cp = pt_cp if self.CP.flags & VolkswagenFlags.MEB_GEN2 else ext_cp
+      ret.leftBlindspot = (bool(bsm_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Info_Driver"]) or
+                           bool(bsm_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Warn_Driver"]))
+      ret.rightBlindspot = (bool(bsm_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Info_Passenger"]) or
+                            bool(bsm_cp.vl["MEB_Side_Assist_01"]["Blind_Spot_Warn_Passenger"]))
 
     self.eps_stock_values = pt_cp.vl["LH_EPS_03"]
     self.ldw_stock_values = cam_cp.vl["LDW_02"] if self.CP.networkLocation == NetworkLocation.fwdCamera else {}

--- a/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
+++ b/opendbc/dbc/generator/volkswagen/_vw_meb_common.dbc
@@ -417,6 +417,20 @@ BO_ 522 EML_06: 64 XXX
  SG_ Yaw_Rate : 200|16@1+ (0.007,-229.34) [0|255] "" XXX
 
 BO_ 564 MEB_Camera_02: 64 XXX
+
+BO_ 588 MEB_Side_Assist_01: 16 XXX
+ SG_ Blind_Spot_Passenger : 12|7@1+ (1,0) [0|15] "" XXX
+ SG_ Blind_Spot_Driver : 19|7@1+ (1,0) [0|15] "" XXX
+ SG_ Blind_Spot_Info_Passenger : 26|1@0+ (1,0) [0|1] "" XXX
+ SG_ Blind_Spot_Warn_Passenger : 27|1@0+ (1,0) [0|1] "" XXX
+ SG_ Blind_Spot_Info_Driver : 29|1@0+ (1,0) [0|1] "" XXX
+ SG_ Blind_Spot_Warn_Driver : 30|1@0+ (1,0) [0|1] "" XXX
+ SG_ Lower_Speed_01 : 32|1@0+ (1,0) [0|1] "" XXX
+ SG_ Higher_Speed_01 : 33|1@0+ (1,0) [0|1] "" XXX
+ SG_ Higher_Speed_02 : 83|1@0+ (1,0) [0|1] "" XXX
+ SG_ Lower_Speed_02 : 84|1@0+ (1,0) [0|1] "" XXX
+ SG_ Standstill : 86|1@0+ (1,0) [0|1] "" XXX
+
 BO_ 589 MEB_Side_Assist_02: 64 XXX
  SG_ Unknown_01 : 100|3@0+ (1,0) [0|7] "" XXX
  SG_ Unknown_02 : 108|3@0+ (1,0) [0|7] "" XXX

--- a/opendbc/dbc/generator/volkswagen/vw_meb.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb.dbc
@@ -59,19 +59,6 @@ BO_ 496 EA_02: 8 Gateway
  SG_ EA_Blinken : 32|3@1+ (1,0) [0|7] "" Vector__XXX
  SG_ EA_Unknown : 60|3@0+ (1,0) [0|7] "" XXX
 
-BO_ 588 MEB_Side_Assist_01: 16 XXX
- SG_ Blind_Spot_Right : 12|7@1+ (1,0) [0|15] "" XXX
- SG_ Blind_Spot_Left : 19|7@1+ (1,0) [0|15] "" XXX
- SG_ Blind_Spot_Info_Right : 26|1@0+ (1,0) [0|1] "" XXX
- SG_ Blind_Spot_Warn_Right : 27|1@0+ (1,0) [0|1] "" XXX
- SG_ Blind_Spot_Info_Left : 29|1@0+ (1,0) [0|1] "" XXX
- SG_ Blind_Spot_Warn_Left : 30|1@0+ (1,0) [0|1] "" XXX
- SG_ Lower_Speed_01 : 32|1@0+ (1,0) [0|1] "" XXX
- SG_ Higher_Speed_01 : 33|1@0+ (1,0) [0|1] "" XXX
- SG_ Higher_Speed_02 : 83|1@0+ (1,0) [0|1] "" XXX
- SG_ Lower_Speed_02 : 84|1@0+ (1,0) [0|1] "" XXX
- SG_ Standstill : 86|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 619 TA_01: 8 XXX
  SG_ CHECKSUM : 0|8@1+ (1,0) [0|255] "" XXX
  SG_ COUNTER : 8|4@1+ (1,0) [0|15] "" XXX

--- a/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
+++ b/opendbc/dbc/generator/volkswagen/vw_meb_2024.dbc
@@ -30,19 +30,6 @@ BO_ 496 EA_02: 8 Gateway
  SG_ EA_Bremslichtblinken : 31|1@1+ (1,0) [0|1] "" Vector__XXX
  SG_ EA_Blinken : 32|3@1+ (1,0) [0|7] "" Vector__XXX
 
-BO_ 588 MEB_Side_Assist_01: 16 XXX
- SG_ Blind_Spot_Passenger : 12|7@1+ (1,0) [0|15] "" XXX
- SG_ Blind_Spot_Driver : 19|7@1+ (1,0) [0|15] "" XXX
- SG_ Blind_Spot_Info_Passenger : 26|1@0+ (1,0) [0|1] "" XXX
- SG_ Blind_Spot_Warn_Passenger : 27|1@0+ (1,0) [0|1] "" XXX
- SG_ Blind_Spot_Info_Driver : 29|1@0+ (1,0) [0|1] "" XXX
- SG_ Blind_Spot_Warn_Driver : 30|1@0+ (1,0) [0|1] "" XXX
- SG_ Lower_Speed_01 : 32|1@0+ (1,0) [0|1] "" XXX
- SG_ Higher_Speed_01 : 33|1@0+ (1,0) [0|1] "" XXX
- SG_ Higher_Speed_02 : 83|1@0+ (1,0) [0|1] "" XXX
- SG_ Lower_Speed_02 : 84|1@0+ (1,0) [0|1] "" XXX
- SG_ Standstill : 86|1@0+ (1,0) [0|1] "" XXX
-
 BO_ 768 ACC_19: 48 XXX
  SG_ ACC_Tempolimit : 64|5@1+ (1,0) [0|31] "" OTA_FC
  SG_ ACC_Wunschgeschw_Farbe : 69|1@1+ (1,0) [0|1] "" Vector__XXX
@@ -131,4 +118,3 @@ BO_ 619 TA_01: 8 XXX
  SG_ Travel_Assist_Available : 23|1@1+ (1,0) [0|1] "" XXX
  SG_ Speed_Mode_Status : 32|3@1+ (1,0) [0|7] "" XXX
  SG_ Lane_Unsure : 37|2@1+ (1,0) [0|3] "" XXX
-


### PR DESCRIPTION
## Summary

- move the identical Gen1 and Gen2 `MEB_Side_Assist_01` layouts into the common MEB DBC
- standardize the shared fields on driver/passenger naming
- collapse the duplicate Gen1/Gen2 blind-spot parsing branches

The CAN bit positions, generation-specific bus selection, and resulting left/right blind-spot mapping are unchanged. This removes 18 net lines and intentionally excludes the separate RHD direction fix.

## Tests

- `opendbc/dbc/generator/generator.py`
- `python -m unittest -v opendbc.can.tests.test_dbc_parser`
- `python -m unittest -v opendbc.car.volkswagen.tests.test_volkswagen`
- `ruff check opendbc/car/volkswagen/carstate.py`
