### PR TITLE
uds: don't send consecutive frames past the end of the payload

### DIFF
--- a/opendbc/car/uds.py
+++ b/opendbc/car/uds.py
@@ -567,7 +567,7 @@ class IsoTpMessage:
         num_bytes = self.max_len - 1
         start = self.max_len - 2 + self.tx_idx * num_bytes
         count = rx_data[1]
-        end = start + count * num_bytes if count > 0 else self.tx_len
+        end = min(start + count * num_bytes, self.tx_len) if count > 0 else self.tx_len
         tx_msgs = []
         for i in range(start, end, num_bytes):
           self.tx_idx += 1


### PR DESCRIPTION
When an ECU's flow control frame asks for a bigger block size than the payload has left, IsoTpMessage keeps emitting consecutive frames past the end of tx_dat. The slice is empty and ljust pads it, so frames carrying no payload go out on the bus, each one costing another separation time delay.

An 8 byte request answered with flow control 30 08 14 sends eight consecutive frames on master: 2117180000000000, then 2200000000000000 through 2800000000000000. Only the first carries payload. With this change it sends that one frame. ISO 15765-2 section 9.6.5.3 says only the last block of a transfer may have fewer than BS frames, so stopping when the payload runs out is the specified behaviour. Multi-block transfers are unchanged, 25 and 30 bytes at block size 2 still send 2 frames per block.

Scope is small and worth stating: opendbc's own firmware queries never reach this path, since all 127 requests in FW_QUERY_CONFIGS are 7 bytes or shorter and take the single frame path. This affects callers using UdsClient or IsoTpMessage directly with a request of 8 bytes or more.

Clamping end to tx_len is the fix pd0wm proposed in the issue. There is no test file for IsoTpMessage today, happy to add one if you want the behaviour pinned.

Fixes #1682
