### PR TITLE
Tesla: remove stale HW3 TODO

### DIFF
--- a/opendbc/car/tesla/values.py
+++ b/opendbc/car/tesla/values.py
@@ -43,7 +43,6 @@ class TeslaPlatformConfig(PlatformConfig):
 class CAR(Platforms):
   TESLA_MODEL_3 = TeslaPlatformConfig(
     [
-      # TODO: do we support 2017? It's HW3
       TeslaCarDocsHW3("Tesla Model 3 (with HW3) 2019-23"),
       TeslaCarDocsHW4("Tesla Model 3 (with HW4) 2024-25"),
     ],


### PR DESCRIPTION
2017 Model 3s shipped with HW2/HW2.5, not HW3 (HW3 rollout began ~April 2019, VINs 332xxx+). Current "2019-23" range is correct as-is; no doc string change needed.

Removes the TODO - no functional behaviour change.

Validation
Dongle ID: N/A
Route: N/A