### PR TITLE
VW MEB safety: check long hold type and ACC status

### DIFF
--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -266,7 +266,7 @@ static bool volkswagen_meb_tx_hook(const CANPacket_t *msg) {
 
     // Signal: ACC_18.ACC_Status_ACC
     // Claiming ACC is regulating is what makes the drivetrain act on our requests, so it may only be
-    // claimed while controls are allowed. Standby, off and the fault state stay available for the HUD.
+    // sent while controls are allowed. Standby, off and the fault state stay available for the HUD.
     uint8_t acc_status = (msg->data[7] >> 4) & 0x07U;
     bool acc_status_active = (acc_status == VOLKSWAGEN_MEB_ACC_AKTIV_REGELT) ||
                              (acc_status == VOLKSWAGEN_MEB_ACC_OVERRIDE);

--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -13,6 +13,16 @@
 #define MSG_KLR_01           0x25DU   // TX, for capacitive steering wheel
 #define MSG_TA_01            0x26BU   // TX by OP, Travel Assist status
 
+// ACC_18.ACC_Anforderung_HMS, the states openpilot is allowed to request
+#define VOLKSWAGEN_MEB_HMS_KEINE_ANFORDERUNG  0U
+#define VOLKSWAGEN_MEB_HMS_HALTEN             1U
+#define VOLKSWAGEN_MEB_HMS_ANFAHREN           4U
+#define VOLKSWAGEN_MEB_HMS_LOESEN_UEBER_RAMPE 5U
+
+// ACC_18.ACC_Status_ACC, the states that tell the drivetrain ACC is regulating
+#define VOLKSWAGEN_MEB_ACC_AKTIV_REGELT       3U
+#define VOLKSWAGEN_MEB_ACC_OVERRIDE           4U
+
 static bool volkswagen_meb_alt_crc = false;
 
 #define VOLKSWAGEN_MEB_COMMON_RX_CHECKS \
@@ -238,6 +248,29 @@ static bool volkswagen_meb_tx_hook(const CANPacket_t *msg) {
     // MEB inactive accel is 3.01, but we also need to send 0.0 for gas override
     bool accel_override = controls_allowed && (desired_accel == 0);
     if (!accel_override && longitudinal_accel_checks(desired_accel, VOLKSWAGEN_MEB_LONG_LIMITS)) {
+      tx = false;
+    }
+
+    // Signal: ACC_18.ACC_Anforderung_HMS
+    // The drivetrain acts on these with ACC disengaged: PARKEN engages the EPB, from rolling as well as
+    // at a stop, and HALTEN holds the car at a standstill. Only the release states are unconditional,
+    // as the disengage ramp sends LOESEN_UEBER_RAMPE after controls are no longer allowed.
+    uint8_t hold_type = (msg->data[9] >> 5) & 0x07U;
+    bool hold_type_allowed = (hold_type == VOLKSWAGEN_MEB_HMS_KEINE_ANFORDERUNG) ||
+                             (hold_type == VOLKSWAGEN_MEB_HMS_LOESEN_UEBER_RAMPE) ||
+                             (controls_allowed && ((hold_type == VOLKSWAGEN_MEB_HMS_HALTEN) ||
+                                                   (hold_type == VOLKSWAGEN_MEB_HMS_ANFAHREN)));
+    if (!hold_type_allowed) {
+      tx = false;
+    }
+
+    // Signal: ACC_18.ACC_Status_ACC
+    // Claiming ACC is regulating is what makes the drivetrain act on our requests, so it may only be
+    // claimed while controls are allowed. Standby, off and the fault state stay available for the HUD.
+    uint8_t acc_status = (msg->data[7] >> 4) & 0x07U;
+    bool acc_status_active = (acc_status == VOLKSWAGEN_MEB_ACC_AKTIV_REGELT) ||
+                             (acc_status == VOLKSWAGEN_MEB_ACC_OVERRIDE);
+    if (acc_status_active && !controls_allowed) {
       tx = false;
     }
   }

--- a/opendbc/safety/modes/volkswagen_meb.h
+++ b/opendbc/safety/modes/volkswagen_meb.h
@@ -14,14 +14,14 @@
 #define MSG_TA_01            0x26BU   // TX by OP, Travel Assist status
 
 // ACC_18.ACC_Anforderung_HMS, the states openpilot is allowed to request
-#define VOLKSWAGEN_MEB_HMS_KEINE_ANFORDERUNG  0U
-#define VOLKSWAGEN_MEB_HMS_HALTEN             1U
-#define VOLKSWAGEN_MEB_HMS_ANFAHREN           4U
-#define VOLKSWAGEN_MEB_HMS_LOESEN_UEBER_RAMPE 5U
+#define VOLKSWAGEN_MEB_HMS_KEINE_ANFORDERUNG   0U
+#define VOLKSWAGEN_MEB_HMS_HALTEN              1U
+#define VOLKSWAGEN_MEB_HMS_ANFAHREN            4U
+#define VOLKSWAGEN_MEB_HMS_LOESEN_UEBER_RAMPE  5U
 
 // ACC_18.ACC_Status_ACC, the states that tell the drivetrain ACC is regulating
-#define VOLKSWAGEN_MEB_ACC_AKTIV_REGELT       3U
-#define VOLKSWAGEN_MEB_ACC_OVERRIDE           4U
+#define VOLKSWAGEN_MEB_ACC_AKTIV_REGELT        3U
+#define VOLKSWAGEN_MEB_ACC_OVERRIDE            4U
 
 static bool volkswagen_meb_alt_crc = false;
 

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -18,7 +18,6 @@ HMS_ANFAHREN = 4
 HMS_LOESEN_UEBER_RAMPE = 5
 
 # ACC_18.ACC_Status_ACC
-ACC_STANDBY = 2
 ACC_AKTIV_REGELT = 3
 ACC_OVERRIDE = 4
 
@@ -368,28 +367,22 @@ class TestVolkswagenMebLongSafety(TestVolkswagenMebSafetyBase):
     # PARKEN engages the EPB and HALTEN holds the car, both with ACC disengaged. KEINE_ANFORDERUNG and
     # LOESEN_UEBER_RAMPE stay unconditional, the disengage ramp sends the latter once disallowed
     for controls_allowed in (True, False):
-      # a real accel and a legal status, so the hold type is the only thing under test
-      accel = MIN_ACCEL / 2 if controls_allowed else self.INACTIVE_ACCEL
-      acc_status = ACC_AKTIV_REGELT if controls_allowed else ACC_STANDBY
       for hold_type in range(8):
         with self.subTest(controls_allowed=controls_allowed, hold_type=hold_type):
           self.safety.set_controls_allowed(controls_allowed)
           send = (hold_type in (HMS_KEINE_ANFORDERUNG, HMS_LOESEN_UEBER_RAMPE) or
                   (controls_allowed and hold_type in (HMS_HALTEN, HMS_ANFAHREN)))
-          self.assertEqual(send, self._tx(self._accel_msg(accel, hold_type=hold_type, acc_status=acc_status)))
+          self.assertEqual(send, self._tx(self._accel_msg(self.INACTIVE_ACCEL, hold_type=hold_type)))
 
   def test_acc_status_safety_check(self):
     # claiming ACC_AKTIV_REGELT or ACC_OVERRIDE is what makes the drivetrain act on our requests.
     # standby, off and the fault state stay available for the HUD with controls disallowed
     for controls_allowed in (True, False):
-      # a real accel and a legal hold type, so the status is the only thing under test
-      accel = MIN_ACCEL / 2 if controls_allowed else self.INACTIVE_ACCEL
-      hold_type = HMS_HALTEN if controls_allowed else HMS_LOESEN_UEBER_RAMPE
       for acc_status in range(8):
         with self.subTest(controls_allowed=controls_allowed, acc_status=acc_status):
           self.safety.set_controls_allowed(controls_allowed)
           send = controls_allowed or acc_status not in (ACC_AKTIV_REGELT, ACC_OVERRIDE)
-          self.assertEqual(send, self._tx(self._accel_msg(accel, hold_type=hold_type, acc_status=acc_status)))
+          self.assertEqual(send, self._tx(self._accel_msg(self.INACTIVE_ACCEL, acc_status=acc_status)))
 
 
 class TestVolkswagenMebGen2LongSafety(TestVolkswagenMebLongSafety):

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -368,21 +368,19 @@ class TestVolkswagenMebLongSafety(TestVolkswagenMebSafetyBase):
     # LOESEN_UEBER_RAMPE stay unconditional, the disengage ramp sends the latter once disallowed
     for controls_allowed in (True, False):
       for hold_type in range(8):
-        with self.subTest(controls_allowed=controls_allowed, hold_type=hold_type):
-          self.safety.set_controls_allowed(controls_allowed)
-          send = (hold_type in (HMS_KEINE_ANFORDERUNG, HMS_LOESEN_UEBER_RAMPE) or
-                  (controls_allowed and hold_type in (HMS_HALTEN, HMS_ANFAHREN)))
-          self.assertEqual(send, self._tx(self._accel_msg(self.INACTIVE_ACCEL, hold_type=hold_type)))
+        self.safety.set_controls_allowed(controls_allowed)
+        send = (hold_type in (HMS_KEINE_ANFORDERUNG, HMS_LOESEN_UEBER_RAMPE) or
+                (controls_allowed and hold_type in (HMS_HALTEN, HMS_ANFAHREN)))
+        self.assertEqual(send, self._tx(self._accel_msg(self.INACTIVE_ACCEL, hold_type=hold_type)))
 
   def test_acc_status_safety_check(self):
     # claiming ACC_AKTIV_REGELT or ACC_OVERRIDE is what makes the drivetrain act on our requests.
     # standby, off and the fault state stay available for the HUD with controls disallowed
     for controls_allowed in (True, False):
       for acc_status in range(8):
-        with self.subTest(controls_allowed=controls_allowed, acc_status=acc_status):
-          self.safety.set_controls_allowed(controls_allowed)
-          send = controls_allowed or acc_status not in (ACC_AKTIV_REGELT, ACC_OVERRIDE)
-          self.assertEqual(send, self._tx(self._accel_msg(self.INACTIVE_ACCEL, acc_status=acc_status)))
+        self.safety.set_controls_allowed(controls_allowed)
+        send = controls_allowed or acc_status not in (ACC_AKTIV_REGELT, ACC_OVERRIDE)
+        self.assertEqual(send, self._tx(self._accel_msg(self.INACTIVE_ACCEL, acc_status=acc_status)))
 
 
 class TestVolkswagenMebGen2LongSafety(TestVolkswagenMebLongSafety):

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -11,6 +11,17 @@ from opendbc.safety.tests.common import CANPackerSafety
 MAX_ACCEL = 2.0
 MIN_ACCEL = -3.5
 
+# ACC_18.ACC_Anforderung_HMS
+HMS_KEINE_ANFORDERUNG = 0
+HMS_HALTEN = 1
+HMS_ANFAHREN = 4
+HMS_LOESEN_UEBER_RAMPE = 5
+
+# ACC_18.ACC_Status_ACC
+ACC_STANDBY = 2
+ACC_AKTIV_REGELT = 3
+ACC_OVERRIDE = 4
+
 # MEB message IDs
 MSG_LH_EPS_03  = 0x9F
 MSG_ESC_51     = 0xFC
@@ -354,26 +365,31 @@ class TestVolkswagenMebLongSafety(TestVolkswagenMebSafetyBase):
     self.assertFalse(self._tx(self._accel_msg(MAX_ACCEL)))
 
   def test_hold_type_safety_check(self):
-    # PARKEN engages the EPB and HALTEN holds the car, both with ACC disengaged. The release states
-    # stay unconditional, the disengage ramp sends LOESEN_UEBER_RAMPE after controls are disallowed
+    # PARKEN engages the EPB and HALTEN holds the car, both with ACC disengaged. KEINE_ANFORDERUNG and
+    # LOESEN_UEBER_RAMPE stay unconditional, the disengage ramp sends the latter once disallowed
     for controls_allowed in (True, False):
+      # a real accel and a legal status, so the hold type is the only thing under test
+      accel = MIN_ACCEL / 2 if controls_allowed else self.INACTIVE_ACCEL
+      acc_status = ACC_AKTIV_REGELT if controls_allowed else ACC_STANDBY
       for hold_type in range(8):
         with self.subTest(controls_allowed=controls_allowed, hold_type=hold_type):
           self.safety.set_controls_allowed(controls_allowed)
-          accel = self.ACCEL_OVERRIDE if controls_allowed else self.INACTIVE_ACCEL
-          send = hold_type in (0, 5) or (controls_allowed and hold_type in (1, 4))
-          self.assertEqual(send, self._tx(self._accel_msg(accel, hold_type=hold_type)))
+          send = (hold_type in (HMS_KEINE_ANFORDERUNG, HMS_LOESEN_UEBER_RAMPE) or
+                  (controls_allowed and hold_type in (HMS_HALTEN, HMS_ANFAHREN)))
+          self.assertEqual(send, self._tx(self._accel_msg(accel, hold_type=hold_type, acc_status=acc_status)))
 
   def test_acc_status_safety_check(self):
-    # claiming ACC is regulating is what makes the drivetrain act on our requests. standby, off and
-    # the fault state stay available for the HUD with controls disallowed
+    # claiming ACC_AKTIV_REGELT or ACC_OVERRIDE is what makes the drivetrain act on our requests.
+    # standby, off and the fault state stay available for the HUD with controls disallowed
     for controls_allowed in (True, False):
+      # a real accel and a legal hold type, so the status is the only thing under test
+      accel = MIN_ACCEL / 2 if controls_allowed else self.INACTIVE_ACCEL
+      hold_type = HMS_HALTEN if controls_allowed else HMS_LOESEN_UEBER_RAMPE
       for acc_status in range(8):
         with self.subTest(controls_allowed=controls_allowed, acc_status=acc_status):
           self.safety.set_controls_allowed(controls_allowed)
-          accel = self.ACCEL_OVERRIDE if controls_allowed else self.INACTIVE_ACCEL
-          send = controls_allowed or acc_status not in (3, 4)
-          self.assertEqual(send, self._tx(self._accel_msg(accel, acc_status=acc_status)))
+          send = controls_allowed or acc_status not in (ACC_AKTIV_REGELT, ACC_OVERRIDE)
+          self.assertEqual(send, self._tx(self._accel_msg(accel, hold_type=hold_type, acc_status=acc_status)))
 
 
 class TestVolkswagenMebGen2LongSafety(TestVolkswagenMebLongSafety):

--- a/opendbc/safety/tests/test_volkswagen_meb.py
+++ b/opendbc/safety/tests/test_volkswagen_meb.py
@@ -131,8 +131,9 @@ class TestVolkswagenMebSafetyBase(common.CarSafetyTest, common.CurvatureSteering
     }
     return self.packer.make_can_msg_safety("HCA_03", 0, values)
 
-  def _accel_msg(self, accel):
-    values = {"ACC_Sollbeschleunigung_02": accel}
+  def _accel_msg(self, accel, hold_type=0, acc_status=0):
+    values = {"ACC_Sollbeschleunigung_02": accel, "ACC_Anforderung_HMS": hold_type,
+              "ACC_Status_ACC": acc_status}
     return self.packer.make_can_msg_safety("ACC_18", 0, values)
 
   def _tsk_status_msg(self, enable, main_switch=True):
@@ -351,6 +352,28 @@ class TestVolkswagenMebLongSafety(TestVolkswagenMebSafetyBase):
     self.safety.set_gas_pressed_prev(True)
     self.assertTrue(self._tx(self._accel_msg(self.ACCEL_OVERRIDE)))
     self.assertFalse(self._tx(self._accel_msg(MAX_ACCEL)))
+
+  def test_hold_type_safety_check(self):
+    # PARKEN engages the EPB and HALTEN holds the car, both with ACC disengaged. The release states
+    # stay unconditional, the disengage ramp sends LOESEN_UEBER_RAMPE after controls are disallowed
+    for controls_allowed in (True, False):
+      for hold_type in range(8):
+        with self.subTest(controls_allowed=controls_allowed, hold_type=hold_type):
+          self.safety.set_controls_allowed(controls_allowed)
+          accel = self.ACCEL_OVERRIDE if controls_allowed else self.INACTIVE_ACCEL
+          send = hold_type in (0, 5) or (controls_allowed and hold_type in (1, 4))
+          self.assertEqual(send, self._tx(self._accel_msg(accel, hold_type=hold_type)))
+
+  def test_acc_status_safety_check(self):
+    # claiming ACC is regulating is what makes the drivetrain act on our requests. standby, off and
+    # the fault state stay available for the HUD with controls disallowed
+    for controls_allowed in (True, False):
+      for acc_status in range(8):
+        with self.subTest(controls_allowed=controls_allowed, acc_status=acc_status):
+          self.safety.set_controls_allowed(controls_allowed)
+          accel = self.ACCEL_OVERRIDE if controls_allowed else self.INACTIVE_ACCEL
+          send = controls_allowed or acc_status not in (3, 4)
+          self.assertEqual(send, self._tx(self._accel_msg(accel, acc_status=acc_status)))
 
 
 class TestVolkswagenMebGen2LongSafety(TestVolkswagenMebLongSafety):


### PR DESCRIPTION
`ACC_18` carries two fields the drivetrain acts on with ACC disengaged, and panda bounds neither. Measured with a branch that requests them from the turn stalk:

- **`ACC_Anforderung_HMS = PARKEN` engages the EPB**, at a stop and while rolling. On `f73c01590368ee5b/00000147--ba0981e48e`, 1394 of 1450 frames went out with ACC not active, and the EPB reached `PARKED` six times with the driver off the brake — four of them initiated while rolling, at 3.8, 2.8, 1.5 and 3.8 km/h. On `f73c01590368ee5b/00000149--8bb84b9992` openpilot never engaged at all, reporting `ACC_STANDBY` throughout, and PARKEN still parked the car from 3.2 km/h at -0.73 m/s². So the hold type actuates independently of the status field.
- **`ACC_Anforderung_HMS = HALTEN` holds the car at a standstill**, and does nothing above a few km/h. The hold is ESP hydraulic, so `EPB_Status` stays `open`.
- **`ACC_Status_ACC = ACC_AKTIV_REGELT` with an accel request commands decel, including in reverse.** Only the accel gate stops this today.

| `ACC_Anforderung_HMS` | allowed |
| --- | --- |
| `KEINE_ANFORDERUNG`, `LOESEN_UEBER_RAMPE` | always |
| `HALTEN`, `ANFAHREN` | controls allowed |
| `PARKEN`, undefined states | never |

`LOESEN_UEBER_RAMPE` has to stay unconditional: the disengage ramp sends it for 100 ms *after* controls are disallowed, and blocking it would reopen the Park fault from #3626. For `ACC_Status_ACC`, only `ACC_AKTIV_REGELT` and `ACC_OVERRIDE` are gated, so standby, off and the reversible fault state stay available for the HUD.

Replayed through `safety_replay`: master blocks 6 messages of `f73c01590368ee5b/00000147--ba0981e48e`, this blocks 1215, and the 6 are identical in both — every added block is the probe's own request. Not covered: the drivetrain also acts on these in reverse, which panda cannot gate today because the MEB mode reads no gear signal.

Validation
* Dongle ID: f73c01590368ee5b
* Route: f73c01590368ee5b/00000147--ba0981e48e, f73c01590368ee5b/00000149--8bb84b9992
