### PR TITLE
Chrysler: fuzzy fingerprint on the part number, not the revision

### DIFF
--- a/opendbc/car/chrysler/tests/test_chrysler.py
+++ b/opendbc/car/chrysler/tests/test_chrysler.py
@@ -1,0 +1,99 @@
+import unittest
+
+from opendbc.car.structs import CarParams
+from opendbc.car.fw_versions import build_fw_dict, match_fw_to_car_fuzzy
+from opendbc.car.chrysler.fingerprints import FW_VERSIONS
+from opendbc.car.chrysler.values import PLATFORM_CODE_ECUS, get_platform_codes, match_fw_to_car_fuzzy as chrysler_fuzzy
+
+CarFw = CarParams.CarFw
+
+# The only FW version in the database that isn't a Mopar part number. It's on the radar, which is
+# in FUZZY_EXCLUDE_ECUS and not a PLATFORM_CODE_ECU, so it can't affect fuzzy fingerprinting.
+NON_PART_NUMBER_FW = {b'22DTRHD_AA'}
+
+
+class TestChryslerFingerprint(unittest.TestCase):
+  def test_platform_codes_parse_every_platform_code_ecu(self):
+    # Every FW version on an ECU we fuzzy match on must yield a part number, otherwise that
+    # ECU silently stops contributing to the match
+    for car_model, ecus in FW_VERSIONS.items():
+      for ecu, fw_versions in ecus.items():
+        if ecu[0] not in PLATFORM_CODE_ECUS:
+          continue
+        for fw in fw_versions:
+          with self.subTest(car_model=car_model, ecu=ecu, fw=fw):
+            self.assertEqual(len(get_platform_codes([fw])), 1, f"Failed to parse a part number from {fw}")
+
+  def test_platform_code_drops_only_the_revision(self):
+    # b'68227902AF' is part 68227902 at revision AF
+    self.assertEqual(get_platform_codes([b'68227902AF']), {b'68227902'})
+    # trailing whitespace is present on some engine ECU versions
+    self.assertEqual(get_platform_codes([b'68267018AO ']), {b'68267018'})
+    # revisions of the same part collapse to one code, different parts do not
+    self.assertEqual(get_platform_codes([b'68227902AF', b'68227902AG']), {b'68227902'})
+    self.assertEqual(get_platform_codes([b'68227902AF', b'68227905AG']), {b'68227902', b'68227905'})
+    # not a part number
+    self.assertEqual(get_platform_codes(list(NON_PART_NUMBER_FW)), set())
+
+  def test_fuzzy_matches_unseen_revision(self):
+    # The point of the brand fuzzy function: a car running a revision of a known part that we have
+    # never seen must still fingerprint. The generic exact-string matcher can't do this.
+    for car_model, ecus in FW_VERSIONS.items():
+      fw = []
+      for (ecu_name, addr, sub_addr), fw_versions in ecus.items():
+        unseen = fw_versions[0].strip()[:-2] + b'ZZ'
+        self.assertNotIn(unseen, [f.strip() for f in fw_versions])
+        fw.append(CarFw(ecu=ecu_name, fwVersion=unseen, brand='chrysler',
+                        address=addr, subAddress=0 if sub_addr is None else sub_addr))
+
+      live_fw = build_fw_dict(fw)
+      with self.subTest(car_model=car_model):
+        self.assertEqual(match_fw_to_car_fuzzy(live_fw, 'chrysler', log=False), set(),
+                         "generic matcher shouldn't match an unseen revision, test is vacuous")
+        self.assertEqual(chrysler_fuzzy(live_fw, None, FW_VERSIONS), {car_model})
+
+  def test_no_match_on_unknown_part_number(self):
+    # A platform with genuinely new hardware must fail to fingerprint rather than match the
+    # closest car we know about
+    for car_model, ecus in FW_VERSIONS.items():
+      fw = []
+      for (ecu_name, addr, sub_addr), fw_versions in ecus.items():
+        unknown = b'99' + fw_versions[0].strip()[2:]
+        fw.append(CarFw(ecu=ecu_name, fwVersion=unknown, brand='chrysler',
+                        address=addr, subAddress=0 if sub_addr is None else sub_addr))
+      with self.subTest(car_model=car_model):
+        self.assertEqual(chrysler_fuzzy(build_fw_dict(fw), None, FW_VERSIONS), set())
+
+  def test_no_cross_platform_false_match(self):
+    # Each platform's own FW must fuzzy match that platform and nothing else
+    for car_model, ecus in FW_VERSIONS.items():
+      fw = [CarFw(ecu=ecu[0], fwVersion=fw_versions[0], brand='chrysler', address=ecu[1],
+                  subAddress=0 if ecu[2] is None else ecu[2])
+            for ecu, fw_versions in ecus.items()]
+      with self.subTest(car_model=car_model):
+        self.assertEqual(chrysler_fuzzy(build_fw_dict(fw), None, FW_VERSIONS), {car_model})
+
+  def test_shared_part_numbers_are_resolved_by_the_other_ecus(self):
+    # Three part numbers are shared between platforms. A car carrying one must still fingerprint
+    # correctly, because every platform code ECU has to agree.
+    codes = {}
+    for car_model, ecus in FW_VERSIONS.items():
+      for ecu, fw_versions in ecus.items():
+        if ecu[0] not in PLATFORM_CODE_ECUS:
+          continue
+        for code in get_platform_codes(fw_versions):
+          codes.setdefault((ecu[1], ecu[2], code), set()).add(car_model)
+
+    shared = {k: v for k, v in codes.items() if len(v) > 1}
+    self.assertEqual(len(shared), 3, f"expected 3 shared part numbers, got {sorted(shared)}")
+    for car_models in shared.values():
+      for car_model in car_models:
+        fw = [CarFw(ecu=ecu[0], fwVersion=fw_versions[0], brand='chrysler', address=ecu[1],
+                    subAddress=0 if ecu[2] is None else ecu[2])
+              for ecu, fw_versions in FW_VERSIONS[car_model].items()]
+        with self.subTest(car_model=car_model):
+          self.assertEqual(chrysler_fuzzy(build_fw_dict(fw), None, FW_VERSIONS), {car_model})
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/opendbc/car/chrysler/values.py
+++ b/opendbc/car/chrysler/values.py
@@ -1,3 +1,4 @@
+import re
 from enum import IntFlag
 from dataclasses import dataclass, field
 
@@ -129,6 +130,62 @@ RAM_CARS = RAM_DT | RAM_HD
 CUSW_CARS = {CAR.JEEP_CHEROKEE_5TH_GEN, }
 
 
+# Chrysler FW versions are Mopar part numbers: an 8 character base part number followed by a two
+# letter revision suffix, e.g. b'68227902AF'. The suffix is bumped for running changes that don't
+# change the platform, so 5 of the 10 platforms below carry several revisions of the same part.
+# Matching on the base part number alone therefore fingerprints a car whose exact FW we've never
+# seen, which is the point of fuzzy fingerprinting.
+#
+# Collapsing the revision costs almost nothing in specificity: across the FW database it takes the
+# fuzzy lookup from 516 exact versions to 380 base part numbers while leaving the number of part
+# numbers shared between platforms unchanged at 3. Those 3 are genuinely shared hardware, not an
+# artifact of dropping the revision - each is shared by every revision of the part.
+CHRYSLER_PLATFORM_CODE_PATTERN = re.compile(b'(?P<part>[A-Z0-9]{8})(?P<revision>[A-Z]{2})$')
+
+# ECUs that carry a platform specific part number. fwdRadar and eps are shared across platforms
+# and are already in FUZZY_EXCLUDE_ECUS; including them here would match the wrong car.
+PLATFORM_CODE_ECUS = [Ecu.abs, Ecu.combinationMeter, Ecu.engine, Ecu.hybrid, Ecu.srs, Ecu.transmission]
+
+
+def get_platform_codes(fw_versions: list[bytes]) -> set[bytes]:
+  # Returns the base part number of each version, dropping the revision suffix
+  codes = set()
+  for fw in fw_versions:
+    match = CHRYSLER_PLATFORM_CODE_PATTERN.match(fw.strip())
+    if match is not None:
+      codes.add(match.group('part'))
+  return codes
+
+
+def match_fw_to_car_fuzzy(live_fw_versions, vin, offline_fw_versions) -> set[str]:
+  candidates: set[str] = set()
+
+  for candidate, fws in offline_fw_versions.items():
+    # Keep track of ECUs which pass all checks (platform codes)
+    valid_found_ecus = set()
+    valid_expected_ecus = {ecu[1:] for ecu in fws if ecu[0] in PLATFORM_CODE_ECUS}
+    for ecu, expected_versions in fws.items():
+      addr = ecu[1:]
+      # Only check ECUs expected to have platform codes
+      if ecu[0] not in PLATFORM_CODE_ECUS:
+        continue
+
+      expected_platform_codes = get_platform_codes(expected_versions)
+      found_platform_codes = get_platform_codes(live_fw_versions.get(addr, set()))
+
+      # Check part number matches for any found versions
+      if not any(found_platform_code in expected_platform_codes for found_platform_code in found_platform_codes):
+        break
+
+      valid_found_ecus.add(addr)
+
+    # If all live ECUs pass all checks for candidate, add it as a match
+    if valid_expected_ecus.issubset(valid_found_ecus):
+      candidates.add(candidate)
+
+  return candidates
+
+
 CHRYSLER_VERSION_REQUEST = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER]) + \
   p16(0xf132)
 CHRYSLER_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTIFIER + 0x40]) + \
@@ -167,6 +224,7 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[
     (Ecu.abs, 0x7e4, None),  # alt address for abs on hybrids, NOTE: not on all hybrid platforms
   ],
+  match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION
Fixes #1092.

Chrysler has no brand fuzzy fingerprinting function, so it falls back to the generic
exact-string fuzzy matcher. That matcher can only match FW it has literally seen, which
is the thing #1092 asks to fix.

## What the FW actually looks like

Chrysler FW versions are Mopar part numbers: an 8 character base part number followed by
a two letter revision suffix, e.g. `b'68227902AF'`. The revision is bumped for running
changes that don't change the platform — 5 of the 10 platforms carry several revisions of
the same part. So the platform code is the base part number and the revision is noise.

## Does dropping the revision cost specificity?

Measured over the whole checked-in FW database rather than assumed:

| | exact versions | base part numbers |
|---|---|---|
| distinct fuzzy keys | 516 | 380 |
| keys shared between platforms | 3 | 3 |

Collapsing the revision removes 136 keys and adds **zero** new cross-platform collisions.
The 3 shared keys are the same 3 either way — genuinely shared hardware (`0x744 68355363`
between the two Grand Cherokees; `0x747 68408639` and `0x747 68499978` between Durango and
Grand Cherokee 2019), shared across every revision of the part, not an artifact of dropping
the suffix. All 10 platforms still clear the 2-unique-ECU threshold.

## Result

Same part number, revision suffix replaced with one that isn't in the database:

| | generic exact-string matcher | this PR |
|---|---|---|
| platforms fingerprinted | 0 / 10 | 10 / 10 |

and each platform's own FW still matches only itself (0 cross-platform false matches).

## Shape

Mirrors `hyundai/values.py` — `PLATFORM_CODE_ECUS`, `get_platform_codes()`,
`match_fw_to_car_fuzzy()` — minus the date handling, since Chrysler FW carries no date.
Every platform code ECU must agree before a candidate is accepted, so a car carrying one of
the 3 shared part numbers is still resolved by its other ECUs, and genuinely new hardware
fails to fingerprint rather than matching the nearest known car.

`PLATFORM_CODE_ECUS` excludes `fwdRadar` and `eps`, which are already in
`FUZZY_EXCLUDE_ECUS` as shared across platforms. One FW in the database isn't a part number
at all (`b'22DTRHD_AA'`, RAM 1500 radar); it's on an excluded ECU, and there's a test
asserting every FW on an included ECU parses.

## Testing

- `opendbc/car/tests/test_fw_fingerprint.py`: 15 passed, 7872 subtests. `test_custom_fuzzy_match`
  now runs for the 10 Chrysler platforms instead of skipping (skips 141 → 131), so the brand
  function is checked against the generic one rather than silently absent.
- Full suite excluding `test_models.py`: 724 passed, 11069 subtests, `ruff` clean.
- New `opendbc/car/chrysler/tests/test_chrysler.py`: 6 tests, 555 subtests.
- Mutation tested — each applied to a clean tree and reverted:
  - keep the revision in the platform code → `test_fuzzy_matches_unseen_revision` and
    `test_platform_code_drops_only_the_revision` fail
  - add `eps`/`fwdRadar` to `PLATFORM_CODE_ECUS` → `test_platform_codes_parse_every_platform_code_ecu`
    and `test_shared_part_numbers_are_resolved_by_the_other_ecus` fail
  - drop the "all expected ECUs must agree" requirement → **openpilot's own
    `test_fuzzy_match_ecu_count` fails**, on RAM HD and Durango

## Validation

No dongle ID or route: I don't have a car, and this changes offline fingerprinting logic
rather than anything on the car. It's validated against the checked-in FW database and the
repo's test suite only. **The 0/10 → 10/10 claim is about part numbers already in the
database with unseen revisions; it is not evidence about a Chrysler platform whose FW we
have never collected at all**, which no offline test can speak to. Happy to be told the
ECU set or the strictness should be different — those are the two judgement calls here.

---

*Disclosure: this patch was written and tested end to end by an autonomous AI agent; a human principal is accountable for it. [What this account is](https://github.com/sujeito-operator). Ask me anything about how it was produced and I will answer.*