### PR TITLE
Remove carParams.mass

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -484,13 +484,13 @@ struct CarParams {
   autoResumeSng @69 :Bool;               # describes whether car can resume from a stop automatically
 
   # things about the car in the manual
-  mass @17 :Float32;            # [kg] curb weight: all fluids no cargo
   wheelbase @18 :Float32;       # [m] distance from rear axle to front axle
   centerToFront @19 :Float32;   # [m] distance from center of mass to front axle
   steerRatio @20 :Float32;      # [] ratio of steering wheel angle to front wheel angle
   steerRatioRear @21 :Float32;  # [] ratio of steering wheel angle to rear wheel angle (usually 0)
 
-  # things we can derive
+  # vehicle dynamics parameters
+  unitMass @17 :Float32;             # [kg] arbitrary mass; cancels out of the vehicle dynamics
   rotationalInertia @22 :Float32;    # [kg*m2] body rotational inertia
   tireStiffnessFactor @72 :Float32;  # scaling factor used in calculating tireStiffness[Front,Rear]
   tireStiffnessFront @23 :Float32;   # [N/rad] front tire coeff of stiff

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -8,7 +8,7 @@ from typing import Any
 from collections.abc import Callable
 from functools import cache
 
-from opendbc.car import DT_CTRL, apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness, STD_CARGO_KG
+from opendbc.car import DT_CTRL, apply_hysteresis, gen_empty_fingerprint, scale_rot_inertia, scale_tire_stiffness
 from opendbc.car import structs
 from opendbc.car.can_definitions import CanData, CanRecvCallable, CanSendCallable
 from opendbc.car.common.basedir import BASEDIR
@@ -133,7 +133,8 @@ class CarInterfaceBase(ABC):
     ret = CarInterfaceBase.get_std_params(candidate)
 
     platform = PLATFORMS[candidate]
-    ret.mass = platform.config.specs.mass
+    # Arbitrary mass; it cancels out of the vehicle dynamics but keeps the formulation readable.
+    ret.unitMass = 1.0
     ret.wheelbase = platform.config.specs.wheelbase
     ret.steerRatio = platform.config.specs.steerRatio
     ret.centerToFront = ret.wheelbase * platform.config.specs.centerToFrontRatio
@@ -144,13 +145,9 @@ class CarInterfaceBase(ABC):
 
     ret = cls._get_params(ret, candidate, fingerprint, car_fw, alpha_long, is_release, docs)
 
-    # Vehicle mass is published curb weight plus assumed payload such as a human driver; notCars have no assumed payload
-    if not ret.notCar:
-      ret.mass = ret.mass + STD_CARGO_KG
-
     # Set params dependent on values set by the car interface
-    ret.rotationalInertia = scale_rot_inertia(ret.mass, ret.wheelbase)
-    ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.mass, ret.wheelbase, ret.centerToFront, ret.tireStiffnessFactor)
+    ret.rotationalInertia = scale_rot_inertia(ret.unitMass, ret.wheelbase)
+    ret.tireStiffnessFront, ret.tireStiffnessRear = scale_tire_stiffness(ret.unitMass, ret.wheelbase, ret.centerToFront, ret.tireStiffnessFactor)
 
     return ret
 

--- a/opendbc/car/tests/test_car_interfaces.py
+++ b/opendbc/car/tests/test_car_interfaces.py
@@ -41,7 +41,7 @@ def _make_car_test(car_name):
     car_interface = get_fuzzy_car_interface(car_name, fuzzy)
     car_params = car_interface.CP.as_reader()
 
-    assert car_params.mass > 1
+    assert car_params.unitMass == 1
     assert car_params.wheelbase > 0
     # centerToFront is center of gravity to front wheels, assert a reasonable range
     assert car_params.wheelbase * 0.3 < car_params.centerToFront < car_params.wheelbase * 0.7

--- a/opendbc/car/tests/test_models.py
+++ b/opendbc/car/tests/test_models.py
@@ -193,7 +193,7 @@ class TestCarModelBase(unittest.TestCase):
     if self.CP.dashcamOnly:
       self.skipTest("no need to check carParams for dashcamOnly")
 
-    self.assertGreater(self.CP.mass, 1)
+    self.assertEqual(self.CP.unitMass, 1)
     if self.CP.steerControlType not in (SteerControlType.angle, SteerControlType.curvature):
       tuning = self.CP.lateralTuning.which()
       if tuning == "pid":

--- a/opendbc/car/vehicle_model.py
+++ b/opendbc/car/vehicle_model.py
@@ -27,7 +27,7 @@ class VehicleModel:
       CP: Car Parameters
     """
     # for math readability, convert long names car params into short names
-    self.m: float = CP.mass
+    self.m: float = CP.unitMass
     self.j: float = CP.rotationalInertia
     self.l: float = CP.wheelbase
     self.aF: float = CP.centerToFront


### PR DESCRIPTION
`CarParams.mass` only feeds the lateral bicycle-model stack:

| Repo | Consumer | Why mass cancels |
|---|---|---|
| opendbc | [`VehicleModel` inputs](https://github.com/commaai/opendbc/blob/d8d3d3c3e0d35e73eacf534a4f35a0bd299dcb07/opendbc/car/vehicle_model.py#L30-L38), [equations](https://github.com/commaai/opendbc/blob/d8d3d3c3e0d35e73eacf534a4f35a0bd299dcb07/opendbc/car/vehicle_model.py#L192-L199) | Tire stiffness scales as `C ∝ m` and inertia as `I ∝ m`; the equations use `C/m` and `C/I`. |
| openpilot | [`paramsd`](https://github.com/commaai/openpilot/blob/cd14dae543f11fafb674fff84f54137ffcad7ae5/openpilot/selfdrive/locationd/paramsd.py#L38-L45), [`CarKalman`](https://github.com/commaai/openpilot/blob/cd14dae543f11fafb674fff84f54137ffcad7ae5/openpilot/selfdrive/locationd/models/car_kf.py#L122-L130) | Uses the same `C/m` and `C/I` bicycle-model terms. |
| xx | [lateral planner](https://github.com/commaai/xx/blob/5fc438eddbd3b08977fc7b7360ef5103da3c4338/arena/agents/lib/planners/lateral_planner.py#L35-L37) | Uses `m/C_rear`, while `C_rear ∝ m`. |

This renames the field to `unitMass` and fixes it at `1 kg`. Tire stiffness remains in `N/rad`, rotational inertia remains in `kg*m²`, and the standard equations and behavior are unchanged.

Other options:

- [Mass-normalize everything (#3666)](https://github.com/commaai/opendbc/pull/3666): slightly simpler equations and no fake mass field, but then stiffness and inertia no longer use their normal SI units and the equations are less recognizable.
- Keep an arbitrary mass local to every consumer: makes the trick obvious at each call site, but duplicates the scaling setup and makes it easier for consumers to get out of sync.

Consumer updates: [openpilot #38594](https://github.com/commaai/openpilot/pull/38594), [xx #6940](https://github.com/commaai/xx/pull/6940)