### PR TITLE
Remove Hyundai Ioniq EV LTD 2019 from 255 steering limit

### DIFF
--- a/opendbc/car/hyundai/values.py
+++ b/opendbc/car/hyundai/values.py
@@ -35,7 +35,7 @@ class CarControllerParams:
     # To determine the limit for your car, find the maximum value that the stock LKAS will request.
     # If the max stock LKAS request is <384, add your car to this list.
     elif CP.carFingerprint in (CAR.GENESIS_G80, CAR.HYUNDAI_ELANTRA, CAR.HYUNDAI_ELANTRA_GT_I30, CAR.HYUNDAI_IONIQ,
-                               CAR.HYUNDAI_IONIQ_EV_LTD, CAR.HYUNDAI_SANTA_FE_PHEV_2022, CAR.HYUNDAI_SONATA_LF, CAR.KIA_FORTE, CAR.KIA_NIRO_PHEV,
+                               CAR.HYUNDAI_SANTA_FE_PHEV_2022, CAR.HYUNDAI_SONATA_LF, CAR.KIA_FORTE, CAR.KIA_NIRO_PHEV,
                                CAR.KIA_OPTIMA_H, CAR.KIA_OPTIMA_H_G4_FL, CAR.KIA_SORENTO):
       self.STEER_MAX = 255
 


### PR DESCRIPTION
### Summary
Removes `CAR.HYUNDAI_IONIQ_EV_LTD` (2019 Hyundai Ioniq Electric Limited) from the 255-torque clamp in `CarControllerParams`, allowing the vehicle to utilize the platform standard `STEER_MAX = 384`.

### Motivation & Validation
The 2019 Hyundai Ioniq Electric Limited factory MDPS accepts the standard Hyundai `STEER_MAX = 384` without steering faults, or torque saturation cutouts.

Validation was performed on stock openpilot across a 10-minute drive with active steering through multiple curves and intersections:

#### Drive Telemetry & Audit Summary:
- **Total Drive Duration**: `10.02 mins`
- **Active Engaged Cruise**: `7.67 mins` (460.3s) up to 77.5 km/h
- **Peak Commanded Torque**: `384 / 384` (100% authority utilized)
- **Time in Extended Torque Range (>255)**: `58.00s`
- **MDPS / LKAS Faults**: `0` (Zero temporary or permanent steer faults)
- **Driver Override / Handover**: Smooth with no resistance or disengagement faults

This was discussed previously in commaai/openpilot#24122

### Changes
- `opendbc/car/hyundai/values.py`: Remove `CAR.HYUNDAI_IONIQ_EV_LTD` from the 255-clamped `STEER_MAX` tuple in `CarControllerParams`.

Validation
* Vehicle: 2019 Hyundai Ioniq Electric Limited (`HYUNDAI_IONIQ_EV_LTD`)
* Dongle ID: b6edfc28e83e71b2
* Route: b6edfc28e83e71b2/00000003--22b88592f2