### PR TITLE
Safety tests: cover angle rate limits around zero

### DIFF
--- a/opendbc/safety/tests/common.py
+++ b/opendbc/safety/tests/common.py
@@ -768,6 +768,29 @@ class AngleSteeringSafetyTest(VehicleSpeedSafetyTest):
         should_tx = abs(a) <= abs(self.STEER_ANGLE_MAX)
         self.assertEqual(should_tx, self._tx(self._angle_cmd_msg(a, False)))
 
+  def test_angle_rate_limit_zero_crossing(self):
+    if self.ANGLE_RATE_BP is None:
+      self.skipTest("uses vehicle model angle limits")
+
+    # At zero, both directions use the unwind limit to tolerate CAN rounding.
+    # One CAN unit away from zero must use the tighter windup limit instead.
+    self._reset_speed_measurement(max(self.ANGLE_RATE_BP) + 2)
+    self._reset_angle_measurement(0)
+    delta_up = int(self.ANGLE_RATE_UP[-1] * self.DEG_TO_CAN) + 1
+    delta_down = int(self.ANGLE_RATE_DOWN[-1] * self.DEG_TO_CAN) + 1
+
+    for last, lower, upper in ((-1, -1 - delta_up, -1 + delta_down),
+                               (0, -delta_down, delta_down),
+                               (1, 1 - delta_down, 1 + delta_up)):
+      for desired in (lower - 1, lower, upper, upper + 1):
+        with self.subTest(last=last, desired=desired):
+          self.safety.set_controls_allowed(True)
+          self._set_prev_desired_angle(0)
+          # Establish the previous command through TX and verify its CAN scaling.
+          self.assertTrue(self._tx(self._angle_cmd_msg(last / self.DEG_TO_CAN, True)))
+          self.assertEqual(self.safety.get_desired_angle_last(), last)
+          self.assertEqual(lower <= desired <= upper, self._tx(self._angle_cmd_msg(desired / self.DEG_TO_CAN, True)))
+
   def test_angle_cmd_when_disabled(self):
     # Tests that only angles close to the meas are allowed while
     # steer actuation bit is 0, regardless of controls allowed.

--- a/opendbc/safety/tests/mutation.py
+++ b/opendbc/safety/tests/mutation.py
@@ -608,8 +608,6 @@ def main():
     # TODO: fix these surviving mutants and delete this block
     known_survivors = {
       ("opendbc/safety/lateral.h", 188, "boundary"),
-      ("opendbc/safety/lateral.h", 218, "boundary"),
-      ("opendbc/safety/lateral.h", 219, "boundary"),
     }
     survivors = [r for r in survivors if (str(r.site.origin_file.relative_to(ROOT)), r.site.origin_line, r.site.mutator) not in known_survivors]
 


### PR DESCRIPTION
Superseded by #3740 to submit this work from khchen428. The code and commits are unchanged. Please continue review on the replacement PR.

The existing angle-command tests advance in five-degree increments and miss the asymmetric rate limits at zero and one CAN unit. Add a shared test that transmits a previous command of -1, 0, or +1 CAN units, then checks acceptance at each rate boundary and rejection one unit beyond it. This catches both overly permissive windup and overly restrictive unwind limits.

Remove the two corresponding mutation survivors from the allowlist. The equivalent `250000U` to `250001U` interval mutation remains. No production safety behavior changes.

Validation on Apple Silicon macOS:

- 555 affected Nissan, Toyota, PSA, and Tesla safety tests run: 483 passed and 72 skipped.
- Both sign-boundary mutants survive the old enabled-angle tests and fail the new test on all three applicable brands; baseline passes without either mutation.
- Five warm repetitions: the three new tests take a median 1.14 ms, versus 689 ms for the three existing enabled-angle tests.
- Full `./test.sh` passes: 3,981 tests run, 3,275 passed and 706 skipped; Ruff, ty, codespell, cpplint, and MISRA checks pass. `git diff --check` passes.

Related to commaai/openpilot#32425. This is a focused boundary-coverage contribution, not the complete route-based TX fuzzer. The surviving-mutant gap was noted in commaai/opendbc#3723; the boundary test and mutation verification here were implemented independently.
