### PR TITLE
VW MEB: fix auto hold issue

### DIFF
--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -106,6 +106,7 @@ class MebLongStateMachine:
       and (
         CS.esp_hold_confirmation
         or (self.prev_acc_hold_type == self.acc_hold_type_vals['HALTEN'] and CS.out.vEgoRaw < 0.1)
+        or (self.prev_acc_hold_type == self.acc_hold_type_vals['LOESEN_UEBER_RAMPE'] and CS.out.vEgoRaw < 0.05)
         or (self.prev_acc_hold_type == self.acc_hold_type_vals['ANFAHREN'] and CS.out.vEgoRaw < 0.25)
       )
     )

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -101,7 +101,20 @@ class MebLongStateMachine:
     # NOTE: this allows KEINE_ANFORDERUNG -> ANFAHREN, but we haven't observed a fault due to this yet
     # TODO: camera can send 7 on disengage at a stop which we don't fully understand yet
     stopping = CC.actuators.longControlState == LongCtrlState.stopping
-    starting = CC.actuators.longControlState == LongCtrlState.pid and CS.esp_hold_confirmation
+    starting = (
+      CC.actuators.longControlState == LongCtrlState.pid
+      and (
+        CS.esp_hold_confirmation
+        or (
+          self.prev_acc_hold_type == self.acc_hold_type_vals['HALTEN']
+          and CS.out.vEgoRaw < 0.1
+        )
+        or (
+          self.prev_acc_hold_type == self.acc_hold_type_vals['ANFAHREN']
+          and CS.out.vEgoRaw < 0.25
+        )
+      )
+    )
     long_active = CC.longActive and not CS.out.accFaulted  # catches it one frame earlier, not sure if needed
 
     if not long_active:

--- a/opendbc/car/volkswagen/mebcan.py
+++ b/opendbc/car/volkswagen/mebcan.py
@@ -105,14 +105,8 @@ class MebLongStateMachine:
       CC.actuators.longControlState == LongCtrlState.pid
       and (
         CS.esp_hold_confirmation
-        or (
-          self.prev_acc_hold_type == self.acc_hold_type_vals['HALTEN']
-          and CS.out.vEgoRaw < 0.1
-        )
-        or (
-          self.prev_acc_hold_type == self.acc_hold_type_vals['ANFAHREN']
-          and CS.out.vEgoRaw < 0.25
-        )
+        or (self.prev_acc_hold_type == self.acc_hold_type_vals['HALTEN'] and CS.out.vEgoRaw < 0.1)
+        or (self.prev_acc_hold_type == self.acc_hold_type_vals['ANFAHREN'] and CS.out.vEgoRaw < 0.25)
       )
     )
     long_active = CC.longActive and not CS.out.accFaulted  # catches it one frame earlier, not sure if needed


### PR DESCRIPTION
Transitioning from ACC_18: HMS HALTEN to RAMP when already stopped (before ESC_50 standstill = 1) can lead to a stuck Auto Hold condition, stock appears to use ANFAHREN in that situation.
See route with this effect. 5c7453f39b717c40/0000009a--52a6079ade/40:44

Instead go to 4 anfahren at low speeds.

If this threshold is too high the vehicle seems to come to a stop before starting again: Threshold of 0.25 m/s
5c7453f39b717c40_000000b8--e140b849ee/8
5c7453f39b717c40_000000b8--e140b849ee/11
If this threshold is too low and the vehicle goes from 1 -> 5 it doesn't seem to release the brake before stopping anyway but at least doesn't cause any faults: Threshold of 0.05 m/s 
5c7453f39b717c40/000000c4--0aa1216a0d/8

Stock route where I first saw the camera go to 4 anfahren before standstill was rasied: 
5c7453f39b717c40/00000081--70a361dd6f/9

Chosen value of 0.1 m/s seems to fit stock usage of HMS 1 -> 4 and 1 -> 5

Validation
* Dongle ID: 5c7453f39b717c40
* Route: 5c7453f39b717c40_000000bd--9ee4cbcafd/37

Validation route was recorded with the patch applied directly on-device rather than from the PR branch.