### PR TITLE
honda: tune N-BOX kp/ki, split from Insight

### DIFF
--- a/opendbc/car/honda/interface.py
+++ b/opendbc/car/honda/interface.py
@@ -173,9 +173,14 @@ class CarInterface(CarInterfaceBase):
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.38], [0.11]]
 
-    elif candidate in (CAR.HONDA_INSIGHT, CAR.HONDA_NBOX_2G):
+    elif candidate == CAR.HONDA_INSIGHT:
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
       ret.lateralTuning.pid.kpV, ret.lateralTuning.pid.kiV = [[0.6], [0.18]]
+
+    elif candidate == CAR.HONDA_NBOX_2G:
+      ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end
+      ret.lateralTuning.pid.kpBP, ret.lateralTuning.pid.kpV = [[10., 20.], [0.30, 0.20]]
+      ret.lateralTuning.pid.kiBP, ret.lateralTuning.pid.kiV = [[10., 20.], [0.09, 0.06]]
 
     elif candidate in (CAR.HONDA_E, CAR.HONDA_E_ADVANCE):
       ret.lateralParams.torqueBP, ret.lateralParams.torqueV = [[0, 4096], [0, 4096]]  # TODO: determine if there is a dead zone at the top end


### PR DESCRIPTION
## Summary
`HONDA_NBOX_2G` shared its lateral PID gains with `HONDA_INSIGHT` (kp=0.6, ki=0.18), a much heavier hybrid sedan. On-road testing on an actual N-BOX showed overshoot/oscillation with those flat gains.

Binning drive logs by vEgo showed tracking error and output usage both drop steadily as speed rises:

| speed | |angleError| median | |angleError| p90 |
|---|---|---|
| 18-36 km/h | 1.46 deg | 12.0 deg |
| 36-54 km/h | 0.81 deg | 3.71 deg |
| 54-72 km/h | 0.39 deg | 0.98 deg |

City-speed driving is consistently the hardest to track. Tapering kp/ki down with speed (kp 0.30->0.20, ki 0.09->0.06 between 36-72km/h) measurably reduced oscillation (output sign-flip rate, angleError stddev) while improving low-speed tracking (p90 error roughly halved in the 18-36km/h band), across multiple on-road test drives on the same car, without touching the already-comfortable higher-speed behavior.

## Validation
* Dongle ID:
* Route:

(WIP: recording a clean, dedicated verification route without unrelated personal driving data. Will fill in before marking ready for review.)

## Test plan
- [x] On-road A/B testing on a Honda N-BOX 2018, multiple drives, comparing flat kp=0.6/ki=0.18 vs the new speed-tapered gains
- [x] Verified reduced output sign-flip rate and angleError stddev, and improved angleError percentiles, especially in the 18-36km/h band
- [ ] Attach verification dongle ID / route above