### PR TITLE
VW MLB: Add warning before 6min HCA lockout and opportunistic reset during low torque

### DIFF
--- a/opendbc/car/car.capnp
+++ b/opendbc/car/car.capnp
@@ -204,6 +204,7 @@ struct CarState {
   lowSpeedAlert @56 :Bool;  # lost steering control due to a dynamic min steering speed
   blockPcmEnable @60 :Bool;  # whether to allow PCM to enable this frame
   carNotReady @61 :Bool;  # car is transiently refusing engagement, used to prevent a fault if engaged
+  steerTimeLimit @62 :Bool;  # steering will soon be refused; inferred from time spent steering, not reported by the car
 
   # cruise state
   cruiseState @10 :CruiseState;

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -15,13 +15,28 @@ class HCAMitigation:
   """
   Manages HCA fault mitigations for VW/Audi EPS racks:
     * Reduces torque by 1 for a single frame after commanding the same torque value for too long
+    * For MLB racks: opportunistically disables HCA during low-torque periods before the 6-minute EPS lockout
   """
 
-  def __init__(self, CCP):
+  MLB_LOCKOUT_MITIGATION_START = 240. # EPS engaged time before attempting opportunistic reset (sec)
+  MLB_LOCKOUT_LOW_TORQUE = 60         # Desired torque must be less than this before and during reset (centi-Nm)
+  MLB_LOCKOUT_LOW_TORQUE_TIME = 0.5   # How long to observe low torque for before starting the reset (sec)
+
+  def __init__(self, CCP, eps_timer_workaround=False):
     self._max_same_torque_frames = CCP.STEER_TIME_STUCK_TORQUE / (DT_CTRL * CCP.STEER_STEP)
     self._same_torque_frames = 0
 
-  def update(self, apply_torque, apply_torque_last):
+    self._eps_timer_workaround = eps_timer_workaround
+    if eps_timer_workaround:
+      self._steer_step = CCP.STEER_STEP
+      self._hca_active_frames = 0
+      self._hca_inactive_frames = 0
+      self._low_torque_frames = 0
+      self._frames_for_mitigation_start = self.MLB_LOCKOUT_MITIGATION_START / DT_CTRL
+      self._frames_for_low_torque = self.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL
+      self._frames_for_reset = CCP.STEER_TIME_RESET / DT_CTRL
+
+  def update(self, apply_torque, apply_torque_last, desired_torque):
     if apply_torque != 0 and apply_torque_last == apply_torque:
       self._same_torque_frames += 1
       if self._same_torque_frames > self._max_same_torque_frames:
@@ -29,6 +44,29 @@ class HCAMitigation:
         self._same_torque_frames = 0
     else:
       self._same_torque_frames = 0
+
+    # MLB steering racks have a 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. After the
+    # ~2.0s lockout period it will return to accepting torque requests by itself. This max engagement timer can also be reset by disabling control for ~1.1s.
+    # Attempt to mitigate this by opportunistically disabling HCA during periods of low torque desired.
+    if self._eps_timer_workaround:
+      self._hca_active_frames += self._steer_step
+
+      if (self._hca_active_frames >= self._frames_for_mitigation_start
+          and abs(desired_torque) <= self.MLB_LOCKOUT_LOW_TORQUE):
+        self._low_torque_frames += self._steer_step
+      else:
+        self._low_torque_frames = 0
+
+      # Only disable HCA if desired torque is <=0.6Nm for 0.5 seconds continuously. A desired torque > 0.6Nm will also abort any in progress reset.
+      if self._low_torque_frames >= self._frames_for_low_torque:
+        apply_torque = 0
+
+      if apply_torque == 0:
+        self._hca_inactive_frames += self._steer_step
+        if self._hca_inactive_frames >= self._frames_for_reset:
+          self._hca_active_frames = 0
+      else:
+        self._hca_inactive_frames = 0
 
     return apply_torque
 
@@ -58,7 +96,7 @@ class CarController(CarControllerBase):
     self.lead_distance_bars_last = None
     self.distance_bar_frame = 0
     self.gra_acc_counter_last = None
-    self.hca_mitigation = HCAMitigation(self.CCP)
+    self.hca_mitigation = HCAMitigation(self.CCP, eps_timer_workaround=bool(CP.flags & VolkswagenFlags.MLB))
 
   def update(self, CC, CS, now_nanos):
     actuators = CC.actuators
@@ -104,11 +142,12 @@ class CarController(CarControllerBase):
         self.steering_power_last = steering_power
 
       else:
+        new_torque = 0
         if CC.latActive:
           new_torque = int(round(actuators.torque * self.CCP.STEER_MAX))
           apply_torque = apply_driver_steer_torque_limits(new_torque, self.apply_torque_last, CS.out.steeringTorque, self.CCP)
 
-        apply_torque = self.hca_mitigation.update(apply_torque, self.apply_torque_last)
+        apply_torque = self.hca_mitigation.update(apply_torque, self.apply_torque_last, new_torque)
         hca_enabled = apply_torque != 0
         self.apply_torque_last = apply_torque
         can_sends.append(self.CCS.create_steering_control(self.packer_pt, self.CAN.pt, apply_torque, hca_enabled))

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -18,22 +18,19 @@ class HCAMitigation:
     * For MLB racks: opportunistically disables HCA during low-torque periods before the 6-minute EPS lockout
   """
 
-  MLB_LOCKOUT_MITIGATION_START = 240. # EPS engaged time before attempting opportunistic reset (sec)
-  MLB_LOCKOUT_LOW_TORQUE = 60         # Desired torque must be less than this before and during reset (centi-Nm)
-  MLB_LOCKOUT_LOW_TORQUE_TIME = 0.5   # How long to observe low torque for before starting the reset (sec)
-
-  def __init__(self, CCP, eps_timer_workaround=False):
+  def __init__(self, CCP, steer_timer_mitigation=False):
     self._max_same_torque_frames = CCP.STEER_TIME_STUCK_TORQUE / (DT_CTRL * CCP.STEER_STEP)
     self._same_torque_frames = 0
 
-    self._eps_timer_workaround = eps_timer_workaround
-    if eps_timer_workaround:
+    self._steer_timer_mitigation = steer_timer_mitigation
+    if steer_timer_mitigation:
       self._hca_active_frames = 0
       self._hca_inactive_frames = 0
       self._low_torque_frames = 0
-      self._frames_for_mitigation_start = self.MLB_LOCKOUT_MITIGATION_START / (DT_CTRL * CCP.STEER_STEP)
-      self._frames_for_low_torque = self.MLB_LOCKOUT_LOW_TORQUE_TIME / (DT_CTRL * CCP.STEER_STEP)
-      self._frames_for_reset = CCP.STEER_TIME_RESET / (DT_CTRL * CCP.STEER_STEP)
+      self._low_torque_threshold = CCP.STEER_TIME_LOW_TORQUE
+      self._frames_mitigation_start = CCP.STEER_TIME_MITIGATION_START / (DT_CTRL * CCP.STEER_STEP)
+      self._frames_low_torque = CCP.STEER_TIME_LOW_TORQUE_TIME / (DT_CTRL * CCP.STEER_STEP)
+      self._frames_reset = CCP.STEER_TIME_RESET / (DT_CTRL * CCP.STEER_STEP)
 
   def update(self, apply_torque, apply_torque_last, desired_torque):
     if apply_torque != 0 and apply_torque_last == apply_torque:
@@ -44,16 +41,16 @@ class HCAMitigation:
     else:
       self._same_torque_frames = 0
 
-    # MLB steering racks have a 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. After the
-    # ~2.0s lockout period it will return to accepting torque requests by itself. This max engagement timer can also be reset by disabling control for ~1.1s.
-    # Attempt to mitigate this by opportunistically disabling HCA during periods of low torque desired.
-    if self._eps_timer_workaround:
-      if self._hca_inactive_frames >= self._frames_for_reset:
+    # Disabling lateral controls for ~1.1s will reset the max steer timer on MLB. This reset is done opportunistically
+    # during sustained periods of low desired torque. In the rare case that no such low desired torque period exists
+    # there is a warning triggered prior to the hard lockout by CarState.steer_time_limit_warning().
+    if self._steer_timer_mitigation:
+      if self._hca_inactive_frames >= self._frames_reset:
         self._hca_active_frames = 0
 
-      low_torque = abs(desired_torque) <= self.MLB_LOCKOUT_LOW_TORQUE
+      low_torque = abs(desired_torque) <= self._low_torque_threshold
 
-      if low_torque and self._low_torque_frames >= self._frames_for_low_torque and self._hca_active_frames >= self._frames_for_mitigation_start:
+      if low_torque and self._low_torque_frames >= self._frames_low_torque and self._hca_active_frames >= self._frames_mitigation_start:
         apply_torque = 0
 
       self._low_torque_frames = self._low_torque_frames + 1 if low_torque else 0
@@ -88,7 +85,7 @@ class CarController(CarControllerBase):
     self.lead_distance_bars_last = None
     self.distance_bar_frame = 0
     self.gra_acc_counter_last = None
-    self.hca_mitigation = HCAMitigation(self.CCP, eps_timer_workaround=bool(CP.flags & VolkswagenFlags.MLB))
+    self.hca_mitigation = HCAMitigation(self.CCP, steer_timer_mitigation=bool(CP.flags & VolkswagenFlags.MLB))
 
   def update(self, CC, CS, now_nanos):
     actuators = CC.actuators

--- a/opendbc/car/volkswagen/carcontroller.py
+++ b/opendbc/car/volkswagen/carcontroller.py
@@ -28,13 +28,12 @@ class HCAMitigation:
 
     self._eps_timer_workaround = eps_timer_workaround
     if eps_timer_workaround:
-      self._steer_step = CCP.STEER_STEP
       self._hca_active_frames = 0
       self._hca_inactive_frames = 0
       self._low_torque_frames = 0
-      self._frames_for_mitigation_start = self.MLB_LOCKOUT_MITIGATION_START / DT_CTRL
-      self._frames_for_low_torque = self.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL
-      self._frames_for_reset = CCP.STEER_TIME_RESET / DT_CTRL
+      self._frames_for_mitigation_start = self.MLB_LOCKOUT_MITIGATION_START / (DT_CTRL * CCP.STEER_STEP)
+      self._frames_for_low_torque = self.MLB_LOCKOUT_LOW_TORQUE_TIME / (DT_CTRL * CCP.STEER_STEP)
+      self._frames_for_reset = CCP.STEER_TIME_RESET / (DT_CTRL * CCP.STEER_STEP)
 
   def update(self, apply_torque, apply_torque_last, desired_torque):
     if apply_torque != 0 and apply_torque_last == apply_torque:
@@ -49,24 +48,17 @@ class HCAMitigation:
     # ~2.0s lockout period it will return to accepting torque requests by itself. This max engagement timer can also be reset by disabling control for ~1.1s.
     # Attempt to mitigate this by opportunistically disabling HCA during periods of low torque desired.
     if self._eps_timer_workaround:
-      self._hca_active_frames += self._steer_step
+      if self._hca_inactive_frames >= self._frames_for_reset:
+        self._hca_active_frames = 0
 
-      if (self._hca_active_frames >= self._frames_for_mitigation_start
-          and abs(desired_torque) <= self.MLB_LOCKOUT_LOW_TORQUE):
-        self._low_torque_frames += self._steer_step
-      else:
-        self._low_torque_frames = 0
+      low_torque = abs(desired_torque) <= self.MLB_LOCKOUT_LOW_TORQUE
 
-      # Only disable HCA if desired torque is <=0.6Nm for 0.5 seconds continuously. A desired torque > 0.6Nm will also abort any in progress reset.
-      if self._low_torque_frames >= self._frames_for_low_torque:
+      if low_torque and self._low_torque_frames >= self._frames_for_low_torque and self._hca_active_frames >= self._frames_for_mitigation_start:
         apply_torque = 0
 
-      if apply_torque == 0:
-        self._hca_inactive_frames += self._steer_step
-        if self._hca_inactive_frames >= self._frames_for_reset:
-          self._hca_active_frames = 0
-      else:
-        self._hca_inactive_frames = 0
+      self._low_torque_frames = self._low_torque_frames + 1 if low_torque else 0
+      self._hca_inactive_frames = self._hca_inactive_frames + 1 if apply_torque == 0 else 0
+      self._hca_active_frames += 1
 
     return apply_torque
 

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -1,5 +1,5 @@
 from opendbc.can import CANParser
-from opendbc.car import Bus, structs
+from opendbc.car import Bus, DT_CTRL, structs
 from opendbc.car.interfaces import CarStateBase
 from opendbc.car.common.conversions import Conversions as CV
 from opendbc.car.volkswagen.values import DBC, CanBus, NetworkLocation, TransmissionType, GearShifter, \
@@ -9,10 +9,16 @@ ButtonType = structs.CarState.ButtonEvent.Type
 
 
 class CarState(CarStateBase):
+  MLB_EPS_TIMER_MAX = 360.   # Maximum EPS engagement time before lockout will reject requests (sec)
+  MLB_EPS_TIMER_WARNING = 5. # How long before lockout should we warn the driver (sec)
+
   def __init__(self, CP):
     super().__init__(CP)
     self.frame = 0
     self.eps_init_complete = False
+    self.eps_init_ready_frames = 0
+    self.hca_active_frames = 0
+    self.hca_inactive_frames = 0
     self.tsk_recovery_timer = 0
     self.CCP = CarControllerParams(CP)
     self.button_states = {button.event_type: False for button in self.CCP.BUTTONS}
@@ -390,13 +396,35 @@ class CarState(CarStateBase):
 
     hca_status = self.CCP.hca_status_values.get(pt_cp.vl["LH_EPS_03"]["EPS_HCA_Status"])
     ret.steerFaultTemporary, ret.steerFaultPermanent = self.update_hca_state(hca_status)
+    if self.CP.flags & VolkswagenFlags.MLB:
+      ret.steerTimeLimit = self.steer_time_limit_warning(hca_status)
+
+  def steer_time_limit_warning(self, hca_status) -> bool:
+    # MLB steering racks have a 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. After the
+    # ~2.0s lockout period it will return to accepting torque requests by itself. This max engagement timer can also be reset by disabling control for ~1.1s.
+    # This warning trigger gives advance notice to the driver that steering is about to become unavailable so they can take control.
+    self.hca_active_frames += 1
+    if hca_status in ("ACTIVE", "ACTIVE_MODE_7"):
+      self.hca_inactive_frames = 0
+    else:
+      self.hca_inactive_frames += 1
+      if self.hca_inactive_frames >= (self.CCP.STEER_TIME_RESET - 0.05) / DT_CTRL: # 50ms buffer for detecting opportunistic resets from HCAMitigation
+        self.hca_active_frames = 0
+    return self.hca_active_frames >= (self.MLB_EPS_TIMER_MAX - self.MLB_EPS_TIMER_WARNING) / DT_CTRL
 
   def update_hca_state(self, hca_status, in_drive=True):
     # Treat FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
-    self.eps_init_complete = self.eps_init_complete or (hca_status in ("DISABLED", "READY", "ACTIVE") or self.frame > 600)
+    # MLB EPS initially returns READY upon boot for ~1.2s until lack of stock HCA_01 message triggers FAULT.
+    # FAULT recovers back to READY once openpilot HCA_01 tx starts.
+    if not self.eps_init_complete:
+      if hca_status in ("READY", "ACTIVE", "ACTIVE_MODE_7"):
+        self.eps_init_ready_frames += 1
+      else:
+        self.eps_init_ready_frames = 0
+      self.eps_init_complete = hca_status == "DISABLED" or self.frame > 1000 or self.eps_init_ready_frames >= 150
     perm_fault = in_drive and hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
-    temp_fault = in_drive and hca_status in ("REJECTED", "PREEMPTED") or not self.eps_init_complete
+    temp_fault = in_drive and hca_status in ("REJECTED", "PREEMPTED") or (not self.eps_init_complete and hca_status == "FAULT")
     return temp_fault, perm_fault
 
   def update_acc_fault(self, acc_fault, engine_off, long_inhibit, recovery_frames=10):

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -9,18 +9,16 @@ ButtonType = structs.CarState.ButtonEvent.Type
 
 
 class CarState(CarStateBase):
-  MLB_EPS_TIMER_MAX = 360.   # Maximum EPS engagement time before lockout will reject requests (sec)
-  MLB_EPS_TIMER_WARNING = 5. # How long before lockout should we warn the driver (sec)
-
   def __init__(self, CP):
     super().__init__(CP)
     self.frame = 0
     self.eps_init_complete = False
-    self.eps_init_ready_frames = 0
     self.hca_active_frames = 0
     self.hca_inactive_frames = 0
     self.tsk_recovery_timer = 0
     self.CCP = CarControllerParams(CP)
+    self.frames_steering_reset_detection = (self.CCP.STEER_TIME_RESET - self.CCP.STEER_TIME_RESET_DETECTION_BUFFER) / DT_CTRL
+    self.frames_steering_time_warning = (self.CCP.STEER_TIME_MAX_ENGAGED - self.CCP.STEER_TIME_WARNING) / DT_CTRL
     self.button_states = {button.event_type: False for button in self.CCP.BUTTONS}
     self.esp_hold_confirmation = False
     self.upscale_lead_car_signal = False
@@ -400,32 +398,22 @@ class CarState(CarStateBase):
       ret.steerTimeLimit = self.steer_time_limit_warning(hca_status)
 
   def steer_time_limit_warning(self, hca_status) -> bool:
-    # MLB steering racks have a 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. After the
-    # ~2.0s lockout period it will return to accepting torque requests by itself. This max engagement timer can also be reset by disabling control for ~1.1s.
-    # This warning trigger gives advance notice to the driver that steering is about to become unavailable so they can take control.
-    warning = self.hca_active_frames >= (self.MLB_EPS_TIMER_MAX - self.MLB_EPS_TIMER_WARNING) / DT_CTRL
+    # MLB steering racks have a hard 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. After
+    # the ~2.0s lockout period it will return to accepting torque requests. This warning trigger gives advance notice to the driver that steering is about to
+    # become unavailable so they can take control. This should only fire very rarely as we will opportunistically reset the steering rack in HCAMitigation.
+    warning = self.hca_active_frames >= self.frames_steering_time_warning
 
     self.hca_inactive_frames = 0 if hca_status in ("ACTIVE", "ACTIVE_MODE_7") else self.hca_inactive_frames + 1
-    # 50 ms buffer for reset so we catch the opportunistic reset mitigation
-    self.hca_active_frames = 0 if self.hca_inactive_frames >= (self.CCP.STEER_TIME_RESET - 0.05) / DT_CTRL else self.hca_active_frames + 1
+    self.hca_active_frames = 0 if self.hca_inactive_frames >= self.frames_steering_reset_detection else self.hca_active_frames + 1
 
     return warning
 
   def update_hca_state(self, hca_status, in_drive=True):
     # Treat FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
-    # MLB EPS initially returns READY upon boot for ~1.2s until lack of stock HCA_01 message triggers FAULT.
-    # FAULT recovers back to READY once openpilot HCA_01 tx starts.
+    self.eps_init_complete = self.eps_init_complete or (hca_status in ("DISABLED", "READY", "ACTIVE") or self.frame > 600)
     perm_fault = in_drive and hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
-    temp_fault = in_drive and hca_status in ("REJECTED", "PREEMPTED") or (not self.eps_init_complete and hca_status == "FAULT")
-
-    if not self.eps_init_complete:
-      self.eps_init_complete = hca_status == "DISABLED" or self.frame > 1000 or self.eps_init_ready_frames >= 150
-      if hca_status in ("READY", "ACTIVE", "ACTIVE_MODE_7"):
-        self.eps_init_ready_frames += 1
-      else:
-        self.eps_init_ready_frames = 0
-
+    temp_fault = in_drive and hca_status in ("REJECTED", "PREEMPTED") or not self.eps_init_complete
     return temp_fault, perm_fault
 
   def update_acc_fault(self, acc_fault, engine_off, long_inhibit, recovery_frames=10):

--- a/opendbc/car/volkswagen/carstate.py
+++ b/opendbc/car/volkswagen/carstate.py
@@ -403,28 +403,29 @@ class CarState(CarStateBase):
     # MLB steering racks have a 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. After the
     # ~2.0s lockout period it will return to accepting torque requests by itself. This max engagement timer can also be reset by disabling control for ~1.1s.
     # This warning trigger gives advance notice to the driver that steering is about to become unavailable so they can take control.
-    self.hca_active_frames += 1
-    if hca_status in ("ACTIVE", "ACTIVE_MODE_7"):
-      self.hca_inactive_frames = 0
-    else:
-      self.hca_inactive_frames += 1
-      if self.hca_inactive_frames >= (self.CCP.STEER_TIME_RESET - 0.05) / DT_CTRL: # 50ms buffer for detecting opportunistic resets from HCAMitigation
-        self.hca_active_frames = 0
-    return self.hca_active_frames >= (self.MLB_EPS_TIMER_MAX - self.MLB_EPS_TIMER_WARNING) / DT_CTRL
+    warning = self.hca_active_frames >= (self.MLB_EPS_TIMER_MAX - self.MLB_EPS_TIMER_WARNING) / DT_CTRL
+
+    self.hca_inactive_frames = 0 if hca_status in ("ACTIVE", "ACTIVE_MODE_7") else self.hca_inactive_frames + 1
+    # 50 ms buffer for reset so we catch the opportunistic reset mitigation
+    self.hca_active_frames = 0 if self.hca_inactive_frames >= (self.CCP.STEER_TIME_RESET - 0.05) / DT_CTRL else self.hca_active_frames + 1
+
+    return warning
 
   def update_hca_state(self, hca_status, in_drive=True):
     # Treat FAULT as temporary for worst likely EPS recovery time, for cars without factory Lane Assist
     # DISABLED means the EPS hasn't been configured to support Lane Assist
     # MLB EPS initially returns READY upon boot for ~1.2s until lack of stock HCA_01 message triggers FAULT.
     # FAULT recovers back to READY once openpilot HCA_01 tx starts.
+    perm_fault = in_drive and hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
+    temp_fault = in_drive and hca_status in ("REJECTED", "PREEMPTED") or (not self.eps_init_complete and hca_status == "FAULT")
+
     if not self.eps_init_complete:
+      self.eps_init_complete = hca_status == "DISABLED" or self.frame > 1000 or self.eps_init_ready_frames >= 150
       if hca_status in ("READY", "ACTIVE", "ACTIVE_MODE_7"):
         self.eps_init_ready_frames += 1
       else:
         self.eps_init_ready_frames = 0
-      self.eps_init_complete = hca_status == "DISABLED" or self.frame > 1000 or self.eps_init_ready_frames >= 150
-    perm_fault = in_drive and hca_status == "DISABLED" or (self.eps_init_complete and hca_status == "FAULT")
-    temp_fault = in_drive and hca_status in ("REJECTED", "PREEMPTED") or (not self.eps_init_complete and hca_status == "FAULT")
+
     return temp_fault, perm_fault
 
   def update_acc_fault(self, acc_fault, engine_off, long_inhibit, recovery_frames=10):

--- a/opendbc/car/volkswagen/tests/test_volkswagen.py
+++ b/opendbc/car/volkswagen/tests/test_volkswagen.py
@@ -23,11 +23,53 @@ class TestVolkswagenHCAMitigation(unittest.TestCase):
     hca_mitigation = HCAMitigation(CCP)
 
     for actuator_value in (-CCP.STEER_MAX, -1, 0, 1, CCP.STEER_MAX):
-      hca_mitigation.update(0, 0)  # Reset mitigation state
+      hca_mitigation.update(0, 0, 0)  # Reset mitigation state
       for frame in range(self.STUCK_TORQUE_FRAMES + 2):
         should_nudge = actuator_value != 0 and frame == self.STUCK_TORQUE_FRAMES
         expected_torque = actuator_value - (1, -1)[actuator_value < 0] if should_nudge else actuator_value
-        assert hca_mitigation.update(actuator_value, actuator_value) == expected_torque, f"{frame=}"
+        assert hca_mitigation.update(actuator_value, actuator_value, actuator_value) == expected_torque, f"{frame=}"
+
+  def test_eps_timer_reset_aborts_on_steering_request(self):
+    hca_mitigation = HCAMitigation(CCP, eps_timer_workaround=True)
+    mitigation_start_calls = round(HCAMitigation.MLB_LOCKOUT_MITIGATION_START / DT_CTRL / CCP.STEER_STEP) + 1
+    low_torque_calls = round(HCAMitigation.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL / CCP.STEER_STEP) + 1
+
+    pinned_output = 1
+    assert pinned_output <= HCAMitigation.MLB_LOCKOUT_LOW_TORQUE
+
+    for _ in range(mitigation_start_calls):
+      apply_torque = hca_mitigation.update(CCP.STEER_MAX, CCP.STEER_MAX, CCP.STEER_MAX)
+      assert apply_torque != 0, "reset must not trigger while the model is requesting high torque"
+
+    for _ in range(low_torque_calls):
+      apply_torque = hca_mitigation.update(pinned_output, pinned_output, 0)
+    assert apply_torque == 0, "sustained low torque should zero the output to reset the EPS timer"
+
+    apply_torque = hca_mitigation.update(pinned_output, 0, CCP.STEER_MAX)
+    assert apply_torque == pinned_output, "reset must abort when the model commands real torque"
+
+  def test_eps_timer_reset_completes(self):
+    """The mitigation arms only after MLB_LOCKOUT_MITIGATION_START, and its reset clears the timer."""
+    hca_mitigation = HCAMitigation(CCP, eps_timer_workaround=True)
+    mitigation_start_calls = round(HCAMitigation.MLB_LOCKOUT_MITIGATION_START / DT_CTRL / CCP.STEER_STEP) + 1
+    low_torque_calls = round(HCAMitigation.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL / CCP.STEER_STEP) + 1
+    reset_calls = round(CCP.STEER_TIME_RESET / DT_CTRL / CCP.STEER_STEP) + 1
+    pinned_output = 1
+
+    for _ in range(low_torque_calls * 2):
+      apply_torque = hca_mitigation.update(pinned_output, 0, 0)
+    assert apply_torque == pinned_output, "mitigation must not engage before MLB_LOCKOUT_MITIGATION_START"
+
+    for _ in range(mitigation_start_calls):
+      hca_mitigation.update(CCP.STEER_MAX, 0, CCP.STEER_MAX)
+    for _ in range(low_torque_calls):
+      apply_torque = hca_mitigation.update(pinned_output, 0, 0)
+    assert apply_torque == 0, "sustained low torque should zero the output to reset the EPS timer"
+
+    for _ in range(reset_calls):
+      apply_torque = hca_mitigation.update(pinned_output, 0, 0)
+    assert apply_torque == pinned_output, "EPS timer reset should complete and release steering"
+
 
 class TestVolkswagenPlatformConfigs(unittest.TestCase):
   def test_spare_part_fw_pattern(self):

--- a/opendbc/car/volkswagen/tests/test_volkswagen.py
+++ b/opendbc/car/volkswagen/tests/test_volkswagen.py
@@ -31,17 +31,17 @@ class TestVolkswagenHCAMitigation(unittest.TestCase):
 
   def test_eps_timer_reset(self):
     """The mitigation respects start time threshold, aborts on real steering requests, and resets when expected."""
-    hca_mitigation = HCAMitigation(CCP, eps_timer_workaround=True)
-    mitigation_start_calls = round(HCAMitigation.MLB_LOCKOUT_MITIGATION_START / DT_CTRL / CCP.STEER_STEP)
-    low_torque_calls = round(HCAMitigation.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL / CCP.STEER_STEP)
-    reset_calls = round(CCP.STEER_TIME_RESET / DT_CTRL / CCP.STEER_STEP)
+    hca_mitigation = HCAMitigation(CCP, steer_timer_mitigation=True)
+    mitigation_start_calls = round(CCP.STEER_TIME_MITIGATION_START / (DT_CTRL * CCP.STEER_STEP))
+    low_torque_calls = round(CCP.STEER_TIME_LOW_TORQUE_TIME / (DT_CTRL * CCP.STEER_STEP))
+    reset_calls = round(CCP.STEER_TIME_RESET / (DT_CTRL * CCP.STEER_STEP))
 
-    low_torque = HCAMitigation.MLB_LOCKOUT_LOW_TORQUE
+    low_torque = CCP.STEER_TIME_LOW_TORQUE
     apply_torque = 0
 
     for _ in range(mitigation_start_calls):
       apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque)
-      assert apply_torque != 0, "mitigation must not engage before MLB_LOCKOUT_MITIGATION_START"
+      assert apply_torque != 0, "mitigation must not engage before STEER_TIME_MITIGATION_START"
 
     # Reset aborted due to desired torque above threshold
     for _ in range(reset_calls - 1):

--- a/opendbc/car/volkswagen/tests/test_volkswagen.py
+++ b/opendbc/car/volkswagen/tests/test_volkswagen.py
@@ -29,46 +29,41 @@ class TestVolkswagenHCAMitigation(unittest.TestCase):
         expected_torque = actuator_value - (1, -1)[actuator_value < 0] if should_nudge else actuator_value
         assert hca_mitigation.update(actuator_value, actuator_value, actuator_value) == expected_torque, f"{frame=}"
 
-  def test_eps_timer_reset_aborts_on_steering_request(self):
+  def test_eps_timer_reset(self):
+    """The mitigation respects start time threshold, aborts on real steering requests, and resets when expected."""
     hca_mitigation = HCAMitigation(CCP, eps_timer_workaround=True)
-    mitigation_start_calls = round(HCAMitigation.MLB_LOCKOUT_MITIGATION_START / DT_CTRL / CCP.STEER_STEP) + 1
-    low_torque_calls = round(HCAMitigation.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL / CCP.STEER_STEP) + 1
+    mitigation_start_calls = round(HCAMitigation.MLB_LOCKOUT_MITIGATION_START / DT_CTRL / CCP.STEER_STEP)
+    low_torque_calls = round(HCAMitigation.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL / CCP.STEER_STEP)
+    reset_calls = round(CCP.STEER_TIME_RESET / DT_CTRL / CCP.STEER_STEP)
 
-    pinned_output = 1
-    assert pinned_output <= HCAMitigation.MLB_LOCKOUT_LOW_TORQUE
+    low_torque = HCAMitigation.MLB_LOCKOUT_LOW_TORQUE
+    apply_torque = 0
 
     for _ in range(mitigation_start_calls):
-      apply_torque = hca_mitigation.update(CCP.STEER_MAX, CCP.STEER_MAX, CCP.STEER_MAX)
+      apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque)
+      assert apply_torque != 0, "mitigation must not engage before MLB_LOCKOUT_MITIGATION_START"
+
+    # Reset aborted due to desired torque above threshold
+    for _ in range(reset_calls - 1):
+      apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque)
+      assert apply_torque == 0, "sustained low torque should start reset"
+    apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque + 1)
+    assert apply_torque != 0, "reset must abort when desired torque is above threshold"
+
+    # Reset should not start during torque above threshold
+    for _ in range(low_torque_calls + 1):
+      apply_torque = hca_mitigation.update(low_torque + 1, apply_torque, low_torque + 1)
       assert apply_torque != 0, "reset must not trigger while the model is requesting high torque"
 
+    # Reset successful
     for _ in range(low_torque_calls):
-      apply_torque = hca_mitigation.update(pinned_output, pinned_output, 0)
-    assert apply_torque == 0, "sustained low torque should zero the output to reset the EPS timer"
-
-    apply_torque = hca_mitigation.update(pinned_output, 0, CCP.STEER_MAX)
-    assert apply_torque == pinned_output, "reset must abort when the model commands real torque"
-
-  def test_eps_timer_reset_completes(self):
-    """The mitigation arms only after MLB_LOCKOUT_MITIGATION_START, and its reset clears the timer."""
-    hca_mitigation = HCAMitigation(CCP, eps_timer_workaround=True)
-    mitigation_start_calls = round(HCAMitigation.MLB_LOCKOUT_MITIGATION_START / DT_CTRL / CCP.STEER_STEP) + 1
-    low_torque_calls = round(HCAMitigation.MLB_LOCKOUT_LOW_TORQUE_TIME / DT_CTRL / CCP.STEER_STEP) + 1
-    reset_calls = round(CCP.STEER_TIME_RESET / DT_CTRL / CCP.STEER_STEP) + 1
-    pinned_output = 1
-
-    for _ in range(low_torque_calls * 2):
-      apply_torque = hca_mitigation.update(pinned_output, 0, 0)
-    assert apply_torque == pinned_output, "mitigation must not engage before MLB_LOCKOUT_MITIGATION_START"
-
-    for _ in range(mitigation_start_calls):
-      hca_mitigation.update(CCP.STEER_MAX, 0, CCP.STEER_MAX)
-    for _ in range(low_torque_calls):
-      apply_torque = hca_mitigation.update(pinned_output, 0, 0)
-    assert apply_torque == 0, "sustained low torque should zero the output to reset the EPS timer"
-
+      apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque)
+      assert apply_torque != 0, "reset should not start until low torque is observed for required period"
     for _ in range(reset_calls):
-      apply_torque = hca_mitigation.update(pinned_output, 0, 0)
-    assert apply_torque == pinned_output, "EPS timer reset should complete and release steering"
+      apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque)
+      assert apply_torque == 0, "sustained low torque should zero the output to reset the EPS timer"
+    apply_torque = hca_mitigation.update(low_torque, apply_torque, low_torque)
+    assert apply_torque == low_torque, "EPS timer reset should complete and release steering"
 
 
 class TestVolkswagenPlatformConfigs(unittest.TestCase):

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -62,6 +62,7 @@ class CarControllerParams:
   STEER_DRIVER_FACTOR = 1                  # from dbc
 
   STEER_TIME_STUCK_TORQUE = 1.9            # EPS limits same torque to 6 seconds, reset timer 3x within that period
+  STEER_TIME_RESET = 1.1                   # HCA must stay disabled this long for the EPS to reset its steer timer
 
   DEFAULT_MIN_STEER_SPEED = 0.4            # m/s, newer EPS racks fault below this speed, don't show a low speed alert
 

--- a/opendbc/car/volkswagen/values.py
+++ b/opendbc/car/volkswagen/values.py
@@ -62,7 +62,13 @@ class CarControllerParams:
   STEER_DRIVER_FACTOR = 1                  # from dbc
 
   STEER_TIME_STUCK_TORQUE = 1.9            # EPS limits same torque to 6 seconds, reset timer 3x within that period
-  STEER_TIME_RESET = 1.1                   # HCA must stay disabled this long for the EPS to reset its steer timer
+  STEER_TIME_RESET = 1.1                   # MLB-only: HCA must stay disabled this long for the EPS to reset its steer timer (sec)
+  STEER_TIME_RESET_DETECTION_BUFFER = 0.05 # MLB-only: Detection uses LH_EPS_03 whereas actuation is HCA_01 so allow some buffer in detection (sec)
+  STEER_TIME_MAX_ENGAGED = 360.            # MLB-only: Maximum EPS engagement time before lockout will reject requests (sec)
+  STEER_TIME_WARNING = 5.                  # MLB-only: How long before max engaged steer time should warning fire (sec)
+  STEER_TIME_MITIGATION_START = 240.       # MLB-only: EPS engaged time before attempting opportunistic reset (sec)
+  STEER_TIME_LOW_TORQUE = 60               # MLB-only: Desired torque must be less than this before and during reset (centi-Nm)
+  STEER_TIME_LOW_TORQUE_TIME = 0.5         # MLB-only: How long to observe low torque for before starting the reset (sec)
 
   DEFAULT_MIN_STEER_SPEED = 0.4            # m/s, newer EPS racks fault below this speed, don't show a low speed alert
 

--- a/opendbc/dbc/vw_mlb.dbc
+++ b/opendbc/dbc/vw_mlb.dbc
@@ -1766,7 +1766,7 @@ BO_ 1318 BCM: 8 XXX
  SG_ BLINKER_RIGHT : 35|1@0+ (1,0) [0|1] "" XXX
  SG_ UNKNOWN_DRIVER_DOOR_RELATED : 43|1@0+ (1,0) [0|1] "" XXX
 
-VAL_ 159 EPS_HCA_Status 0 "disabled" 1 "initializing" 2 "fault" 3 "ready" 4 "rejected" 5 "active" ;
+VAL_ 159 EPS_HCA_Status 0 "disabled" 1 "initializing" 2 "fault" 3 "ready" 4 "rejected" 5 "active" 7 "active_mode_7" ;
 VAL_ 269 ACC_Freigabe_Momentenanf 0 "Momanf_nicht_freigegeben" 1 "Momanf_freigegeben" ;
 VAL_ 269 ACC_Freigabe_Verzanf 0 "Verzanf_nicht_freigegeben" 1 "Verzanf_freigegeben" ;
 VAL_ 269 ACC_Getriebestellung_P 0 "P_Stellung_nicht_angefordert" 1 "Anforderung_P_Stellung" ;


### PR DESCRIPTION
MLB steering racks have a 6min max engagement. After that time it will return status = 'rejected' for ~2.0s and not execute torque requests. Upon observing that openpilot drops HCA_01 status to 'ready' and after a ~2.0s lockout period the EPS switches from rejected to ready and openpilot immediately applies torque again. This max engagement timer can also be reset by disabling control for ~1.1s at any point before 6 mins. 

In the current MLB lateral implementation there are no mitigations for this so every 6 mins of engaged time there will be a temporary fault for ~2.0s without any advanced warning that stops lateral control requiring driver to take immediate control.

This PR adds 2 mitigations to make this safer and less annoying:
1. Add a warning ~5 seconds before the forced steering reset so that the driver has plenty of time to take control prior to the actual steering dropout
2. Opportunistically disengage lateral control for 1.1 seconds during periods when low torque is requested. This resets the 6min timer without any perceptible effect and in practice makes it very rare to actually get the warning/lockout.


Openpilot will require changes similar to this to support the new warning type https://github.com/oscarmcnulty/openpilot/commit/d709ca9ee016df95e04749005ed31ae743268634 

<!--
We need these details to verify your pull request.

Find your device's dongle ID and a route at https://connect.comma.ai.
Ideally, the route is recorded with the exact branch of your pull request.

If you are porting a car with a new harness variant, please add it to https://github.com/commaai/opendbc/blob/master/opendbc/car/docs_definitions.py. Let us know and we can add it to the shop at the time of merge.
-->

Test route: 35258b7bb90057ff/00000003--676e449e6e (4.5 hours drive showing ~59 opportunistic resets and 0 lockouts at 6 mins)

Test route 35258b7bb90057ff/00000005--22d16cde7f (opportunistic reset disabled to show pre-lockout warning alert)
