### PR TITLE
os: add support for windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,11 +16,20 @@ jobs:
         include:
           - os: ${{ github.repository == 'commaai/opendbc' && 'namespace-profile-amd64-8x16' || 'ubuntu-24.04' }}
           - os: ${{ github.repository == 'commaai/opendbc' && 'namespace-profile-macos-8x14' || 'macos-latest' }}
+          - os: windows-latest
+    defaults:
+      run:
+        shell: ${{ contains(matrix.os, 'windows') && 'msys2 {0}' || 'bash -e {0}' }}
     steps:
     - uses: actions/checkout@v4
+    - uses: msys2/setup-msys2@v2
+      if: contains(matrix.os, 'windows')
+      with:
+        msystem: CLANG64
+        install: mingw-w64-clang-x86_64-clang mingw-w64-clang-x86_64-git mingw-w64-clang-x86_64-uv  # cc for libsafety, git for misra
     - uses: commaai/timeout@v1
       with:
-        timeout: ${{ github.repository == 'commaai/opendbc' && '90' || '999' }}
+        timeout: ${{ contains(matrix.os, 'windows') && '180' || github.repository == 'commaai/opendbc' && '90' || '999' }}  # a 4-core hosted runner
     - run: ./test.sh
 
   safety_tests:

--- a/opendbc/car/interfaces.py
+++ b/opendbc/car/interfaces.py
@@ -382,7 +382,7 @@ def get_interface_attr(attr: str, combine_brands: bool = False, ignore_none: boo
   result = {}
   for car_folder in sorted([x[0] for x in os.walk(BASEDIR)]):
     try:
-      brand_name = car_folder.split('/')[-1]
+      brand_name = os.path.basename(car_folder)
       brand_values = __import__(f'opendbc.car.{brand_name}.{INTERFACE_ATTR_FILE.get(attr, "values")}', fromlist=[attr])
       if hasattr(brand_values, attr) or not ignore_none:
         attr_data = getattr(brand_values, attr, None)

--- a/opendbc/safety/tests/libsafety/libsafety_py.py
+++ b/opendbc/safety/tests/libsafety/libsafety_py.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -23,6 +24,8 @@ def _build_libsafety(release: bool = False) -> str:
   ldflags = [
     '-fsanitize=undefined', '-fno-sanitize-recover=undefined',
   ]
+  if sys.platform == 'win32':
+    cflags += ['-mno-ms-bitfields']  # the firmware's packed layout, not mingw's MS one
   if not release:
     cflags += ['-DALLOW_DEBUG', '-fprofile-arcs', '-ftest-coverage']
     ldflags += ['-fprofile-arcs', '-ftest-coverage']
@@ -44,9 +47,10 @@ typedef struct {
   unsigned char fd : 1;
   unsigned char bus : 3;
   unsigned char data_len_code : 4;
-  unsigned char rejected : 1;
-  unsigned char returned : 1;
-  unsigned char extended : 1;
+  // unsigned int like addr: same layout under GCC, and the one cffi's MSVC rules also lay out like the firmware
+  unsigned int rejected : 1;
+  unsigned int returned : 1;
+  unsigned int extended : 1;
   unsigned int addr : 29;
   unsigned char checksum;
   unsigned char data[64];

--- a/opendbc/safety/tests/misra/test_misra.sh
+++ b/opendbc/safety/tests/misra/test_misra.sh
@@ -11,10 +11,10 @@ YELLOW="\e[1;33m"
 RED="\e[1;31m"
 NC='\033[0m'
 
-: "${CPPCHECK_DIR:=$(python3 -c "import cppcheck; print(cppcheck.DIR)")}"
+: "${CPPCHECK_DIR:=$(python -c "import cppcheck; print(cppcheck.DIR)")}"
 
 # ensure checked in coverage table is up to date
-python3 $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
+python $CPPCHECK_DIR/addons/misra.py -generate-table > coverage_table
 if ! git diff --quiet coverage_table; then
   echo -e "${YELLOW}MISRA coverage table doesn't match. Update and commit:${NC}"
   exit 3

--- a/opendbc/safety/tests/misra/test_misra.sh
+++ b/opendbc/safety/tests/misra/test_misra.sh
@@ -2,7 +2,7 @@
 set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR
+cd "$DIR"
 
 source ../../../../setup.sh
 
@@ -20,7 +20,7 @@ if ! git diff --quiet coverage_table; then
   exit 3
 fi
 
-cd $BASEDIR
+cd "$BASEDIR"
 
 CHECKLIST=$(mktemp)
 echo "Cppcheck checkers list from test_misra.sh:" > $CHECKLIST
@@ -65,10 +65,10 @@ printf "\n${GREEN}Success!${NC} took $SECONDS seconds\n"
 
 # ensure list of checkers is up to date
 if [ -z "$OPENDBC_ROOT" ]; then
-  cd $DIR
+  cd "$DIR"
   if ! git diff --quiet $CHECKLIST; then
     echo -e "\n${YELLOW}WARNING: Cppcheck checkers.txt report has changed. Review and commit...${NC}"
-    mv $CHECKLIST $DIR/checkers.txt
+    mv "$CHECKLIST" "$DIR/checkers.txt"
     exit 4
   fi
 fi

--- a/opendbc/safety/tests/test.sh
+++ b/opendbc/safety/tests/test.sh
@@ -2,7 +2,7 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-cd $DIR
+cd "$DIR"
 
 source ../../../setup.sh
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,3 +133,13 @@ include-package-data = true
 "opendbc.car" = ["**/*.capnp", "**/*.toml"]
 "opendbc.dbc" = ["**/*.dbc"]
 "opendbc.safety" = ["*.h", "modes/*.h"]
+
+# --- TODO REMOVE AFTER DEPENDENCY PR MERGES (commaai/dependencies#107): fork-only index of the comma-deps Windows wheels until PyPI has them; not for upstream ---
+[[tool.uv.index]]
+name = "comma-deps-windows"
+url = "https://github.com/AmyJeanes/commaai-dependencies/releases/download/windows-post117/index.html"
+format = "flat"
+explicit = true
+
+[tool.uv.sources]
+comma-deps-cppcheck = [{ index = "comma-deps-windows", marker = "sys_platform == 'win32'" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ examples = [
 [dependency-groups]
 testing = [
   "comma-car-segments @ https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl",
-  "cppcheck @ git+https://github.com/commaai/dependencies.git@release-cppcheck#subdirectory=cppcheck",
+  "comma-deps-cppcheck ; python_full_version >= '3.12'",  # the wheel needs 3.12
 ]
 
 [build-system]

--- a/setup.sh
+++ b/setup.sh
@@ -19,4 +19,4 @@ fi
 
 export UV_PROJECT_ENVIRONMENT="$BASEDIR/.venv"
 uv sync --all-extras --all-groups --inexact
-source "$PYTHONPATH/.venv/bin/activate"
+source "$PYTHONPATH"/.venv/*/activate  # bin/, or Scripts/ on Windows

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ if ! command -v uv &>/dev/null; then
 
   # must source this after install on some platforms
   if [ -f $HOME/.local/bin/env ]; then
-    source $HOME/.local/bin/env
+    source "$HOME/.local/bin/env"
   fi
 fi
 

--- a/test.sh
+++ b/test.sh
@@ -2,7 +2,7 @@
 set -e
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
-cd $DIR
+cd "$DIR"
 
 source ./setup.sh
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.13"
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
     "python_full_version < '3.12'",
 ]
 
@@ -134,10 +135,24 @@ requires-dist = [{ name = "requests" }]
 name = "comma-deps-cppcheck"
 version = "2.21.0.post101"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
+]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/57/364a71d9c58c26e32a7943303f62d5dd8f405acc0a96a834fab5b86cf5fc/comma_deps_cppcheck-2.21.0.post101-py3-none-macosx_11_0_arm64.whl", hash = "sha256:00d93d9a8c02e6f00c36b39a9f35d5a7248eb2cba5389f8334cb7c8390dfacb6", size = 2709883, upload-time = "2026-08-27T18:22:56.715Z" },
     { url = "https://files.pythonhosted.org/packages/7a/c6/e3b115a15b44eba7b1431592c4376aa3c59bed7437d37ffdcc586c3c6ce9/comma_deps_cppcheck-2.21.0.post101-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:89c1d9b89e8459cadad705f33dc710f8cdc6cb489477042bbf4e3d1f872fd8be", size = 3050896, upload-time = "2026-08-27T18:23:00.435Z" },
     { url = "https://files.pythonhosted.org/packages/68/12/7214df4928c86f29ea25e350acb2a4ad28365d65b19a884a1ab26e9c9944/comma_deps_cppcheck-2.21.0.post101-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:4170753f8451abe980d73b2135836565b3a7c4a887f6a3d68e452541bac6f00c", size = 3307666, upload-time = "2026-08-27T18:23:04.023Z" },
+]
+
+[[package]]
+name = "comma-deps-cppcheck"
+version = "2.21.0.post117"
+source = { registry = "https://github.com/AmyJeanes/commaai-dependencies/releases/download/windows-post117/index.html" }
+resolution-markers = [
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+]
+wheels = [
+    { url = "https://github.com/AmyJeanes/commaai-dependencies/releases/download/windows-post117/comma_deps_cppcheck-2.21.0.post117-py3-none-win_amd64.whl", hash = "sha256:5bfcbfa3077a0d799999dd840e21306b27d78a30cb1ea55287e8ec760c82ad0c" },
 ]
 
 [[package]]
@@ -369,7 +384,8 @@ name = "numpy"
 version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12'",
+    "python_full_version >= '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
 wheels = [
@@ -419,7 +435,8 @@ testing = [
 [package.dev-dependencies]
 testing = [
     { name = "comma-car-segments" },
-    { name = "comma-deps-cppcheck", marker = "python_full_version >= '3.12'" },
+    { name = "comma-deps-cppcheck", version = "2.21.0.post101", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform != 'win32'" },
+    { name = "comma-deps-cppcheck", version = "2.21.0.post117", source = { registry = "https://github.com/AmyJeanes/commaai-dependencies/releases/download/windows-post117/index.html" }, marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -446,7 +463,8 @@ provides-extras = ["testing", "examples"]
 [package.metadata.requires-dev]
 testing = [
     { name = "comma-car-segments", url = "https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl" },
-    { name = "comma-deps-cppcheck", marker = "python_full_version >= '3.12'" },
+    { name = "comma-deps-cppcheck", marker = "python_full_version >= '3.12' and sys_platform == 'win32'", index = "https://github.com/AmyJeanes/commaai-dependencies/releases/download/windows-post117/index.html" },
+    { name = "comma-deps-cppcheck", marker = "python_full_version >= '3.12' and sys_platform != 'win32'" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -131,6 +131,16 @@ wheels = [
 requires-dist = [{ name = "requests" }]
 
 [[package]]
+name = "comma-deps-cppcheck"
+version = "2.21.0.post101"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/57/364a71d9c58c26e32a7943303f62d5dd8f405acc0a96a834fab5b86cf5fc/comma_deps_cppcheck-2.21.0.post101-py3-none-macosx_11_0_arm64.whl", hash = "sha256:00d93d9a8c02e6f00c36b39a9f35d5a7248eb2cba5389f8334cb7c8390dfacb6", size = 2709883, upload-time = "2026-08-27T18:22:56.715Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c6/e3b115a15b44eba7b1431592c4376aa3c59bed7437d37ffdcc586c3c6ce9/comma_deps_cppcheck-2.21.0.post101-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:89c1d9b89e8459cadad705f33dc710f8cdc6cb489477042bbf4e3d1f872fd8be", size = 3050896, upload-time = "2026-08-27T18:23:00.435Z" },
+    { url = "https://files.pythonhosted.org/packages/68/12/7214df4928c86f29ea25e350acb2a4ad28365d65b19a884a1ab26e9c9944/comma_deps_cppcheck-2.21.0.post101-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:4170753f8451abe980d73b2135836565b3a7c4a887f6a3d68e452541bac6f00c", size = 3307666, upload-time = "2026-08-27T18:23:04.023Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.15.4"
 source = { registry = "https://pypi.org/simple" }
@@ -168,11 +178,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/e4/2a4561f89ff6bf7c925c287d0f2cce8bdf139c3a33735c87e3203401cf94/coverage-7.15.4-cp312-cp312-win_arm64.whl", hash = "sha256:67bc345491ab55b837277d76f5775d057e8c7f1ac44d890d8c2c82adde258c6f", size = 224515, upload-time = "2026-08-06T13:47:58.977Z" },
     { url = "https://files.pythonhosted.org/packages/b4/d9/e70c286c979378f061d8266e279b686ab0b0b688e1fe0af864684f23a77d/coverage-7.15.4-py3-none-any.whl", hash = "sha256:964730a1e9de9c0cf11be6a1a3c79ce419c34882842abd256086ba4698705e84", size = 214332, upload-time = "2026-08-06T13:50:22.192Z" },
 ]
-
-[[package]]
-name = "cppcheck"
-version = "2.21.0"
-source = { git = "https://github.com/commaai/dependencies.git?subdirectory=cppcheck&rev=release-cppcheck#b7253ddb101ed6add04fc2a2ce0688d5e21a55ee" }
 
 [[package]]
 name = "cpplint"
@@ -414,7 +419,7 @@ testing = [
 [package.dev-dependencies]
 testing = [
     { name = "comma-car-segments" },
-    { name = "cppcheck" },
+    { name = "comma-deps-cppcheck", marker = "python_full_version >= '3.12'" },
 ]
 
 [package.metadata]
@@ -441,7 +446,7 @@ provides-extras = ["testing", "examples"]
 [package.metadata.requires-dev]
 testing = [
     { name = "comma-car-segments", url = "https://huggingface.co/datasets/commaai/commaCarSegments/resolve/main/dist/comma_car_segments-0.1.0-py3-none-any.whl" },
-    { name = "cppcheck", git = "https://github.com/commaai/dependencies.git?subdirectory=cppcheck&rev=release-cppcheck" },
+    { name = "comma-deps-cppcheck", marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]


### PR DESCRIPTION
Small changes so opendbc's car interfaces and safety tests work on a native Windows development build (MSYS2 CLANG64), plus a windows-latest CI entry.

- `get_interface_attr()` uses `os.path.basename()` instead of splitting paths on `/`, which failed on Windows and left `FW_VERSIONS`/`FW_QUERY_CONFIGS` empty.
- libsafety builds with `-mno-ms-bitfields` and `unsigned int` flag bitfields so `CANPacket_t` keeps its layout under cffi's MSVC rules; Linux/macOS unchanged (same fix as panda).
- `./test.sh` runs on windows-latest as a third matrix entry (same 3971 tests); cppcheck comes from its PyPI wheel.

Line endings were split out and comma has already merged them.

Draft: the one `TEMP` commit at the tip (marked `TODO REMOVE`) drops once [commaai/dependencies#107](https://github.com/commaai/dependencies/pull/107) publishes the win_amd64 cppcheck wheel; it points uv at a pre-release index meanwhile.

Part of a six-repo series: [commaai/openpilot#38810](https://github.com/commaai/openpilot/pull/38810), [commaai/msgq#709](https://github.com/commaai/msgq/pull/709), [commaai/panda#2427](https://github.com/commaai/panda/pull/2427), [commaai/rednose#61](https://github.com/commaai/rednose/pull/61), [commaai/dependencies#107](https://github.com/commaai/dependencies/pull/107). dependencies merges first; the rest independently.

Generated with Claude, human-reviewed and tested locally and in CI.
