### PR TITLE
Chrysler: reliable fuzzy fingerprinting

### DIFF
--- a/opendbc/car/chrysler/tests/print_platform_codes.py
+++ b/opendbc/car/chrysler/tests/print_platform_codes.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from collections import defaultdict
+
+from opendbc.car.structs import CarParams
+from opendbc.car.chrysler.values import get_platform_codes
+from opendbc.car.chrysler.fingerprints import FW_VERSIONS
+
+Ecu = CarParams.Ecu
+
+if __name__ == "__main__":
+  cars_for_code: defaultdict = defaultdict(lambda: defaultdict(set))
+
+  for car_model, ecus in FW_VERSIONS.items():
+    print(car_model)
+    for ecu in sorted(ecus):
+      platform_codes = get_platform_codes(ecus[ecu])
+      for code in platform_codes:
+        cars_for_code[ecu][code].add(car_model)
+
+      print(f'  (Ecu.{ecu[0]}, {hex(ecu[1])}, {ecu[2]}):')
+      print(f'    Codes: {sorted(platform_codes)}')
+    print()
+
+  print('\nCar models vs. platform codes:')
+  for ecu, codes in cars_for_code.items():
+    print(f'  (Ecu.{ecu[0]}, {hex(ecu[1])}, {ecu[2]}):')
+    for code, cars in codes.items():
+      print(f'    {code!r}: {sorted(map(str, cars))}')

--- a/opendbc/car/chrysler/tests/test_chrysler.py
+++ b/opendbc/car/chrysler/tests/test_chrysler.py
@@ -1,0 +1,221 @@
+import itertools
+import random
+import unittest
+
+from opendbc.car.structs import CarParams
+from opendbc.car.fw_versions import build_fw_dict
+from opendbc.car.chrysler.values import CAR, FW_QUERY_CONFIG, FW_PATTERN, PLATFORM_CODE_ECUS, get_platform_codes
+from opendbc.car.chrysler.fingerprints import FW_VERSIONS
+from opendbc.testing import fuzzy_test, parameterized
+
+Ecu = CarParams.Ecu
+
+# One FW in the database isn't a Mopar part number. It's on the radar, which isn't a platform
+# code ECU, so it never contributes a platform code and only has to parse without raising.
+NON_PART_NUMBER_FW = {b'22DTRHD_AA'}
+
+# How many platform code ECUs must disagree before one platform can look like another.
+# match_fw_to_car_fuzzy tolerates one unseen ECU, so this has to stay above one.
+MIN_DISTINGUISHING_ECUS = 2
+
+
+def platform_codes_by_addr(car_model):
+  return {ecu[1:]: get_platform_codes(fws) for ecu, fws in FW_VERSIONS[car_model].items()
+          if ecu[0] in PLATFORM_CODE_ECUS}
+
+
+def draw_fw(car_model, rng, replace=None, addrs=None):
+  """Build the live FW dict for a car, optionally replacing the FW on some platform code ECUs."""
+  live: dict[tuple[int, int | None], set[bytes]] = {}
+  for (_ecu, addr, sub_addr), fws in FW_VERSIONS[car_model].items():
+    fw = rng.choice(fws)
+    if replace is not None and (addrs is None or (addr, sub_addr) in addrs):
+      fw = replace(fw)
+    live.setdefault((addr, sub_addr), set()).add(fw)
+  return live
+
+
+def unseen_revision(fw):
+  """Same part number, a revision that isn't in the database. What a dealer flash looks like."""
+  match = FW_PATTERN.match(fw)
+  if match is None:  # not a part number, nothing to bump
+    return fw
+  return match.group('part_number') + b'ZZ' + (b' ' if fw.endswith(b' ') else b'')
+
+
+def unseen_part_number(fw):
+  """A part number that isn't in the database. What new hardware looks like."""
+  match = FW_PATTERN.match(fw)
+  if match is None:  # not a part number, contributes no platform code either way
+    return fw
+  return b'99999999' + match.group('revision') + (b' ' if fw.endswith(b' ') else b'')
+
+
+class TestChryslerFW(unittest.TestCase):
+  @parameterized("car_model, fw_versions", FW_VERSIONS.items())
+  def test_fw_versions(self, car_model, fw_versions):
+    for (ecu, _addr, _sub_addr), fws in fw_versions.items():
+      for fw in fws:
+        if fw in NON_PART_NUMBER_FW:
+          assert ecu not in PLATFORM_CODE_ECUS, f"{fw!r} can't be parsed but is on a platform code ECU"
+          assert get_platform_codes([fw]) == set()
+          continue
+
+        assert FW_PATTERN.match(fw) is not None, f"Unable to parse FW: {fw!r}"
+        assert len(get_platform_codes([fw])) == 1, f"Unable to parse FW: {fw!r}"
+
+  @fuzzy_test(max_examples=100)
+  def test_platform_codes_fuzzy_fw(self, fuzzy):
+    """Ensure function doesn't raise an exception"""
+    get_platform_codes(fuzzy.list(fuzzy.binary))
+
+  def test_platform_codes_spot_check(self):
+    # Asserts basic platform code parsing behavior for a few cases
+    results = get_platform_codes([
+      b'68227902AF',   # combinationMeter, CHRYSLER_PACIFICA_2018
+      b'68267018AO ',  # engine, trailing space
+      b'68421036AC',   # eps, RAM_HD_5TH_GEN
+      b'22DTRHD_AA',   # fwdRadar, RAM_1500_5TH_GEN, not a part number
+      b'68227902AG',   # same part number as the first, newer revision
+    ])
+    assert results == {b'68227902', b'68267018', b'68421036'}
+
+  def test_platform_codes_drop_only_the_revision(self):
+    # The revision is the only thing dropped, so two different parts never collapse together
+    for car_model, fw_versions in FW_VERSIONS.items():
+      for ecu, fws in fw_versions.items():
+        for fw in fws:
+          if fw in NON_PART_NUMBER_FW:
+            continue
+          code = next(iter(get_platform_codes([fw])))
+          assert len(code) == 8, f"{car_model} {ecu[0]}: {fw!r} -> {code!r}"
+          assert fw.rstrip().startswith(code), f"{car_model} {ecu[0]}: {fw!r} -> {code!r}"
+
+  def test_fuzzy_match(self):
+    rng = random.Random(0)
+    for platform, _fw_by_addr in FW_VERSIONS.items():
+      # Ensure there's no overlaps in platform codes
+      for _ in range(20):
+        car_fw = []
+        for ecu, fw_versions in FW_VERSIONS[platform].items():
+          ecu_name, addr, sub_addr = ecu
+          fw = rng.choice(fw_versions)
+          car_fw.append(CarParams.CarFw(ecu=ecu_name, fwVersion=fw, address=addr,
+                                        subAddress=0 if sub_addr is None else sub_addr))
+
+        CP = CarParams(carFw=car_fw)
+        matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(build_fw_dict(CP.carFw), CP.carVin, FW_VERSIONS)
+        assert matches == {platform}
+
+  def test_fuzzy_match_unseen_revision(self):
+    # A dealer flash bumps the revision on every ECU. The car is still the same car, and this is
+    # the case the generic exact-string matcher can't handle.
+    rng = random.Random(1)
+    for platform in FW_VERSIONS:
+      code_addrs = set(platform_codes_by_addr(platform))
+      for _ in range(20):
+        live = draw_fw(platform, rng, unseen_revision, code_addrs)
+        matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(live, '', FW_VERSIONS)
+        assert matches == {platform}, f"{platform}: {matches}"
+
+  def test_fuzzy_match_one_unseen_part_number(self):
+    # A new model year usually swaps one platform code ECU's part number. Tolerated, as long as
+    # the platform still has two other platform code ECUs agreeing.
+    rng = random.Random(2)
+    for platform in FW_VERSIONS:
+      code_addrs = sorted(platform_codes_by_addr(platform))
+      for addr in code_addrs:
+        live = draw_fw(platform, rng, unseen_part_number, {addr})
+        matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(live, '', FW_VERSIONS)
+        if len(code_addrs) - 1 >= MIN_DISTINGUISHING_ECUS:
+          assert matches == {platform}, f"{platform} with unseen {addr}: {matches}"
+        else:
+          # Too few left to be sure which car it is. The Pacifica hybrids have no ABS entry, so
+          # they only have two platform code ECUs and can't spare one.
+          assert matches == set(), f"{platform} with unseen {addr} matched on one ECU: {matches}"
+
+  def test_fuzzy_no_match_two_unseen_part_numbers(self):
+    # Two unseen part numbers is new hardware, not a running change. Staying unmatched is the
+    # safe outcome: openpilot asks the user rather than guessing at the nearest known car.
+    rng = random.Random(3)
+    for platform in FW_VERSIONS:
+      code_addrs = sorted(platform_codes_by_addr(platform))
+      for pair in itertools.combinations(code_addrs, 2):
+        live = draw_fw(platform, rng, unseen_part_number, set(pair))
+        matches = FW_QUERY_CONFIG.match_fw_to_car_fuzzy(live, '', FW_VERSIONS)
+        assert matches == set(), f"{platform} with two unseen part numbers matched {matches}"
+
+  def test_fuzzy_no_match_unknown_car(self):
+    # Every platform code ECU reporting an unknown part number matches nothing
+    rng = random.Random(4)
+    for platform in FW_VERSIONS:
+      live = draw_fw(platform, rng, unseen_part_number)
+      assert FW_QUERY_CONFIG.match_fw_to_car_fuzzy(live, '', FW_VERSIONS) == set()
+
+  def test_platforms_distinguishable(self):
+    # match_fw_to_car_fuzzy tolerates one unseen platform code ECU, which is only safe while every
+    # platform needs at least two of them replaced to look like another one. If a future
+    # fingerprint submission breaks this, the tolerance has to be revisited.
+    for candidate, car in itertools.permutations(FW_VERSIONS, 2):
+      # how many of the candidate's platform code ECUs a car that is really `car` fails to satisfy
+      car_codes = platform_codes_by_addr(car)
+      unmet = sum(1 for addr, codes in platform_codes_by_addr(candidate).items()
+                  if not (car_codes.get(addr, set()) & codes))
+      assert unmet >= MIN_DISTINGUISHING_ECUS, \
+        f"{car} is only {unmet} platform code ECU(s) away from {candidate}"
+
+  def test_match_fw_fuzzy(self):
+    # Synthetic database, so the tolerance itself is pinned rather than whatever the real database
+    # happens to allow. Four platform code ECU addresses: hybrids carry ABS at an alternate address
+    # (FW_QUERY_CONFIG.extra_ecus), so two ABS addresses on one platform is a shape that exists.
+    offline_fw = {
+      (Ecu.combinationMeter, 0x742, None): [b'68227902AF', b'68227902AG'],
+      (Ecu.srs, 0x744, None): [b'68211617AF', b'68211617AG'],
+      (Ecu.abs, 0x747, None): [b'68222747AG'],
+      (Ecu.abs, 0x7e4, None): [b'68330876AA'],
+      # not a platform code ECU, must not affect the result either way
+      (Ecu.engine, 0x7e0, None): [b'68267018AO '],
+    }
+    expected_fingerprint = CAR.CHRYSLER_PACIFICA_2018
+    offline = {expected_fingerprint: offline_fw}
+    match = FW_QUERY_CONFIG.match_fw_to_car_fuzzy
+
+    known = {
+      (0x742, None): {b'68227902AF'},
+      (0x744, None): {b'68211617AF'},
+      (0x747, None): {b'68222747AG'},
+      (0x7e4, None): {b'68330876AA'},
+      (0x7e0, None): {b'68267018AO '},
+    }
+    assert match(known, '', offline) == {expected_fingerprint}
+
+    # every ECU on an unseen revision of a known part still matches
+    unseen_revs = {addr: {unseen_revision(fw) for fw in fws} for addr, fws in known.items()}
+    assert match(unseen_revs, '', offline) == {expected_fingerprint}
+
+    # one unseen part number is tolerated, three of four still agree
+    one_unseen = dict(known) | {(0x742, None): {b'99999999AA'}}
+    assert match(one_unseen, '', offline) == {expected_fingerprint}
+
+    # two unseen part numbers is not, even though two others still agree
+    two_unseen = dict(known) | {(0x742, None): {b'99999999AA'}, (0x744, None): {b'99999998AA'}}
+    assert match(two_unseen, '', offline) == set()
+
+    # a missing ECU counts the same as an unseen one
+    assert match({k: v for k, v in known.items() if k != (0x742, None)}, '', offline) == {expected_fingerprint}
+    assert match({k: v for k, v in known.items()
+                  if k not in ((0x742, None), (0x744, None))}, '', offline) == set()
+
+    # with only two platform code ECUs there is nothing to spare: one unseen means no match,
+    # because a single agreeing ECU is never enough to name a car
+    two_ecu_offline = {expected_fingerprint: {k: v for k, v in offline_fw.items()
+                                              if k[0] != Ecu.abs}}
+    assert match(known, '', two_ecu_offline) == {expected_fingerprint}
+    assert match(one_unseen, '', two_ecu_offline) == set()
+
+  def test_platform_code_ecus_are_present(self):
+    # Every platform needs at least two platform code ECUs in the database, or it can never
+    # fuzzy match at all
+    for platform in FW_VERSIONS:
+      found = sorted(str(ecu[0]) for ecu in FW_VERSIONS[platform] if ecu[0] in PLATFORM_CODE_ECUS)
+      assert len(found) >= MIN_DISTINGUISHING_ECUS, f"{platform} only has {found}"

--- a/opendbc/car/chrysler/values.py
+++ b/opendbc/car/chrysler/values.py
@@ -1,10 +1,11 @@
+import re
 from enum import IntFlag
 from dataclasses import dataclass, field
 
 from opendbc.car import Bus, CarSpecs, DbcDict, PlatformConfig, Platforms, uds
 from opendbc.car.structs import CarParams
 from opendbc.car.docs_definitions import CarHarness, CarDocs, CarParts
-from opendbc.car.fw_query_definitions import FwQueryConfig, Request, p16
+from opendbc.car.fw_query_definitions import FwQueryConfig, LiveFwVersions, OfflineFwVersions, Request, p16
 
 Ecu = CarParams.Ecu
 
@@ -141,6 +142,63 @@ CHRYSLER_SOFTWARE_VERSION_RESPONSE = bytes([uds.SERVICE_TYPE.READ_DATA_BY_IDENTI
 
 CHRYSLER_RX_OFFSET = -0x280
 
+
+# FW response is a Mopar part number: an 8 character base part number followed by a two letter
+# revision, e.g. b'68227902AF'. Engine responses carry a trailing space.
+# e.g. 68227902AF
+#      11111111 22
+# 1 = base part number, specific to the platform
+# 2 = revision, bumped for running software changes that don't change the platform
+FW_PATTERN = re.compile(b'^(?P<part_number>[0-9A-Z]{8})(?P<revision>[A-Z]{2}) ?$')
+
+
+def get_platform_codes(fw_versions: list[bytes] | set[bytes]) -> set[bytes]:
+  codes = set()
+  for fw in fw_versions:
+    match = FW_PATTERN.match(fw)
+    if match is not None:
+      codes.add(match.group('part_number'))
+
+  return codes
+
+
+def match_fw_to_car_fuzzy(live_fw_versions: LiveFwVersions, vin: str, offline_fw_versions: OfflineFwVersions) -> set[str]:
+  candidates: set[str] = set()
+
+  for candidate, fws in offline_fw_versions.items():
+    # Keep track of ECUs which pass all checks (part number is one we've seen on this platform)
+    valid_found_ecus = set()
+    valid_expected_ecus = {ecu[1:] for ecu in fws if ecu[0] in PLATFORM_CODE_ECUS}
+    for ecu, expected_versions in fws.items():
+      addr = ecu[1:]
+      # Only check ECUs expected to have platform codes
+      if ecu[0] not in PLATFORM_CODE_ECUS:
+        continue
+
+      expected_platform_codes = get_platform_codes(expected_versions)
+      found_platform_codes = get_platform_codes(live_fw_versions.get(addr, set()))
+
+      # Check platform code matches for any found versions
+      if not any(found_platform_code in expected_platform_codes for found_platform_code in found_platform_codes):
+        continue
+
+      valid_found_ecus.add(addr)
+
+    # A new model year usually swaps one platform code ECU's part number and leaves the rest of the
+    # platform alone, so tolerate one unseen or missing ECU. This can't match a sibling platform:
+    # every platform needs at least two of these ECUs replaced to look like any other one, which
+    # test_platforms_distinguishable pins.
+    if len(valid_found_ecus) >= 2 and len(valid_expected_ecus - valid_found_ecus) <= 1:
+      candidates.add(candidate)
+
+  return candidates
+
+
+# ECUs expected to have platform codes we can match. Engine and transmission part numbers change
+# with nearly every calibration, and radar and EPS part numbers are shared across sibling platforms,
+# so neither adds discrimination here.
+PLATFORM_CODE_ECUS = (Ecu.abs, Ecu.combinationMeter, Ecu.srs)
+
 FW_QUERY_CONFIG = FwQueryConfig(
   fw_version_regex=br"[A-Z0-9_]{10} ?",
   requests=[
@@ -167,6 +225,8 @@ FW_QUERY_CONFIG = FwQueryConfig(
   extra_ecus=[
     (Ecu.abs, 0x7e4, None),  # alt address for abs on hybrids, NOTE: not on all hybrid platforms
   ],
+  # Custom fuzzy fingerprinting function using platform codes (Mopar part numbers)
+  match_fw_to_car_fuzzy=match_fw_to_car_fuzzy,
 )
 
 DBC = CAR.create_dbc_map()


### PR DESCRIPTION
Closes #1092.

## The problem

Chrysler FW versions are Mopar part numbers: an 8 character base part number followed by a two letter revision, so `b'68227902AF'` is part `68227902` at revision `AF`. The revision gets bumped for running software changes that don't change the platform.

Chrysler has no brand fuzzy matcher, so it falls back to the generic one, which can only match FW strings it has literally seen. That means a dealer flash moving any ECU from `AF` to `AG` makes a known car unfingerprintable until someone submits a new route.

## The change

A `match_fw_to_car_fuzzy` for Chrysler in the same shape as Ford and Hyundai: match on the part number, ignore the revision. Platform code ECUs are ABS, cluster and SRS, and one of them is allowed to carry an unseen part number or be missing, as long as the other two agree.

## Why those ECUs, and why one is tolerated

I measured this over the whole checked-in database rather than picking. 10 platforms, 652 FW versions, 200 draws per platform per scenario, plus a replay of every commit that has ever added Chrysler FW.

| platform code ECUs | tol | known FW | unseen revision | 1 unseen part no. | 2 unseen part nos. | false accepts | historical |
|---|---|---|---|---|---|---|---|
| abs+cluster+srs | 0 | 2000/2000 | 2000/2000 | 0/2000 | 0/2000 | **0** | 20/30 |
| **abs+cluster+srs** | **1** | **2000/2000** | **2000/2000** | **1600/2000** | **0/2000** | **0** | **27/30** |
| abs+cluster+srs+eps | 0 | 2000/2000 | 2000/2000 | 0/2000 | 0/2000 | 0 | 18/30 |
| abs+cluster+srs+eps | 1 | 2000/2000 | 2000/2000 | 2000/2000 | 0/2000 | 0 | 25/30 |
| cluster+srs+eps | 0 | 2000/2000 | 2000/2000 | 0/2000 | 0/2000 | 0 | 18/30 |
| cluster+srs+eps | 1 | 2000/2000 | 2000/2000 | 2000/2000 | 0/2000 | 0 | 25/30 |
| abs+cluster+srs+eps+radar | 0 | 1984/2000 | 1988/2000 | 0/2000 | 0/2000 | 0 | 18/30 |
| abs+cluster+srs+eps+radar | 1 | 2000/2000 | 2000/2000 | 1988/2000 | 0/2000 | 0 | 25/30 |

Two things fall out of that.

Precision doesn't decide it. Every variant has zero cross-platform false accepts, so choosing ECUs on specificity grounds is choosing between ties. What actually separates them is recall on firmware we haven't seen.

The historical replay does decide it. For every commit that added FW to an existing Chrysler platform, I built the car as it would have reported afterwards and matched it against the database as it stood before that commit. `abs+cluster+srs` with one tolerated ECU fingerprints 27 of 30, against 20 for the same set with no tolerance and 25 for every variant that includes EPS. Zero mismatches in all eight variants, which is the number that matters: an unmatched car is the safe outcome, a wrong match is not.

The three remaining misses are genuinely new hardware, on two or more platform code ECUs at once: `7689bdd2` (2018 Grand Cherokee Trackhawk), `725fe0e8` (Pacifica 2019 hybrid), `d8abecb8` (RAM 1500).

EPS and radar are excluded because their part numbers are shared between sibling platforms, and engine and transmission because they change with nearly every calibration. Neither adds discrimination here.

## Why tolerating one ECU is safe

A false accept needs a car to satisfy all but one of another platform's platform code ECUs. I measured that distance for every ordered pair of platforms and the minimum is 2, so one unseen ECU can never turn a platform into its sibling. `test_platforms_distinguishable` asserts exactly that, and it fails the moment a future fingerprint submission erodes the margin, which is the signal to revisit the tolerance rather than finding out on a car.

The rule also degrades safely on its own. The two Pacifica hybrids have no ABS entry, so they only have two platform code ECUs and can't spare one. That's the `1600/2000` above rather than a gap.

## Tests

`opendbc/car/chrysler/tests/test_chrysler.py`, modelled on the Ford suite, 12 tests. Every FW in the database parses (`b'22DTRHD_AA'` is the one that isn't a part number, and it sits on the radar, so it never contributes a platform code). A fuzz test that `get_platform_codes` never raises. A spot check including a trailing-space engine FW. Every platform matches only itself. Unseen revisions still match, one unseen part number still matches, two never do. And a synthetic four-ECU database that pins the tolerance itself rather than whatever the current database happens to allow.

I checked each test by reverting the thing it covers:

| mutation | tests that fail |
|---|---|
| keep the revision in the platform code | 4 |
| widen `PLATFORM_CODE_ECUS` to every ECU | 3 |
| tolerate two unseen ECUs | 1 |
| accept on one agreeing ECU | 1 |
| require all ECUs, no tolerance | 2 |

`test_custom_fuzzy_match` in `test_fw_fingerprint.py` stops skipping for the 10 Chrysler platforms, so the brand function is now checked against the generic one instead of being silently absent. Skips go from 702 to 692.

## Validation

* `./test.sh`: 3983 tests, 0 failures, up from 3971. ruff, ty, codespell, cpplint and MISRA all clean.
* Full CI green on a fork, every job: `./test.sh` on ubuntu-24.04 and macos-latest, safety, safety mutation on both, all four `test models` shards, and `car diff`.
* `car diff`: 0 changed, 40 passed, 0 errors over 40 Chrysler segments.
* No new `Request`, so `test_fw_query_timing`'s `'chrysler': 0.3` and total `8.3` are untouched.

## Route

n/a. This only changes offline fingerprint matching, with no CAN or control behaviour, and the `car diff` replay above is the evidence for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
