### PR TITLE
VW MEB: don't check camera ACC fault

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -298,9 +298,7 @@ class CarState(CarStateBase):
     tsk_faulted = pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7)
     engine_off = pt_cp.vl["Motor_54"]["Engine_On"] == 0
     long_control_inhibit = pt_cp.vl["VMM_02"]["Long_Control_Inhibit"] == 2
-    # TODO: check permanent camera fault, it happens too often right now
-    ret.accFaulted = (self.update_acc_fault(tsk_faulted, engine_off, long_control_inhibit) or
-                      ext_cp.vl["ACC_18"]["ACC_Status_ACC"] == 6)  # reversible fault in ACC system
+    ret.accFaulted = self.update_acc_fault(tsk_faulted, engine_off, long_control_inhibit)
 
     # TSK winds braking down through brake_only after driver brakes at low speeds. Requesting drive-off in this
     # state can fault TSK, and stock refuses to engage here as well, so block entry until it clears.


### PR DESCRIPTION
we only added this to catch a fault when radar is covered up, but now op long will be default, and radar interface catches it

in this op long route testing stock AEB, you can see stock ACC_18 faulted permanently, yet AEB continued working, and its status bits remain valid

f73c01590368ee5b/00000085--52c6476ea9

<img width="603" height="1200" alt="image" src="https://github.com/user-attachments/assets/5fc8a5de-e201-48d2-8199-aa25c699c6fa" />
