### PR TITLE
Honda Accord: speed-schedule the lateral PID gains

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -112,7 +112,10 @@ class CarInterface(CarInterfaceBase):
 
     elif candidate == CAR.HONDA_ACCORD:
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
-      ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]]
+      # speed-schedule the gains: the flat 0.6 saturates the EPS at low speed (the rack is heavily
+      # speed-scheduled), causing a low-speed weave. Ease the gain in below ~36 km/h; unchanged on the highway.
+      ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kpV = [[0, 10], [0.2, 0.6]]
+      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kiV = [[0, 10], [0.06, 0.18]]
 
     elif candidate == CAR.ACURA_ILX:
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 3840], [0, 3840]]  # TODO: determine if there is a dead zone at the top end


### PR DESCRIPTION
Speed-schedule the Honda Accord lateral PID gains.

The Accord uses a flat `kp=0.6 / ki=0.18` with no speed schedule. The EPS rack
assist is itself heavily speed-scheduled, so at low speed the flat 0.6 over-drives
the rack: the controller output pins to ±1.0 and the car weaves. This eases the
gains in below ~36 km/h and restores the stock values by highway speed, the same
pattern the Civic already uses. Highway behaviour is unchanged.

The change is intentionally conservative, it only *lowers* the low-speed gain and
leaves the highway operating point exactly as it was, so regression risk on the
high-speed use case is minimal.

## Measurements

2018 US Accord 1.5T, EPS `39990-TVA-A140`, CD210 driving model. Controller output
saturation = fraction of engaged samples with `|output| > 0.95`:

| speed band | flat kp=0.6 (before) | scheduled (after) |
|---|---|---|
| 0–30 km/h | 40–73% saturated | ~4% (541 s of low-speed driving in one route) |
| 30–50 km/h | — | 0% |
| 50–90 km/h | ~5% | 0% |
| 90+ km/h | (highway, unchanged) | 0% |

The low-speed saturation drop corresponds to the low-speed weave disappearing on
the road, confirmed across several drives.

## Route

https://connect.comma.ai/49d0fc1df3e7320b/0000006a--888858f9ae

~60 min mixed drive (Accord 1.5T); openpilot engaged for ~19.5 min of it,
covering 0–30 km/h city through 90+ km/h highway.
