### PR TITLE
VW MEB: check AEB available

### DIFF
--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -298,7 +298,8 @@ class CarState(CarStateBase):
     tsk_faulted = pt_cp.vl["Motor_51"]["TSK_Status"] in (6, 7)
     engine_off = pt_cp.vl["Motor_54"]["Engine_On"] == 0
     long_control_inhibit = pt_cp.vl["VMM_02"]["Long_Control_Inhibit"] == 2
-    ret.accFaulted = self.update_acc_fault(tsk_faulted, engine_off, long_control_inhibit)
+    ret.accFaulted = (self.update_acc_fault(tsk_faulted, engine_off, long_control_inhibit) or
+                      cam_cp.vl["AWV_03"]["AWV_Unavailable"] == 1)  # AEB unavailable (from radar covered or PT ECUs not sending)
 
     # TSK winds braking down through brake_only after driver brakes at low speeds. Requesting drive-off in this
     # state can fault TSK, and stock refuses to engage here as well, so block entry until it clears.

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -299,7 +299,7 @@ class CarState(CarStateBase):
     engine_off = pt_cp.vl["Motor_54"]["Engine_On"] == 0
     long_control_inhibit = pt_cp.vl["VMM_02"]["Long_Control_Inhibit"] == 2
     ret.accFaulted = (self.update_acc_fault(tsk_faulted, engine_off, long_control_inhibit) or
-                      cam_cp.vl["AWV_03"]["AWV_Unavailable"] == 1)  # AEB unavailable (from radar covered or PT ECUs not sending)
+                      cam_cp.vl["AWV_03"]["AWV_Unavailable"] == 1)  # AEB unavailable (i.e. radar covered)
 
     # TSK winds braking down through brake_only after driver brakes at low speeds. Requesting drive-off in this
     # state can fault TSK, and stock refuses to engage here as well, so block entry until it clears.


### PR DESCRIPTION
From https://github.com/commaai/opendbc/pull/3637

tracks when I covered the radar with some foil in this route: https://github.com/commaai/opendbc/pulls?q=is%3Apr+id4+covered+is%3Aclosed+#issuecomment-4989522219

confirmed safe to check when "engine" off (route from https://github.com/commaai/opendbc/pull/3617)

<img width="533" height="1200" alt="image" src="https://github.com/user-attachments/assets/e100c7e2-8f89-4fca-a613-78c166691724" />
