### PR TITLE
VW MEB: braking while the ESP holds the car is a hold request

### DIFF
--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -84,6 +84,8 @@ ACC_HUD_DISABLED = 0
 
 
 class MebLongStateMachine:
+  BRAKE_THRESHOLD = -0.1  # m/s^2, deadband so accel noise around zero cannot chatter the request
+
   def __init__(self, CP, CCP):
     self.CCP = CCP
     self.RAMP_FRAMES = 10 // CCP.ACC_CONTROL_STEP  # 100 ms
@@ -108,15 +110,21 @@ class MebLongStateMachine:
     else:
       return self.acc_status_vals['ACC_OFF_HAUPTSCHALTER_AUS']  # disabled
 
-  def _get_hold_type(self, CS, CC) -> int:
+  def _get_hold_type(self, CS, CC, accel) -> int:
     # warning: car is reacting to hold mechanic even with long control off
     # NOTE: this allows KEINE_ANFORDERUNG -> ANFAHREN, but we haven't observed a fault due to this yet
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
     starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
 
+    # braking while the car is held is a hold request, not a drive-off request. pairing a negative
+    # accel with anything else permanently faults the TSK: 000000bb seg 7 rolled backwards down a
+    # 24% grade, which cleared should_stop because vEgo is a magnitude, and we sent ANFAHREN with
+    # -1.00 m/s^2 for 7.32 s before TSK went to 7. stock only ever brakes at a standstill via HALTEN
+    braking_while_held = CS.esp_hold_confirmation and accel < self.BRAKE_THRESHOLD
+
     if CS.out.accFaulted or not CC.longActive:
       acc_hold_type = self.acc_hold_type_vals['KEINE_ANFORDERUNG']  # no request
-    elif stopping:
+    elif stopping or braking_while_held:
       acc_hold_type = self.acc_hold_type_vals['HALTEN']  # stopping/stopped
     elif starting:
       acc_hold_type = self.acc_hold_type_vals['ANFAHREN']  # resume after reaching full stop
@@ -140,7 +148,7 @@ class MebLongStateMachine:
 
   def update(self, CS, CC, accel) -> tuple[float, int, int, bool]:
     acc_status = self._get_acc_status(CS, CC)
-    acc_hold_type = self._get_hold_type(CS, CC)
+    acc_hold_type = self._get_hold_type(CS, CC, accel)
 
     # transition to inactive accel and jerks as soon as we enter ESP standstill
     requesting_hold = acc_hold_type == self.acc_hold_type_vals['HALTEN']


### PR DESCRIPTION
Pairing a negative accel with a drive-off request permanently faults the TSK. 000000bb seg 7 rolled backwards down a 24% grade, which cleared should_stop because vEgo is a magnitude, so longControlState went to pid while the accel stayed at -1.00 and we sent ANFAHREN with it for 3.66 s before TSK went to 7. Shane reproduced the same thing from the joystick: drop the stopping state, command a negative accel, two temp faults then a permanent one.

Stock only ever brakes at a standstill through HALTEN, so route a braking request there instead, past a small deadband so accel noise around zero cannot chatter the request.

Replayed against the three routes that permanently faulted: on bb/7 it replaces all 183 frames of ANFAHREN + -1.00 with HALTEN and an inactive accel, and cuts two HMS transitions. On b6/23 and b8/9 it changes nothing at all, so it does not address those two, which faulted from HMS churn with no braking involved.

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->
Validation
* Dongle ID:
* Route:
