### PR TITLE
safety: recover Toyota LTA after torque oscillation

### DIFF
--- a/opendbc/safety/modes/toyota.h
+++ b/opendbc/safety/modes/toyota.h
@@ -296,12 +296,14 @@ static bool toyota_tx_hook(const CANPacket_t *msg) {
         }
 
         // check if we should wind down torque
-        int driver_torque = SAFETY_MIN(SAFETY_ABS(torque_driver.min), SAFETY_ABS(torque_driver.max));
+        // Use the current and 60ms-old samples. A min/max over the full window
+        // can keep a stale oscillation above the wind-down threshold.
+        int driver_torque = SAFETY_MIN(SAFETY_ABS(torque_driver.values[0]), SAFETY_ABS(torque_driver.values[3]));
         if ((driver_torque > TOYOTA_LTA_MAX_DRIVER_TORQUE) && (torque_wind_down != 0)) {
           tx = false;
         }
 
-        int eps_torque = SAFETY_MIN(SAFETY_ABS(torque_meas.min), SAFETY_ABS(torque_meas.max));
+        int eps_torque = SAFETY_MIN(SAFETY_ABS(torque_meas.values[0]), SAFETY_ABS(torque_meas.values[3]));
         if ((eps_torque > TOYOTA_LTA_MAX_MEAS_TORQUE) && (torque_wind_down != 0)) {
           tx = false;
         }

--- a/opendbc/safety/tests/test_toyota.py
+++ b/opendbc/safety/tests/test_toyota.py
@@ -243,6 +243,20 @@ class TestToyotaSafetyAngle(TestToyotaSafetyBase, common.AngleSteeringSafetyTest
           self.assertEqual(should_tx, self._tx(self._lta_msg(1, 1, angle, 100)))
           self.assertTrue(self._tx(self._lta_msg(1, 1, angle, 0)))  # should tx if we wind down torque
 
+  def test_lta_torque_wind_down_recovers_after_oscillation(self):
+    """Recent zero torque must clear a previous oscillating EPS torque."""
+    self.safety.set_controls_allowed(True)
+    self._reset_angle_measurement(0)
+    self._set_prev_desired_angle(0)
+
+    high_torque = self.MAX_MEAS_TORQUE + 100
+    for torque in (-high_torque, high_torque) * 3:
+      self._rx(self._torque_meas_msg(torque, 0))
+    self.assertFalse(self._tx(self._lta_msg(1, 1, 0, 100)))
+
+    self._rx(self._torque_meas_msg(0, 0))
+    self.assertTrue(self._tx(self._lta_msg(1, 1, 0, 100)))
+
   def test_angle_measurements(self):
     """
     * Tests angle meas quality flag dictates whether angle measurement is parsed, and if rx is valid


### PR DESCRIPTION
## Summary

Fixes Toyota LTA safety incorrectly blocking valid torque re-enable after an oscillating EPS torque signal settles to zero.

Related to commaai/openpilot#32425 and the regression described in commaai/panda#1948.

## Root cause

The LTA torque wind-down check used the minimum and maximum over the full six-sample measurement window. After an alternating high positive/negative torque sequence, those stale extrema remained above the threshold even after the newest EPS torque measurement was zero.

Use the newest sample and the sample three messages ago (60 ms) instead. This preserves a short measurement tolerance while allowing a settled torque value to recover promptly.

## Regression test

The new test first reproduces the failure:

1. Feed alternating high positive/negative EPS torque measurements.
2. Verify full-torque LTA is blocked while the torque is high.
3. Feed a zero-torque measurement.
4. Verify full-torque LTA is accepted.

The test fails on upstream `master` before this fix and passes with it.

## Validation

- `python -m unittest opendbc.safety.tests.test_toyota.TestToyotaSafetyAngle -v`
  - 32 passed, 5 expected skips.
- `git diff --check`
