### PR TITLE
[experiment] support groups

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,40 @@
+# Component fingerprinting notes
+
+## Proving write compatibility
+
+We can observe stock command messages and potentially prove that a candidate
+writer reproduces their address, size, counter, checksum, frequency, and static
+fields. It is still unclear what evidence proves that a generated nonzero
+command has the expected meaning, authority, limits, and fault behavior on an
+otherwise unknown vehicle.
+
+Question to explore: can write compatibility be established from passive stock
+traffic plus carefully chosen invariants, or is independent ECU/firmware
+attestation or a safe active challenge required?
+
+## Toyota EPS torque scale
+
+Toyota EPS torque uses several platform-selected scale factors (66, 73, 77,
+88, or 100). The factor affects both decoded EPS torque and panda's steering
+safety limits. In a component-fingerprinted Toyota, this must be detected or
+learned live without assuming the vehicle platform. The safe observation,
+initialization, and convergence strategy remains an open problem.
+
+## `whats_a_platform` Toyota prototype
+
+Toyota runtime behavior is decomposed into support groups for PT decoding,
+cruise decoding, ACC ownership, lateral writing, longitudinal writing, SecOC,
+hybrid behavior, HUD availability, stop-and-go, EPS scaling, and wheel-speed
+scaling. Existing platforms are migration manifests only; Toyota CarState,
+CarController, radar, DBC selection, and safety configuration do not dispatch
+on platform identity.
+
+All Toyotas currently use one generic dynamics prior. This intentionally tests
+the hypothesis that paramsd/torqued can absorb platform variation. Replay data
+is still required to validate startup and convergence behavior.
+
+Support policy is downstream and represented as explicit make/model/year
+tuples. VIN currently supplies model year only. Strict tuple enforcement is
+implemented for a fully decoded identity, but global Toyota VDS-to-model
+decoding remains to be added; until then the live fallback can only reject a
+year unsupported by every identity in the legacy manifest.

--- a/opendbc/car/car_helpers.py
+++ b/opendbc/car/car_helpers.py
@@ -8,6 +8,7 @@ from opendbc.car.structs import CarParams, CarParamsT
 from opendbc.car.fingerprints import eliminate_incompatible_cars, all_legacy_fingerprint_cars
 from opendbc.car.fw_versions import ObdCallback, get_fw_versions_ordered, get_present_ecus, match_fw_to_car
 from opendbc.car.mock.values import CAR as MOCK
+from opendbc.car.support_policy import is_platform_vin_supported
 from opendbc.car.values import BRANDS
 from opendbc.car.vin import get_vin, is_valid_vin, VIN_UNKNOWN
 
@@ -162,6 +163,13 @@ def get_car(can_recv: CanRecvCallable, can_send: CanSendCallable, set_obd_multip
   CP.carFw = car_fw
   CP.fingerprintSource = source
   CP.fuzzyFingerprint = not exact_match
+
+  # Vehicle identity support policy is deliberately downstream from protocol
+  # fingerprinting. A car may resolve to valid read/write support groups while
+  # a new, unvalidated model year remains dashcam-only until whitelisted.
+  if CP.brand == "toyota" and not is_platform_vin_supported(candidate, vin):
+    carlog.error({"event": "unsupported vehicle identity", "car_fingerprint": str(candidate), "vin": vin})
+    CP.dashcamOnly = True
 
   return interfaces[CP.carFingerprint](CP)
 

--- a/opendbc/car/support_policy.py
+++ b/opendbc/car/support_policy.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+
+from opendbc.car.docs_definitions import CarDocs
+from opendbc.car.values import PLATFORMS
+from opendbc.car.vin import VIN_UNKNOWN, is_valid_vin
+
+
+VIN_MODEL_YEAR_CODES = {
+  **dict(zip("ABCDEFGHJKLMNPRSTVWXY", range(2010, 2031), strict=True)),
+  **dict(zip("123456789", range(2031, 2040), strict=True)),
+}
+
+
+@dataclass(frozen=True, order=True)
+class SupportedVehicle:
+  make: str
+  model: str
+  year: int
+
+
+def get_vin_model_year(vin: str) -> int | None:
+  """Decode the current (2010-2039) North American VIN year cycle."""
+  if not is_valid_vin(vin) or vin == VIN_UNKNOWN:
+    return None
+  return VIN_MODEL_YEAR_CODES.get(vin[9])
+
+
+def get_platform_whitelist(platform: str) -> frozenset[SupportedVehicle]:
+  """Build the make/model/year support policy from documentation metadata."""
+  config = PLATFORMS[platform].config
+  docs = config.car_docs
+  return frozenset(
+    SupportedVehicle(doc.make, doc.model, int(year))
+    for doc in docs if isinstance(doc, CarDocs)
+    for year in doc.year_list
+  )
+
+
+def is_vehicle_supported(vehicle: SupportedVehicle, whitelist: frozenset[SupportedVehicle]) -> bool:
+  """Strict make/model/year policy check for a fully decoded identity."""
+  return vehicle in whitelist
+
+
+def is_platform_vin_supported(platform: str, vin: str) -> bool:
+  """Apply identity policy after protocol fingerprinting.
+
+  Unknown VINs cannot be checked and preserve existing behavior. Make/model is
+  temporarily supplied by the legacy identity; a Toyota VDS decoder can later
+  narrow the candidate tuple without changing this policy representation.
+  """
+  year = get_vin_model_year(vin)
+  if year is None:
+    return True
+  return any(vehicle.year == year for vehicle in get_platform_whitelist(platform))

--- a/opendbc/car/tests/test_support_policy.py
+++ b/opendbc/car/tests/test_support_policy.py
@@ -1,0 +1,30 @@
+import unittest
+
+from opendbc.car.support_policy import SupportedVehicle, get_platform_whitelist, get_vin_model_year, is_platform_vin_supported, is_vehicle_supported
+from opendbc.car.toyota.values import CAR
+
+
+def vin_for_year_code(code: str) -> str:
+  return f"JTDBR32E0{code}1234567"
+
+
+class TestSupportPolicy(unittest.TestCase):
+  def test_vin_year(self):
+    self.assertEqual(get_vin_model_year(vin_for_year_code("S")), 2025)
+    self.assertEqual(get_vin_model_year(vin_for_year_code("T")), 2026)
+
+  def test_whitelist_is_make_model_year_tuples(self):
+    whitelist = get_platform_whitelist(CAR.TOYOTA_COROLLA_TSS2)
+    self.assertIn(SupportedVehicle("Toyota", "Corolla", 2022), whitelist)
+
+  def test_new_model_year_rejected_after_same_platform_match(self):
+    self.assertTrue(is_platform_vin_supported(CAR.TOYOTA_COROLLA_TSS2, vin_for_year_code("N")))
+    self.assertFalse(is_platform_vin_supported(CAR.TOYOTA_COROLLA_TSS2, vin_for_year_code("T")))
+
+  def test_strict_tuple_check_does_not_confuse_models_in_one_manifest(self):
+    whitelist = get_platform_whitelist(CAR.TOYOTA_COROLLA_TSS2)
+    self.assertTrue(is_vehicle_supported(SupportedVehicle("Toyota", "Corolla Cross (Non-US only)", 2023), whitelist))
+    self.assertFalse(is_vehicle_supported(SupportedVehicle("Toyota", "Corolla", 2023), whitelist))
+
+  def test_unknown_vin_does_not_change_existing_behavior(self):
+    self.assertTrue(is_platform_vin_supported(CAR.TOYOTA_COROLLA_TSS2, "0" * 17))

--- a/opendbc/car/toyota/carcontroller.py
+++ b/opendbc/car/toyota/carcontroller.py
@@ -8,7 +8,7 @@ from opendbc.car.common.pid import PIDController
 from opendbc.car.secoc import add_mac, build_sync_mac
 from opendbc.car.interfaces import CarControllerBase
 from opendbc.car.toyota import toyotacan
-from opendbc.car.toyota.values import CAR, TSS2_CAR, UNSUPPORTED_DSU_CAR, CarControllerParams, ToyotaFlags
+from opendbc.car.toyota.values import CarControllerParams, ToyotaFlags
 from opendbc.can import CANPacker
 
 Ecu = structs.CarParams.Ecu
@@ -34,7 +34,7 @@ MAX_USER_TORQUE = 500
 
 
 def get_long_tune(CP, params):
-  if CP.carFingerprint in TSS2_CAR:
+  if CP.flags & ToyotaFlags.TSS2:
     kiBP = [2., 5.]
     kiV = [0.5, 0.25]
   else:
@@ -143,7 +143,7 @@ class CarController(CarControllerBase):
     can_sends.append(steer_command)
 
     # STEERING_LTA does not seem to allow more rate by sending faster, and may wind up easier
-    if self.frame % 2 == 0 and self.CP.carFingerprint in TSS2_CAR:
+    if self.frame % 2 == 0 and self.CP.flags & ToyotaFlags.TSS2:
       lta_active = lat_active and self.CP.steerControlType == SteerControlType.angle
       # cut steering torque with TORQUE_WIND_DOWN when either EPS torque or driver torque is above
       # the threshold, to limit max lateral acceleration and for driver torque blending respectively.
@@ -267,13 +267,13 @@ class CarController(CarControllerBase):
     else:
       # we can spam can to cancel the system even if we are using lat only control
       if pcm_cancel_cmd:
-        if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
+        if self.CP.flags & ToyotaFlags.UNSUPPORTED_DSU:
           can_sends.append(toyotacan.create_acc_cancel_command(self.packer))
         else:
           can_sends.append(toyotacan.create_accel_command(self.packer, 0, pcm_cancel_cmd, True, False, lead, CS.acc_type, False, self.distance_button))
 
     # *** hud ui ***
-    if self.CP.carFingerprint != CAR.TOYOTA_PRIUS_V:
+    if self.CP.flags & ToyotaFlags.LKA_HUD:
       # ui mesg is at 1Hz but we send asap if:
       # - there is something to display
       # - there is something to stop displaying

--- a/opendbc/car/toyota/carstate.py
+++ b/opendbc/car/toyota/carstate.py
@@ -5,8 +5,8 @@ from opendbc.car import Bus, DT_CTRL, create_button_events, structs
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.common.filter_simple import FirstOrderFilter
 from opendbc.car.interfaces import CarStateBase
-from opendbc.car.toyota.values import ToyotaFlags, CAR, DBC, STEER_THRESHOLD, TSS2_CAR, RADAR_ACC_CAR, \
-                                                  EPS_SCALE, UNSUPPORTED_DSU_CAR, SECOC_CAR
+from opendbc.car.toyota.values import ToyotaFlags, STEER_THRESHOLD
+from opendbc.car.toyota.support_groups import ToyotaAccGroup, get_acc_group, get_pt_dbc
 
 ButtonType = structs.CarState.ButtonEvent.Type
 SteerControlType = structs.CarParams.SteerControlType
@@ -26,8 +26,8 @@ PERM_STEER_FAULTS = (3, 17)
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
-    can_define = CANDefine(DBC[CP.carFingerprint][Bus.pt])
-    self.eps_torque_scale = EPS_SCALE[CP.carFingerprint] / 100.
+    can_define = CANDefine(get_pt_dbc(CP))
+    self.eps_torque_scale = (CP.safetyConfigs[-1].safetyParam & 0xFF) / 100.
     self.cluster_speed_hyst_gap = CV.KPH_TO_MS / 2.
     self.cluster_min_speed = CV.KPH_TO_MS / 2.
 
@@ -57,7 +57,7 @@ class CarState(CarStateBase):
     cp_cam = can_parsers[Bus.cam]
 
     ret = structs.CarState()
-    cp_acc = cp_cam if self.CP.carFingerprint in (TSS2_CAR - RADAR_ACC_CAR) else cp
+    cp_acc = cp_cam if get_acc_group(self.CP) == ToyotaAccGroup.CAMERA else cp
 
     if not self.CP.flags & ToyotaFlags.SECOC.value:
       self.gvc = cp.vl["VSC1S07"]["GVC"]
@@ -132,7 +132,7 @@ class CarState(CarStateBase):
       if not self.accurate_steer_angle_seen:
         ret.vehicleSensorsInvalid = True
 
-    if self.CP.carFingerprint in UNSUPPORTED_DSU_CAR:
+    if self.CP.flags & ToyotaFlags.UNSUPPORTED_DSU:
       # TODO: find the bit likely in DSU_CRUISE that describes an ACC fault. one may also exist in CLUTCH
       ret.cruiseState.available = cp.vl["DSU_CRUISE"]["MAIN_ON"] != 0
       ret.cruiseState.speed = cp.vl["DSU_CRUISE"]["SET_SPEED"] * CV.KPH_TO_MS
@@ -150,7 +150,7 @@ class CarState(CarStateBase):
       conversion_factor = CV.KPH_TO_MS if is_metric else CV.MPH_TO_MS
       ret.cruiseState.speedCluster = cluster_set_speed * conversion_factor
 
-    if self.CP.carFingerprint in TSS2_CAR and not self.CP.flags & ToyotaFlags.DISABLE_RADAR.value:
+    if self.CP.flags & ToyotaFlags.TSS2 and not self.CP.flags & ToyotaFlags.DISABLE_RADAR.value:
       self.acc_type = cp_acc.vl["ACC_CONTROL"]["ACC_TYPE"]
       ret.stockFcw = bool(cp_acc.vl["PCS_HUD"]["FCW"])
 
@@ -158,8 +158,8 @@ class CarState(CarStateBase):
     # these cars are identified by an ACC_TYPE value of 2.
     # TODO: it is possible to avoid the lockout and gain stop and go if you
     # send your own ACC_CONTROL msg on startup with ACC_TYPE set to 1
-    if (self.CP.carFingerprint not in TSS2_CAR and self.CP.carFingerprint not in UNSUPPORTED_DSU_CAR) or \
-       (self.CP.carFingerprint in TSS2_CAR and self.acc_type == 1):
+    if (not self.CP.flags & ToyotaFlags.TSS2 and not self.CP.flags & ToyotaFlags.UNSUPPORTED_DSU) or \
+       (self.CP.flags & ToyotaFlags.TSS2 and self.acc_type == 1):
       if self.CP.openpilotLongitudinalControl:
         ret.accFaulted = ret.accFaulted or cp.vl["PCM_CRUISE_2"]["LOW_SPEED_LOCKOUT"] == 2
 
@@ -175,14 +175,14 @@ class CarState(CarStateBase):
       ret.leftBlindspot = (cp.vl["BSM"]["L_ADJACENT"] == 1) or (cp.vl["BSM"]["L_APPROACHING"] == 1)
       ret.rightBlindspot = (cp.vl["BSM"]["R_ADJACENT"] == 1) or (cp.vl["BSM"]["R_APPROACHING"] == 1)
 
-    if self.CP.carFingerprint != CAR.TOYOTA_PRIUS_V:
+    if self.CP.flags & ToyotaFlags.LKA_HUD:
       self.lkas_hud = copy.copy(cp_cam.vl["LKAS_HUD"])
 
-    if self.CP.carFingerprint not in UNSUPPORTED_DSU_CAR:
+    if not self.CP.flags & ToyotaFlags.UNSUPPORTED_DSU:
       self.pcm_follow_distance = cp.vl["PCM_CRUISE_2"]["PCM_FOLLOW_DISTANCE"]
 
     buttonEvents = []
-    if self.CP.carFingerprint in TSS2_CAR:
+    if self.CP.flags & ToyotaFlags.TSS2:
       # lkas button is wired to the camera
       prev_lkas_button = self.lkas_button
       self.lkas_button = cp_cam.vl["LKAS_HUD"]["LDA_ON_MESSAGE"]
@@ -192,7 +192,7 @@ class CarState(CarStateBase):
         buttonEvents.extend(create_button_events(1, 0, {1: ButtonType.lkas}) +
                             create_button_events(0, 1, {1: ButtonType.lkas}))
 
-      if self.CP.carFingerprint not in (RADAR_ACC_CAR | SECOC_CAR):
+      if not self.CP.flags & (ToyotaFlags.ACC_RADAR | ToyotaFlags.SECOC):
         # distance button is wired to the ACC module (camera or radar)
         prev_distance_button = self.distance_button
         self.distance_button = cp_acc.vl["ACC_CONTROL"]["DISTANCE"]
@@ -209,6 +209,6 @@ class CarState(CarStateBase):
     ]
 
     return {
-      Bus.pt: CANParser(DBC[CP.carFingerprint][Bus.pt], pt_messages, 0),
-      Bus.cam: CANParser(DBC[CP.carFingerprint][Bus.pt], [], 2),
+      Bus.pt: CANParser(get_pt_dbc(CP), pt_messages, 0),
+      Bus.cam: CANParser(get_pt_dbc(CP), [], 2),
     }

--- a/opendbc/car/toyota/interface.py
+++ b/opendbc/car/toyota/interface.py
@@ -1,9 +1,10 @@
-from opendbc.car import Bus, structs, get_safety_config, uds
+from opendbc.car import structs, get_safety_config, uds
 from opendbc.car.toyota.carstate import CarState
 from opendbc.car.toyota.carcontroller import CarController
 from opendbc.car.toyota.radar_interface import RadarInterface
-from opendbc.car.toyota.values import Ecu, CAR, DBC, ToyotaFlags, CarControllerParams, TSS2_CAR, RADAR_ACC_CAR, MIN_ACC_SPEED, \
-                                                  EPS_SCALE, ANGLE_CONTROL_CAR, ToyotaSafetyFlags
+from opendbc.car.toyota.values import ToyotaFlags, CarControllerParams, MIN_ACC_SPEED, ToyotaSafetyFlags
+from opendbc.car.toyota.support_groups import ToyotaAccGroup, ToyotaLateralGroup, ToyotaLongitudinalGroup, ToyotaPtGroup, ToyotaSupportGroups, \
+                                                       apply_support_groups
 from opendbc.car.disable_ecu import disable_ecu
 from opendbc.car.interfaces import CarInterfaceBase
 
@@ -24,19 +25,31 @@ class CarInterface(CarInterfaceBase):
   @staticmethod
   def _get_params(ret: structs.CarParams, candidate, fingerprint, car_fw, alpha_long, is_release, docs) -> structs.CarParams:
     ret.brand = "toyota"
+    groups = ToyotaSupportGroups.from_platform(candidate, fingerprint, car_fw)
+    apply_support_groups(ret, groups)
+    openpilot_longitudinal = groups.tss2 and (groups.acc != ToyotaAccGroup.RADAR or alpha_long)
+
+    # Protocol-compatible Toyotas share one deliberately generic dynamics
+    # prior. paramsd/torqued learn the effective steering model online.
+    ret.mass = 1700.
+    ret.wheelbase = 2.75
+    ret.steerRatio = 15.0
+    ret.tireStiffnessFactor = 0.55
+    ret.maxLateralAccel = 2.0
+
     ret.safetyConfigs = [get_safety_config(structs.CarParams.SafetyModel.toyota)]
-    ret.safetyConfigs[0].safetyParam = EPS_SCALE[candidate]
+    ret.safetyConfigs[0].safetyParam = groups.eps_torque_scale
 
     # BRAKE_MODULE is on a different address for these cars
-    if DBC[candidate][Bus.pt] == "toyota_new_mc_pt_generated":
+    if groups.pt == ToyotaPtGroup.NEW_MC:
       ret.safetyConfigs[0].safetyParam |= ToyotaSafetyFlags.ALT_BRAKE.value
 
-    if ret.flags & ToyotaFlags.SECOC.value:
+    if groups.secoc:
       ret.secOcRequired = True
       ret.safetyConfigs[0].safetyParam |= ToyotaSafetyFlags.SECOC.value
       ret.dashcamOnly = is_release
 
-    if candidate in ANGLE_CONTROL_CAR:
+    if groups.lateral == ToyotaLateralGroup.LTA_ANGLE:
       ret.steerControlType = SteerControlType.angle
       ret.safetyConfigs[0].safetyParam |= ToyotaSafetyFlags.LTA.value
 
@@ -44,53 +57,34 @@ class CarInterface(CarInterfaceBase):
       ret.steerActuatorDelay = 0.18
       ret.steerLimitTimer = 0.8
     else:
-      CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning)
+      # Generic initialization only; liveTorqueParameters learns the vehicle.
+      CarInterfaceBase.configure_torque_tune("TOYOTA_RAV4_TSS2", ret.lateralTuning)
 
       ret.steerActuatorDelay = 0.12  # Default delay, Prius has larger delay
       ret.steerLimitTimer = 0.4
 
-    stop_and_go = candidate in TSS2_CAR
-
-    # In TSS2 cars, the camera does long control
-    found_ecus = [fw.ecu for fw in car_fw]
-
-    if Ecu.hybrid in found_ecus:
+    if groups.hybrid:
       ret.flags |= ToyotaFlags.HYBRID.value
 
-    if candidate == CAR.TOYOTA_PRIUS:
-      stop_and_go = True
-      # Only give steer angle deadzone to for bad angle sensor prius
-      for fw in car_fw:
-        if fw.ecu == "eps" and not fw.fwVersion == b'8965B47060\x00\x00\x00\x00\x00\x00':
-          ret.steerActuatorDelay = 0.25
-          CarInterfaceBase.configure_torque_tune(candidate, ret.lateralTuning, steering_angle_deadzone_deg=0.2)
-        # 2021+ TSS2 steering rack swapped into a TSS-P car, not supported
-        if fw.ecu == "eps" and fw.fwVersion == b'8965B47070\x00\x00\x00\x00\x00\x00':
-          ret.dashcamOnly = True
+    ret.wheelSpeedFactor = groups.wheel_speed_factor
 
-    elif candidate in (CAR.LEXUS_RX, CAR.LEXUS_RX_TSS2):
-      stop_and_go = True
-      ret.wheelSpeedFactor = 1.035
-
-    elif candidate in (CAR.TOYOTA_AVALON, CAR.TOYOTA_AVALON_2019, CAR.TOYOTA_AVALON_TSS2):
-      # starting from 2019, all Avalon variants have stop and go
-      # https://engage.toyota.com/static/images/toyota_safety_sense/TSS_Applicability_Chart.pdf
-      stop_and_go = candidate != CAR.TOYOTA_AVALON
-
-    elif candidate in (CAR.TOYOTA_CHR, CAR.TOYOTA_CAMRY, CAR.TOYOTA_SIENNA, CAR.LEXUS_CTH, CAR.LEXUS_LS, CAR.LEXUS_NX):
-      # TODO: Some of these platforms are not advertised to have full range ACC, do they really all have sng?
-      stop_and_go = True
+    # EPS firmware attests exceptional rack behavior independently of identity.
+    for fw in car_fw:
+      if fw.ecu == "eps" and fw.fwVersion.startswith(b'8965B470') and fw.fwVersion != b'8965B47060\x00\x00\x00\x00\x00\x00':
+        CarInterfaceBase.configure_torque_tune("TOYOTA_RAV4_TSS2", ret.lateralTuning, steering_angle_deadzone_deg=0.2)
+      if fw.ecu == "eps" and fw.fwVersion == b'8965B47070\x00\x00\x00\x00\x00\x00':
+        ret.dashcamOnly = True
 
     ret.centerToFront = ret.wheelbase * 0.44
 
     # TODO: Some TSS-P platforms have BSM, but are flipped based on region or driving direction.
     # Detect flipped signals and enable for C-HR and others
-    ret.enableBsm = 0x3F6 in fingerprint[0] and candidate in TSS2_CAR
+    ret.enableBsm = 0x3F6 in fingerprint[0] and groups.tss2
 
-    ret.radarUnavailable = Bus.radar not in DBC[candidate]
+    ret.radarUnavailable = groups.acc == ToyotaAccGroup.RADAR
 
     # since we don't yet parse radar on TSS2 radar-based ACC cars, gate longitudinal behind alpha toggle
-    if candidate in RADAR_ACC_CAR:
+    if groups.longitudinal == ToyotaLongitudinalGroup.RADAR_ACC or bool(ret.flags & ToyotaFlags.RADAR_ACC):
       ret.alphaLongitudinalAvailable = True
 
       if alpha_long:
@@ -101,8 +95,7 @@ class CarInterface(CarInterfaceBase):
     # openpilot longitudinal behind alpha long toggle:
     #  - TSS2 radar ACC cars (disables radar)
 
-    ret.openpilotLongitudinalControl = (candidate in (TSS2_CAR - RADAR_ACC_CAR) or
-                                        bool(ret.flags & ToyotaFlags.DISABLE_RADAR.value))
+    ret.openpilotLongitudinalControl = openpilot_longitudinal
 
     ret.autoResumeSng = ret.openpilotLongitudinalControl
 
@@ -111,9 +104,9 @@ class CarInterface(CarInterfaceBase):
 
     # min speed to enable ACC. if car can do stop and go, then set enabling speed
     # to a negative value, so it won't matter.
-    ret.minEnableSpeed = -1. if stop_and_go else MIN_ACC_SPEED
+    ret.minEnableSpeed = -1. if groups.stop_and_go else MIN_ACC_SPEED
 
-    if candidate in TSS2_CAR:
+    if groups.raised_accel_limit:
       ret.flags |= ToyotaFlags.RAISED_ACCEL_LIMIT.value
 
       # Hybrids have much quicker longitudinal actuator response

--- a/opendbc/car/toyota/radar_interface.py
+++ b/opendbc/car/toyota/radar_interface.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
 from opendbc.can import CANParser
-from opendbc.car import Bus
 from opendbc.car.structs import RadarData
-from opendbc.car.toyota.values import DBC, TSS2_CAR
+from opendbc.car.toyota.values import ToyotaFlags
 from opendbc.car.interfaces import RadarInterfaceBase
 
 
-def _create_radar_can_parser(car_fingerprint):
-  if car_fingerprint in TSS2_CAR:
+def _create_radar_can_parser(tss2: bool):
+  if tss2:
     RADAR_A_MSGS = list(range(0x180, 0x190))
     RADAR_B_MSGS = list(range(0x190, 0x1a0))
   else:
@@ -20,13 +19,14 @@ def _create_radar_can_parser(car_fingerprint):
 
   messages.append(('STATUS_MSG', 10))
 
-  return CANParser(DBC[car_fingerprint][Bus.radar], messages, 1)
+  return CANParser("toyota_tss2_adas" if tss2 else "toyota_adas", messages, 1)
 
 
 class RadarInterface(RadarInterfaceBase):
   def __init__(self, CP):
     super().__init__(CP)
-    if CP.carFingerprint in TSS2_CAR:
+    tss2 = bool(CP.flags & ToyotaFlags.TSS2)
+    if tss2:
       self.RADAR_A_MSGS = list(range(0x180, 0x190))
       self.RADAR_B_MSGS = list(range(0x190, 0x1a0))
     else:
@@ -35,7 +35,7 @@ class RadarInterface(RadarInterfaceBase):
 
     self.valid_cnt = {key: 0 for key in self.RADAR_A_MSGS}
 
-    self.rcp = None if CP.radarUnavailable else _create_radar_can_parser(CP.carFingerprint)
+    self.rcp = None if CP.radarUnavailable else _create_radar_can_parser(tss2)
     self.trigger_msg = self.RADAR_B_MSGS[-1]
     self.updated_messages = set()
 

--- a/opendbc/car/toyota/support_groups.py
+++ b/opendbc/car/toyota/support_groups.py
@@ -1,0 +1,270 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+from opendbc.car import Bus, structs
+
+
+class ToyotaPtGroup(StrEnum):
+  NEW_MC = "new_mc"
+  TNGA_K = "tnga_k"
+  NO_DSU = "no_dsu"
+  SECOC = "secoc"
+
+
+class ToyotaCruiseGroup(StrEnum):
+  PCM = "pcm"
+  DSU = "dsu"
+
+
+class ToyotaAccGroup(StrEnum):
+  POWERTRAIN = "powertrain"
+  CAMERA = "camera"
+  RADAR = "radar"
+
+
+class ToyotaLateralGroup(StrEnum):
+  LKA_TORQUE = "lka_torque"
+  LTA_ANGLE = "lta_angle"
+
+
+class ToyotaLongitudinalGroup(StrEnum):
+  STOCK = "stock"
+  CAMERA_ACC = "camera_acc"
+  RADAR_ACC = "radar_acc"
+  SECOC_ACC = "secoc_acc"
+
+
+@dataclass(frozen=True)
+class ToyotaSupportGroups:
+  pt: ToyotaPtGroup
+  cruise: ToyotaCruiseGroup
+  acc: ToyotaAccGroup
+  lateral: ToyotaLateralGroup
+  longitudinal: ToyotaLongitudinalGroup
+  eps_torque_scale: int
+  tss2: bool
+  secoc: bool
+  hybrid: bool
+  has_lkas_hud: bool
+  stop_and_go: bool
+  raised_accel_limit: bool
+  wheel_speed_factor: float
+
+  @property
+  def protocol_key(self) -> tuple:
+    """The protocol composition, intentionally excluding identity."""
+    return (self.pt, self.cruise, self.acc, self.lateral, self.longitudinal,
+            self.eps_torque_scale, self.tss2, self.secoc, self.hybrid,
+            self.has_lkas_hud, self.stop_and_go, self.raised_accel_limit,
+            self.wheel_speed_factor)
+
+  @classmethod
+  def from_platform(cls, candidate: str, fingerprint: dict[int, dict[int, int]],
+                    car_fw: list[structs.CarParams.CarFw]) -> 'ToyotaSupportGroups':
+    """Migration adapter from a platform identity to independently consumed groups.
+
+    This is deliberately the only place where the prototype translates the old
+    platform bundle. A live resolver can replace it without changing CarState or
+    CarController.
+    """
+    from opendbc.car.toyota.values import ANGLE_CONTROL_CAR, CAR, DBC, EPS_SCALE, RADAR_ACC_CAR, SECOC_CAR, TSS2_CAR, UNSUPPORTED_DSU_CAR
+
+    pt_dbc = DBC[candidate][Bus.pt]
+    pt = {
+      "toyota_new_mc_pt_generated": ToyotaPtGroup.NEW_MC,
+      "toyota_tnga_k_pt_generated": ToyotaPtGroup.TNGA_K,
+      "toyota_nodsu_pt_generated": ToyotaPtGroup.NO_DSU,
+      "toyota_secoc_pt_generated": ToyotaPtGroup.SECOC,
+    }[pt_dbc]
+
+    tss2 = candidate in TSS2_CAR
+    secoc = candidate in SECOC_CAR
+    radar_acc = candidate in RADAR_ACC_CAR
+    if radar_acc:
+      acc = ToyotaAccGroup.RADAR
+    elif tss2:
+      acc = ToyotaAccGroup.CAMERA
+    else:
+      acc = ToyotaAccGroup.POWERTRAIN
+
+    if secoc:
+      longitudinal = ToyotaLongitudinalGroup.SECOC_ACC
+    elif radar_acc:
+      longitudinal = ToyotaLongitudinalGroup.RADAR_ACC
+    elif tss2:
+      longitudinal = ToyotaLongitudinalGroup.CAMERA_ACC
+    else:
+      longitudinal = ToyotaLongitudinalGroup.STOCK
+
+    stop_and_go = tss2
+    if candidate in (CAR.TOYOTA_PRIUS, CAR.LEXUS_RX, CAR.LEXUS_RX_TSS2):
+      stop_and_go = True
+    elif candidate in (CAR.TOYOTA_AVALON, CAR.TOYOTA_AVALON_2019, CAR.TOYOTA_AVALON_TSS2):
+      stop_and_go = candidate != CAR.TOYOTA_AVALON
+    elif candidate in (CAR.TOYOTA_CHR, CAR.TOYOTA_CAMRY, CAR.TOYOTA_SIENNA, CAR.LEXUS_CTH, CAR.LEXUS_LS, CAR.LEXUS_NX):
+      stop_and_go = True
+
+    return cls(
+      pt=pt,
+      cruise=ToyotaCruiseGroup.DSU if candidate in UNSUPPORTED_DSU_CAR else ToyotaCruiseGroup.PCM,
+      acc=acc,
+      lateral=ToyotaLateralGroup.LTA_ANGLE if candidate in ANGLE_CONTROL_CAR else ToyotaLateralGroup.LKA_TORQUE,
+      longitudinal=longitudinal,
+      eps_torque_scale=EPS_SCALE[candidate],
+      tss2=tss2,
+      secoc=secoc,
+      hybrid=any(fw.ecu == structs.CarParams.Ecu.hybrid for fw in car_fw),
+      has_lkas_hud=candidate != CAR.TOYOTA_PRIUS_V,
+      stop_and_go=stop_and_go,
+      raised_accel_limit=tss2,
+      wheel_speed_factor=1.035 if candidate in (CAR.LEXUS_RX, CAR.LEXUS_RX_TSS2) else 1.0,
+    )
+
+
+@dataclass(frozen=True)
+class ToyotaSupportEvidence:
+  """Facts produced by parallel readers and stock-message observation."""
+  pt: ToyotaPtGroup | None = None
+  cruise: ToyotaCruiseGroup | None = None
+  acc: ToyotaAccGroup | None = None
+  stock_lta_active: bool | None = None
+  eps_torque_scale: int | None = None
+  hybrid: bool | None = None
+  has_lkas_hud: bool | None = None
+  stop_and_go: bool | None = None
+  wheel_speed_factor: float | None = None
+
+
+@dataclass(frozen=True)
+class ToyotaSupportResolution:
+  groups: ToyotaSupportGroups | None
+  missing: frozenset[str]
+
+
+def resolve_from_evidence(evidence: ToyotaSupportEvidence) -> ToyotaSupportResolution:
+  """Resolve support groups without a platform identity, failing on unknowns."""
+  required = {
+    "pt": evidence.pt,
+    "cruise": evidence.cruise,
+    "acc": evidence.acc,
+    "stock_lta_active": evidence.stock_lta_active,
+    "eps_torque_scale": evidence.eps_torque_scale,
+    "hybrid": evidence.hybrid,
+    "has_lkas_hud": evidence.has_lkas_hud,
+    "stop_and_go": evidence.stop_and_go,
+  }
+  missing = frozenset(name for name, value in required.items() if value is None)
+  if missing:
+    return ToyotaSupportResolution(None, missing)
+
+  assert evidence.pt is not None
+  assert evidence.cruise is not None
+  assert evidence.acc is not None
+  assert evidence.stock_lta_active is not None
+  assert evidence.eps_torque_scale is not None
+  assert evidence.hybrid is not None
+  assert evidence.has_lkas_hud is not None
+  assert evidence.stop_and_go is not None
+
+  tss2 = evidence.pt in (ToyotaPtGroup.NO_DSU, ToyotaPtGroup.SECOC)
+  secoc = evidence.pt == ToyotaPtGroup.SECOC
+  if secoc:
+    longitudinal = ToyotaLongitudinalGroup.SECOC_ACC
+  elif evidence.acc == ToyotaAccGroup.RADAR:
+    longitudinal = ToyotaLongitudinalGroup.RADAR_ACC
+  elif evidence.acc == ToyotaAccGroup.CAMERA:
+    longitudinal = ToyotaLongitudinalGroup.CAMERA_ACC
+  else:
+    longitudinal = ToyotaLongitudinalGroup.STOCK
+
+  groups = ToyotaSupportGroups(
+    pt=evidence.pt,
+    cruise=evidence.cruise,
+    acc=evidence.acc,
+    lateral=ToyotaLateralGroup.LTA_ANGLE if evidence.stock_lta_active else ToyotaLateralGroup.LKA_TORQUE,
+    longitudinal=longitudinal,
+    eps_torque_scale=evidence.eps_torque_scale,
+    tss2=tss2,
+    secoc=secoc,
+    hybrid=evidence.hybrid,
+    has_lkas_hud=evidence.has_lkas_hud,
+    stop_and_go=evidence.stop_and_go,
+    raised_accel_limit=tss2,
+    wheel_speed_factor=evidence.wheel_speed_factor if evidence.wheel_speed_factor is not None else 1.0,
+  )
+  return ToyotaSupportResolution(groups, frozenset())
+
+
+TOYOTA_PT_DBC = {
+  ToyotaPtGroup.NEW_MC: "toyota_new_mc_pt_generated",
+  ToyotaPtGroup.TNGA_K: "toyota_tnga_k_pt_generated",
+  ToyotaPtGroup.NO_DSU: "toyota_nodsu_pt_generated",
+  ToyotaPtGroup.SECOC: "toyota_secoc_pt_generated",
+}
+
+PT_GROUP_FLAGS = {
+  ToyotaPtGroup.NEW_MC: 1 << 12,
+  ToyotaPtGroup.TNGA_K: 1 << 13,
+  ToyotaPtGroup.NO_DSU: 1 << 14,
+  ToyotaPtGroup.SECOC: 1 << 15,
+}
+
+
+def apply_support_groups(CP: structs.CarParams, groups: ToyotaSupportGroups) -> None:
+  """Encode resolved groups in CarParams without retaining platform dispatch."""
+  from opendbc.car.toyota.values import ToyotaFlags
+
+  CP.flags = int(CP.flags | PT_GROUP_FLAGS[groups.pt])
+  if groups.tss2:
+    CP.flags = int(CP.flags | ToyotaFlags.TSS2.value | ToyotaFlags.NO_DSU.value)
+  if groups.secoc:
+    CP.flags = int(CP.flags | ToyotaFlags.SECOC.value)
+  if groups.cruise == ToyotaCruiseGroup.DSU:
+    CP.flags = int(CP.flags | ToyotaFlags.UNSUPPORTED_DSU.value)
+  if groups.lateral == ToyotaLateralGroup.LTA_ANGLE:
+    CP.flags = int(CP.flags | ToyotaFlags.ANGLE_CONTROL.value)
+  if groups.raised_accel_limit:
+    CP.flags = int(CP.flags | ToyotaFlags.RAISED_ACCEL_LIMIT.value)
+  if groups.hybrid:
+    CP.flags = int(CP.flags | ToyotaFlags.HYBRID.value)
+  if groups.acc == ToyotaAccGroup.CAMERA:
+    CP.flags = int(CP.flags | ToyotaFlags.ACC_CAMERA.value)
+  elif groups.acc == ToyotaAccGroup.RADAR:
+    CP.flags = int(CP.flags | ToyotaFlags.ACC_RADAR.value | ToyotaFlags.RADAR_ACC.value)
+  if groups.has_lkas_hud:
+    CP.flags = int(CP.flags | ToyotaFlags.LKA_HUD.value)
+
+
+def get_pt_group(CP: structs.CarParams) -> ToyotaPtGroup:
+  matches = [group for group, flag in PT_GROUP_FLAGS.items() if CP.flags & flag]
+  if len(matches) != 1:
+    raise ValueError(f"expected one Toyota PT group, found {matches}")
+  return matches[0]
+
+
+def get_pt_dbc(CP: structs.CarParams) -> str:
+  return TOYOTA_PT_DBC[get_pt_group(CP)]
+
+
+def get_acc_group(CP: structs.CarParams) -> ToyotaAccGroup:
+  from opendbc.car.toyota.values import ToyotaFlags
+
+  if CP.flags & ToyotaFlags.ACC_RADAR:
+    return ToyotaAccGroup.RADAR
+  if CP.flags & ToyotaFlags.ACC_CAMERA:
+    return ToyotaAccGroup.CAMERA
+  return ToyotaAccGroup.POWERTRAIN
+
+
+def resolve_manifest_candidates(candidates: set[str], fingerprint: dict[int, dict[int, int]],
+                                car_fw: list[structs.CarParams.CarFw]) -> tuple[ToyotaSupportGroups | None, frozenset[str]]:
+  """Collapse identity candidates when they imply one support-group composition.
+
+  This is the bridge needed for group fingerprinting: ambiguity between Camry,
+  Corolla, and Highlander does not block protocol selection when their complete
+  read/write manifests agree. Identity candidates remain available to the
+  separate VIN support-policy layer.
+  """
+  manifests = {ToyotaSupportGroups.from_platform(candidate, fingerprint, car_fw) for candidate in candidates}
+  resolved = next(iter(manifests)) if len(manifests) == 1 else None
+  return resolved, frozenset(candidates)

--- a/opendbc/car/toyota/tests/test_support_groups.py
+++ b/opendbc/car/toyota/tests/test_support_groups.py
@@ -1,0 +1,73 @@
+import unittest
+
+from opendbc.car import gen_empty_fingerprint
+from opendbc.car.car_helpers import interfaces
+from opendbc.car.toyota.support_groups import ToyotaAccGroup, ToyotaCruiseGroup, ToyotaLateralGroup, ToyotaPtGroup, ToyotaSupportEvidence, \
+                                                       ToyotaSupportGroups, get_pt_dbc, resolve_from_evidence, resolve_manifest_candidates
+from opendbc.car.toyota.values import CAR, EPS_SCALE
+
+
+class TestToyotaSupportGroups(unittest.TestCase):
+  def setUp(self):
+    self.fingerprint = gen_empty_fingerprint()
+
+  def groups(self, candidate):
+    return ToyotaSupportGroups.from_platform(candidate, self.fingerprint, [])
+
+  def test_identity_ambiguity_can_resolve_one_protocol(self):
+    candidates = {CAR.TOYOTA_CAMRY_TSS2, CAR.TOYOTA_COROLLA_TSS2, CAR.TOYOTA_HIGHLANDER_TSS2}
+    groups, identities = resolve_manifest_candidates(candidates, self.fingerprint, [])
+    self.assertIsNotNone(groups)
+    self.assertEqual(identities, candidates)
+
+  def test_real_protocol_change_remains_ambiguous(self):
+    candidates = {CAR.TOYOTA_RAV4_TSS2_2022, CAR.TOYOTA_RAV4_TSS2_2023}
+    groups, _ = resolve_manifest_candidates(candidates, self.fingerprint, [])
+    self.assertIsNone(groups)
+    self.assertEqual(self.groups(CAR.TOYOTA_RAV4_TSS2_2022).lateral, ToyotaLateralGroup.LKA_TORQUE)
+    self.assertEqual(self.groups(CAR.TOYOTA_RAV4_TSS2_2023).lateral, ToyotaLateralGroup.LTA_ANGLE)
+
+  def test_generic_toyota_dynamics(self):
+    expected = None
+    for candidate in CAR:
+      CP = interfaces[candidate].get_params(candidate, self.fingerprint, [], False, False, False)
+      dynamics = (CP.mass, CP.wheelbase, CP.steerRatio, CP.tireStiffnessFactor, CP.centerToFront)
+      expected = dynamics if expected is None else expected
+      self.assertEqual(dynamics, expected)
+
+  def test_carstate_dbc_comes_from_group(self):
+    for candidate in CAR:
+      CP = interfaces[candidate].get_params(candidate, self.fingerprint, [], False, False, False)
+      self.assertEqual(interfaces[candidate].CarState.get_can_parsers(CP)["pt"].dbc_name, get_pt_dbc(CP))
+
+  def test_eps_scale_is_preserved_as_open_problem(self):
+    for candidate in CAR:
+      CP = interfaces[candidate].get_params(candidate, self.fingerprint, [], False, False, False)
+      self.assertEqual(CP.safetyConfigs[-1].safetyParam & 0xFF, EPS_SCALE[candidate])
+
+  def test_live_resolution_does_not_need_identity(self):
+    resolution = resolve_from_evidence(ToyotaSupportEvidence(
+      pt=ToyotaPtGroup.NO_DSU,
+      cruise=ToyotaCruiseGroup.PCM,
+      acc=ToyotaAccGroup.CAMERA,
+      stock_lta_active=False,
+      eps_torque_scale=73,
+      hybrid=False,
+      has_lkas_hud=True,
+      stop_and_go=True,
+    ))
+    self.assertFalse(resolution.missing)
+    self.assertEqual(resolution.groups.lateral, ToyotaLateralGroup.LKA_TORQUE)
+
+  def test_live_resolution_fails_closed_on_eps_scale(self):
+    resolution = resolve_from_evidence(ToyotaSupportEvidence(
+      pt=ToyotaPtGroup.NO_DSU,
+      cruise=ToyotaCruiseGroup.PCM,
+      acc=ToyotaAccGroup.CAMERA,
+      stock_lta_active=False,
+      hybrid=False,
+      has_lkas_hud=True,
+      stop_and_go=True,
+    ))
+    self.assertIsNone(resolution.groups)
+    self.assertEqual(resolution.missing, {"eps_torque_scale"})

--- a/opendbc/car/toyota/values.py
+++ b/opendbc/car/toyota/values.py
@@ -74,6 +74,16 @@ class ToyotaFlags(IntFlag):
   RAISED_ACCEL_LIMIT = 1024
   SECOC = 2048
 
+  # Runtime support groups. These replace platform checks downstream while
+  # existing platform manifests remain as a migration/attestation source.
+  PT_DBC_NEW_MC = 4096
+  PT_DBC_TNGA_K = 8192
+  PT_DBC_NO_DSU = 16384
+  PT_DBC_SECOC = 32768
+  ACC_CAMERA = 65536
+  ACC_RADAR = 131072
+  LKA_HUD = 262144
+
   # deprecated flags
   # these cars are speculated to allow stop and go when the DSU is unplugged
   SNG_WITHOUT_DSU_DEPRECATED = 512


### PR DESCRIPTION
An attempt at solving fingerprinting, once and for all. If you see a car on [comma.ai/vehicles](https://comma.ai/vehicles), it'll just work.

Motivating issues:
* **Car unrecognized on supported cars** All cars listed in the supported docs . No more PRs piling up
* **International variants** We frequently see models outside the US that appear to be the same as their US version, except for maybe shipping the old gen's ADAS platform. These should be automatically handled if the proper support group can be constructed, and otherwise not fingerprint with a nice message explaining why.

---

We currently use proxies to fingerprint, one of CAN ID list matching, ECU FW version matching, or VIN decoding. However, these don't quite check what we need, and we see both false positives and false negatives as a result. What if this trim of car has a different ECU handling ACC (e.g. HDA1 vs HDA2 Hyundai)? What if the Brazilian 2022 Corolla ships with TSS-P ADAS? We should enumerate every instance of something like this we've seen in the past, and make sure it's handled in the new paradigm.

At its core an opendbc "platform" can be broken down into these core pieces:
* **Read:** We need to be able to construct a `carState`.
* **Write:** We need to be able to actuate a `carControl`. This also includes the designed safety model bein
* **Static parameters:** Mass, wheelbase, steer ratio, etc. How much of this can we remove? How much can we learn online?
  * The actual Make & Model are purely for docs (and whitelisting purposes).

---

Notes:
* New `(make, model, model year)` should still have to be manually added, e.g. even if a 2026 Corolla fully matches to the 2025 Corolla support group, it should have to be added to the whitelist. This can happen after our new fingerprinting message, and we can show a nice specific message for this ("New model year detected! Go to Discord...").
* Similar to the above, I think we can surface partial matches better than "car unrecognized." 
* I think we still want to maintain a list of confirmed working ECU versions, though these will not be required to fingerprint at runtime.