### PR TITLE
Ford: fix blocked steering msgs

### DIFF
--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -257,6 +257,11 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
     // *** absolute curvature cap ***
     violation |= safety_max_limit_check(desired_curvature, limits.max_curvature, -limits.max_curvature);
 
+    // *** ISO lateral accel limit ***
+    const float max_curvature = MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed);
+    const int max_curvature_can = (max_curvature * limits.curvature_to_can) + 1.;
+    violation |= safety_max_limit_check(desired_curvature, max_curvature_can, -max_curvature_can);
+
     // *** ISO lateral jerk limit ***
     const float max_curvature_rate_sec = MAX_LATERAL_JERK / (fudged_speed * fudged_speed);
     const float max_curvature_delta = max_curvature_rate_sec / (float)limits.frequency;
@@ -264,11 +269,6 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
 
     int highest_desired_curvature = curvature_state.desired_last + max_curvature_delta_can;
     int lowest_desired_curvature = curvature_state.desired_last - max_curvature_delta_can;
-
-    // *** ISO lateral accel limit ***
-    const float max_curvature = MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed);
-    const int max_curvature_can = (max_curvature * limits.curvature_to_can) + 1.;
-    violation |= safety_max_limit_check(desired_curvature, max_curvature_can, -max_curvature_can);
 
     // *** curvature error from measured ***
     // ensure we start moving in direction of meas while respecting relaxed rate limits if error is exceeded

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -265,6 +265,11 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
     int highest_desired_curvature = curvature_state.desired_last + max_curvature_delta_can;
     int lowest_desired_curvature = curvature_state.desired_last - max_curvature_delta_can;
 
+    // *** ISO lateral accel limit ***
+    const float max_curvature = MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed);
+    const int max_curvature_can = (max_curvature * limits.curvature_to_can) + 1.;
+    violation |= safety_max_limit_check(desired_curvature, max_curvature_can, -max_curvature_can);
+
     // *** curvature error from measured ***
     // ensure we start moving in direction of meas while respecting relaxed rate limits if error is exceeded
     if (limits.max_curvature_error && ((vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR) > limits.curvature_error_min_speed)) {
@@ -298,11 +303,6 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       }
     }
     violation |= safety_max_limit_check(desired_curvature, highest_desired_curvature, lowest_desired_curvature);
-
-    // *** ISO lateral accel limit ***
-    const float max_curvature = MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed);
-    const int max_curvature_can = (max_curvature * limits.curvature_to_can) + 1.;
-    violation |= safety_max_limit_check(desired_curvature, max_curvature_can, -max_curvature_can);
 
     // *** real time rate limit check ***
     violation |= rt_curvature_rate_limit_check(limits);

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -266,21 +266,29 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
     int lowest_desired_curvature = curvature_state.desired_last - max_curvature_delta_can;
 
     // *** curvature error from measured ***
-    // never require a minimum curvature, and never require moving toward the bounds faster than
-    // openpilot's own jerk limit allows
+    // ensure we start moving in direction of meas while respecting relaxed rate limits if error is exceeded
     if (limits.max_curvature_error && ((vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR) > limits.curvature_error_min_speed)) {
-      // flipped fudge keeps the required movement under openpilot's rate limit
-      const float fudged_speed_error = (vehicle_speed.max / VEHICLE_SPEED_FACTOR) + 1.0;
-      const float max_curvature_delta_relaxed = MAX_LATERAL_JERK / (fudged_speed_error * fudged_speed_error) / (float)limits.frequency;
-      const int max_curvature_delta_relaxed_can = (max_curvature_delta_relaxed * limits.curvature_to_can) - 1.;
+      // flipped fudge to avoid false positives
+      const float fudged_speed_error = (vehicle_speed.max / VEHICLE_SPEED_FACTOR) + 1.;
+      const float max_curvature_rate_sec_relaxed = MAX_LATERAL_JERK / (fudged_speed_error * fudged_speed_error);
+      const int max_curvature_delta_relaxed_can = (max_curvature_rate_sec_relaxed / (float)limits.frequency * limits.curvature_to_can) - 1.;
 
-      const int highest_desired_curvature_error = SAFETY_MAX(curvature_state.meas.max + limits.max_curvature_error + 1, 0);
-      const int lowest_desired_curvature_error = SAFETY_MIN(curvature_state.meas.min - limits.max_curvature_error - 1, 0);
+      // the minimum and maximum curvature allowed based on the measured curvature
+      const int lowest_desired_curvature_error = curvature_state.meas.min - limits.max_curvature_error - 1;
+      const int highest_desired_curvature_error = curvature_state.meas.max + limits.max_curvature_error + 1;
 
-      highest_desired_curvature = SAFETY_MAX(SAFETY_MIN(highest_desired_curvature, highest_desired_curvature_error),
-                                             curvature_state.desired_last - max_curvature_delta_relaxed_can);
-      lowest_desired_curvature = SAFETY_MIN(SAFETY_MAX(lowest_desired_curvature, lowest_desired_curvature_error),
-                                            curvature_state.desired_last + max_curvature_delta_relaxed_can);
+      // the MAX is to allow the desired curvature to hit the edge of the bounds and not require going under it
+      if (curvature_state.desired_last > highest_desired_curvature_error) {
+        highest_desired_curvature = SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can, highest_desired_curvature_error);
+
+      } else if (curvature_state.desired_last < lowest_desired_curvature_error) {
+        lowest_desired_curvature = SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can, lowest_desired_curvature_error);
+
+      } else {
+        // already inside error boundary, don't allow commanding outside it
+        highest_desired_curvature = SAFETY_MIN(highest_desired_curvature, highest_desired_curvature_error);
+        lowest_desired_curvature = SAFETY_MAX(lowest_desired_curvature, lowest_desired_curvature_error);
+      }
     }
     violation |= safety_max_limit_check(desired_curvature, highest_desired_curvature, lowest_desired_curvature);
 

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -287,17 +287,17 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       const int lowest_desired_curvature_error = curvature_state.meas.min - limits.max_curvature_error - 1;
       const int highest_desired_curvature_error = curvature_state.meas.max + limits.max_curvature_error + 1;
 
-      if (curvature_state.desired_last > highest_desired_curvature_error) {
-        // demand winding down: never require more than the relaxed step, never past the band edge,
+      if (curvature_state.desired_last < lowest_desired_curvature_error) {
+        // demand winding up: never require more than the relaxed step, never past the band edge,
         // and never past what openpilot can reach (lat accel or max_curvature).
-        const int required = SAFETY_MAX(SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can,
-                                                   highest_desired_curvature_error), -max_curvature_relaxed_can);
-        highest_desired_curvature = SAFETY_MIN(highest_desired_curvature, required);  // can't widen the rate limit window
-
-      } else if (curvature_state.desired_last < lowest_desired_curvature_error) {
         const int required = SAFETY_MIN(SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can,
                                                    lowest_desired_curvature_error), max_curvature_relaxed_can);
-        lowest_desired_curvature = SAFETY_MAX(lowest_desired_curvature, required);
+        lowest_desired_curvature = SAFETY_MAX(lowest_desired_curvature, required);  // can't widen the rate limit window
+
+      } else if (curvature_state.desired_last > highest_desired_curvature_error) {
+        const int required = SAFETY_MAX(SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can,
+                                                   highest_desired_curvature_error), -max_curvature_relaxed_can);
+        highest_desired_curvature = SAFETY_MIN(highest_desired_curvature, required);
 
       } else {
         // already inside error boundary, don't allow commanding outside it

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -288,7 +288,7 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       const int highest_desired_curvature_error = curvature_state.meas.max + limits.max_curvature_error + 1;
 
       if (curvature_state.desired_last < lowest_desired_curvature_error) {
-        // demand winding up: never require more than the relaxed step, never past the band edge,
+        // demand winding up: never require more than the relaxed step, never past the error band edge,
         // and never past what openpilot can reach (lat accel or max_curvature).
         const int required = SAFETY_MIN(SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can,
                                                    lowest_desired_curvature_error), max_curvature_relaxed_can);

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -289,12 +289,15 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
 
       // the MAX is to allow the desired curvature to hit the edge of the bounds and not require going under it
       if (curvature_state.desired_last > highest_desired_curvature_error) {
-        highest_desired_curvature = SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can, highest_desired_curvature_error);
-        highest_desired_curvature = SAFETY_MAX(highest_desired_curvature, -max_curvature_relaxed_can);
+        int required = SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can, highest_desired_curvature_error);
+        required = SAFETY_MAX(required, -max_curvature_relaxed_can);
+        // relaxing what we require must never widen the rate limit window
+        highest_desired_curvature = SAFETY_MIN(highest_desired_curvature, required);
 
       } else if (curvature_state.desired_last < lowest_desired_curvature_error) {
-        lowest_desired_curvature = SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can, lowest_desired_curvature_error);
-        lowest_desired_curvature = SAFETY_MIN(lowest_desired_curvature, max_curvature_relaxed_can);
+        int required = SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can, lowest_desired_curvature_error);
+        required = SAFETY_MIN(required, max_curvature_relaxed_can);
+        lowest_desired_curvature = SAFETY_MAX(lowest_desired_curvature, required);
 
       } else {
         // already inside error boundary, don't allow commanding outside it

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -287,16 +287,16 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       const int lowest_desired_curvature_error = curvature_state.meas.min - limits.max_curvature_error - 1;
       const int highest_desired_curvature_error = curvature_state.meas.max + limits.max_curvature_error + 1;
 
-      // the MAX is to allow the desired curvature to hit the edge of the bounds and not require going under it
       if (curvature_state.desired_last > highest_desired_curvature_error) {
-        int required = SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can, highest_desired_curvature_error);
-        required = SAFETY_MAX(required, -max_curvature_relaxed_can);
-        // relaxing what we require must never widen the rate limit window
-        highest_desired_curvature = SAFETY_MIN(highest_desired_curvature, required);
+        // demand winding down: never require more than the relaxed step, never past the band edge,
+        // and never past what openpilot can reach (lat accel or max_curvature).
+        const int required = SAFETY_MAX(SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can,
+                                                   highest_desired_curvature_error), -max_curvature_relaxed_can);
+        highest_desired_curvature = SAFETY_MIN(highest_desired_curvature, required);  // can't widen the rate limit window
 
       } else if (curvature_state.desired_last < lowest_desired_curvature_error) {
-        int required = SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can, lowest_desired_curvature_error);
-        required = SAFETY_MIN(required, max_curvature_relaxed_can);
+        const int required = SAFETY_MIN(SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can,
+                                                   lowest_desired_curvature_error), max_curvature_relaxed_can);
         lowest_desired_curvature = SAFETY_MAX(lowest_desired_curvature, required);
 
       } else {

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -273,8 +273,10 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       const float max_curvature_rate_sec_relaxed = MAX_LATERAL_JERK / (fudged_speed_error * fudged_speed_error);
       const int max_curvature_delta_relaxed_can = (max_curvature_rate_sec_relaxed / (float)limits.frequency * limits.curvature_to_can) - 1.;
 
-      // openpilot clips its command to the lateral accel limit, so requiring more than this can never be met
-      const int max_curvature_relaxed_can = (MAX_LATERAL_ACCEL / (fudged_speed_error * fudged_speed_error) * limits.curvature_to_can) - 1.;
+      // openpilot clips its command to the lateral accel limit and to what the EPS accepts,
+      // so requiring more curvature than either can never be met
+      const int max_curvature_accel_can = (MAX_LATERAL_ACCEL / (fudged_speed_error * fudged_speed_error) * limits.curvature_to_can) - 1.;
+      const int max_curvature_relaxed_can = SAFETY_MIN(max_curvature_accel_can, limits.max_curvature);
 
       // the minimum and maximum curvature allowed based on the measured curvature
       const int lowest_desired_curvature_error = curvature_state.meas.min - limits.max_curvature_error - 1;

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -262,21 +262,32 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
     const float max_curvature_delta = max_curvature_rate_sec / (float)limits.frequency;
     const int max_curvature_delta_can = (max_curvature_delta * limits.curvature_to_can) + 1.;
 
-    const int highest_desired_curvature = curvature_state.desired_last + max_curvature_delta_can;
-    const int lowest_desired_curvature = curvature_state.desired_last - max_curvature_delta_can;
+    int highest_desired_curvature = curvature_state.desired_last + max_curvature_delta_can;
+    int lowest_desired_curvature = curvature_state.desired_last - max_curvature_delta_can;
+
+    // *** curvature error from measured ***
+    // never require a minimum curvature, and never require moving toward the bounds faster than
+    // openpilot's own jerk limit allows
+    if (limits.max_curvature_error && ((vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR) > limits.curvature_error_min_speed)) {
+      // flipped fudge keeps the required movement under openpilot's rate limit
+      const float fudged_speed_error = (vehicle_speed.max / VEHICLE_SPEED_FACTOR) + 1.0;
+      const float max_curvature_delta_relaxed = MAX_LATERAL_JERK / (fudged_speed_error * fudged_speed_error) / (float)limits.frequency;
+      const int max_curvature_delta_relaxed_can = (max_curvature_delta_relaxed * limits.curvature_to_can) - 1.;
+
+      const int highest_desired_curvature_error = SAFETY_MAX(curvature_state.meas.max + limits.max_curvature_error + 1, 0);
+      const int lowest_desired_curvature_error = SAFETY_MIN(curvature_state.meas.min - limits.max_curvature_error - 1, 0);
+
+      highest_desired_curvature = SAFETY_MAX(SAFETY_MIN(highest_desired_curvature, highest_desired_curvature_error),
+                                             curvature_state.desired_last - max_curvature_delta_relaxed_can);
+      lowest_desired_curvature = SAFETY_MIN(SAFETY_MAX(lowest_desired_curvature, lowest_desired_curvature_error),
+                                            curvature_state.desired_last + max_curvature_delta_relaxed_can);
+    }
     violation |= safety_max_limit_check(desired_curvature, highest_desired_curvature, lowest_desired_curvature);
 
     // *** ISO lateral accel limit ***
     const float max_curvature = MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed);
     const int max_curvature_can = (max_curvature * limits.curvature_to_can) + 1.;
     violation |= safety_max_limit_check(desired_curvature, max_curvature_can, -max_curvature_can);
-
-    // *** curvature error from measured ***
-    if (limits.max_curvature_error && ((vehicle_speed.values[0] / VEHICLE_SPEED_FACTOR) > limits.curvature_error_min_speed)) {
-      const int lowest_desired_curvature_error = curvature_state.meas.min - limits.max_curvature_error - 1;
-      const int highest_desired_curvature_error = curvature_state.meas.max + limits.max_curvature_error + 1;
-      violation |= safety_max_limit_check(desired_curvature, highest_desired_curvature_error, lowest_desired_curvature_error);
-    }
 
     // *** real time rate limit check ***
     violation |= rt_curvature_rate_limit_check(limits);

--- a/opendbc/safety/lateral.h
+++ b/opendbc/safety/lateral.h
@@ -273,6 +273,9 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       const float max_curvature_rate_sec_relaxed = MAX_LATERAL_JERK / (fudged_speed_error * fudged_speed_error);
       const int max_curvature_delta_relaxed_can = (max_curvature_rate_sec_relaxed / (float)limits.frequency * limits.curvature_to_can) - 1.;
 
+      // openpilot clips its command to the lateral accel limit, so requiring more than this can never be met
+      const int max_curvature_relaxed_can = (MAX_LATERAL_ACCEL / (fudged_speed_error * fudged_speed_error) * limits.curvature_to_can) - 1.;
+
       // the minimum and maximum curvature allowed based on the measured curvature
       const int lowest_desired_curvature_error = curvature_state.meas.min - limits.max_curvature_error - 1;
       const int highest_desired_curvature_error = curvature_state.meas.max + limits.max_curvature_error + 1;
@@ -280,9 +283,11 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
       // the MAX is to allow the desired curvature to hit the edge of the bounds and not require going under it
       if (curvature_state.desired_last > highest_desired_curvature_error) {
         highest_desired_curvature = SAFETY_MAX(curvature_state.desired_last - max_curvature_delta_relaxed_can, highest_desired_curvature_error);
+        highest_desired_curvature = SAFETY_MAX(highest_desired_curvature, -max_curvature_relaxed_can);
 
       } else if (curvature_state.desired_last < lowest_desired_curvature_error) {
         lowest_desired_curvature = SAFETY_MIN(curvature_state.desired_last + max_curvature_delta_relaxed_can, lowest_desired_curvature_error);
+        lowest_desired_curvature = SAFETY_MIN(lowest_desired_curvature, max_curvature_relaxed_can);
 
       } else {
         // already inside error boundary, don't allow commanding outside it

--- a/opendbc/safety/modes/ford.h
+++ b/opendbc/safety/modes/ford.h
@@ -119,6 +119,7 @@ static void ford_rx_hook(const CANPacket_t *msg) {
 
     // Update vehicle yaw rate
     if (msg->addr == FORD_Yaw_Data_FD1) {
+      // FIXME: safety can receive yaw before new vehicle speed, it should recompute meas on either received
       // Signal: VehYaw_W_Actl
       // TODO: we should use the speed which results in the closest angle measurement to the desired angle
       float ford_yaw_rate = (((msg->data[2] << 8U) | msg->data[3]) * 0.0002) - 6.5;

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -328,18 +328,15 @@ class TestFordSafetyBase(common.CarSafetyTest):
       limit_command = speed > self.CURVATURE_ERROR_MIN_SPEED
       # ensure our limits match the safety's rounded limits
       # lateral jerk is symmetric, so the wind up and wind down limits are the same
-      max_delta_up = self._get_max_curvature_delta_can(speed) / self.DEG_TO_CAN
-      max_delta_up_lower = self._get_max_curvature_delta_relaxed_can(speed) / self.DEG_TO_CAN
-
-      max_delta_down = max_delta_up
-      max_delta_down_lower = max_delta_up_lower
+      max_delta = self._get_max_curvature_delta_can(speed) / self.DEG_TO_CAN
+      max_delta_relaxed = self._get_max_curvature_delta_relaxed_can(speed) / self.DEG_TO_CAN
 
       up_cases = (self.MAX_CURVATURE_ERROR * 2, [
         (not limit_command, 0, 0),
-        (not limit_command, 0, max_delta_up_lower - small_curvature),
-        (True, 0, max_delta_up_lower),
-        (True, 0, max_delta_up),
-        (False, 0, max_delta_up + small_curvature),
+        (not limit_command, 0, max_delta_relaxed - small_curvature),
+        (True, 0, max_delta_relaxed),
+        (True, 0, max_delta),
+        (False, 0, max_delta + small_curvature),
         # stay at boundary limit
         (True, self.MAX_CURVATURE_ERROR - small_curvature, self.MAX_CURVATURE_ERROR - small_curvature),
         # 1 unit below boundary limit
@@ -350,10 +347,10 @@ class TestFordSafetyBase(common.CarSafetyTest):
 
       down_cases = (self.MAX_CURVATURE - self.MAX_CURVATURE_ERROR * 2, [
         (not limit_command, self.MAX_CURVATURE, self.MAX_CURVATURE),
-        (not limit_command, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down_lower + small_curvature),
-        (True, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down_lower),
-        (True, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down),
-        (False, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down - small_curvature),
+        (not limit_command, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_relaxed + small_curvature),
+        (True, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_relaxed),
+        (True, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta),
+        (False, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta - small_curvature),
       ])
 
       # the driver can hold a curvature openpilot may not command, safety must never require moving past

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -103,6 +103,12 @@ class TestFordSafetyBase(common.CarSafetyTest):
     fudged_speed = speed + 1.0
     return int(MAX_LATERAL_JERK / (fudged_speed * fudged_speed) / self.LATERAL_FREQUENCY * self.DEG_TO_CAN) - 1
 
+  def _get_max_curvature_relaxed_can(self, speed):
+    # flipped fudge, safety never requires commanding more curvature than openpilot can send
+    fudged_speed = speed + 1.0
+    max_curvature_accel_can = int(MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed) * self.DEG_TO_CAN) - 1
+    return min(max_curvature_accel_can, round(self.MAX_CURVATURE * self.DEG_TO_CAN))
+
   def _set_prev_desired_angle(self, t):
     t = round(t * self.DEG_TO_CAN)
     self.safety.set_desired_curvature_last(t)
@@ -366,6 +372,30 @@ class TestFordSafetyBase(common.CarSafetyTest):
 
             self._set_prev_desired_angle(sign * initial_curvature)
             self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_curvature, 0)))
+
+  def test_curvature_error_relaxed_limits(self):
+    """
+    The driver can hold a curvature openpilot is not allowed to command, either above the lateral
+    acceleration limit or above the max the EPS accepts. Safety must not require moving past either.
+    """
+    self.safety.set_controls_allowed(True)
+    # measured well outside anything openpilot may send, so the error bounds always demand more
+    curvature_meas = self.MAX_CURVATURE * 2
+
+    for speed in np.arange(self.CURVATURE_ERROR_MIN_SPEED + 1, 40, 0.5):
+      max_curvature_relaxed = self._get_max_curvature_relaxed_can(speed)
+
+      cases = [
+        (True, max_curvature_relaxed),       # holding at the most openpilot can send is accepted
+        (False, max_curvature_relaxed - 1),  # anything less has to keep moving toward measured
+      ]
+
+      for sign in (-1, 1):
+        self._reset_curvature_measurement(sign * curvature_meas, speed)
+        for should_tx, desired_can in cases:
+          self._set_prev_desired_angle(sign * max_curvature_relaxed / self.DEG_TO_CAN)
+          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_can / self.DEG_TO_CAN, 0)),
+                           (speed, sign, desired_can))
 
   def test_curvature_error_limits(self):
     # above CURVATURE_ERROR_MIN_SPEED, command must be within max_curvature_error of measured, below the check is skipped

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -90,6 +90,13 @@ class TestFordSafetyBase(common.CarSafetyTest):
   packer: CANPackerSafety
   safety: libsafety_py.LibSafety
 
+  def get_canfd_curvature_limits(self, speed):
+    # Round it in accordance with the safety
+    curvature_accel_limit = MAX_LATERAL_ACCEL / (max(speed, 1) ** 2)
+    curvature_accel_limit_lower = int(curvature_accel_limit * self.DEG_TO_CAN - 1) / self.DEG_TO_CAN
+    curvature_accel_limit_upper = int(curvature_accel_limit * self.DEG_TO_CAN + 1) / self.DEG_TO_CAN
+    return curvature_accel_limit_lower, curvature_accel_limit_upper
+
   def _get_max_curvature_can(self, speed):
     fudged_speed = max(speed - 1.0, 1.0)
     return int(MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed) * self.DEG_TO_CAN) + 1
@@ -309,75 +316,64 @@ class TestFordSafetyBase(common.CarSafetyTest):
                     self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(steer_control_enabled, path_offset, path_angle, curvature, curvature_rate)))
 
   def test_curvature_rate_limits(self):
-    """Curvature command must satisfy the ISO 11270 lateral jerk limit per frame."""
+    """
+    When the curvature error is exceeded, commanded curvature must start moving towards meas respecting rate limits.
+    Since safety allows higher rate limits to avoid false positives, we need to allow a lower rate to move towards meas.
+    """
     self.safety.set_controls_allowed(True)
-    max_encoded_can = int(self.MAX_CURVATURE * self.DEG_TO_CAN)
+    # safety fudges the speed (1 m/s) and rate limits (1 CAN unit) to avoid false positives
+    small_curvature = 1 / self.DEG_TO_CAN  # significant small amount of curvature to cross boundary
 
     for speed in np.arange(0, 40, 0.5):
-      max_can = self._get_max_curvature_can(speed)
-      max_delta_can = self._get_max_curvature_delta_can(speed)
-      base_can = max_delta_can * 2
-      if base_can + max_delta_can + 5 > min(max_can, max_encoded_can):
-        continue
+      curvature_accel_limit_lower, curvature_accel_limit_upper = self.get_canfd_curvature_limits(speed)
+      limit_command = speed > self.CURVATURE_ERROR_MIN_SPEED
+      # ensure our limits match the safety's rounded limits
+      # lateral jerk is symmetric, so the wind up and wind down limits are the same
+      max_delta_up = self._get_max_curvature_delta_can(speed) / self.DEG_TO_CAN
+      max_delta_up_lower = self._get_max_curvature_delta_relaxed_can(speed) / self.DEG_TO_CAN
 
-      # (should_tx, desired_curvature_can) relative to base_can
-      cases = [
-        (True, max_delta_can),       # at jerk limit
-        (False, max_delta_can + 5),  # over jerk limit
-      ]
+      max_delta_down = max_delta_up
+      max_delta_down_lower = max_delta_up_lower
 
-      for sign in (-1, 1):
-        self._reset_curvature_measurement(sign * base_can / self.DEG_TO_CAN, speed)
-        for should_tx, delta_can in cases:
-          self.safety.set_desired_curvature_last(sign * base_can)
-          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * (base_can + delta_can) / self.DEG_TO_CAN, 0)))
+      up_cases = (self.MAX_CURVATURE_ERROR * 2, [
+        (not limit_command, 0, 0),
+        (not limit_command, 0, max_delta_up_lower - small_curvature),
+        (True, 0, max_delta_up_lower),
+        (True, 0, max_delta_up),
+        (False, 0, max_delta_up + small_curvature),
+        # stay at boundary limit
+        (True, self.MAX_CURVATURE_ERROR - small_curvature, self.MAX_CURVATURE_ERROR - small_curvature),
+        # 1 unit below boundary limit
+        (not limit_command, self.MAX_CURVATURE_ERROR - small_curvature * 2, self.MAX_CURVATURE_ERROR - small_curvature * 2),
+        # shouldn't allow command to move outside the boundary limit if last was inside
+        (not limit_command, self.MAX_CURVATURE_ERROR - small_curvature, self.MAX_CURVATURE_ERROR - small_curvature * 2),
+      ])
 
-  def test_curvature_error_rate_limits(self):
-    """
-    When the command is outside the curvature error bounds it must move back toward them respecting
-    rate limits. Since safety fudges its rate limits up to avoid false positives, it has to require
-    a lower rate of movement than openpilot's own.
-    """
-    self.safety.set_controls_allowed(True)
-    max_error_can = round(self.MAX_CURVATURE_ERROR * self.DEG_TO_CAN)
-
-    for speed in np.arange(self.CURVATURE_ERROR_MIN_SPEED + 1, 40, 0.5):
-      delta = self._get_max_curvature_delta_can(speed)
-      relaxed = self._get_max_curvature_delta_relaxed_can(speed)
-      if self._get_max_curvature_can(speed) < 4 * max_error_can:
-        continue
-
-      # command sits well beyond the error bounds, it has to wind back down toward them
-      last = 3 * max_error_can
-      down_cases = [
-        (False, last),                  # holding still is not enough
-        (False, last - relaxed + 1),    # moving, but slower than required
-        (True, last - relaxed),         # least movement safety accepts
-        (True, last - delta),           # openpilot's own rate limit
-        (False, last - delta - 1),      # faster than the jerk limit
-      ]
-
-      # command sits well below the error bounds, it has to wind back up toward them
-      up_cases = [
-        (False, 0),                     # holding still is not enough
-        (False, relaxed - 1),           # moving, but slower than required
-        (True, relaxed),                # least movement safety accepts
-        (True, delta),                  # openpilot's own rate limit
-        (False, delta + 1),             # faster than the jerk limit
-      ]
+      down_cases = (self.MAX_CURVATURE - self.MAX_CURVATURE_ERROR * 2, [
+        (not limit_command, self.MAX_CURVATURE, self.MAX_CURVATURE),
+        (not limit_command, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down_lower + small_curvature),
+        (True, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down_lower),
+        (True, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down),
+        (False, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down - small_curvature),
+      ])
 
       for sign in (-1, 1):
-        self._reset_curvature_measurement(0, speed)
-        for should_tx, desired_can in down_cases:
-          self.safety.set_desired_curvature_last(sign * last)
-          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_can / self.DEG_TO_CAN, 0)),
-                           (speed, sign, desired_can))
+        for angle_meas, cases in (up_cases, down_cases):
+          self._reset_curvature_measurement(sign * angle_meas, speed)
+          for should_tx, initial_curvature, desired_curvature in cases:
 
-        self._reset_curvature_measurement(sign * 3 * max_error_can / self.DEG_TO_CAN, speed)
-        for should_tx, desired_can in up_cases:
-          self.safety.set_desired_curvature_last(0)
-          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_can / self.DEG_TO_CAN, 0)),
-                           (speed, sign, desired_can))
+            # Only CAN FD has the max lateral acceleration limit
+            if self.STEER_MESSAGE == MSG_LateralMotionControl2:
+              if should_tx:
+                # can not send if the curvature is above the max lateral acceleration
+                should_tx = should_tx and abs(desired_curvature) <= curvature_accel_limit_upper
+              else:
+                # if desired curvature violates driver curvature error, it can only send if
+                # the curvature is being limited by max lateral acceleration
+                should_tx = should_tx or curvature_accel_limit_lower <= abs(desired_curvature) <= curvature_accel_limit_upper
+
+            self._set_prev_desired_angle(sign * initial_curvature)
+            self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_curvature, 0)))
 
   def test_curvature_error_limits(self):
     # above CURVATURE_ERROR_MIN_SPEED, command must be within max_curvature_error of measured, below the check is skipped

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -381,25 +381,13 @@ class TestFordSafetyBase(common.CarSafetyTest):
             self._set_prev_desired_angle(sign * initial_curvature)
             self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_curvature, 0)))
 
-  def test_curvature_error_limits(self):
-    # above CURVATURE_ERROR_MIN_SPEED, command must be within max_curvature_error of measured, below the check is skipped
-    self.safety.set_controls_allowed(True)
-    max_error_can = round(self.MAX_CURVATURE_ERROR * self.DEG_TO_CAN)
-
-    for speed in (self.CURVATURE_ERROR_MIN_SPEED - 1, self.CURVATURE_ERROR_MIN_SPEED + 1):
-      limit_command = speed > self.CURVATURE_ERROR_MIN_SPEED
-      self._reset_curvature_measurement(0, speed)
-      for sign in (-1, 1):
-        self.safety.set_desired_curvature_last(sign * max_error_can)
-        self.assertTrue(self._tx(self._lat_ctl_msg(True, 0, 0, sign * (max_error_can + 1) / self.DEG_TO_CAN, 0)))
-        self.safety.set_desired_curvature_last(sign * max_error_can)
-        self.assertEqual(not limit_command, self._tx(self._lat_ctl_msg(True, 0, 0, sign * (max_error_can + 2) / self.DEG_TO_CAN, 0)))
-
-    # newest speed sample gates the check
-    self._reset_curvature_measurement(0, self.CURVATURE_ERROR_MIN_SPEED - 1)
-    self._rx(self._speed_msg(self.CURVATURE_ERROR_MIN_SPEED + 1))
-    self.safety.set_desired_curvature_last(max_error_can)
-    self.assertFalse(self._tx(self._lat_ctl_msg(True, 0, 0, (max_error_can + 2) / self.DEG_TO_CAN, 0)))
+    # the newest speed sample gates the check, not the whole sample window
+    max_error = self.MAX_CURVATURE_ERROR + small_curvature * 2
+    for sign in (-1, 1):
+      self._reset_curvature_measurement(0, self.CURVATURE_ERROR_MIN_SPEED - 1)
+      self._rx(self._speed_msg(self.CURVATURE_ERROR_MIN_SPEED + 1))
+      self._set_prev_desired_angle(sign * self.MAX_CURVATURE_ERROR)
+      self.assertFalse(self._tx(self._lat_ctl_msg(True, 0, 0, sign * max_error, 0)))
 
   def test_curvature_violation(self):
     # If violation occurs, curvature cmd is blocked until reset to 0

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -356,9 +356,15 @@ class TestFordSafetyBase(common.CarSafetyTest):
       # the driver can hold a curvature openpilot may not command, safety must never require moving past
       # the most it can send: the lower of the lateral acceleration limit and what the EPS accepts
       max_curvature_relaxed = self._get_max_curvature_relaxed_can(speed) / self.DEG_TO_CAN
+      # safety fudges the speed down for the accel check and up for the cap, so the last command can sit above the cap
+      max_curvature_allowed_can = min(self._get_max_curvature_can(speed), round(self.MAX_CURVATURE * self.DEG_TO_CAN))
+      winds_down_within_jerk = (max_curvature_allowed_can - self._get_max_curvature_relaxed_can(speed) <=
+                                self._get_max_curvature_delta_can(speed))
       relaxed_cases = (self.MAX_CURVATURE * 2, [
         (True, max_curvature_relaxed, max_curvature_relaxed),
         (not limit_command, max_curvature_relaxed, max_curvature_relaxed - small_curvature),
+        # no longer requiring the command to wind towards meas doesn't stop rate limiting it winding away
+        (winds_down_within_jerk, max_curvature_allowed_can / self.DEG_TO_CAN, max_curvature_relaxed),
       ])
 
       for sign in (-1, 1):

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -356,8 +356,9 @@ class TestFordSafetyBase(common.CarSafetyTest):
           for should_tx, initial_curvature, desired_curvature in cases:
 
             # at low speeds one frame of jerk exceeds the curvature signal, so the falsy cases will rightly not fail.
+            # assert we never drop a case at a speed where the curvature error is enforced
             if abs(desired_curvature) > self.MAX_CURVATURE:
-              self.assertLessEqual(speed, 3.5)
+              self.assertLess(speed, self.CURVATURE_ERROR_MIN_SPEED)
               continue
 
             # can not send if the curvature is above the max lateral acceleration

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -355,6 +355,11 @@ class TestFordSafetyBase(common.CarSafetyTest):
           self._reset_curvature_measurement(sign * angle_meas, speed)
           for should_tx, initial_curvature, desired_curvature in cases:
 
+            # at low speeds one frame of jerk exceeds the curvature signal, so the falsy cases will rightly not fail.
+            if abs(desired_curvature) > self.MAX_CURVATURE:
+              self.assertLessEqual(speed, 3.5)
+              continue
+
             # can not send if the curvature is above the max lateral acceleration
             should_tx = should_tx and abs(desired_curvature) <= curvature_accel_limit
 

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -356,8 +356,16 @@ class TestFordSafetyBase(common.CarSafetyTest):
         (False, self.MAX_CURVATURE, self.MAX_CURVATURE - max_delta_down - small_curvature),
       ])
 
+      # the driver can hold a curvature openpilot may not command, safety must never require moving past
+      # the most it can send: the lower of the lateral acceleration limit and what the EPS accepts
+      max_curvature_relaxed = self._get_max_curvature_relaxed_can(speed) / self.DEG_TO_CAN
+      relaxed_cases = (self.MAX_CURVATURE * 2, [
+        (True, max_curvature_relaxed, max_curvature_relaxed),
+        (not limit_command, max_curvature_relaxed, max_curvature_relaxed - small_curvature),
+      ])
+
       for sign in (-1, 1):
-        for angle_meas, cases in (up_cases, down_cases):
+        for angle_meas, cases in (up_cases, down_cases, relaxed_cases):
           self._reset_curvature_measurement(sign * angle_meas, speed)
           for should_tx, initial_curvature, desired_curvature in cases:
 
@@ -372,30 +380,6 @@ class TestFordSafetyBase(common.CarSafetyTest):
 
             self._set_prev_desired_angle(sign * initial_curvature)
             self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_curvature, 0)))
-
-  def test_curvature_error_relaxed_limits(self):
-    """
-    The driver can hold a curvature openpilot is not allowed to command, either above the lateral
-    acceleration limit or above the max the EPS accepts. Safety must not require moving past either.
-    """
-    self.safety.set_controls_allowed(True)
-    # measured well outside anything openpilot may send, so the error bounds always demand more
-    curvature_meas = self.MAX_CURVATURE * 2
-
-    for speed in np.arange(self.CURVATURE_ERROR_MIN_SPEED + 1, 40, 0.5):
-      max_curvature_relaxed = self._get_max_curvature_relaxed_can(speed)
-
-      cases = [
-        (True, max_curvature_relaxed),       # holding at the most openpilot can send is accepted
-        (False, max_curvature_relaxed - 1),  # anything less has to keep moving toward measured
-      ]
-
-      for sign in (-1, 1):
-        self._reset_curvature_measurement(sign * curvature_meas, speed)
-        for should_tx, desired_can in cases:
-          self._set_prev_desired_angle(sign * max_curvature_relaxed / self.DEG_TO_CAN)
-          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_can / self.DEG_TO_CAN, 0)),
-                           (speed, sign, desired_can))
 
   def test_curvature_error_limits(self):
     # above CURVATURE_ERROR_MIN_SPEED, command must be within max_curvature_error of measured, below the check is skipped

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -90,13 +90,6 @@ class TestFordSafetyBase(common.CarSafetyTest):
   packer: CANPackerSafety
   safety: libsafety_py.LibSafety
 
-  def get_canfd_curvature_limits(self, speed):
-    # Round it in accordance with the safety
-    curvature_accel_limit = MAX_LATERAL_ACCEL / (max(speed, 1) ** 2)
-    curvature_accel_limit_lower = int(curvature_accel_limit * self.DEG_TO_CAN - 1) / self.DEG_TO_CAN
-    curvature_accel_limit_upper = int(curvature_accel_limit * self.DEG_TO_CAN + 1) / self.DEG_TO_CAN
-    return curvature_accel_limit_lower, curvature_accel_limit_upper
-
   def _get_max_curvature_can(self, speed):
     fudged_speed = max(speed - 1.0, 1.0)
     return int(MAX_LATERAL_ACCEL / (fudged_speed * fudged_speed) * self.DEG_TO_CAN) + 1
@@ -325,7 +318,7 @@ class TestFordSafetyBase(common.CarSafetyTest):
     small_curvature = 1 / self.DEG_TO_CAN  # significant small amount of curvature to cross boundary
 
     for speed in np.arange(0, 40, 0.5):
-      curvature_accel_limit_lower, curvature_accel_limit_upper = self.get_canfd_curvature_limits(speed)
+      curvature_accel_limit = self._get_max_curvature_can(speed) / self.DEG_TO_CAN
       limit_command = speed > self.CURVATURE_ERROR_MIN_SPEED
       # ensure our limits match the safety's rounded limits
       # lateral jerk is symmetric, so the wind up and wind down limits are the same
@@ -362,15 +355,8 @@ class TestFordSafetyBase(common.CarSafetyTest):
           self._reset_curvature_measurement(sign * angle_meas, speed)
           for should_tx, initial_curvature, desired_curvature in cases:
 
-            # Only CAN FD has the max lateral acceleration limit
-            if self.STEER_MESSAGE == MSG_LateralMotionControl2:
-              if should_tx:
-                # can not send if the curvature is above the max lateral acceleration
-                should_tx = should_tx and abs(desired_curvature) <= curvature_accel_limit_upper
-              else:
-                # if desired curvature violates driver curvature error, it can only send if
-                # the curvature is being limited by max lateral acceleration
-                should_tx = should_tx or curvature_accel_limit_lower <= abs(desired_curvature) <= curvature_accel_limit_upper
+            # can not send if the curvature is above the max lateral acceleration
+            should_tx = should_tx and abs(desired_curvature) <= curvature_accel_limit
 
             self._set_prev_desired_angle(sign * initial_curvature)
             self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_curvature, 0)))

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -355,7 +355,7 @@ class TestFordSafetyBase(common.CarSafetyTest):
           self._reset_curvature_measurement(sign * angle_meas, speed)
           for should_tx, initial_curvature, desired_curvature in cases:
 
-            # at low speeds one frame of jerk exceeds the curvature signal, so the falsy cases will rightly not fail.
+            # at low speeds one frame of jerk exceeds the curvature signal, so the should_tx=False cases will rightly not fail.
             # assert we never drop a case at a speed where the curvature error is enforced
             if abs(desired_curvature) > self.MAX_CURVATURE:
               self.assertLess(speed, self.CURVATURE_ERROR_MIN_SPEED)

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -336,7 +336,7 @@ class TestFordSafetyBase(common.CarSafetyTest):
     """
     When the command is outside the curvature error bounds it must move back toward them respecting
     rate limits. Since safety fudges its rate limits up to avoid false positives, it has to require
-    a lower rate of movement than openpilot's own. Moving toward zero is never required.
+    a lower rate of movement than openpilot's own.
     """
     self.safety.set_controls_allowed(True)
     max_error_can = round(self.MAX_CURVATURE_ERROR * self.DEG_TO_CAN)
@@ -357,11 +357,13 @@ class TestFordSafetyBase(common.CarSafetyTest):
         (False, last - delta - 1),      # faster than the jerk limit
       ]
 
-      # command is inside the bounds on the zero side, it is never required to catch up to measured
+      # command sits well below the error bounds, it has to wind back up toward them
       up_cases = [
-        (True, 0),                      # zero is always allowed
-        (True, delta),                  # may move toward measured at the jerk limit
-        (False, delta + 1),             # but no faster
+        (False, 0),                     # holding still is not enough
+        (False, relaxed - 1),           # moving, but slower than required
+        (True, relaxed),                # least movement safety accepts
+        (True, delta),                  # openpilot's own rate limit
+        (False, delta + 1),             # faster than the jerk limit
       ]
 
       for sign in (-1, 1):

--- a/opendbc/safety/tests/test_ford.py
+++ b/opendbc/safety/tests/test_ford.py
@@ -98,6 +98,11 @@ class TestFordSafetyBase(common.CarSafetyTest):
     fudged_speed = max(speed - 1.0, 1.0)
     return int(MAX_LATERAL_JERK / (fudged_speed * fudged_speed) / self.LATERAL_FREQUENCY * self.DEG_TO_CAN) + 1
 
+  def _get_max_curvature_delta_relaxed_can(self, speed):
+    # flipped fudge, this is the least movement toward the error bounds safety requires
+    fudged_speed = speed + 1.0
+    return int(MAX_LATERAL_JERK / (fudged_speed * fudged_speed) / self.LATERAL_FREQUENCY * self.DEG_TO_CAN) - 1
+
   def _set_prev_desired_angle(self, t):
     t = round(t * self.DEG_TO_CAN)
     self.safety.set_desired_curvature_last(t)
@@ -326,6 +331,51 @@ class TestFordSafetyBase(common.CarSafetyTest):
         for should_tx, delta_can in cases:
           self.safety.set_desired_curvature_last(sign * base_can)
           self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * (base_can + delta_can) / self.DEG_TO_CAN, 0)))
+
+  def test_curvature_error_rate_limits(self):
+    """
+    When the command is outside the curvature error bounds it must move back toward them respecting
+    rate limits. Since safety fudges its rate limits up to avoid false positives, it has to require
+    a lower rate of movement than openpilot's own. Moving toward zero is never required.
+    """
+    self.safety.set_controls_allowed(True)
+    max_error_can = round(self.MAX_CURVATURE_ERROR * self.DEG_TO_CAN)
+
+    for speed in np.arange(self.CURVATURE_ERROR_MIN_SPEED + 1, 40, 0.5):
+      delta = self._get_max_curvature_delta_can(speed)
+      relaxed = self._get_max_curvature_delta_relaxed_can(speed)
+      if self._get_max_curvature_can(speed) < 4 * max_error_can:
+        continue
+
+      # command sits well beyond the error bounds, it has to wind back down toward them
+      last = 3 * max_error_can
+      down_cases = [
+        (False, last),                  # holding still is not enough
+        (False, last - relaxed + 1),    # moving, but slower than required
+        (True, last - relaxed),         # least movement safety accepts
+        (True, last - delta),           # openpilot's own rate limit
+        (False, last - delta - 1),      # faster than the jerk limit
+      ]
+
+      # command is inside the bounds on the zero side, it is never required to catch up to measured
+      up_cases = [
+        (True, 0),                      # zero is always allowed
+        (True, delta),                  # may move toward measured at the jerk limit
+        (False, delta + 1),             # but no faster
+      ]
+
+      for sign in (-1, 1):
+        self._reset_curvature_measurement(0, speed)
+        for should_tx, desired_can in down_cases:
+          self.safety.set_desired_curvature_last(sign * last)
+          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_can / self.DEG_TO_CAN, 0)),
+                           (speed, sign, desired_can))
+
+        self._reset_curvature_measurement(sign * 3 * max_error_can / self.DEG_TO_CAN, speed)
+        for should_tx, desired_can in up_cases:
+          self.safety.set_desired_curvature_last(0)
+          self.assertEqual(should_tx, self._tx(self._lat_ctl_msg(True, 0, 0, sign * desired_can / self.DEG_TO_CAN, 0)),
+                           (speed, sign, desired_can))
 
   def test_curvature_error_limits(self):
     # above CURVATURE_ERROR_MIN_SPEED, command must be within max_curvature_error of measured, below the check is skipped


### PR DESCRIPTION
Fixes three regressions from https://github.com/commaai/opendbc/pull/3405

This asserts requested and and measured curvature are within 100 (0.002) units:

https://github.com/commaai/opendbc/blob/a3ed7d18e8b39952f35eaa81e60effe555d3f8b0/opendbc/safety/lateral.h#L274-L279

But is not aware of the lateral accel, jerk, or max supported curvature checks. If user moves wheel faster than allowed jerk, latching block. If user moves wheel above max allowed accel (+ meas error band), latching block.

```
  speed 25 m/s   delta 16   delta_relaxed 12
      last   meas |       old window |    master window
         0      0 |        [-16, 16] |        [-16, 16]
         0    100 |         [-1, 16] |         [-1, 16]
         0    200 |         [12, 16] |         [99, 16]  EMPTY
       300      0 |       [284, 288] |       [284, 101]
```