### PR TITLE
subaru: disable alpha long for now

### DIFF
--- a/opendbc/car/subaru/interface.py
+++ b/opendbc/car/subaru/interface.py
@@ -87,8 +87,9 @@ class CarInterface(CarInterfaceBase):
     else:
       raise ValueError(f"unknown car: {candidate}")
 
-    ret.alphaLongitudinalAvailable = not (ret.flags & (SubaruFlags.GLOBAL_GEN2 | SubaruFlags.PREGLOBAL |
-                                                       SubaruFlags.LKAS_ANGLE | SubaruFlags.HYBRID))
+    # TODO: the longitudinal limits need to be speed-dependent, so alpha long is disabled for now
+    # revert this in the PR that re-enables Subaru longitudinal: https://github.com/commaai/opendbc/pull/3689
+    ret.alphaLongitudinalAvailable = False
     ret.openpilotLongitudinalControl = alpha_long and ret.alphaLongitudinalAvailable
 
     if ret.flags & SubaruFlags.GLOBAL_GEN2 and ret.openpilotLongitudinalControl:

--- a/opendbc/safety/declarations.h
+++ b/opendbc/safety/declarations.h
@@ -246,7 +246,6 @@ bool steer_curvature_cmd_checks(int desired_curvature, int steer_power, bool ste
 bool longitudinal_accel_checks(int desired_accel, const LongitudinalLimits limits);
 bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limits);
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits);
-bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits);
 bool longitudinal_brake_checks(int desired_brake, const LongitudinalLimits limits);
 void pcm_cruise_check(bool cruise_engaged);
 void speed_mismatch_check(const float speed_2);

--- a/opendbc/safety/longitudinal.h
+++ b/opendbc/safety/longitudinal.h
@@ -15,12 +15,6 @@ bool longitudinal_speed_checks(int desired_speed, const LongitudinalLimits limit
   return !get_longitudinal_allowed() && (desired_speed != limits.inactive_speed);
 }
 
-bool longitudinal_transmission_rpm_checks(int desired_transmission_rpm, const LongitudinalLimits limits) {
-  bool transmission_rpm_valid = get_longitudinal_allowed() && !safety_max_limit_check(desired_transmission_rpm, limits.max_transmission_rpm, limits.min_transmission_rpm);
-  bool transmission_rpm_inactive = desired_transmission_rpm == limits.inactive_transmission_rpm;
-  return !(transmission_rpm_valid || transmission_rpm_inactive);
-}
-
 bool longitudinal_gas_checks(int desired_gas, const LongitudinalLimits limits) {
   bool gas_valid = get_longitudinal_allowed() && !safety_max_limit_check(desired_gas, limits.max_gas, limits.min_gas);
   bool gas_inactive = desired_gas == limits.inactive_gas;

--- a/opendbc/safety/modes/subaru.h
+++ b/opendbc/safety/modes/subaru.h
@@ -26,18 +26,10 @@
 #define MSG_SUBARU_Wheel_Speeds          0x13aU
 
 #define MSG_SUBARU_ES_LKAS               0x122U
-#define MSG_SUBARU_ES_Brake              0x220U
 #define MSG_SUBARU_ES_Distance           0x221U
-#define MSG_SUBARU_ES_Status             0x222U
 #define MSG_SUBARU_ES_DashStatus         0x321U
 #define MSG_SUBARU_ES_LKAS_State         0x322U
 #define MSG_SUBARU_ES_Infotainment       0x323U
-
-#define MSG_SUBARU_ES_UDS_Request        0x787U
-
-#define MSG_SUBARU_ES_HighBeamAssist     0x22AU
-#define MSG_SUBARU_ES_STATIC_1           0x325U
-#define MSG_SUBARU_ES_STATIC_2           0x121U
 
 #define SUBARU_MAIN_BUS 0U
 #define SUBARU_ALT_BUS  1U
@@ -52,17 +44,6 @@
 #define SUBARU_COMMON_TX_MSGS(alt_bus) \
   {MSG_SUBARU_ES_Distance, alt_bus, 8, .check_relay = false}, \
 
-#define SUBARU_COMMON_LONG_TX_MSGS(alt_bus) \
-  {MSG_SUBARU_ES_Distance,       alt_bus,         8, .check_relay = true}, \
-  {MSG_SUBARU_ES_Brake,          alt_bus,         8, .check_relay = true}, \
-  {MSG_SUBARU_ES_Status,         alt_bus,         8, .check_relay = true}, \
-
-#define SUBARU_GEN2_LONG_ADDITIONAL_TX_MSGS() \
-  {MSG_SUBARU_ES_UDS_Request,    SUBARU_CAM_BUS,  8, .check_relay = false}, \
-  {MSG_SUBARU_ES_HighBeamAssist, SUBARU_MAIN_BUS, 8, .check_relay = false}, \
-  {MSG_SUBARU_ES_STATIC_1,       SUBARU_MAIN_BUS, 8, .check_relay = false}, \
-  {MSG_SUBARU_ES_STATIC_2,       SUBARU_MAIN_BUS, 8, .check_relay = false}, \
-
 #define SUBARU_COMMON_RX_CHECKS(alt_bus)                                                                                                         \
   {.msg = {{MSG_SUBARU_Throttle,        SUBARU_MAIN_BUS, 8, 100U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}}, \
   {.msg = {{MSG_SUBARU_Steering_Torque, SUBARU_MAIN_BUS, 8, 50U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
@@ -71,7 +52,6 @@
   {.msg = {{MSG_SUBARU_CruiseControl,   alt_bus,         8, 20U, .max_counter = 15U, .ignore_quality_flag = true}, { 0 }, { 0 }}},  \
 
 static bool subaru_gen2 = false;
-static bool subaru_longitudinal = false;
 
 static uint32_t subaru_get_checksum(const CANPacket_t *msg) {
   return (uint8_t)msg->data[0];
@@ -155,41 +135,15 @@ static bool subaru_tx_hook(const CANPacket_t *msg) {
     violation |= steer_torque_cmd_checks(desired_torque, steer_req, limits);
   }
 
-  // check es_brake brake_pressure limits
-  if (msg->addr == MSG_SUBARU_ES_Brake) {
-    int es_brake_pressure = GET_BYTES(msg, 2, 2);
-    violation |= longitudinal_brake_checks(es_brake_pressure, SUBARU_LONG_LIMITS);
-  }
-
   // check es_distance cruise_throttle limits
   if (msg->addr == MSG_SUBARU_ES_Distance) {
     int cruise_throttle = (GET_BYTES(msg, 2, 2) & 0x1FFFU);
     bool cruise_cancel = (msg->data[7] >> 0) & 1U;
 
-    if (subaru_longitudinal) {
-      violation |= longitudinal_gas_checks(cruise_throttle, SUBARU_LONG_LIMITS);
-    } else {
-      // If openpilot is not controlling long, only allow ES_Distance for cruise cancel requests,
-      // (when Cruise_Cancel is true, and Cruise_Throttle is inactive)
-      violation |= (cruise_throttle != SUBARU_LONG_LIMITS.inactive_gas);
-      violation |= (!cruise_cancel);
-    }
-  }
-
-  // check es_status transmission_rpm limits
-  if (msg->addr == MSG_SUBARU_ES_Status) {
-    int transmission_rpm = (GET_BYTES(msg, 2, 2) & 0x1FFFU);
-    violation |= longitudinal_transmission_rpm_checks(transmission_rpm, SUBARU_LONG_LIMITS);
-  }
-
-  if (msg->addr == MSG_SUBARU_ES_UDS_Request) {
-    // tester present ('\x02\x3E\x80\x00\x00\x00\x00\x00') is allowed for gen2 longitudinal to keep eyesight disabled
-    bool is_tester_present = (GET_BYTES(msg, 0, 4) == 0x00803E02U) && (GET_BYTES(msg, 4, 4) == 0x0U);
-
-    // reading ES button data by identifier (b'\x03\x22\x11\x30\x00\x00\x00\x00') is also allowed (DID 0x1130)
-    bool is_button_rdbi = (GET_BYTES(msg, 0, 4) == 0x30112203U) && (GET_BYTES(msg, 4, 4) == 0x0U);
-
-    violation |= !(is_tester_present || is_button_rdbi);
+    // If openpilot is not controlling long, only allow ES_Distance for cruise cancel requests,
+    // (when Cruise_Cancel is true, and Cruise_Throttle is inactive)
+    violation |= (cruise_throttle != SUBARU_LONG_LIMITS.inactive_gas);
+    violation |= (!cruise_cancel);
   }
 
   if (violation){
@@ -204,46 +158,29 @@ static safety_config subaru_init(uint16_t param) {
     SUBARU_COMMON_TX_MSGS(SUBARU_MAIN_BUS)
   };
 
-  static const CanMsg SUBARU_LONG_TX_MSGS[] = {
-    SUBARU_BASE_TX_MSGS(SUBARU_MAIN_BUS, MSG_SUBARU_ES_LKAS)
-    SUBARU_COMMON_LONG_TX_MSGS(SUBARU_MAIN_BUS)
-  };
-
   static const CanMsg SUBARU_GEN2_TX_MSGS[] = {
     SUBARU_BASE_TX_MSGS(SUBARU_ALT_BUS, MSG_SUBARU_ES_LKAS)
     SUBARU_COMMON_TX_MSGS(SUBARU_ALT_BUS)
-  };
-
-  static const CanMsg SUBARU_GEN2_LONG_TX_MSGS[] = {
-    SUBARU_BASE_TX_MSGS(SUBARU_ALT_BUS, MSG_SUBARU_ES_LKAS)
-    SUBARU_COMMON_LONG_TX_MSGS(SUBARU_ALT_BUS)
-    SUBARU_GEN2_LONG_ADDITIONAL_TX_MSGS()
-  };
-
-  static RxCheck subaru_rx_checks[] = {
-    SUBARU_COMMON_RX_CHECKS(SUBARU_MAIN_BUS)
-  };
-
-  static RxCheck subaru_gen2_rx_checks[] = {
-    SUBARU_COMMON_RX_CHECKS(SUBARU_ALT_BUS)
   };
 
   const uint16_t SUBARU_PARAM_GEN2 = 1;
 
   subaru_gen2 = GET_FLAG(param, SUBARU_PARAM_GEN2);
 
-#ifdef ALLOW_DEBUG
-  const uint16_t SUBARU_PARAM_LONGITUDINAL = 2;
-  subaru_longitudinal = GET_FLAG(param, SUBARU_PARAM_LONGITUDINAL);
-#endif
+  // TODO: re-enable once more work is done on the limits
+  // revert this in the PR that re-enables Subaru longitudinal: https://github.com/commaai/opendbc/pull/3689
 
   safety_config ret;
   if (subaru_gen2) {
-    ret = subaru_longitudinal ? BUILD_SAFETY_CFG(subaru_gen2_rx_checks, SUBARU_GEN2_LONG_TX_MSGS) : \
-                                BUILD_SAFETY_CFG(subaru_gen2_rx_checks, SUBARU_GEN2_TX_MSGS);
+    static RxCheck subaru_gen2_rx_checks[] = {
+      SUBARU_COMMON_RX_CHECKS(SUBARU_ALT_BUS)
+    };
+    ret = BUILD_SAFETY_CFG(subaru_gen2_rx_checks, SUBARU_GEN2_TX_MSGS);
   } else {
-    ret = subaru_longitudinal ? BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_LONG_TX_MSGS) : \
-                                BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_TX_MSGS);
+    static RxCheck subaru_rx_checks[] = {
+      SUBARU_COMMON_RX_CHECKS(SUBARU_MAIN_BUS)
+    };
+    ret = BUILD_SAFETY_CFG(subaru_rx_checks, SUBARU_TX_MSGS);
   }
   return ret;
 }

--- a/opendbc/safety/tests/test_subaru.py
+++ b/opendbc/safety/tests/test_subaru.py
@@ -18,16 +18,10 @@ class SubaruMsg(enum.IntEnum):
   Wheel_Speeds      = 0x13a
   ES_LKAS           = 0x122
   ES_LKAS_ANGLE     = 0x124
-  ES_Brake          = 0x220
   ES_Distance       = 0x221
-  ES_Status         = 0x222
   ES_DashStatus     = 0x321
   ES_LKAS_State     = 0x322
   ES_Infotainment   = 0x323
-  ES_UDS_Request    = 0x787
-  ES_HighBeamAssist = 0x22A
-  ES_STATIC_1       = 0x325
-  ES_STATIC_2       = 0x121
 
 
 SUBARU_MAIN_BUS = 0
@@ -41,18 +35,6 @@ def lkas_tx_msgs(alt_bus, lkas_msg=SubaruMsg.ES_LKAS):
           [SubaruMsg.ES_DashStatus,     SUBARU_MAIN_BUS],
           [SubaruMsg.ES_LKAS_State,     SUBARU_MAIN_BUS],
           [SubaruMsg.ES_Infotainment,   SUBARU_MAIN_BUS]]
-
-
-def long_tx_msgs(alt_bus):
-  return [[SubaruMsg.ES_Brake,          alt_bus],
-          [SubaruMsg.ES_Status,         alt_bus]]
-
-
-def gen2_long_additional_tx_msgs():
-  return [[SubaruMsg.ES_UDS_Request,    SUBARU_CAM_BUS],
-          [SubaruMsg.ES_HighBeamAssist, SUBARU_MAIN_BUS],
-          [SubaruMsg.ES_STATIC_1,       SUBARU_MAIN_BUS],
-          [SubaruMsg.ES_STATIC_2,       SUBARU_MAIN_BUS]]
 
 
 def fwd_blacklisted_addr(lkas_msg=SubaruMsg.ES_LKAS):
@@ -119,40 +101,6 @@ class TestSubaruStockLongitudinalSafetyBase(TestSubaruSafetyBase):
       self._generic_limit_safety_check(partial(self._cancel_msg, cancel), self.INACTIVE_GAS, self.INACTIVE_GAS, 0, 2**12, 1, self.INACTIVE_GAS, cancel)
 
 
-class TestSubaruLongitudinalSafetyBase(TestSubaruSafetyBase, common.LongitudinalGasBrakeSafetyTest):
-  MIN_GAS = 808
-  MAX_GAS = 3400
-  INACTIVE_GAS = 1818
-  MAX_POSSIBLE_GAS = 2**13
-
-  MIN_BRAKE = 0
-  MAX_BRAKE = 600
-  MAX_POSSIBLE_BRAKE = 2**16
-
-  MIN_RPM = 0
-  MAX_RPM = 3600
-  MAX_POSSIBLE_RPM = 2**13
-
-  FWD_BLACKLISTED_ADDRS = {2: [SubaruMsg.ES_LKAS, SubaruMsg.ES_Brake, SubaruMsg.ES_Distance,
-                               SubaruMsg.ES_Status, SubaruMsg.ES_DashStatus,
-                               SubaruMsg.ES_LKAS_State, SubaruMsg.ES_Infotainment]}
-
-  def test_rpm_safety_check(self):
-    self._generic_limit_safety_check(self._send_rpm_msg, self.MIN_RPM, self.MAX_RPM, 0, self.MAX_POSSIBLE_RPM, 1)
-
-  def _send_brake_msg(self, brake):
-    values = {"Brake_Pressure": brake}
-    return self.packer.make_can_msg_safety("ES_Brake", self.ALT_MAIN_BUS, values)
-
-  def _send_gas_msg(self, gas):
-    values = {"Cruise_Throttle": gas}
-    return self.packer.make_can_msg_safety("ES_Distance", self.ALT_MAIN_BUS, values)
-
-  def _send_rpm_msg(self, rpm):
-    values = {"Cruise_RPM": rpm}
-    return self.packer.make_can_msg_safety("ES_Status", self.ALT_MAIN_BUS, values)
-
-
 class TestSubaruTorqueSafetyBase(TestSubaruSafetyBase, common.DriverTorqueSteeringSafetyTest, common.SteerRequestCutSafetyTest):
   MAX_RATE_UP = 50
   MAX_RATE_DOWN = 70
@@ -185,52 +133,6 @@ class TestSubaruGen2TorqueSafetyBase(TestSubaruTorqueSafetyBase):
 class TestSubaruGen2TorqueStockLongitudinalSafety(TestSubaruStockLongitudinalSafetyBase, TestSubaruGen2TorqueSafetyBase):
   FLAGS = SubaruSafetyFlags.GEN2
   TX_MSGS = lkas_tx_msgs(SUBARU_ALT_BUS)
-
-
-class TestSubaruGen1LongitudinalSafety(TestSubaruLongitudinalSafetyBase, TestSubaruTorqueSafetyBase):
-  FLAGS = SubaruSafetyFlags.LONG
-  TX_MSGS = lkas_tx_msgs(SUBARU_MAIN_BUS) + long_tx_msgs(SUBARU_MAIN_BUS)
-  RELAY_MALFUNCTION_ADDRS = {SUBARU_MAIN_BUS: (SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
-                                               SubaruMsg.ES_Infotainment, SubaruMsg.ES_Brake, SubaruMsg.ES_Status,
-                                               SubaruMsg.ES_Distance)}
-
-
-class TestSubaruGen2LongitudinalSafety(TestSubaruLongitudinalSafetyBase, TestSubaruGen2TorqueSafetyBase):
-  FLAGS = SubaruSafetyFlags.LONG | SubaruSafetyFlags.GEN2
-  TX_MSGS = lkas_tx_msgs(SUBARU_ALT_BUS) + long_tx_msgs(SUBARU_ALT_BUS) + gen2_long_additional_tx_msgs()
-  FWD_BLACKLISTED_ADDRS = {2: [SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
-                               SubaruMsg.ES_Infotainment]}
-  RELAY_MALFUNCTION_ADDRS = {SUBARU_MAIN_BUS: (SubaruMsg.ES_LKAS, SubaruMsg.ES_DashStatus, SubaruMsg.ES_LKAS_State,
-                                               SubaruMsg.ES_Infotainment),
-                             SUBARU_ALT_BUS: (SubaruMsg.ES_Brake, SubaruMsg.ES_Status, SubaruMsg.ES_Distance)}
-
-  def _rdbi_msg(self, did: int):
-    return b'\x03\x22' + did.to_bytes(2) + b'\x00\x00\x00\x00'
-
-  def _es_uds_msg(self, msg: bytes):
-    return libsafety_py.make_CANPacket(SubaruMsg.ES_UDS_Request, 2, msg)
-
-  def test_es_uds_message(self):
-    tester_present = b'\x02\x3E\x80\x00\x00\x00\x00\x00'
-    not_tester_present = b"\x03\xAA\xAA\x00\x00\x00\x00\x00"
-
-    button_did = 0x1130
-
-    # Tester present is allowed for gen2 long to keep eyesight disabled
-    self.assertTrue(self._tx(self._es_uds_msg(tester_present)))
-
-    # Non-Tester present is not allowed
-    self.assertFalse(self._tx(self._es_uds_msg(not_tester_present)))
-
-    # Only button_did is allowed to be read via UDS
-    for did in range(0xFFFF):
-      should_tx = (did == button_did)
-      self.assertEqual(self._tx(self._es_uds_msg(self._rdbi_msg(did))), should_tx)
-
-    # any other msg is not allowed
-    for sid in range(0xFF):
-      msg = b'\x03' + sid.to_bytes(1) + b'\x00' * 6
-      self.assertFalse(self._tx(self._es_uds_msg(msg)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For anyone interesting in working on Subaru longitudinal, this should be easy to bring back:
1. Revert this PR
2. Investigate the longitudinal actuation API and set new limits that stay within [these limits](https://github.com/commaai/opendbc/blob/95f3d52f474b677c28fc8f10fef3f2f0386aff92/opendbc/car/interfaces.py#L25) at all times
3. Use our [longitudinal maneuver report](https://github.com/commaai/openpilot/tree/master/openpilot/tools/longitudinal_maneuvers) to tune the controls to be better than ever 
4. Make a PR with your changes