### PR TITLE
hyundai: add 2025 EU Sportage firmware

### DIFF
--- a/opendbc/car/hyundai/fingerprints.py
+++ b/opendbc/car/hyundai/fingerprints.py
@@ -1118,6 +1118,7 @@ FW_VERSIONS = {
   CAR.KIA_SPORTAGE_5TH_GEN: {
     (Ecu.fwdCamera, 0x7c4, None): [
       b'\xf1\x00NQ5 FR_CMR AT AUS RHD 1.00 1.00 99211-P1040 663',
+      b'\xf1\x00NQ5 FR_CMR AT EUR LHD 1.00 1.02 99211-R2000 D12',
       b'\xf1\x00NQ5 FR_CMR AT EUR LHD 1.00 1.00 99211-P1040 663',
       b'\xf1\x00NQ5 FR_CMR AT GEN LHD 1.00 1.00 99211-P1040 663',
       b'\xf1\x00NQ5 FR_CMR AT GEN LHD 1.00 1.00 99211-P1060 665',
@@ -1133,6 +1134,7 @@ FW_VERSIONS = {
       b'\xf1\x00NQ5__               1.00 1.03 99110-P1000         ',
       b'\xf1\x00NQ5__               1.01 1.03 99110-CH000         ',
       b'\xf1\x00NQ5__               1.01 1.03 99110-P1000         ',
+      b'\xf1\x00NQ5__               1.00 1.03 99110R2000          ',
     ],
   },
   CAR.GENESIS_GV70_1ST_GEN: {


### PR DESCRIPTION
## Goal

Add firmware versions for a 2025 EU Kia Sportage MHEV GT-Line under the existing `KIA_SPORTAGE_5TH_GEN` platform.

## Vehicle Test

Tested on vehicle with sunnypilot staging:
- auto-detected as Kia Sportage 5th Gen
- CAN valid
- torque lateral engaged successfully
- longitudinal control tested successfully

No route or dongle ID is included in this PR body because the test device is currently offline.

## Local Checks

- `python3 -m py_compile opendbc/car/hyundai/fingerprints.py`

Full pytest was not run locally because `pytest` is not installed in the temporary checkout environment.
